### PR TITLE
Remove SmartAnswer namespace from Flow classes

### DIFF
--- a/config/initializers/zeitwerk.rb
+++ b/config/initializers/zeitwerk.rb
@@ -1,0 +1,22 @@
+Rails.autoloaders.each do |autoloader|
+  flow_inflector = Class.new(Zeitwerk::Inflector) do
+    def camelize(basename, abspath)
+      # Smart Answer Flow classes don't have a conventional Ruby file path
+      # and instead use a kebab-case approach of the flow's slug
+      if abspath.include?("smart_answer_flows") && basename.include?("-")
+        super "#{basename.gsub('-', '_')}_flow", abspath
+      else
+        super
+      end
+    end
+  end
+
+  autoloader.inflector = flow_inflector.new
+
+  # Smart Answer Flow classes are stored in a lib/smart_answer_flows directory
+  # but aren't under a SmartAnswerFlows namespace. These files are intended
+  # to move to an app/flows directory.
+  autoloader.collapse("lib/smart_answer_flows")
+  # Flows in the shared directory use the same namespace as other Flows.
+  autoloader.collapse("lib/smart_answer_flows/shared")
+end

--- a/docs/tasks/creating-a-new-smart-answer.md
+++ b/docs/tasks/creating-a-new-smart-answer.md
@@ -43,21 +43,19 @@ $ touch lib/smart_answer_flows/example-smart-answer.rb
 Open the new file in your editor and copy/paste this skeleton flow:
 
 ```ruby
-module SmartAnswer
-  class ExampleSmartAnswerFlow < Flow
-    def define
-      name 'example-smart-answer'
-      content_id "<SecureRandom.uuid>"
-      status :draft
+class ExampleSmartAnswerFlow < SmartAnswer::Flow
+  def define
+    name 'example-smart-answer'
+    content_id "<SecureRandom.uuid>"
+    status :draft
 
-      value_question :question_1? do
-        next_node do
-          outcome :outcome_1
-        end
+    value_question :question_1? do
+      next_node do
+        outcome :outcome_1
       end
-
-      outcome :outcome_1
     end
+
+    outcome :outcome_1
   end
 end
 ```

--- a/lib/generators/smart_answer/templates/flow.rb
+++ b/lib/generators/smart_answer/templates/flow.rb
@@ -1,49 +1,46 @@
 # ======================================================================
 # The flow logic.
 # ======================================================================
+class SmartAnswerNameFlow < SmartAnswer::Flow
+  def define
+    # ======================================================================
+    # Available input types:
+    # ======================================================================
+    # - Checkbox
+    # - Country select
+    # - Date
+    # - Money
+    # - Radio
+    # - Postcode
+    # - Salary
+    # - Value (text)
 
-module SmartAnswer
-  class SmartAnswerNameFlow < Flow
-    def define
-      # ======================================================================
-      # Available input types:
-      # ======================================================================
-      # - Checkbox
-      # - Country select
-      # - Date
-      # - Money
-      # - Radio
-      # - Postcode
-      # - Salary
-      # - Value (text)
+    # ======================================================================
+    # Question
+    # ======================================================================
+    checkbox_question :question? do
+      option :blue
+      option :green
+      option :red
+      option :yellow
 
-      # ======================================================================
-      # Question
-      # ======================================================================
-      checkbox_question :question? do
-        option :blue
-        option :green
-        option :red
-        option :yellow
-
-        on_response do |response|
-          self.calculator = Calculators::SmartAnswerNameCalculator.new
-          calculator.question = response
-        end
-
-        validate do
-          calculator.validate?
-        end
-
-        next_node do
-          outcome :results
-        end
+      on_response do |response|
+        self.calculator = SmartAnswer::Calculators::SmartAnswerNameCalculator.new
+        calculator.question = response
       end
 
-      # ======================================================================
-      # Outcome
-      # ======================================================================
-      outcome :results
+      validate do
+        calculator.validate?
+      end
+
+      next_node do
+        outcome :results
+      end
     end
+
+    # ======================================================================
+    # Outcome
+    # ======================================================================
+    outcome :results
   end
 end

--- a/lib/smart_answer/flow_registry.rb
+++ b/lib/smart_answer/flow_registry.rb
@@ -58,7 +58,7 @@ module SmartAnswer
       else
         require @load_path.join(name)
       end
-      namespaced_class = "SmartAnswer::#{class_prefix}Flow".constantize
+      namespaced_class = "#{class_prefix}Flow".constantize
       namespaced_class.build
     end
 

--- a/lib/smart_answer/flow_registry.rb
+++ b/lib/smart_answer/flow_registry.rb
@@ -53,11 +53,6 @@ module SmartAnswer
 
     def build_flow(name)
       class_prefix = name.tr("-", "_").camelize
-      if Rails.env.development?
-        load @load_path.join("#{name}.rb")
-      else
-        require @load_path.join(name)
-      end
       namespaced_class = "#{class_prefix}Flow".constantize
       namespaced_class.build
     end

--- a/lib/smart_answer_flows/additional-commodity-code.rb
+++ b/lib/smart_answer_flows/additional-commodity-code.rb
@@ -1,215 +1,213 @@
-module SmartAnswer
-  class AdditionalCommodityCodeFlow < Flow
-    def define
-      content_id "bfda3b4f-166b-48e7-9aaf-21bfbd606207"
-      name "additional-commodity-code"
+class AdditionalCommodityCodeFlow < SmartAnswer::Flow
+  def define
+    content_id "bfda3b4f-166b-48e7-9aaf-21bfbd606207"
+    name "additional-commodity-code"
 
-      status :published
+    status :published
 
-      # Q1
-      radio :how_much_starch_glucose? do
-        option 0
-        option 5
-        option 25
-        option 50
-        option 75
+    # Q1
+    radio :how_much_starch_glucose? do
+      option 0
+      option 5
+      option 25
+      option 50
+      option 75
 
-        on_response do |response|
-          self.calculator = Calculators::CommodityCodeCalculator.new
-          calculator.starch_glucose_weight = response.to_i
-        end
-
-        next_node do |response|
-          case response.to_i
-          when 25
-            question :how_much_sucrose_2?
-          when 50
-            question :how_much_sucrose_3?
-          when 75
-            question :how_much_sucrose_4?
-          else
-            question :how_much_sucrose_1?
-          end
-        end
+      on_response do |response|
+        self.calculator = SmartAnswer::Calculators::CommodityCodeCalculator.new
+        calculator.starch_glucose_weight = response.to_i
       end
 
-      # Q2ab
-      radio :how_much_sucrose_1? do
-        option 0
-        option 5
-        option 30
-        option 50
-        option 70
-
-        on_response do |response|
-          calculator.sucrose_weight = response.to_i
-        end
-
-        next_node do
-          question :how_much_milk_fat?
+      next_node do |response|
+        case response.to_i
+        when 25
+          question :how_much_sucrose_2?
+        when 50
+          question :how_much_sucrose_3?
+        when 75
+          question :how_much_sucrose_4?
+        else
+          question :how_much_sucrose_1?
         end
       end
-
-      # Q2c
-      radio :how_much_sucrose_2? do
-        option 0
-        option 5
-        option 30
-        option 50
-
-        on_response do |response|
-          calculator.sucrose_weight = response.to_i
-        end
-
-        next_node do
-          question :how_much_milk_fat?
-        end
-      end
-
-      # Q2d
-      radio :how_much_sucrose_3? do
-        option 0
-        option 5
-        option 30
-
-        on_response do |response|
-          calculator.sucrose_weight = response.to_i
-        end
-
-        next_node do
-          question :how_much_milk_fat?
-        end
-      end
-
-      # Q2e
-      radio :how_much_sucrose_4? do
-        option 0
-        option 5
-
-        on_response do |response|
-          calculator.sucrose_weight = response.to_i
-        end
-
-        next_node do
-          question :how_much_milk_fat?
-        end
-      end
-
-      # Q3
-      radio :how_much_milk_fat? do
-        option 0
-        option 1
-        option 3
-        option 6
-        option 9
-        option 12
-        option 18
-        option 26
-        option 40
-        option 55
-        option 70
-        option 85
-
-        on_response do |response|
-          calculator.milk_fat_weight = response.to_i
-        end
-
-        next_node do |response|
-          case response.to_i
-          when 0, 1
-            question :how_much_milk_protein_ab?
-          when 3
-            question :how_much_milk_protein_c?
-          when 6
-            question :how_much_milk_protein_d?
-          when 9, 12
-            question :how_much_milk_protein_ef?
-          when 18, 26
-            question :how_much_milk_protein_gh?
-          else
-            outcome :commodity_code_result
-          end
-        end
-      end
-
-      # Q3ab
-      radio :how_much_milk_protein_ab? do
-        option 0
-        option 2
-        option 6
-        option 18
-        option 30
-        option 60
-
-        on_response do |response|
-          calculator.milk_protein_weight = response.to_i
-        end
-
-        next_node do
-          outcome :commodity_code_result
-        end
-      end
-
-      # Q3c
-      radio :how_much_milk_protein_c? do
-        option 0
-        option 2
-        option 12
-
-        on_response do |response|
-          calculator.milk_protein_weight = response.to_i
-        end
-
-        next_node do
-          outcome :commodity_code_result
-        end
-      end
-
-      # Q3d
-      radio :how_much_milk_protein_d? do
-        option 0
-        option 4
-        option 15
-
-        on_response do |response|
-          calculator.milk_protein_weight = response.to_i
-        end
-
-        next_node do
-          outcome :commodity_code_result
-        end
-      end
-
-      # Q3ef
-      radio :how_much_milk_protein_ef? do
-        option 0
-        option 6
-        option 18
-
-        on_response do |response|
-          calculator.milk_protein_weight = response.to_i
-        end
-
-        next_node do
-          outcome :commodity_code_result
-        end
-      end
-
-      # Q3gh
-      radio :how_much_milk_protein_gh? do
-        option 0
-        option 6
-
-        on_response do |response|
-          calculator.milk_protein_weight = response.to_i
-        end
-
-        next_node do
-          outcome :commodity_code_result
-        end
-      end
-
-      outcome :commodity_code_result
     end
+
+    # Q2ab
+    radio :how_much_sucrose_1? do
+      option 0
+      option 5
+      option 30
+      option 50
+      option 70
+
+      on_response do |response|
+        calculator.sucrose_weight = response.to_i
+      end
+
+      next_node do
+        question :how_much_milk_fat?
+      end
+    end
+
+    # Q2c
+    radio :how_much_sucrose_2? do
+      option 0
+      option 5
+      option 30
+      option 50
+
+      on_response do |response|
+        calculator.sucrose_weight = response.to_i
+      end
+
+      next_node do
+        question :how_much_milk_fat?
+      end
+    end
+
+    # Q2d
+    radio :how_much_sucrose_3? do
+      option 0
+      option 5
+      option 30
+
+      on_response do |response|
+        calculator.sucrose_weight = response.to_i
+      end
+
+      next_node do
+        question :how_much_milk_fat?
+      end
+    end
+
+    # Q2e
+    radio :how_much_sucrose_4? do
+      option 0
+      option 5
+
+      on_response do |response|
+        calculator.sucrose_weight = response.to_i
+      end
+
+      next_node do
+        question :how_much_milk_fat?
+      end
+    end
+
+    # Q3
+    radio :how_much_milk_fat? do
+      option 0
+      option 1
+      option 3
+      option 6
+      option 9
+      option 12
+      option 18
+      option 26
+      option 40
+      option 55
+      option 70
+      option 85
+
+      on_response do |response|
+        calculator.milk_fat_weight = response.to_i
+      end
+
+      next_node do |response|
+        case response.to_i
+        when 0, 1
+          question :how_much_milk_protein_ab?
+        when 3
+          question :how_much_milk_protein_c?
+        when 6
+          question :how_much_milk_protein_d?
+        when 9, 12
+          question :how_much_milk_protein_ef?
+        when 18, 26
+          question :how_much_milk_protein_gh?
+        else
+          outcome :commodity_code_result
+        end
+      end
+    end
+
+    # Q3ab
+    radio :how_much_milk_protein_ab? do
+      option 0
+      option 2
+      option 6
+      option 18
+      option 30
+      option 60
+
+      on_response do |response|
+        calculator.milk_protein_weight = response.to_i
+      end
+
+      next_node do
+        outcome :commodity_code_result
+      end
+    end
+
+    # Q3c
+    radio :how_much_milk_protein_c? do
+      option 0
+      option 2
+      option 12
+
+      on_response do |response|
+        calculator.milk_protein_weight = response.to_i
+      end
+
+      next_node do
+        outcome :commodity_code_result
+      end
+    end
+
+    # Q3d
+    radio :how_much_milk_protein_d? do
+      option 0
+      option 4
+      option 15
+
+      on_response do |response|
+        calculator.milk_protein_weight = response.to_i
+      end
+
+      next_node do
+        outcome :commodity_code_result
+      end
+    end
+
+    # Q3ef
+    radio :how_much_milk_protein_ef? do
+      option 0
+      option 6
+      option 18
+
+      on_response do |response|
+        calculator.milk_protein_weight = response.to_i
+      end
+
+      next_node do
+        outcome :commodity_code_result
+      end
+    end
+
+    # Q3gh
+    radio :how_much_milk_protein_gh? do
+      option 0
+      option 6
+
+      on_response do |response|
+        calculator.milk_protein_weight = response.to_i
+      end
+
+      next_node do
+        outcome :commodity_code_result
+      end
+    end
+
+    outcome :commodity_code_result
   end
 end

--- a/lib/smart_answer_flows/all-smart-answer-questions.rb
+++ b/lib/smart_answer_flows/all-smart-answer-questions.rb
@@ -1,124 +1,122 @@
 # not a real smart answer, this is here to make testing and changing all front-end elements easier
-module SmartAnswer
-  class AllSmartAnswerQuestionsFlow < Flow
-    def define
-      content_id "92661afb-63ce-4ded-b06e-cf6288c0d629"
-      name "all-smart-answer-questions"
-      status :draft
+class AllSmartAnswerQuestionsFlow < SmartAnswer::Flow
+  def define
+    content_id "92661afb-63ce-4ded-b06e-cf6288c0d629"
+    name "all-smart-answer-questions"
+    status :draft
 
-      additional_countries = [OpenStruct.new(slug: "mordor", name: "Mordor")]
+    additional_countries = [OpenStruct.new(slug: "mordor", name: "Mordor")]
 
-      checkbox_question :which_checkboxes? do
-        option :radagast
-        option :mithrandir
-        option :olorin
-        option :tharkun
-        option :elrohir
+    checkbox_question :which_checkboxes? do
+      option :radagast
+      option :mithrandir
+      option :olorin
+      option :tharkun
+      option :elrohir
 
-        next_node do
-          question :which_country?
-        end
+      next_node do
+        question :which_country?
       end
-
-      country_select :which_country?, additional_countries: additional_countries do
-        next_node do
-          question :which_date?
-        end
-      end
-
-      date_question :which_date? do
-        next_node do
-          question :which_date_of_birth?
-        end
-      end
-
-      date_question :which_date_of_birth? do
-        date_of_birth_defaults
-
-        next_node do
-          question :which_date_within_range?
-        end
-      end
-
-      date_question :which_date_within_range? do
-        from { Time.zone.today }
-        to { 4.years.since(Time.zone.today) }
-
-        validate_in_range
-
-        next_node do
-          question :which_date_this_year?
-        end
-      end
-
-      date_question :which_date_this_year? do
-        from { 1.year.ago.beginning_of_year.to_date }
-        to { ::Time.zone.today.end_of_year }
-
-        default_year { 0 }
-
-        next_node do
-          question :how_much_money?
-        end
-      end
-
-      money_question :how_much_money? do
-        next_node do
-          question :which_choice?
-        end
-      end
-
-      radio :which_choice? do
-        option :one
-        option :two
-        option :three
-        option :four
-
-        next_node do
-          question :which_boolean_choice?
-        end
-      end
-
-      radio :which_boolean_choice? do
-        option :yes
-        option :no
-
-        next_node do
-          question :which_postcode?
-        end
-      end
-
-      postcode_question :which_postcode? do
-        next_node do
-          question :how_much_salary?
-        end
-      end
-
-      salary_question :how_much_salary? do
-        next_node do
-          question :which_value?
-        end
-      end
-
-      value_question :which_value? do
-        next_node do
-          outcome :which_integer?
-        end
-      end
-
-      value_question :which_integer?, parse: Integer do
-        next_node do
-          outcome :which_float?
-        end
-      end
-
-      value_question :which_float?, parse: Float do
-        next_node do
-          outcome :outcome
-        end
-      end
-
-      outcome :outcome
     end
+
+    country_select :which_country?, additional_countries: additional_countries do
+      next_node do
+        question :which_date?
+      end
+    end
+
+    date_question :which_date? do
+      next_node do
+        question :which_date_of_birth?
+      end
+    end
+
+    date_question :which_date_of_birth? do
+      date_of_birth_defaults
+
+      next_node do
+        question :which_date_within_range?
+      end
+    end
+
+    date_question :which_date_within_range? do
+      from { Time.zone.today }
+      to { 4.years.since(Time.zone.today) }
+
+      validate_in_range
+
+      next_node do
+        question :which_date_this_year?
+      end
+    end
+
+    date_question :which_date_this_year? do
+      from { 1.year.ago.beginning_of_year.to_date }
+      to { ::Time.zone.today.end_of_year }
+
+      default_year { 0 }
+
+      next_node do
+        question :how_much_money?
+      end
+    end
+
+    money_question :how_much_money? do
+      next_node do
+        question :which_choice?
+      end
+    end
+
+    radio :which_choice? do
+      option :one
+      option :two
+      option :three
+      option :four
+
+      next_node do
+        question :which_boolean_choice?
+      end
+    end
+
+    radio :which_boolean_choice? do
+      option :yes
+      option :no
+
+      next_node do
+        question :which_postcode?
+      end
+    end
+
+    postcode_question :which_postcode? do
+      next_node do
+        question :how_much_salary?
+      end
+    end
+
+    salary_question :how_much_salary? do
+      next_node do
+        question :which_value?
+      end
+    end
+
+    value_question :which_value? do
+      next_node do
+        outcome :which_integer?
+      end
+    end
+
+    value_question :which_integer?, parse: Integer do
+      next_node do
+        outcome :which_float?
+      end
+    end
+
+    value_question :which_float?, parse: Float do
+      next_node do
+        outcome :outcome
+      end
+    end
+
+    outcome :outcome
   end
 end

--- a/lib/smart_answer_flows/am-i-getting-minimum-wage.rb
+++ b/lib/smart_answer_flows/am-i-getting-minimum-wage.rb
@@ -1,50 +1,48 @@
 require "smart_answer_flows/shared/minimum_wage_flow"
 
-module SmartAnswer
-  class AmIGettingMinimumWageFlow < Flow
-    def define
-      content_id "111e006d-2b22-4b1f-989a-56bb61355d68"
-      name "am-i-getting-minimum-wage"
-      status :published
+class AmIGettingMinimumWageFlow < SmartAnswer::Flow
+  def define
+    content_id "111e006d-2b22-4b1f-989a-56bb61355d68"
+    name "am-i-getting-minimum-wage"
+    status :published
 
-      # Q1
-      radio :what_would_you_like_to_check? do
-        option "current_payment"
-        option "past_payment"
+    # Q1
+    radio :what_would_you_like_to_check? do
+      option "current_payment"
+      option "past_payment"
 
-        on_response do |response|
-          date = Date.parse("2020-04-01") if response == "past_payment"
-          self.calculator = Calculators::MinimumWageCalculator.new(date: date)
-          self.accommodation_charge = nil
-        end
-
-        next_node do |response|
-          case response
-          when "current_payment"
-            question :are_you_an_apprentice?
-          when "past_payment"
-            question :were_you_an_apprentice?
-          end
-        end
+      on_response do |response|
+        date = Date.parse("2020-04-01") if response == "past_payment"
+        self.calculator = SmartAnswer::Calculators::MinimumWageCalculator.new(date: date)
+        self.accommodation_charge = nil
       end
 
-      # Q3
-      value_question :how_old_are_you?, parse: Integer do
-        validate do |response|
-          calculator.valid_age?(response)
-        end
-
-        next_node do |response|
-          calculator.age = response
-          if calculator.under_school_leaving_age?
-            outcome :under_school_leaving_age
-          else
-            question :how_often_do_you_get_paid?
-          end
+      next_node do |response|
+        case response
+        when "current_payment"
+          question :are_you_an_apprentice?
+        when "past_payment"
+          question :were_you_an_apprentice?
         end
       end
-
-      append(Shared::MinimumWageFlow.build)
     end
+
+    # Q3
+    value_question :how_old_are_you?, parse: Integer do
+      validate do |response|
+        calculator.valid_age?(response)
+      end
+
+      next_node do |response|
+        calculator.age = response
+        if calculator.under_school_leaving_age?
+          outcome :under_school_leaving_age
+        else
+          question :how_often_do_you_get_paid?
+        end
+      end
+    end
+
+    append(MinimumWageFlow.build)
   end
 end

--- a/lib/smart_answer_flows/am-i-getting-minimum-wage.rb
+++ b/lib/smart_answer_flows/am-i-getting-minimum-wage.rb
@@ -1,5 +1,3 @@
-require "smart_answer_flows/shared/minimum_wage_flow"
-
 class AmIGettingMinimumWageFlow < SmartAnswer::Flow
   def define
     content_id "111e006d-2b22-4b1f-989a-56bb61355d68"

--- a/lib/smart_answer_flows/benefit-cap-calculator.rb
+++ b/lib/smart_answer_flows/benefit-cap-calculator.rb
@@ -1,178 +1,176 @@
-module SmartAnswer
-  class BenefitCapCalculatorFlow < Flow
-    def define
-      content_id "ffe22070-123b-4390-8cc4-51f9d5b5cc74"
-      name "benefit-cap-calculator"
-      status :published
+class BenefitCapCalculatorFlow < SmartAnswer::Flow
+  def define
+    content_id "ffe22070-123b-4390-8cc4-51f9d5b5cc74"
+    name "benefit-cap-calculator"
+    status :published
 
-      calculator = Calculators::BenefitCapCalculatorConfiguration
+    calculator = SmartAnswer::Calculators::BenefitCapCalculatorConfiguration
 
-      # Q1
-      radio :receive_housing_benefit? do
-        option :yes
-        option :no
+    # Q1
+    radio :receive_housing_benefit? do
+      option :yes
+      option :no
 
+      on_response do |response|
+        self.calculator = calculator
+        self.housing_benefit = response
+      end
+
+      next_node do |response|
+        if response == "yes"
+          question :working_tax_credit?
+        else
+          outcome :outcome_not_affected_no_housing_benefit
+        end
+      end
+    end
+
+    # Q2
+    radio :working_tax_credit? do
+      option :yes
+      option :no
+
+      on_response do
+        self.exempt_benefits_descriptions = calculator.exempt_benefits.values
+        self.exempt_benefits = calculator.exempt_benefits
+      end
+
+      next_node do |response|
+        if response == "yes"
+          outcome :outcome_not_affected_exemptions
+        else
+          question :receiving_exemption_benefits?
+        end
+      end
+    end
+
+    # Q3
+    checkbox_question :receiving_exemption_benefits? do
+      calculator.exempt_benefits.each_key do |exempt_benefit|
+        option exempt_benefit
+      end
+
+      on_response do
+        self.benefit_options = calculator.descriptions.merge(none_above: "None of the above")
+        self.total_benefits = 0
+        self.benefit_cap = 0
+      end
+
+      next_node do |response|
+        if calculator.exempted_benefits?(response.split(","))
+          outcome :outcome_not_affected_exemptions
+        else
+          question :receiving_non_exemption_benefits?
+        end
+      end
+    end
+
+    # Q4
+    checkbox_question :receiving_non_exemption_benefits? do
+      calculator.benefits.each_key do |benefit|
+        option benefit
+      end
+
+      on_response do |response|
+        self.benefit_types = response.split(",").map(&:to_sym)
+      end
+
+      next_node do |response|
+        if response == "none"
+          question :housing_benefit_amount?
+        else
+          question BenefitCapCalculatorFlow.next_benefit_amount_question(calculator.questions, benefit_types)
+        end
+      end
+    end
+
+    # Q5a-o
+    calculator.questions.each do |(_benefit, method)|
+      money_question method do
         on_response do |response|
-          self.calculator = calculator
-          self.housing_benefit = response
-        end
-
-        next_node do |response|
-          if response == "yes"
-            question :working_tax_credit?
-          else
-            outcome :outcome_not_affected_no_housing_benefit
-          end
-        end
-      end
-
-      # Q2
-      radio :working_tax_credit? do
-        option :yes
-        option :no
-
-        on_response do
-          self.exempt_benefits_descriptions = calculator.exempt_benefits.values
-          self.exempt_benefits = calculator.exempt_benefits
-        end
-
-        next_node do |response|
-          if response == "yes"
-            outcome :outcome_not_affected_exemptions
-          else
-            question :receiving_exemption_benefits?
-          end
-        end
-      end
-
-      # Q3
-      checkbox_question :receiving_exemption_benefits? do
-        calculator.exempt_benefits.each_key do |exempt_benefit|
-          option exempt_benefit
-        end
-
-        on_response do
-          self.benefit_options = calculator.descriptions.merge(none_above: "None of the above")
-          self.total_benefits = 0
-          self.benefit_cap = 0
-        end
-
-        next_node do |response|
-          if calculator.exempted_benefits?(response.split(","))
-            outcome :outcome_not_affected_exemptions
-          else
-            question :receiving_non_exemption_benefits?
-          end
-        end
-      end
-
-      # Q4
-      checkbox_question :receiving_non_exemption_benefits? do
-        calculator.benefits.each_key do |benefit|
-          option benefit
-        end
-
-        on_response do |response|
-          self.benefit_types = response.split(",").map(&:to_sym)
-        end
-
-        next_node do |response|
-          if response == "none"
-            question :housing_benefit_amount?
-          else
-            question BenefitCapCalculatorFlow.next_benefit_amount_question(calculator.questions, benefit_types)
-          end
-        end
-      end
-
-      # Q5a-o
-      calculator.questions.each do |(_benefit, method)|
-        money_question method do
-          on_response do |response|
-            self.total_benefits = total_benefits + response.to_f
-          end
-
-          next_node do
-            question BenefitCapCalculatorFlow.next_benefit_amount_question(calculator.questions, benefit_types)
-          end
-        end
-      end
-
-      # Q5p
-      money_question :housing_benefit_amount? do
-        on_response do |response|
-          self.housing_benefit_amount = response
-          self.total_benefits += housing_benefit_amount.to_f
-          self.housing_benefit_amount = sprintf("%.2f", housing_benefit_amount)
+          self.total_benefits = total_benefits + response.to_f
         end
 
         next_node do
-          question :single_couple_lone_parent?
+          question BenefitCapCalculatorFlow.next_benefit_amount_question(calculator.questions, benefit_types)
         end
       end
+    end
 
-      # Q6
-      radio :single_couple_lone_parent? do
-        calculator.weekly_benefit_caps.each_key do |weekly_benefit_cap|
-          option weekly_benefit_cap
-        end
-
-        on_response do |response|
-          self.family_type = response
-        end
-
-        next_node do
-          question :enter_postcode?
-        end
+    # Q5p
+    money_question :housing_benefit_amount? do
+      on_response do |response|
+        self.housing_benefit_amount = response
+        self.total_benefits += housing_benefit_amount.to_f
+        self.housing_benefit_amount = sprintf("%.2f", housing_benefit_amount)
       end
 
-      # Q7 Enter a postcode
-      postcode_question :enter_postcode? do
-        on_response do |response|
-          self.benefit_cap = sprintf("%.2f", calculator.weekly_benefit_cap_amount(family_type, calculator.region(response)))
-          self.total_benefits_amount = sprintf("%.2f", total_benefits)
-          self.total_over_cap = sprintf("%.2f", (total_benefits.to_f - benefit_cap.to_f))
-        end
+      next_node do
+        question :single_couple_lone_parent?
+      end
+    end
 
-        next_node do |response|
-          region = calculator.region(response)
-          if total_benefits > calculator.weekly_benefit_cap_amount(family_type, region)
-            if region == :london
-              outcome :outcome_affected_greater_than_cap_london
-            else
-              outcome :outcome_affected_greater_than_cap_national
-            end
-          elsif region == :london
-            outcome :outcome_not_affected_less_than_cap_london
+    # Q6
+    radio :single_couple_lone_parent? do
+      calculator.weekly_benefit_caps.each_key do |weekly_benefit_cap|
+        option weekly_benefit_cap
+      end
+
+      on_response do |response|
+        self.family_type = response
+      end
+
+      next_node do
+        question :enter_postcode?
+      end
+    end
+
+    # Q7 Enter a postcode
+    postcode_question :enter_postcode? do
+      on_response do |response|
+        self.benefit_cap = sprintf("%.2f", calculator.weekly_benefit_cap_amount(family_type, calculator.region(response)))
+        self.total_benefits_amount = sprintf("%.2f", total_benefits)
+        self.total_over_cap = sprintf("%.2f", (total_benefits.to_f - benefit_cap.to_f))
+      end
+
+      next_node do |response|
+        region = calculator.region(response)
+        if total_benefits > calculator.weekly_benefit_cap_amount(family_type, region)
+          if region == :london
+            outcome :outcome_affected_greater_than_cap_london
           else
-            outcome :outcome_not_affected_less_than_cap_national
+            outcome :outcome_affected_greater_than_cap_national
           end
+        elsif region == :london
+          outcome :outcome_not_affected_less_than_cap_london
+        else
+          outcome :outcome_not_affected_less_than_cap_national
         end
       end
-
-      # #OUTCOMES
-
-      ## Outcome 1
-      outcome :outcome_not_affected_exemptions
-
-      ## Outcome 2
-      outcome :outcome_not_affected_no_housing_benefit
-
-      ## Outcome 8
-      outcome :outcome_affected_greater_than_cap_london
-
-      ## Outcome 10
-      outcome :outcome_affected_greater_than_cap_national
-
-      ## Outcome 9
-      outcome :outcome_not_affected_less_than_cap_london
-
-      ## Outcome 11
-      outcome :outcome_not_affected_less_than_cap_national
     end
 
-    def self.next_benefit_amount_question(benefits, selected_benefits)
-      benefits.fetch(selected_benefits.shift, :housing_benefit_amount?)
-    end
+    # #OUTCOMES
+
+    ## Outcome 1
+    outcome :outcome_not_affected_exemptions
+
+    ## Outcome 2
+    outcome :outcome_not_affected_no_housing_benefit
+
+    ## Outcome 8
+    outcome :outcome_affected_greater_than_cap_london
+
+    ## Outcome 10
+    outcome :outcome_affected_greater_than_cap_national
+
+    ## Outcome 9
+    outcome :outcome_not_affected_less_than_cap_london
+
+    ## Outcome 11
+    outcome :outcome_not_affected_less_than_cap_national
+  end
+
+  def self.next_benefit_amount_question(benefits, selected_benefits)
+    benefits.fetch(selected_benefits.shift, :housing_benefit_amount?)
   end
 end

--- a/lib/smart_answer_flows/business-coronavirus-support-finder.rb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder.rb
@@ -1,113 +1,111 @@
-module SmartAnswer
-  class BusinessCoronavirusSupportFinderFlow < Flow
-    def define
-      content_id "89edffd2-3046-40bd-810c-cc1a13c05b6a"
-      name "business-coronavirus-support-finder"
-      status :published
+class BusinessCoronavirusSupportFinderFlow < SmartAnswer::Flow
+  def define
+    content_id "89edffd2-3046-40bd-810c-cc1a13c05b6a"
+    name "business-coronavirus-support-finder"
+    status :published
 
-      radio :business_based? do
-        option :england
-        option :scotland
-        option :wales
-        option :northern_ireland
+    radio :business_based? do
+      option :england
+      option :scotland
+      option :wales
+      option :northern_ireland
 
-        on_response do |response|
-          self.calculator = Calculators::BusinessCoronavirusSupportFinderCalculator.new
-          calculator.business_based = response
-        end
-
-        next_node do
-          question :business_size?
-        end
+      on_response do |response|
+        self.calculator = SmartAnswer::Calculators::BusinessCoronavirusSupportFinderCalculator.new
+        calculator.business_based = response
       end
 
-      radio :business_size? do
-        option :"0_to_249"
-        option :over_249
-
-        on_response do |response|
-          calculator.business_size = response
-        end
-
-        next_node do
-          question :paye_scheme?
-        end
+      next_node do
+        question :business_size?
       end
-
-      radio :paye_scheme? do
-        option :yes
-        option :no
-
-        on_response do |response|
-          calculator.paye_scheme = response
-        end
-
-        next_node do
-          question :self_employed?
-        end
-      end
-
-      radio :self_employed? do
-        option :yes
-        option :no
-
-        on_response do |response|
-          calculator.self_employed = response
-        end
-        next_node do
-          question :non_domestic_property?
-        end
-      end
-
-      radio :non_domestic_property? do
-        option :yes
-        option :no
-        option :not_sure
-
-        on_response do |response|
-          calculator.non_domestic_property = response
-        end
-
-        next_node do
-          question :sectors?
-        end
-      end
-
-      checkbox_question :sectors? do
-        option :nurseries
-        option :retail_hospitality_or_leisure
-        option :nightclubs_or_adult_entertainment
-        option :personal_care
-        none_option
-
-        on_response do |response|
-          calculator.sectors = response.split(",")
-        end
-
-        next_node do
-          question :closed_by_restrictions?
-        end
-      end
-
-      checkbox_question :closed_by_restrictions? do
-        option :local_1
-        option :local_2
-        option :national
-        none_option
-
-        on_response do |response|
-          responses = response.split(",")
-
-          calculator.closed_by_restrictions << "local" if (%w[local_1 local_2] & responses).present?
-          calculator.closed_by_restrictions << "national" if responses.include?("national")
-        end
-
-        next_node do
-          outcome :results
-        end
-      end
-
-      outcome :results
     end
+
+    radio :business_size? do
+      option :"0_to_249"
+      option :over_249
+
+      on_response do |response|
+        calculator.business_size = response
+      end
+
+      next_node do
+        question :paye_scheme?
+      end
+    end
+
+    radio :paye_scheme? do
+      option :yes
+      option :no
+
+      on_response do |response|
+        calculator.paye_scheme = response
+      end
+
+      next_node do
+        question :self_employed?
+      end
+    end
+
+    radio :self_employed? do
+      option :yes
+      option :no
+
+      on_response do |response|
+        calculator.self_employed = response
+      end
+      next_node do
+        question :non_domestic_property?
+      end
+    end
+
+    radio :non_domestic_property? do
+      option :yes
+      option :no
+      option :not_sure
+
+      on_response do |response|
+        calculator.non_domestic_property = response
+      end
+
+      next_node do
+        question :sectors?
+      end
+    end
+
+    checkbox_question :sectors? do
+      option :nurseries
+      option :retail_hospitality_or_leisure
+      option :nightclubs_or_adult_entertainment
+      option :personal_care
+      none_option
+
+      on_response do |response|
+        calculator.sectors = response.split(",")
+      end
+
+      next_node do
+        question :closed_by_restrictions?
+      end
+    end
+
+    checkbox_question :closed_by_restrictions? do
+      option :local_1
+      option :local_2
+      option :national
+      none_option
+
+      on_response do |response|
+        responses = response.split(",")
+
+        calculator.closed_by_restrictions << "local" if (%w[local_1 local_2] & responses).present?
+        calculator.closed_by_restrictions << "national" if responses.include?("national")
+      end
+
+      next_node do
+        outcome :results
+      end
+    end
+
+    outcome :results
   end
 end

--- a/lib/smart_answer_flows/calculate-agricultural-holiday-entitlement.rb
+++ b/lib/smart_answer_flows/calculate-agricultural-holiday-entitlement.rb
@@ -1,102 +1,100 @@
-module SmartAnswer
-  class CalculateAgriculturalHolidayEntitlementFlow < Flow
-    def define
-      content_id "8834bc7c-7ac7-4d45-8a57-1d5a5dcd70a0"
-      name "calculate-agricultural-holiday-entitlement"
-      status :published
+class CalculateAgriculturalHolidayEntitlementFlow < SmartAnswer::Flow
+  def define
+    content_id "8834bc7c-7ac7-4d45-8a57-1d5a5dcd70a0"
+    name "calculate-agricultural-holiday-entitlement"
+    status :published
 
-      radio :work_the_same_number_of_days_each_week? do
-        option "same-number-of-days"
-        option "different-number-of-days"
+    radio :work_the_same_number_of_days_each_week? do
+      option "same-number-of-days"
+      option "different-number-of-days"
 
-        on_response do
-          self.calculator = Calculators::AgriculturalHolidayEntitlementCalculator.new
-        end
-
-        next_node do |response|
-          case response
-          when "same-number-of-days"
-            question :how_many_days_per_week?
-          when "different-number-of-days"
-            question :what_date_does_holiday_start?
-          end
-        end
+      on_response do
+        self.calculator = SmartAnswer::Calculators::AgriculturalHolidayEntitlementCalculator.new
       end
 
-      radio :how_many_days_per_week? do
-        option "7-days"
-        option "6-days"
-        option "5-days"
-        option "4-days"
-        option "3-days"
-        option "2-days"
-        option "1-day"
-
-        on_response do |response|
-          # XXX: this is a bit nasty and takes advantage of the fact that
-          # to_i only looks for the very first integer
-          calculator.days_worked_per_week = response.to_i
-        end
-
-        next_node do
-          question :worked_for_same_employer?
+      next_node do |response|
+        case response
+        when "same-number-of-days"
+          question :how_many_days_per_week?
+        when "different-number-of-days"
+          question :what_date_does_holiday_start?
         end
       end
-
-      date_question :what_date_does_holiday_start? do
-        from { Date.civil(Time.zone.today.year, 1, 1) }
-        to { Date.civil(Time.zone.today.year + 1, 12, 31) }
-
-        on_response do |response|
-          calculator.holiday_starts_on = response
-        end
-
-        next_node do
-          question :how_many_total_days?
-        end
-      end
-
-      radio :worked_for_same_employer? do
-        option "same-employer"
-        option "multiple-employers"
-
-        next_node do |response|
-          case response
-          when "same-employer"
-            outcome :done
-          when "multiple-employers"
-            question :how_many_weeks_at_current_employer?
-          end
-        end
-      end
-
-      value_question :how_many_total_days?, parse: Integer do
-        on_response do |response|
-          calculator.total_days_worked = response
-        end
-
-        validate { calculator.valid_total_days_worked? }
-
-        next_node do
-          question :worked_for_same_employer?
-        end
-      end
-
-      value_question :how_many_weeks_at_current_employer?, parse: Integer do
-        # Has to be less than a full year
-        validate { calculator.valid_weeks_at_current_employer? }
-
-        on_response do |response|
-          calculator.weeks_at_current_employer = response
-        end
-
-        next_node do
-          outcome :done_with_number_formatting
-        end
-      end
-
-      outcome :done
-      outcome :done_with_number_formatting
     end
+
+    radio :how_many_days_per_week? do
+      option "7-days"
+      option "6-days"
+      option "5-days"
+      option "4-days"
+      option "3-days"
+      option "2-days"
+      option "1-day"
+
+      on_response do |response|
+        # XXX: this is a bit nasty and takes advantage of the fact that
+        # to_i only looks for the very first integer
+        calculator.days_worked_per_week = response.to_i
+      end
+
+      next_node do
+        question :worked_for_same_employer?
+      end
+    end
+
+    date_question :what_date_does_holiday_start? do
+      from { Date.civil(Time.zone.today.year, 1, 1) }
+      to { Date.civil(Time.zone.today.year + 1, 12, 31) }
+
+      on_response do |response|
+        calculator.holiday_starts_on = response
+      end
+
+      next_node do
+        question :how_many_total_days?
+      end
+    end
+
+    radio :worked_for_same_employer? do
+      option "same-employer"
+      option "multiple-employers"
+
+      next_node do |response|
+        case response
+        when "same-employer"
+          outcome :done
+        when "multiple-employers"
+          question :how_many_weeks_at_current_employer?
+        end
+      end
+    end
+
+    value_question :how_many_total_days?, parse: Integer do
+      on_response do |response|
+        calculator.total_days_worked = response
+      end
+
+      validate { calculator.valid_total_days_worked? }
+
+      next_node do
+        question :worked_for_same_employer?
+      end
+    end
+
+    value_question :how_many_weeks_at_current_employer?, parse: Integer do
+      # Has to be less than a full year
+      validate { calculator.valid_weeks_at_current_employer? }
+
+      on_response do |response|
+        calculator.weeks_at_current_employer = response
+      end
+
+      next_node do
+        outcome :done_with_number_formatting
+      end
+    end
+
+    outcome :done
+    outcome :done_with_number_formatting
   end
 end

--- a/lib/smart_answer_flows/calculate-employee-redundancy-pay.rb
+++ b/lib/smart_answer_flows/calculate-employee-redundancy-pay.rb
@@ -1,14 +1,12 @@
 require "smart_answer_flows/shared/redundancy_pay_flow"
 
-module SmartAnswer
-  class CalculateEmployeeRedundancyPayFlow < Flow
-    def define
-      content_id "a5b52037-1712-4544-a3d1-a352ce8a8287"
-      name "calculate-employee-redundancy-pay"
+class CalculateEmployeeRedundancyPayFlow < SmartAnswer::Flow
+  def define
+    content_id "a5b52037-1712-4544-a3d1-a352ce8a8287"
+    name "calculate-employee-redundancy-pay"
 
-      status :published
+    status :published
 
-      append(Shared::RedundancyPayFlow.build)
-    end
+    append(RedundancyPayFlow.build)
   end
 end

--- a/lib/smart_answer_flows/calculate-employee-redundancy-pay.rb
+++ b/lib/smart_answer_flows/calculate-employee-redundancy-pay.rb
@@ -1,5 +1,3 @@
-require "smart_answer_flows/shared/redundancy_pay_flow"
-
 class CalculateEmployeeRedundancyPayFlow < SmartAnswer::Flow
   def define
     content_id "a5b52037-1712-4544-a3d1-a352ce8a8287"

--- a/lib/smart_answer_flows/calculate-married-couples-allowance.rb
+++ b/lib/smart_answer_flows/calculate-married-couples-allowance.rb
@@ -1,159 +1,157 @@
-module SmartAnswer
-  class CalculateMarriedCouplesAllowanceFlow < Flow
-    def define
-      content_id "e04dc5fe-9a31-4229-9de9-884dd0c0a8ce"
-      name "calculate-married-couples-allowance"
-      status :published
+class CalculateMarriedCouplesAllowanceFlow < SmartAnswer::Flow
+  def define
+    content_id "e04dc5fe-9a31-4229-9de9-884dd0c0a8ce"
+    name "calculate-married-couples-allowance"
+    status :published
 
-      radio :were_you_or_your_partner_born_on_or_before_6_april_1935? do
-        option :yes
-        option :no
+    radio :were_you_or_your_partner_born_on_or_before_6_april_1935? do
+      option :yes
+      option :no
 
-        on_response do |response|
-          self.calculator = Calculators::MarriedCouplesAllowanceCalculator.new
-          calculator.born_on_or_before_6_april_1935 = response
-        end
-
-        next_node do
-          if calculator.qualifies?
-            question :did_you_marry_or_civil_partner_before_5_december_2005?
-          else
-            outcome :sorry
-          end
-        end
+      on_response do |response|
+        self.calculator = SmartAnswer::Calculators::MarriedCouplesAllowanceCalculator.new
+        calculator.born_on_or_before_6_april_1935 = response
       end
 
-      radio :did_you_marry_or_civil_partner_before_5_december_2005? do
-        option :yes
-        option :no
-
-        on_response do |response|
-          calculator.marriage_or_civil_partnership_before_5_december_2005 = response
-        end
-
-        next_node do
-          if calculator.husband_income_measured?
-            question :whats_the_husbands_date_of_birth?
-          else
-            question :whats_the_highest_earners_date_of_birth?
-          end
+      next_node do
+        if calculator.qualifies?
+          question :did_you_marry_or_civil_partner_before_5_december_2005?
+        else
+          outcome :sorry
         end
       end
+    end
 
-      date_question :whats_the_husbands_date_of_birth? do
-        from { Time.zone.today.end_of_year }
-        to { Date.parse("1 Jan 1896") }
+    radio :did_you_marry_or_civil_partner_before_5_december_2005? do
+      option :yes
+      option :no
 
-        on_response do |response|
-          calculator.birth_date = response
-        end
-
-        next_node do
-          question :whats_the_husbands_income?
-        end
+      on_response do |response|
+        calculator.marriage_or_civil_partnership_before_5_december_2005 = response
       end
 
-      date_question :whats_the_highest_earners_date_of_birth? do
-        to { Date.parse("1 Jan 1896") }
-        from { Time.zone.today.end_of_year }
-
-        on_response do |response|
-          calculator.birth_date = response
-        end
-
-        next_node do
-          question :whats_the_highest_earners_income?
+      next_node do
+        if calculator.husband_income_measured?
+          question :whats_the_husbands_date_of_birth?
+        else
+          question :whats_the_highest_earners_date_of_birth?
         end
       end
+    end
 
-      money_question :whats_the_husbands_income? do
-        on_response do |response|
-          calculator.income = response
-        end
+    date_question :whats_the_husbands_date_of_birth? do
+      from { Time.zone.today.end_of_year }
+      to { Date.parse("1 Jan 1896") }
 
-        validate { calculator.valid_income? }
-
-        next_node do
-          if calculator.income_within_limit_for_personal_allowance?
-            outcome :husband_done
-          else
-            question :paying_into_a_pension?
-          end
-        end
+      on_response do |response|
+        calculator.birth_date = response
       end
 
-      money_question :whats_the_highest_earners_income? do
-        on_response do |response|
-          calculator.income = response
-        end
+      next_node do
+        question :whats_the_husbands_income?
+      end
+    end
 
-        validate { calculator.valid_income? }
+    date_question :whats_the_highest_earners_date_of_birth? do
+      to { Date.parse("1 Jan 1896") }
+      from { Time.zone.today.end_of_year }
 
-        next_node do
-          if calculator.income_within_limit_for_personal_allowance?
-            outcome :highest_earner_done
-          else
-            question :paying_into_a_pension?
-          end
-        end
+      on_response do |response|
+        calculator.birth_date = response
       end
 
-      radio :paying_into_a_pension? do
-        option :yes
-        option :no
+      next_node do
+        question :whats_the_highest_earners_income?
+      end
+    end
 
-        on_response do |response|
-          calculator.paying_into_a_pension = response
-        end
-
-        next_node do
-          if calculator.paying_into_a_pension?
-            question :how_much_expected_contributions_before_tax?
-          else
-            question :how_much_expected_gift_aided_donations?
-          end
-        end
+    money_question :whats_the_husbands_income? do
+      on_response do |response|
+        calculator.income = response
       end
 
-      money_question :how_much_expected_contributions_before_tax? do
-        on_response do |response|
-          calculator.gross_pension_contributions = response
-        end
+      validate { calculator.valid_income? }
 
-        next_node do
-          question :how_much_expected_contributions_with_tax_relief?
+      next_node do
+        if calculator.income_within_limit_for_personal_allowance?
+          outcome :husband_done
+        else
+          question :paying_into_a_pension?
         end
       end
+    end
 
-      money_question :how_much_expected_contributions_with_tax_relief? do
-        on_response do |response|
-          calculator.net_pension_contributions = response
+    money_question :whats_the_highest_earners_income? do
+      on_response do |response|
+        calculator.income = response
+      end
+
+      validate { calculator.valid_income? }
+
+      next_node do
+        if calculator.income_within_limit_for_personal_allowance?
+          outcome :highest_earner_done
+        else
+          question :paying_into_a_pension?
         end
+      end
+    end
 
-        next_node do
+    radio :paying_into_a_pension? do
+      option :yes
+      option :no
+
+      on_response do |response|
+        calculator.paying_into_a_pension = response
+      end
+
+      next_node do
+        if calculator.paying_into_a_pension?
+          question :how_much_expected_contributions_before_tax?
+        else
           question :how_much_expected_gift_aided_donations?
         end
       end
+    end
 
-      money_question :how_much_expected_gift_aided_donations? do
-        on_response do |response|
-          calculator.gift_aided_donations = response
-        end
-
-        next_node do
-          if calculator.husband_income_measured?
-            outcome :husband_done
-          else
-            outcome :highest_earner_done
-          end
-        end
+    money_question :how_much_expected_contributions_before_tax? do
+      on_response do |response|
+        calculator.gross_pension_contributions = response
       end
 
-      outcome :husband_done
-
-      outcome :highest_earner_done
-
-      outcome :sorry
+      next_node do
+        question :how_much_expected_contributions_with_tax_relief?
+      end
     end
+
+    money_question :how_much_expected_contributions_with_tax_relief? do
+      on_response do |response|
+        calculator.net_pension_contributions = response
+      end
+
+      next_node do
+        question :how_much_expected_gift_aided_donations?
+      end
+    end
+
+    money_question :how_much_expected_gift_aided_donations? do
+      on_response do |response|
+        calculator.gift_aided_donations = response
+      end
+
+      next_node do
+        if calculator.husband_income_measured?
+          outcome :husband_done
+        else
+          outcome :highest_earner_done
+        end
+      end
+    end
+
+    outcome :husband_done
+
+    outcome :highest_earner_done
+
+    outcome :sorry
   end
 end

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -1,407 +1,405 @@
-module SmartAnswer
-  class CalculateStatutorySickPayFlow < Flow
-    def define
-      content_id "1c676a9e-0424-4ebb-bab8-d8cb8d2fc6f8"
-      name "calculate-statutory-sick-pay"
+class CalculateStatutorySickPayFlow < SmartAnswer::Flow
+  def define
+    content_id "1c676a9e-0424-4ebb-bab8-d8cb8d2fc6f8"
+    name "calculate-statutory-sick-pay"
 
-      status :published
+    status :published
 
-      # Question 1
-      checkbox_question :is_your_employee_getting? do
-        option :statutory_maternity_pay
-        option :maternity_allowance
-        option :statutory_paternity_pay
-        option :statutory_adoption_pay
-        option :statutory_parental_bereavement_pay
-        option :shared_parental_leave_and_pay
+    # Question 1
+    checkbox_question :is_your_employee_getting? do
+      option :statutory_maternity_pay
+      option :maternity_allowance
+      option :statutory_paternity_pay
+      option :statutory_adoption_pay
+      option :statutory_parental_bereavement_pay
+      option :shared_parental_leave_and_pay
 
-        on_response do |response|
-          self.calculator = Calculators::StatutorySickPayCalculator.new
-          calculator.other_pay_types_received = response.split(",")
-        end
-
-        next_node do
-          if calculator.already_getting_maternity_pay?
-            outcome :already_getting_maternity
-          else
-            question :coronavirus_related?
-          end
-        end
+      on_response do |response|
+        self.calculator = SmartAnswer::Calculators::StatutorySickPayCalculator.new
+        calculator.other_pay_types_received = response.split(",")
       end
 
-      # Question 2
-      radio :coronavirus_related? do
-        option :yes
-        option :no
-
-        on_response do |response|
-          calculator.coronavirus_related = response == "yes"
-        end
-
-        next_node do
-          if calculator.coronavirus_related
-            question :coronavirus_gp_letter?
-          else
-            question :employee_tell_within_limit?
-          end
+      next_node do
+        if calculator.already_getting_maternity_pay?
+          outcome :already_getting_maternity
+        else
+          question :coronavirus_related?
         end
       end
+    end
 
-      # Question 2.1
-      radio :coronavirus_gp_letter? do
-        option :yes
-        option :no
+    # Question 2
+    radio :coronavirus_related? do
+      option :yes
+      option :no
 
-        on_response do |response|
-          calculator.coronavirus_gp_letter = response == "yes"
-        end
-
-        next_node do
-          if calculator.coronavirus_gp_letter
-            question :employee_tell_within_limit?
-          else
-            question :coronavirus_self_or_cohabitant?
-          end
-        end
+      on_response do |response|
+        calculator.coronavirus_related = response == "yes"
       end
 
-      # Question 2.2
-      radio :coronavirus_self_or_cohabitant? do
-        option :self
-        option :cohabitant
-
-        on_response do |response|
-          calculator.has_coronavirus = response == "self"
-          calculator.cohabitant_has_coronavirus = response == "cohabitant"
-        end
-
-        next_node do
+      next_node do
+        if calculator.coronavirus_related
+          question :coronavirus_gp_letter?
+        else
           question :employee_tell_within_limit?
         end
       end
+    end
 
-      # Question 3
-      radio :employee_tell_within_limit? do
-        option :yes
-        option :no
+    # Question 2.1
+    radio :coronavirus_gp_letter? do
+      option :yes
+      option :no
 
-        on_response do |response|
-          calculator.enough_notice_of_absence = response == "yes"
+      on_response do |response|
+        calculator.coronavirus_gp_letter = response == "yes"
+      end
+
+      next_node do
+        if calculator.coronavirus_gp_letter
+          question :employee_tell_within_limit?
+        else
+          question :coronavirus_self_or_cohabitant?
         end
+      end
+    end
 
-        next_node do
-          question :employee_work_different_days?
+    # Question 2.2
+    radio :coronavirus_self_or_cohabitant? do
+      option :self
+      option :cohabitant
+
+      on_response do |response|
+        calculator.has_coronavirus = response == "self"
+        calculator.cohabitant_has_coronavirus = response == "cohabitant"
+      end
+
+      next_node do
+        question :employee_tell_within_limit?
+      end
+    end
+
+    # Question 3
+    radio :employee_tell_within_limit? do
+      option :yes
+      option :no
+
+      on_response do |response|
+        calculator.enough_notice_of_absence = response == "yes"
+      end
+
+      next_node do
+        question :employee_work_different_days?
+      end
+    end
+
+    # Question 4
+    radio :employee_work_different_days? do
+      option :yes
+      option :no
+
+      next_node do |response|
+        case response
+        when "yes"
+          outcome :not_regular_schedule # Answer 4
+        when "no"
+          question :first_sick_day? # Question 4
+        end
+      end
+    end
+
+    # Question 5
+    date_question :first_sick_day? do
+      from { Date.new(2011, 1, 1) }
+      to { SmartAnswer::Calculators::StatutorySickPayCalculator.year_of_sickness }
+
+      on_response do |response|
+        calculator.sick_start_date = response
+      end
+
+      validate_in_range
+
+      next_node do
+        question :last_sick_day?
+      end
+    end
+
+    # Question 6
+    date_question :last_sick_day? do
+      from { Date.new(2011, 1, 1) }
+      to { SmartAnswer::Calculators::StatutorySickPayCalculator.year_of_sickness }
+
+      on_response do |response|
+        calculator.sick_end_date = response
+      end
+
+      validate_in_range
+
+      validate do
+        calculator.valid_last_sick_day?
+      end
+
+      next_node do
+        if calculator.valid_period_of_incapacity_for_work?
+          question :has_linked_sickness?
+        else
+          outcome :must_be_sick_for_4_days
+        end
+      end
+    end
+
+    # Question 7
+    radio :has_linked_sickness? do
+      option :yes
+      option :no
+
+      on_response do |response|
+        case response
+        when "yes"
+          calculator.has_linked_sickness = true
+        when "no"
+          calculator.has_linked_sickness = false
         end
       end
 
-      # Question 4
-      radio :employee_work_different_days? do
-        option :yes
-        option :no
-
-        next_node do |response|
-          case response
-          when "yes"
-            outcome :not_regular_schedule # Answer 4
-          when "no"
-            question :first_sick_day? # Question 4
-          end
-        end
-      end
-
-      # Question 5
-      date_question :first_sick_day? do
-        from { Date.new(2011, 1, 1) }
-        to { Calculators::StatutorySickPayCalculator.year_of_sickness }
-
-        on_response do |response|
-          calculator.sick_start_date = response
-        end
-
-        validate_in_range
-
-        next_node do
-          question :last_sick_day?
-        end
-      end
-
-      # Question 6
-      date_question :last_sick_day? do
-        from { Date.new(2011, 1, 1) }
-        to { Calculators::StatutorySickPayCalculator.year_of_sickness }
-
-        on_response do |response|
-          calculator.sick_end_date = response
-        end
-
-        validate_in_range
-
-        validate do
-          calculator.valid_last_sick_day?
-        end
-
-        next_node do
-          if calculator.valid_period_of_incapacity_for_work?
-            question :has_linked_sickness?
-          else
-            outcome :must_be_sick_for_4_days
-          end
-        end
-      end
-
-      # Question 7
-      radio :has_linked_sickness? do
-        option :yes
-        option :no
-
-        on_response do |response|
-          case response
-          when "yes"
-            calculator.has_linked_sickness = true
-          when "no"
-            calculator.has_linked_sickness = false
-          end
-        end
-
-        next_node do
-          if calculator.has_linked_sickness
-            question :linked_sickness_start_date?
-          else
-            question :paid_at_least_8_weeks?
-          end
-        end
-      end
-
-      # Question 7.1
-      date_question :linked_sickness_start_date? do
-        from { Date.new(2010, 1, 1) }
-        to { Calculators::StatutorySickPayCalculator.year_of_sickness }
-
-        on_response do |response|
-          calculator.linked_sickness_start_date = response
-        end
-
-        validate_in_range
-
-        validate :error_linked_sickness_must_be_before do
-          calculator.valid_linked_sickness_start_date?
-        end
-
-        next_node do
-          question :linked_sickness_end_date?
-        end
-      end
-
-      # Question 7.2
-      date_question :linked_sickness_end_date? do
-        from { Date.new(2010, 1, 1) }
-        to { Calculators::StatutorySickPayCalculator.year_of_sickness }
-
-        on_response do |response|
-          calculator.linked_sickness_end_date = response
-        end
-
-        validate_in_range
-
-        validate :error_must_be_within_eight_weeks do
-          calculator.within_eight_weeks_of_current_sickness_period?
-        end
-
-        validate :error_must_be_at_least_1_day_before_first_sick_day do
-          calculator.at_least_1_day_before_first_sick_day?
-        end
-
-        validate :error_must_be_valid_period_of_incapacity_for_work do
-          calculator.valid_linked_period_of_incapacity_for_work?
-        end
-
-        next_node do
+      next_node do
+        if calculator.has_linked_sickness
+          question :linked_sickness_start_date?
+        else
           question :paid_at_least_8_weeks?
         end
       end
-
-      # Question 8.1
-      radio :paid_at_least_8_weeks? do
-        option :eight_weeks_more
-        option :eight_weeks_less
-        option :before_payday
-
-        on_response do |response|
-          calculator.eight_weeks_earnings = response
-        end
-
-        next_node do
-          if calculator.paid_at_least_8_weeks_of_earnings?
-            question :how_often_pay_employee_pay_patterns? # Question 7.2
-          elsif calculator.paid_less_than_8_weeks_of_earnings?
-            question :total_earnings_before_sick_period? # Question 10
-          elsif calculator.fell_sick_before_payday?
-            question :how_often_pay_employee_pay_patterns? # Question 7.2
-          end
-        end
-      end
-
-      # Question 8.2
-      radio :how_often_pay_employee_pay_patterns? do
-        option :weekly
-        option :fortnightly
-        option :every_4_weeks
-        option :monthly
-        option :irregularly
-
-        on_response do |response|
-          calculator.pay_pattern = response
-        end
-
-        next_node do
-          if calculator.paid_at_least_8_weeks_of_earnings?
-            question :last_payday_before_sickness? # Question 8
-          else
-            question :pay_amount_if_not_sick? # Question 9
-          end
-        end
-      end
-
-      # Question 9
-      date_question :last_payday_before_sickness? do
-        from { Date.new(2010, 1, 1) }
-        to { Calculators::StatutorySickPayCalculator.year_of_sickness }
-        validate_in_range
-
-        on_response do |response|
-          calculator.relevant_period_to = response
-        end
-
-        validate do
-          calculator.valid_last_payday_before_sickness?
-        end
-
-        next_node do
-          question :last_payday_before_offset?
-        end
-      end
-
-      # Question 9.1
-      date_question :last_payday_before_offset? do
-        from { Date.new(2010, 1, 1) }
-        to { Calculators::StatutorySickPayCalculator.year_of_sickness }
-        validate_in_range
-
-        on_response do |response|
-          calculator.relevant_period_from = response + 1.day
-        end
-
-        validate do
-          calculator.valid_last_payday_before_offset?
-        end
-
-        next_node do
-          question :total_employee_earnings?
-        end
-      end
-
-      # Question 9.2
-      money_question :total_employee_earnings? do
-        on_response do |response|
-          calculator.total_employee_earnings = response
-        end
-
-        next_node do
-          question :usual_work_days?
-        end
-      end
-
-      # Question 10
-      money_question :pay_amount_if_not_sick? do
-        on_response do |response|
-          calculator.relevant_contractual_pay = response
-        end
-
-        next_node do
-          question :contractual_days_covered_by_earnings?
-        end
-      end
-
-      # Question 10.1
-      value_question :contractual_days_covered_by_earnings? do
-        on_response do |response|
-          calculator.contractual_days_covered_by_earnings = response
-        end
-
-        validate :must_be_a_number_of_days do
-          calculator.valid_contractual_days_covered_by_earnings?
-        end
-
-        next_node do
-          question :usual_work_days?
-        end
-      end
-
-      # Question 11
-      money_question :total_earnings_before_sick_period? do
-        on_response do |response|
-          calculator.total_earnings_before_sick_period = response
-        end
-
-        next_node do
-          question :days_covered_by_earnings?
-        end
-      end
-
-      # Question 11.1
-      value_question :days_covered_by_earnings? do
-        on_response do |response|
-          calculator.days_covered_by_earnings = response.to_i
-        end
-
-        next_node do
-          question :usual_work_days?
-        end
-      end
-
-      # Question 12
-      checkbox_question :usual_work_days? do
-        %w[1 2 3 4 5 6 0].each { |n| option n.to_s }
-
-        on_response do |response|
-          calculator.days_of_the_week_worked = response.split(",")
-        end
-
-        next_node do
-          if calculator.not_earned_enough?
-            outcome :not_earned_enough
-          elsif calculator.maximum_entitlement_reached?
-            outcome :maximum_entitlement_reached # Answer 8
-          elsif calculator.entitled_to_sick_pay?
-            outcome :entitled_to_sick_pay # Answer 6
-          elsif calculator.maximum_entitlement_reached_v2?
-            outcome :maximum_entitlement_reached # Answer 8
-          else
-            outcome :not_entitled_3_days_not_paid # Answer 7
-          end
-        end
-      end
-
-      # Answer 1
-      outcome :already_getting_maternity
-
-      # Answer 2
-      outcome :must_be_sick_for_4_days
-
-      # Answer 4
-      outcome :not_regular_schedule
-
-      # Answer 5
-      outcome :not_earned_enough
-
-      # Answer 6
-      outcome :entitled_to_sick_pay
-
-      # Answer 7
-      outcome :not_entitled_3_days_not_paid
-
-      # Answer 8
-      outcome :maximum_entitlement_reached
     end
+
+    # Question 7.1
+    date_question :linked_sickness_start_date? do
+      from { Date.new(2010, 1, 1) }
+      to { SmartAnswer::Calculators::StatutorySickPayCalculator.year_of_sickness }
+
+      on_response do |response|
+        calculator.linked_sickness_start_date = response
+      end
+
+      validate_in_range
+
+      validate :error_linked_sickness_must_be_before do
+        calculator.valid_linked_sickness_start_date?
+      end
+
+      next_node do
+        question :linked_sickness_end_date?
+      end
+    end
+
+    # Question 7.2
+    date_question :linked_sickness_end_date? do
+      from { Date.new(2010, 1, 1) }
+      to { SmartAnswer::Calculators::StatutorySickPayCalculator.year_of_sickness }
+
+      on_response do |response|
+        calculator.linked_sickness_end_date = response
+      end
+
+      validate_in_range
+
+      validate :error_must_be_within_eight_weeks do
+        calculator.within_eight_weeks_of_current_sickness_period?
+      end
+
+      validate :error_must_be_at_least_1_day_before_first_sick_day do
+        calculator.at_least_1_day_before_first_sick_day?
+      end
+
+      validate :error_must_be_valid_period_of_incapacity_for_work do
+        calculator.valid_linked_period_of_incapacity_for_work?
+      end
+
+      next_node do
+        question :paid_at_least_8_weeks?
+      end
+    end
+
+    # Question 8.1
+    radio :paid_at_least_8_weeks? do
+      option :eight_weeks_more
+      option :eight_weeks_less
+      option :before_payday
+
+      on_response do |response|
+        calculator.eight_weeks_earnings = response
+      end
+
+      next_node do
+        if calculator.paid_at_least_8_weeks_of_earnings?
+          question :how_often_pay_employee_pay_patterns? # Question 7.2
+        elsif calculator.paid_less_than_8_weeks_of_earnings?
+          question :total_earnings_before_sick_period? # Question 10
+        elsif calculator.fell_sick_before_payday?
+          question :how_often_pay_employee_pay_patterns? # Question 7.2
+        end
+      end
+    end
+
+    # Question 8.2
+    radio :how_often_pay_employee_pay_patterns? do
+      option :weekly
+      option :fortnightly
+      option :every_4_weeks
+      option :monthly
+      option :irregularly
+
+      on_response do |response|
+        calculator.pay_pattern = response
+      end
+
+      next_node do
+        if calculator.paid_at_least_8_weeks_of_earnings?
+          question :last_payday_before_sickness? # Question 8
+        else
+          question :pay_amount_if_not_sick? # Question 9
+        end
+      end
+    end
+
+    # Question 9
+    date_question :last_payday_before_sickness? do
+      from { Date.new(2010, 1, 1) }
+      to { SmartAnswer::Calculators::StatutorySickPayCalculator.year_of_sickness }
+      validate_in_range
+
+      on_response do |response|
+        calculator.relevant_period_to = response
+      end
+
+      validate do
+        calculator.valid_last_payday_before_sickness?
+      end
+
+      next_node do
+        question :last_payday_before_offset?
+      end
+    end
+
+    # Question 9.1
+    date_question :last_payday_before_offset? do
+      from { Date.new(2010, 1, 1) }
+      to { SmartAnswer::Calculators::StatutorySickPayCalculator.year_of_sickness }
+      validate_in_range
+
+      on_response do |response|
+        calculator.relevant_period_from = response + 1.day
+      end
+
+      validate do
+        calculator.valid_last_payday_before_offset?
+      end
+
+      next_node do
+        question :total_employee_earnings?
+      end
+    end
+
+    # Question 9.2
+    money_question :total_employee_earnings? do
+      on_response do |response|
+        calculator.total_employee_earnings = response
+      end
+
+      next_node do
+        question :usual_work_days?
+      end
+    end
+
+    # Question 10
+    money_question :pay_amount_if_not_sick? do
+      on_response do |response|
+        calculator.relevant_contractual_pay = response
+      end
+
+      next_node do
+        question :contractual_days_covered_by_earnings?
+      end
+    end
+
+    # Question 10.1
+    value_question :contractual_days_covered_by_earnings? do
+      on_response do |response|
+        calculator.contractual_days_covered_by_earnings = response
+      end
+
+      validate :must_be_a_number_of_days do
+        calculator.valid_contractual_days_covered_by_earnings?
+      end
+
+      next_node do
+        question :usual_work_days?
+      end
+    end
+
+    # Question 11
+    money_question :total_earnings_before_sick_period? do
+      on_response do |response|
+        calculator.total_earnings_before_sick_period = response
+      end
+
+      next_node do
+        question :days_covered_by_earnings?
+      end
+    end
+
+    # Question 11.1
+    value_question :days_covered_by_earnings? do
+      on_response do |response|
+        calculator.days_covered_by_earnings = response.to_i
+      end
+
+      next_node do
+        question :usual_work_days?
+      end
+    end
+
+    # Question 12
+    checkbox_question :usual_work_days? do
+      %w[1 2 3 4 5 6 0].each { |n| option n.to_s }
+
+      on_response do |response|
+        calculator.days_of_the_week_worked = response.split(",")
+      end
+
+      next_node do
+        if calculator.not_earned_enough?
+          outcome :not_earned_enough
+        elsif calculator.maximum_entitlement_reached?
+          outcome :maximum_entitlement_reached # Answer 8
+        elsif calculator.entitled_to_sick_pay?
+          outcome :entitled_to_sick_pay # Answer 6
+        elsif calculator.maximum_entitlement_reached_v2?
+          outcome :maximum_entitlement_reached # Answer 8
+        else
+          outcome :not_entitled_3_days_not_paid # Answer 7
+        end
+      end
+    end
+
+    # Answer 1
+    outcome :already_getting_maternity
+
+    # Answer 2
+    outcome :must_be_sick_for_4_days
+
+    # Answer 4
+    outcome :not_regular_schedule
+
+    # Answer 5
+    outcome :not_earned_enough
+
+    # Answer 6
+    outcome :entitled_to_sick_pay
+
+    # Answer 7
+    outcome :not_entitled_3_days_not_paid
+
+    # Answer 8
+    outcome :maximum_entitlement_reached
   end
 end

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement.rb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement.rb
@@ -1,292 +1,290 @@
-module SmartAnswer
-  class CalculateYourHolidayEntitlementFlow < Flow
-    def define
-      content_id "deedf6f8-389b-4b34-a5b1-faa9ef909a70"
-      name "calculate-your-holiday-entitlement"
-      status :published
+class CalculateYourHolidayEntitlementFlow < SmartAnswer::Flow
+  def define
+    content_id "deedf6f8-389b-4b34-a5b1-faa9ef909a70"
+    name "calculate-your-holiday-entitlement"
+    status :published
 
-      # Q1
-      radio :basis_of_calculation? do
-        option "days-worked-per-week"
-        option "hours-worked-per-week"
-        option "irregular-hours"
-        option "annualised-hours"
-        option "compressed-hours"
-        option "shift-worker"
+    # Q1
+    radio :basis_of_calculation? do
+      option "days-worked-per-week"
+      option "hours-worked-per-week"
+      option "irregular-hours"
+      option "annualised-hours"
+      option "compressed-hours"
+      option "shift-worker"
 
-        on_response do |response|
-          self.calculator = Calculators::HolidayEntitlement.new
-          calculator.calculation_basis = response
+      on_response do |response|
+        self.calculator = SmartAnswer::Calculators::HolidayEntitlement.new
+        calculator.calculation_basis = response
+      end
+
+      next_node do
+        case calculator.calculation_basis
+        when "days-worked-per-week", "hours-worked-per-week", "compressed-hours", "irregular-hours", "annualised-hours"
+          question :calculation_period?
+        when "shift-worker"
+          question :shift_worker_basis?
         end
+      end
+    end
 
-        next_node do
+    # Q2, Q35
+    radio :calculation_period? do
+      option "full-year"
+      option "starting"
+      option "leaving"
+      option "starting-and-leaving"
+
+      on_response do |response|
+        calculator.holiday_period = response
+      end
+
+      next_node do
+        case calculator.holiday_period
+        when "starting", "starting-and-leaving"
+          question :what_is_your_starting_date?
+        when "leaving"
+          question :what_is_your_leaving_date?
+        when "full-year"
           case calculator.calculation_basis
-          when "days-worked-per-week", "hours-worked-per-week", "compressed-hours", "irregular-hours", "annualised-hours"
-            question :calculation_period?
-          when "shift-worker"
-            question :shift_worker_basis?
-          end
-        end
-      end
-
-      # Q2, Q35
-      radio :calculation_period? do
-        option "full-year"
-        option "starting"
-        option "leaving"
-        option "starting-and-leaving"
-
-        on_response do |response|
-          calculator.holiday_period = response
-        end
-
-        next_node do
-          case calculator.holiday_period
-          when "starting", "starting-and-leaving"
-            question :what_is_your_starting_date?
-          when "leaving"
-            question :what_is_your_leaving_date?
-          when "full-year"
-            case calculator.calculation_basis
-            when "irregular-hours", "annualised-hours"
-              outcome :irregular_and_annualised_done
-            when "days-worked-per-week"
-              question :how_many_days_per_week?
-            else
-              question :how_many_hours_per_week?
-            end
-          end
-        end
-      end
-
-      # Q3 - Q7 - Q8
-      value_question :how_many_days_per_week?, parse: Float do
-        on_response do |response|
-          calculator.working_days_per_week = response
-        end
-
-        validate :error_message do
-          calculator.working_days_per_week.between?(1, 7)
-        end
-
-        next_node do
-          outcome :days_per_week_done
-        end
-      end
-
-      # Q4 - Q12 - Q20 - Q29 - Q36
-      date_question :what_is_your_starting_date? do
-        from { Date.civil(1.year.ago.year, 1, 1) }
-        to { Date.civil(1.year.since(Time.zone.today).year, 12, 31) }
-
-        on_response do |response|
-          calculator.start_date = response
-        end
-
-        next_node do
-          if calculator.holiday_period == "starting-and-leaving"
-            question :what_is_your_leaving_date?
+          when "irregular-hours", "annualised-hours"
+            outcome :irregular_and_annualised_done
+          when "days-worked-per-week"
+            question :how_many_days_per_week?
           else
-            question :when_does_your_leave_year_start?
+            question :how_many_hours_per_week?
           end
         end
       end
+    end
 
-      # Q5 - Q13 - Q21 - Q29 - Q30 - Q37
-      date_question :what_is_your_leaving_date? do
-        from { Date.civil(1.year.ago.year, 1, 1) }
-        to { Date.civil(1.year.since(Time.zone.today).year, 12, 31) }
-
-        on_response do |response|
-          calculator.leaving_date = response
-        end
-
-        validate :error_end_date_before_start_date do
-          calculator.holiday_period != "starting-and-leaving" || calculator.start_date.before?(calculator.leaving_date)
-        end
-
-        validate :error_end_date_outside_year_range do
-          calculator.holiday_period != "starting-and-leaving" || YearRange.new(begins_on: calculator.start_date).include?(calculator.leaving_date)
-        end
-
-        next_node do
-          if calculator.holiday_period == "starting-and-leaving"
-            case calculator.calculation_basis
-            when "days-worked-per-week"
-              question :how_many_days_per_week?
-            when "hours-worked-per-week", "compressed-hours"
-              question :how_many_hours_per_week?
-            when "shift-worker"
-              question :shift_worker_hours_per_shift?
-            when "irregular-hours", "annualised-hours"
-              outcome :irregular_and_annualised_done
-            end
-          else
-            question :when_does_your_leave_year_start?
-          end
-        end
+    # Q3 - Q7 - Q8
+    value_question :how_many_days_per_week?, parse: Float do
+      on_response do |response|
+        calculator.working_days_per_week = response
       end
 
-      # Q6 - Q14 - Q22 - Q31 - Q38
-      date_question :when_does_your_leave_year_start? do
-        from { Date.civil(1.year.ago.year, 1, 1) }
-        to { Date.civil(1.year.since(Time.zone.today).year, 12, 31) }
+      validate :error_message do
+        calculator.working_days_per_week.between?(1, 7)
+      end
 
-        on_response do |response|
-          calculator.leave_year_start_date = response
+      next_node do
+        outcome :days_per_week_done
+      end
+    end
+
+    # Q4 - Q12 - Q20 - Q29 - Q36
+    date_question :what_is_your_starting_date? do
+      from { Date.civil(1.year.ago.year, 1, 1) }
+      to { Date.civil(1.year.since(Time.zone.today).year, 12, 31) }
+
+      on_response do |response|
+        calculator.start_date = response
+      end
+
+      next_node do
+        if calculator.holiday_period == "starting-and-leaving"
+          question :what_is_your_leaving_date?
+        else
+          question :when_does_your_leave_year_start?
         end
+      end
+    end
 
-        validate :error_end_date_before_start_date do
-          calculator.leaving_date.blank? || calculator.leave_year_start_date.before?(calculator.leaving_date)
-        end
+    # Q5 - Q13 - Q21 - Q29 - Q30 - Q37
+    date_question :what_is_your_leaving_date? do
+      from { Date.civil(1.year.ago.year, 1, 1) }
+      to { Date.civil(1.year.since(Time.zone.today).year, 12, 31) }
 
-        validate :error_end_date_outside_leave_year_range do
-          calculator.leaving_date.blank? || YearRange.new(begins_on: calculator.leave_year_start_date).include?(calculator.leaving_date)
-        end
+      on_response do |response|
+        calculator.leaving_date = response
+      end
 
-        validate :error_start_date_before_start_leave_year_date do
-          calculator.start_date.nil? || calculator.leave_year_start_date.before?(calculator.start_date)
-        end
+      validate :error_end_date_before_start_date do
+        calculator.holiday_period != "starting-and-leaving" || calculator.start_date.before?(calculator.leaving_date)
+      end
 
-        validate :error_start_date_outside_leave_year_range do
-          calculator.start_date.nil? || YearRange.new(begins_on: calculator.leave_year_start_date).include?(calculator.start_date)
-        end
+      validate :error_end_date_outside_year_range do
+        calculator.holiday_period != "starting-and-leaving" || SmartAnswer::YearRange.new(begins_on: calculator.start_date).include?(calculator.leaving_date)
+      end
 
-        next_node do
+      next_node do
+        if calculator.holiday_period == "starting-and-leaving"
           case calculator.calculation_basis
           when "days-worked-per-week"
             question :how_many_days_per_week?
           when "hours-worked-per-week", "compressed-hours"
             question :how_many_hours_per_week?
-          when "irregular-hours", "annualised-hours"
-            outcome :irregular_and_annualised_done
           when "shift-worker"
             question :shift_worker_hours_per_shift?
+          when "irregular-hours", "annualised-hours"
+            outcome :irregular_and_annualised_done
           end
+        else
+          question :when_does_your_leave_year_start?
         end
       end
-
-      # Q10 - Q15 - Q18
-      value_question :how_many_hours_per_week?, parse: Float do
-        on_response do |response|
-          calculator.hours_per_week = response
-        end
-
-        validate :error_no_hours_worked do
-          calculator.hours_per_week.positive?
-        end
-
-        validate :error_over_168_hours_worked do
-          calculator.hours_per_week <= 168
-        end
-
-        next_node do
-          question :how_many_days_per_week_for_hours?
-        end
-      end
-
-      # Q11 - Q16 - Q19
-      value_question :how_many_days_per_week_for_hours?, parse: Float do
-        on_response do |response|
-          calculator.working_days_per_week = response
-        end
-
-        validate :error_over_7_days_per_week do
-          calculator.working_days_per_week.between?(1, 7)
-        end
-
-        validate :error_over_24_hours_per_day do
-          calculator.hours_per_week.blank? || (calculator.hours_per_week / calculator.working_days_per_week) <= 24
-        end
-
-        next_node do
-          if calculator.calculation_basis == "compressed-hours"
-            outcome :compressed_hours_done
-          else
-            outcome :hours_per_week_done
-          end
-        end
-      end
-
-      radio :shift_worker_basis? do
-        option "full-year"
-        option "starting"
-        option "leaving"
-        option "starting-and-leaving"
-
-        on_response do |response|
-          calculator.holiday_period = response
-        end
-
-        next_node do
-          case calculator.holiday_period
-          when "full-year"
-            question :shift_worker_hours_per_shift?
-          when "starting", "starting-and-leaving"
-            question :what_is_your_starting_date?
-          when "leaving"
-            question :what_is_your_leaving_date?
-          end
-        end
-      end
-
-      # Q26 - Q32
-      value_question :shift_worker_hours_per_shift?, parse: Float do
-        on_response do |response|
-          calculator.hours_per_shift = response
-        end
-
-        validate :error_no_hours_worked do
-          calculator.hours_per_shift.positive?
-        end
-
-        validate :error_over_24_hours_worked do
-          calculator.hours_per_shift <= 24
-        end
-
-        next_node do
-          question :shift_worker_shifts_per_shift_pattern?
-        end
-      end
-
-      # Q27 - Q33
-      value_question :shift_worker_shifts_per_shift_pattern?, parse: Integer do
-        on_response do |response|
-          calculator.shifts_per_shift_pattern = response
-        end
-
-        validate :error_message do
-          calculator.shifts_per_shift_pattern.positive?
-        end
-
-        next_node do
-          question :shift_worker_days_per_shift_pattern?
-        end
-      end
-
-      # Q28 - Q34
-      value_question :shift_worker_days_per_shift_pattern?, parse: Float do
-        on_response do |response|
-          calculator.days_per_shift_pattern = response
-        end
-
-        validate :error_message do
-          calculator.days_per_shift_pattern >= calculator.shifts_per_shift_pattern
-        end
-
-        next_node do
-          outcome :shift_worker_done
-        end
-      end
-
-      # ======================================================================
-      # Results
-      # ======================================================================
-      outcome :shift_worker_done
-      outcome :days_per_week_done
-      outcome :hours_per_week_done
-      outcome :compressed_hours_done
-      outcome :irregular_and_annualised_done
     end
+
+    # Q6 - Q14 - Q22 - Q31 - Q38
+    date_question :when_does_your_leave_year_start? do
+      from { Date.civil(1.year.ago.year, 1, 1) }
+      to { Date.civil(1.year.since(Time.zone.today).year, 12, 31) }
+
+      on_response do |response|
+        calculator.leave_year_start_date = response
+      end
+
+      validate :error_end_date_before_start_date do
+        calculator.leaving_date.blank? || calculator.leave_year_start_date.before?(calculator.leaving_date)
+      end
+
+      validate :error_end_date_outside_leave_year_range do
+        calculator.leaving_date.blank? || SmartAnswer::YearRange.new(begins_on: calculator.leave_year_start_date).include?(calculator.leaving_date)
+      end
+
+      validate :error_start_date_before_start_leave_year_date do
+        calculator.start_date.nil? || calculator.leave_year_start_date.before?(calculator.start_date)
+      end
+
+      validate :error_start_date_outside_leave_year_range do
+        calculator.start_date.nil? || SmartAnswer::YearRange.new(begins_on: calculator.leave_year_start_date).include?(calculator.start_date)
+      end
+
+      next_node do
+        case calculator.calculation_basis
+        when "days-worked-per-week"
+          question :how_many_days_per_week?
+        when "hours-worked-per-week", "compressed-hours"
+          question :how_many_hours_per_week?
+        when "irregular-hours", "annualised-hours"
+          outcome :irregular_and_annualised_done
+        when "shift-worker"
+          question :shift_worker_hours_per_shift?
+        end
+      end
+    end
+
+    # Q10 - Q15 - Q18
+    value_question :how_many_hours_per_week?, parse: Float do
+      on_response do |response|
+        calculator.hours_per_week = response
+      end
+
+      validate :error_no_hours_worked do
+        calculator.hours_per_week.positive?
+      end
+
+      validate :error_over_168_hours_worked do
+        calculator.hours_per_week <= 168
+      end
+
+      next_node do
+        question :how_many_days_per_week_for_hours?
+      end
+    end
+
+    # Q11 - Q16 - Q19
+    value_question :how_many_days_per_week_for_hours?, parse: Float do
+      on_response do |response|
+        calculator.working_days_per_week = response
+      end
+
+      validate :error_over_7_days_per_week do
+        calculator.working_days_per_week.between?(1, 7)
+      end
+
+      validate :error_over_24_hours_per_day do
+        calculator.hours_per_week.blank? || (calculator.hours_per_week / calculator.working_days_per_week) <= 24
+      end
+
+      next_node do
+        if calculator.calculation_basis == "compressed-hours"
+          outcome :compressed_hours_done
+        else
+          outcome :hours_per_week_done
+        end
+      end
+    end
+
+    radio :shift_worker_basis? do
+      option "full-year"
+      option "starting"
+      option "leaving"
+      option "starting-and-leaving"
+
+      on_response do |response|
+        calculator.holiday_period = response
+      end
+
+      next_node do
+        case calculator.holiday_period
+        when "full-year"
+          question :shift_worker_hours_per_shift?
+        when "starting", "starting-and-leaving"
+          question :what_is_your_starting_date?
+        when "leaving"
+          question :what_is_your_leaving_date?
+        end
+      end
+    end
+
+    # Q26 - Q32
+    value_question :shift_worker_hours_per_shift?, parse: Float do
+      on_response do |response|
+        calculator.hours_per_shift = response
+      end
+
+      validate :error_no_hours_worked do
+        calculator.hours_per_shift.positive?
+      end
+
+      validate :error_over_24_hours_worked do
+        calculator.hours_per_shift <= 24
+      end
+
+      next_node do
+        question :shift_worker_shifts_per_shift_pattern?
+      end
+    end
+
+    # Q27 - Q33
+    value_question :shift_worker_shifts_per_shift_pattern?, parse: Integer do
+      on_response do |response|
+        calculator.shifts_per_shift_pattern = response
+      end
+
+      validate :error_message do
+        calculator.shifts_per_shift_pattern.positive?
+      end
+
+      next_node do
+        question :shift_worker_days_per_shift_pattern?
+      end
+    end
+
+    # Q28 - Q34
+    value_question :shift_worker_days_per_shift_pattern?, parse: Float do
+      on_response do |response|
+        calculator.days_per_shift_pattern = response
+      end
+
+      validate :error_message do
+        calculator.days_per_shift_pattern >= calculator.shifts_per_shift_pattern
+      end
+
+      next_node do
+        outcome :shift_worker_done
+      end
+    end
+
+    # ======================================================================
+    # Results
+    # ======================================================================
+    outcome :shift_worker_done
+    outcome :days_per_week_done
+    outcome :hours_per_week_done
+    outcome :compressed_hours_done
+    outcome :irregular_and_annualised_done
   end
 end

--- a/lib/smart_answer_flows/calculate-your-redundancy-pay.rb
+++ b/lib/smart_answer_flows/calculate-your-redundancy-pay.rb
@@ -1,14 +1,12 @@
 require "smart_answer_flows/shared/redundancy_pay_flow"
 
-module SmartAnswer
-  class CalculateYourRedundancyPayFlow < Flow
-    def define
-      content_id "d2786d90-20fa-467e-ac4a-ff51dcd01b4f"
-      name "calculate-your-redundancy-pay"
+class CalculateYourRedundancyPayFlow < SmartAnswer::Flow
+  def define
+    content_id "d2786d90-20fa-467e-ac4a-ff51dcd01b4f"
+    name "calculate-your-redundancy-pay"
 
-      status :published
+    status :published
 
-      append(Shared::RedundancyPayFlow.build)
-    end
+    append(RedundancyPayFlow.build)
   end
 end

--- a/lib/smart_answer_flows/calculate-your-redundancy-pay.rb
+++ b/lib/smart_answer_flows/calculate-your-redundancy-pay.rb
@@ -1,5 +1,3 @@
-require "smart_answer_flows/shared/redundancy_pay_flow"
-
 class CalculateYourRedundancyPayFlow < SmartAnswer::Flow
   def define
     content_id "d2786d90-20fa-467e-ac4a-ff51dcd01b4f"

--- a/lib/smart_answer_flows/check-uk-visa.rb
+++ b/lib/smart_answer_flows/check-uk-visa.rb
@@ -1,405 +1,403 @@
-module SmartAnswer
-  class CheckUkVisaFlow < Flow
-    def define
-      flow = self
-      content_id "dc1a1744-4089-43b3-b2e3-4e397b6b15b1"
-      name "check-uk-visa"
-      status :published
+class CheckUkVisaFlow < SmartAnswer::Flow
+  def define
+    flow = self
+    content_id "dc1a1744-4089-43b3-b2e3-4e397b6b15b1"
+    name "check-uk-visa"
+    status :published
 
-      additional_countries = UkbaCountry.all
+    additional_countries = UkbaCountry.all
 
-      # Q1
-      country_select :what_passport_do_you_have?, additional_countries: additional_countries, exclude_countries: Calculators::UkVisaCalculator::EXCLUDE_COUNTRIES do
-        on_response do |response|
-          self.calculator = Calculators::UkVisaCalculator.new
-          calculator.passport_country = response
-          self.purpose_of_visit_answer = nil
-        end
-
-        next_node do
-          if calculator.passport_country_is_israel?
-            question :israeli_document_type?
-          elsif calculator.passport_country_is_estonia?
-            question :what_sort_of_passport?
-          elsif calculator.passport_country_is_latvia?
-            question :what_sort_of_passport?
-          elsif calculator.passport_country_is_hong_kong?
-            question :what_sort_of_travel_document?
-          elsif calculator.passport_country_is_macao?
-            question :what_sort_of_travel_document?
-          elsif calculator.passport_country_is_ireland?
-            outcome :outcome_no_visa_needed_ireland
-          else
-            question :purpose_of_visit?
-          end
-        end
+    # Q1
+    country_select :what_passport_do_you_have?, additional_countries: additional_countries, exclude_countries: SmartAnswer::Calculators::UkVisaCalculator::EXCLUDE_COUNTRIES do
+      on_response do |response|
+        self.calculator = SmartAnswer::Calculators::UkVisaCalculator.new
+        calculator.passport_country = response
+        self.purpose_of_visit_answer = nil
       end
 
-      # Q1b
-      radio :israeli_document_type? do
-        option :"full-passport"
-        option :"provisional-passport"
-
-        on_response do |response|
-          calculator.passport_country = "israel-provisional-passport" if response == "provisional-passport"
-        end
-
-        next_node do
+      next_node do
+        if calculator.passport_country_is_israel?
+          question :israeli_document_type?
+        elsif calculator.passport_country_is_estonia?
+          question :what_sort_of_passport?
+        elsif calculator.passport_country_is_latvia?
+          question :what_sort_of_passport?
+        elsif calculator.passport_country_is_hong_kong?
+          question :what_sort_of_travel_document?
+        elsif calculator.passport_country_is_macao?
+          question :what_sort_of_travel_document?
+        elsif calculator.passport_country_is_ireland?
+          outcome :outcome_no_visa_needed_ireland
+        else
           question :purpose_of_visit?
         end
       end
-
-      # Q1c / Q1d
-      radio :what_sort_of_passport? do
-        option :citizen
-        option :alien
-
-        next_node do |response|
-          if response == "alien"
-            if calculator.passport_country_is_estonia?
-              calculator.passport_country = "estonia-alien-passport"
-            elsif calculator.passport_country_is_latvia?
-              calculator.passport_country = "latvia-alien-passport"
-            end
-          end
-          question :purpose_of_visit?
-        end
-      end
-
-      # Q1e / Q1f
-      radio :what_sort_of_travel_document? do
-        option :passport
-        option :travel_document
-
-        on_response do |response|
-          calculator.travel_document_type = response
-        end
-
-        next_node do |_|
-          question :purpose_of_visit?
-        end
-      end
-
-      # Q2
-      radio :purpose_of_visit? do
-        option :tourism
-        option :work
-        option :study
-        option :transit
-        option :family
-        option :marriage
-        option :school
-        option :medical
-        option :diplomatic
-
-        flow.travel_response_next_route(self)
-      end
-
-      # Q2a
-      radio :travelling_to_cta? do
-        option :channel_islands_or_isle_of_man
-        option :republic_of_ireland
-        option :somewhere_else
-
-        on_response do |response|
-          calculator.travelling_to_cta_answer = response
-        end
-
-        next_node do
-          if calculator.travelling_to_channel_islands_or_isle_of_man?
-            next question(:channel_islands_or_isle_of_man?)
-          elsif calculator.travelling_to_ireland?
-            if (calculator.passport_country_in_non_visa_national_list? ||
-                calculator.passport_country_in_eea? ||
-                calculator.passport_country_in_ukot_list?) &&
-                !calculator.travel_document?
-              next outcome(:outcome_no_visa_needed)
-            else
-              next outcome(:outcome_transit_to_the_republic_of_ireland)
-            end
-          elsif calculator.travelling_to_elsewhere?
-            if (calculator.passport_country_in_non_visa_national_list? ||
-                calculator.passport_country_in_eea? ||
-                calculator.passport_country_in_ukot_list?) &&
-                !calculator.travel_document?
-              next outcome(:outcome_no_visa_needed)
-            else
-              next question(:passing_through_uk_border_control?)
-            end
-          end
-        end
-      end
-
-      # Q2b
-      radio :channel_islands_or_isle_of_man? do
-        option :tourism
-        option :work
-        option :study
-        option :family
-        option :marriage
-        option :school
-        option :medical
-        option :diplomatic
-
-        flow.travel_response_next_route(self)
-      end
-
-      # Q3
-      radio :passing_through_uk_border_control? do
-        option :yes
-        option :no
-
-        on_response do |response|
-          calculator.passing_through_uk_border_control_answer = response
-        end
-
-        next_node do
-          if calculator.passing_through_uk_border_control?
-            if calculator.passport_country_is_taiwan?
-              outcome :outcome_transit_taiwan_through_border_control
-            elsif calculator.passport_country_in_visa_national_list? ||
-                calculator.passport_country_in_electronic_visa_waiver_list? ||
-                calculator.travel_document?
-              outcome :outcome_transit_leaving_airport
-            elsif calculator.passport_country_in_datv_list?
-              outcome :outcome_transit_leaving_airport_datv
-            end
-          elsif calculator.passport_country_is_taiwan?
-            outcome :outcome_transit_taiwan
-          elsif calculator.passport_country_is_venezuela?
-            outcome :outcome_no_visa_needed
-          elsif calculator.applicant_is_stateless_or_a_refugee?
-            outcome :outcome_transit_refugee_not_leaving_airport
-          elsif calculator.passport_country_in_datv_list?
-            outcome :outcome_transit_not_leaving_airport
-          elsif calculator.passport_country_in_visa_national_list? || calculator.travel_document?
-            outcome :outcome_no_visa_needed
-          end
-        end
-      end
-
-      # Q4
-      radio :staying_for_how_long? do
-        option :six_months_or_less
-        option :longer_than_six_months
-
-        next_node do |response|
-          case response
-          when "longer_than_six_months"
-            if calculator.study_visit?
-              outcome :outcome_study_y # outcome 2 study y
-            elsif calculator.work_visit?
-              outcome :outcome_work_y # outcome 4 work y
-            end
-          when "six_months_or_less"
-            if calculator.study_visit?
-              if calculator.passport_country_in_electronic_visa_waiver_list?
-                outcome :outcome_study_waiver
-              elsif calculator.passport_country_is_taiwan?
-                outcome :outcome_study_waiver_taiwan
-              elsif calculator.passport_country_in_datv_list? ||
-                  calculator.passport_country_in_visa_national_list? ||
-                  calculator.travel_document?
-                outcome :outcome_study_m # outcome 3 study m visa needed short courses
-              elsif calculator.passport_country_in_ukot_list? || calculator.passport_country_in_non_visa_national_list? || calculator.passport_country_in_eea?
-                outcome :outcome_study_no_visa_needed # outcome 1 no visa needed
-              end
-            elsif calculator.work_visit?
-              if calculator.passport_country_in_electronic_visa_waiver_list?
-                outcome :outcome_work_waiver
-              elsif (calculator.passport_country_in_ukot_list? ||
-                  calculator.passport_country_is_taiwan? ||
-                  calculator.passport_country_in_non_visa_national_list? ||
-                  calculator.passport_country_in_eea?) &&
-                  !calculator.travel_document?
-                # outcome 5.5 work N no visa needed
-                outcome :outcome_work_n
-              else
-                # outcome 5 work m visa needed short courses
-                outcome :outcome_work_m
-              end
-            end
-          end
-        end
-      end
-
-      # Q5
-      radio :travelling_visiting_partner_family_member? do
-        option :yes
-        option :no
-
-        next_node do |response|
-          if response == "yes"
-            outcome :outcome_tourism_visa_partner
-          elsif calculator.family_visit?
-            question :partner_family_british_citizen?
-          else
-            outcome :outcome_standard_visitor_visa
-          end
-        end
-      end
-
-      # Q6
-      radio :partner_family_british_citizen? do
-        option :yes
-        option :no
-
-        next_node do |response|
-          if response == "yes"
-            outcome :outcome_partner_family_british_citizen_y
-          else
-            question :partner_family_eea?
-          end
-        end
-      end
-
-      # Q7
-      radio :partner_family_eea? do
-        option :yes
-        option :no
-
-        next_node do |response|
-          if response == "yes"
-            outcome :outcome_partner_family_eea_y
-          else
-            outcome :outcome_partner_family_eea_n
-          end
-        end
-      end
-
-      outcome :outcome_diplomatic_business
-      outcome :outcome_joining_family_m
-      outcome :outcome_joining_family_nvn
-      outcome :outcome_marriage_nvn_ukot
-      outcome :outcome_marriage_taiwan
-      outcome :outcome_marriage_visa_nat_datv
-      outcome :outcome_marriage_electronic_visa_waiver
-      outcome :outcome_medical_n
-      outcome :outcome_medical_y
-      outcome :outcome_no_visa_needed
-      outcome :outcome_no_visa_needed_ireland
-      outcome :outcome_partner_family_british_citizen_y
-      outcome :outcome_partner_family_eea_y
-      outcome :outcome_partner_family_eea_n
-      outcome :outcome_school_n
-      outcome :outcome_school_waiver
-      outcome :outcome_school_y
-      outcome :outcome_standard_visitor_visa
-      outcome :outcome_study_m
-      outcome :outcome_study_waiver
-      outcome :outcome_study_waiver_taiwan
-      outcome :outcome_study_no_visa_needed
-      outcome :outcome_study_y
-      outcome :outcome_transit_leaving_airport
-      outcome :outcome_transit_leaving_airport_datv
-      outcome :outcome_transit_not_leaving_airport
-      outcome :outcome_transit_refugee_not_leaving_airport
-      outcome :outcome_transit_taiwan
-      outcome :outcome_transit_taiwan_through_border_control
-      outcome :outcome_transit_to_the_republic_of_ireland
-      outcome :outcome_tourism_n
-      outcome :outcome_tourism_visa_partner
-      outcome :outcome_visit_waiver
-      outcome :outcome_visit_waiver_taiwan
-      outcome :outcome_work_m
-      outcome :outcome_work_n
-      outcome :outcome_work_waiver
-      outcome :outcome_work_y
     end
 
-    def travel_response_next_route(node)
-      node.on_response do |response|
-        calculator.purpose_of_visit_answer = response
+    # Q1b
+    radio :israeli_document_type? do
+      option :"full-passport"
+      option :"provisional-passport"
+
+      on_response do |response|
+        calculator.passport_country = "israel-provisional-passport" if response == "provisional-passport"
       end
 
-      node.next_node do
-        if calculator.study_visit? || calculator.work_visit?
-          next question(:staying_for_how_long?)
-        end
+      next_node do
+        question :purpose_of_visit?
+      end
+    end
 
-        if calculator.diplomatic_visit?
-          next outcome(:outcome_diplomatic_business)
-        end
+    # Q1c / Q1d
+    radio :what_sort_of_passport? do
+      option :citizen
+      option :alien
 
-        if calculator.school_visit?
-          if calculator.passport_country_in_electronic_visa_waiver_list?
-            next outcome(:outcome_school_waiver)
-          elsif calculator.passport_country_is_taiwan?
-            next outcome(:outcome_study_waiver_taiwan)
-          elsif calculator.passport_country_in_non_visa_national_list? || calculator.passport_country_in_ukot_list? || calculator.passport_country_in_eea?
-            next outcome(:outcome_school_n)
-          else
-            next outcome(:outcome_school_y)
+      next_node do |response|
+        if response == "alien"
+          if calculator.passport_country_is_estonia?
+            calculator.passport_country = "estonia-alien-passport"
+          elsif calculator.passport_country_is_latvia?
+            calculator.passport_country = "latvia-alien-passport"
           end
         end
+        question :purpose_of_visit?
+      end
+    end
 
-        if calculator.medical_visit?
-          if calculator.passport_country_in_electronic_visa_waiver_list?
-            next outcome(:outcome_visit_waiver)
-          elsif calculator.passport_country_is_taiwan?
-            next outcome(:outcome_visit_waiver_taiwan)
-          elsif (calculator.passport_country_in_non_visa_national_list? ||
+    # Q1e / Q1f
+    radio :what_sort_of_travel_document? do
+      option :passport
+      option :travel_document
+
+      on_response do |response|
+        calculator.travel_document_type = response
+      end
+
+      next_node do |_|
+        question :purpose_of_visit?
+      end
+    end
+
+    # Q2
+    radio :purpose_of_visit? do
+      option :tourism
+      option :work
+      option :study
+      option :transit
+      option :family
+      option :marriage
+      option :school
+      option :medical
+      option :diplomatic
+
+      flow.travel_response_next_route(self)
+    end
+
+    # Q2a
+    radio :travelling_to_cta? do
+      option :channel_islands_or_isle_of_man
+      option :republic_of_ireland
+      option :somewhere_else
+
+      on_response do |response|
+        calculator.travelling_to_cta_answer = response
+      end
+
+      next_node do
+        if calculator.travelling_to_channel_islands_or_isle_of_man?
+          next question(:channel_islands_or_isle_of_man?)
+        elsif calculator.travelling_to_ireland?
+          if (calculator.passport_country_in_non_visa_national_list? ||
               calculator.passport_country_in_eea? ||
               calculator.passport_country_in_ukot_list?) &&
               !calculator.travel_document?
-            next outcome(:outcome_medical_n)
-          else
-            next outcome(:outcome_medical_y)
-          end
-        end
-
-        if calculator.tourism_visit?
-          if calculator.passport_country_in_electronic_visa_waiver_list?
-            next outcome(:outcome_visit_waiver)
-          elsif calculator.passport_country_is_taiwan?
-            next outcome(:outcome_visit_waiver_taiwan)
-          elsif (calculator.passport_country_in_non_visa_national_list? ||
-              calculator.passport_country_in_eea? ||
-              calculator.passport_country_in_ukot_list?) &&
-              !calculator.travel_document?
-            next outcome(:outcome_tourism_n)
-          else
-            next question(:travelling_visiting_partner_family_member?)
-          end
-        end
-
-        if calculator.marriage_visit?
-          if calculator.passport_country_in_eea?
-            next outcome(:outcome_marriage_nvn_ukot)
-          elsif calculator.passport_country_in_non_visa_national_list? || calculator.passport_country_in_ukot_list?
-            next outcome(:outcome_marriage_nvn_ukot)
-          elsif calculator.passport_country_in_electronic_visa_waiver_list?
-            next outcome(:outcome_marriage_electronic_visa_waiver)
-          elsif calculator.passport_country_is_taiwan?
-            next outcome(:outcome_marriage_taiwan)
-          elsif calculator.passport_country_in_datv_list? || calculator.passport_country_in_visa_national_list?
-            next outcome(:outcome_marriage_visa_nat_datv)
-          end
-        end
-
-        if calculator.transit_visit?
-          if calculator.passport_country_in_datv_list? ||
-              calculator.passport_country_in_visa_national_list? ||
-              calculator.passport_country_is_taiwan? ||
-              calculator.passport_country_is_venezuela? ||
-              calculator.passport_country_in_non_visa_national_list? ||
-              calculator.passport_country_in_eea? ||
-              calculator.passport_country_in_ukot_list? ||
-              calculator.travel_document?
-            next question(:travelling_to_cta?)
-          else
             next outcome(:outcome_no_visa_needed)
+          else
+            next outcome(:outcome_transit_to_the_republic_of_ireland)
+          end
+        elsif calculator.travelling_to_elsewhere?
+          if (calculator.passport_country_in_non_visa_national_list? ||
+              calculator.passport_country_in_eea? ||
+              calculator.passport_country_in_ukot_list?) &&
+              !calculator.travel_document?
+            next outcome(:outcome_no_visa_needed)
+          else
+            next question(:passing_through_uk_border_control?)
           end
         end
+      end
+    end
 
-        if calculator.family_visit?
-          if calculator.passport_country_in_ukot_list?
-            next outcome(:outcome_joining_family_m)
-          elsif calculator.passport_country_in_non_visa_national_list? || calculator.passport_country_in_eea?
-            next outcome(:outcome_joining_family_nvn)
-          else
-            next question(:partner_family_british_citizen?)
+    # Q2b
+    radio :channel_islands_or_isle_of_man? do
+      option :tourism
+      option :work
+      option :study
+      option :family
+      option :marriage
+      option :school
+      option :medical
+      option :diplomatic
+
+      flow.travel_response_next_route(self)
+    end
+
+    # Q3
+    radio :passing_through_uk_border_control? do
+      option :yes
+      option :no
+
+      on_response do |response|
+        calculator.passing_through_uk_border_control_answer = response
+      end
+
+      next_node do
+        if calculator.passing_through_uk_border_control?
+          if calculator.passport_country_is_taiwan?
+            outcome :outcome_transit_taiwan_through_border_control
+          elsif calculator.passport_country_in_visa_national_list? ||
+              calculator.passport_country_in_electronic_visa_waiver_list? ||
+              calculator.travel_document?
+            outcome :outcome_transit_leaving_airport
+          elsif calculator.passport_country_in_datv_list?
+            outcome :outcome_transit_leaving_airport_datv
           end
+        elsif calculator.passport_country_is_taiwan?
+          outcome :outcome_transit_taiwan
+        elsif calculator.passport_country_is_venezuela?
+          outcome :outcome_no_visa_needed
+        elsif calculator.applicant_is_stateless_or_a_refugee?
+          outcome :outcome_transit_refugee_not_leaving_airport
+        elsif calculator.passport_country_in_datv_list?
+          outcome :outcome_transit_not_leaving_airport
+        elsif calculator.passport_country_in_visa_national_list? || calculator.travel_document?
+          outcome :outcome_no_visa_needed
+        end
+      end
+    end
+
+    # Q4
+    radio :staying_for_how_long? do
+      option :six_months_or_less
+      option :longer_than_six_months
+
+      next_node do |response|
+        case response
+        when "longer_than_six_months"
+          if calculator.study_visit?
+            outcome :outcome_study_y # outcome 2 study y
+          elsif calculator.work_visit?
+            outcome :outcome_work_y # outcome 4 work y
+          end
+        when "six_months_or_less"
+          if calculator.study_visit?
+            if calculator.passport_country_in_electronic_visa_waiver_list?
+              outcome :outcome_study_waiver
+            elsif calculator.passport_country_is_taiwan?
+              outcome :outcome_study_waiver_taiwan
+            elsif calculator.passport_country_in_datv_list? ||
+                calculator.passport_country_in_visa_national_list? ||
+                calculator.travel_document?
+              outcome :outcome_study_m # outcome 3 study m visa needed short courses
+            elsif calculator.passport_country_in_ukot_list? || calculator.passport_country_in_non_visa_national_list? || calculator.passport_country_in_eea?
+              outcome :outcome_study_no_visa_needed # outcome 1 no visa needed
+            end
+          elsif calculator.work_visit?
+            if calculator.passport_country_in_electronic_visa_waiver_list?
+              outcome :outcome_work_waiver
+            elsif (calculator.passport_country_in_ukot_list? ||
+                calculator.passport_country_is_taiwan? ||
+                calculator.passport_country_in_non_visa_national_list? ||
+                calculator.passport_country_in_eea?) &&
+                !calculator.travel_document?
+              # outcome 5.5 work N no visa needed
+              outcome :outcome_work_n
+            else
+              # outcome 5 work m visa needed short courses
+              outcome :outcome_work_m
+            end
+          end
+        end
+      end
+    end
+
+    # Q5
+    radio :travelling_visiting_partner_family_member? do
+      option :yes
+      option :no
+
+      next_node do |response|
+        if response == "yes"
+          outcome :outcome_tourism_visa_partner
+        elsif calculator.family_visit?
+          question :partner_family_british_citizen?
+        else
+          outcome :outcome_standard_visitor_visa
+        end
+      end
+    end
+
+    # Q6
+    radio :partner_family_british_citizen? do
+      option :yes
+      option :no
+
+      next_node do |response|
+        if response == "yes"
+          outcome :outcome_partner_family_british_citizen_y
+        else
+          question :partner_family_eea?
+        end
+      end
+    end
+
+    # Q7
+    radio :partner_family_eea? do
+      option :yes
+      option :no
+
+      next_node do |response|
+        if response == "yes"
+          outcome :outcome_partner_family_eea_y
+        else
+          outcome :outcome_partner_family_eea_n
+        end
+      end
+    end
+
+    outcome :outcome_diplomatic_business
+    outcome :outcome_joining_family_m
+    outcome :outcome_joining_family_nvn
+    outcome :outcome_marriage_nvn_ukot
+    outcome :outcome_marriage_taiwan
+    outcome :outcome_marriage_visa_nat_datv
+    outcome :outcome_marriage_electronic_visa_waiver
+    outcome :outcome_medical_n
+    outcome :outcome_medical_y
+    outcome :outcome_no_visa_needed
+    outcome :outcome_no_visa_needed_ireland
+    outcome :outcome_partner_family_british_citizen_y
+    outcome :outcome_partner_family_eea_y
+    outcome :outcome_partner_family_eea_n
+    outcome :outcome_school_n
+    outcome :outcome_school_waiver
+    outcome :outcome_school_y
+    outcome :outcome_standard_visitor_visa
+    outcome :outcome_study_m
+    outcome :outcome_study_waiver
+    outcome :outcome_study_waiver_taiwan
+    outcome :outcome_study_no_visa_needed
+    outcome :outcome_study_y
+    outcome :outcome_transit_leaving_airport
+    outcome :outcome_transit_leaving_airport_datv
+    outcome :outcome_transit_not_leaving_airport
+    outcome :outcome_transit_refugee_not_leaving_airport
+    outcome :outcome_transit_taiwan
+    outcome :outcome_transit_taiwan_through_border_control
+    outcome :outcome_transit_to_the_republic_of_ireland
+    outcome :outcome_tourism_n
+    outcome :outcome_tourism_visa_partner
+    outcome :outcome_visit_waiver
+    outcome :outcome_visit_waiver_taiwan
+    outcome :outcome_work_m
+    outcome :outcome_work_n
+    outcome :outcome_work_waiver
+    outcome :outcome_work_y
+  end
+
+  def travel_response_next_route(node)
+    node.on_response do |response|
+      calculator.purpose_of_visit_answer = response
+    end
+
+    node.next_node do
+      if calculator.study_visit? || calculator.work_visit?
+        next question(:staying_for_how_long?)
+      end
+
+      if calculator.diplomatic_visit?
+        next outcome(:outcome_diplomatic_business)
+      end
+
+      if calculator.school_visit?
+        if calculator.passport_country_in_electronic_visa_waiver_list?
+          next outcome(:outcome_school_waiver)
+        elsif calculator.passport_country_is_taiwan?
+          next outcome(:outcome_study_waiver_taiwan)
+        elsif calculator.passport_country_in_non_visa_national_list? || calculator.passport_country_in_ukot_list? || calculator.passport_country_in_eea?
+          next outcome(:outcome_school_n)
+        else
+          next outcome(:outcome_school_y)
+        end
+      end
+
+      if calculator.medical_visit?
+        if calculator.passport_country_in_electronic_visa_waiver_list?
+          next outcome(:outcome_visit_waiver)
+        elsif calculator.passport_country_is_taiwan?
+          next outcome(:outcome_visit_waiver_taiwan)
+        elsif (calculator.passport_country_in_non_visa_national_list? ||
+            calculator.passport_country_in_eea? ||
+            calculator.passport_country_in_ukot_list?) &&
+            !calculator.travel_document?
+          next outcome(:outcome_medical_n)
+        else
+          next outcome(:outcome_medical_y)
+        end
+      end
+
+      if calculator.tourism_visit?
+        if calculator.passport_country_in_electronic_visa_waiver_list?
+          next outcome(:outcome_visit_waiver)
+        elsif calculator.passport_country_is_taiwan?
+          next outcome(:outcome_visit_waiver_taiwan)
+        elsif (calculator.passport_country_in_non_visa_national_list? ||
+            calculator.passport_country_in_eea? ||
+            calculator.passport_country_in_ukot_list?) &&
+            !calculator.travel_document?
+          next outcome(:outcome_tourism_n)
+        else
+          next question(:travelling_visiting_partner_family_member?)
+        end
+      end
+
+      if calculator.marriage_visit?
+        if calculator.passport_country_in_eea?
+          next outcome(:outcome_marriage_nvn_ukot)
+        elsif calculator.passport_country_in_non_visa_national_list? || calculator.passport_country_in_ukot_list?
+          next outcome(:outcome_marriage_nvn_ukot)
+        elsif calculator.passport_country_in_electronic_visa_waiver_list?
+          next outcome(:outcome_marriage_electronic_visa_waiver)
+        elsif calculator.passport_country_is_taiwan?
+          next outcome(:outcome_marriage_taiwan)
+        elsif calculator.passport_country_in_datv_list? || calculator.passport_country_in_visa_national_list?
+          next outcome(:outcome_marriage_visa_nat_datv)
+        end
+      end
+
+      if calculator.transit_visit?
+        if calculator.passport_country_in_datv_list? ||
+            calculator.passport_country_in_visa_national_list? ||
+            calculator.passport_country_is_taiwan? ||
+            calculator.passport_country_is_venezuela? ||
+            calculator.passport_country_in_non_visa_national_list? ||
+            calculator.passport_country_in_eea? ||
+            calculator.passport_country_in_ukot_list? ||
+            calculator.travel_document?
+          next question(:travelling_to_cta?)
+        else
+          next outcome(:outcome_no_visa_needed)
+        end
+      end
+
+      if calculator.family_visit?
+        if calculator.passport_country_in_ukot_list?
+          next outcome(:outcome_joining_family_m)
+        elsif calculator.passport_country_in_non_visa_national_list? || calculator.passport_country_in_eea?
+          next outcome(:outcome_joining_family_nvn)
+        else
+          next question(:partner_family_british_citizen?)
         end
       end
     end

--- a/lib/smart_answer_flows/child-benefit-tax-calculator.rb
+++ b/lib/smart_answer_flows/child-benefit-tax-calculator.rb
@@ -1,126 +1,98 @@
-module SmartAnswer
-  class ChildBenefitTaxCalculatorFlow < Flow
-    def define
-      name "child-benefit-tax-calculator"
-      content_id "0e1de8f1-9909-4e45-a6a3-bffe95470275"
-      status :published
+class ChildBenefitTaxCalculatorFlow < SmartAnswer::Flow
+  def define
+    name "child-benefit-tax-calculator"
+    content_id "0e1de8f1-9909-4e45-a6a3-bffe95470275"
+    status :published
 
-      # Q1
-      value_question :how_many_children?, parse: Integer do
+    # Q1
+    value_question :how_many_children?, parse: Integer do
+      on_response do |response|
+        self.calculator = SmartAnswer::Calculators::ChildBenefitTaxCalculator.new
+        calculator.children_count = response.to_i
+      end
+
+      validate(:valid_number_of_children) do
+        calculator.valid_number_of_children?
+      end
+
+      next_node do
+        question :which_tax_year?
+      end
+    end
+
+    # Q2
+    radio :which_tax_year? do
+      SmartAnswer::Calculators::ChildBenefitTaxCalculator.tax_years.each do |tax_year|
+        option :"#{tax_year}"
+      end
+
+      on_response do |response|
+        calculator.tax_year = response
+      end
+
+      next_node do
+        question :is_part_year_claim?
+      end
+    end
+
+    # Q3
+    radio :is_part_year_claim? do
+      option :yes
+      option :no
+
+      next_node do |response|
+        if response == "yes"
+          question :how_many_children_part_year?
+        else
+          question :income_details?
+        end
+      end
+    end
+
+    # Q3a
+    value_question :how_many_children_part_year?, parse: Integer do
+      on_response do |response|
+        calculator.part_year_children_count = response
+      end
+
+      validate(:valid_number_of_part_year_children) do
+        calculator.valid_number_of_part_year_children?
+      end
+
+      next_node do
+        question :child_benefit_1_start?
+      end
+    end
+
+    (1..SmartAnswer::Calculators::ChildBenefitTaxCalculator::MAX_CHILDREN).each do |child_number|
+      # Q3b
+      date_question "child_benefit_#{child_number}_start?".to_sym do
+        template_name "child_benefit_start"
+
         on_response do |response|
-          self.calculator = Calculators::ChildBenefitTaxCalculator.new
-          calculator.children_count = response.to_i
+          calculator.store_date(:start_date, response)
         end
 
-        validate(:valid_number_of_children) do
-          calculator.valid_number_of_children?
+        validate(:valid_within_tax_year) do
+          calculator.valid_within_tax_year?(:start_date)
         end
 
         next_node do
-          question :which_tax_year?
+          question "add_child_benefit_#{child_number}_stop?".to_sym
         end
       end
 
-      # Q2
-      radio :which_tax_year? do
-        Calculators::ChildBenefitTaxCalculator.tax_years.each do |tax_year|
-          option :"#{tax_year}"
-        end
+      # Q3c
+      radio "add_child_benefit_#{child_number}_stop?".to_sym do
+        template_name "add_child_benefit_stop"
 
-        on_response do |response|
-          calculator.tax_year = response
-        end
-
-        next_node do
-          question :is_part_year_claim?
-        end
-      end
-
-      # Q3
-      radio :is_part_year_claim? do
         option :yes
         option :no
 
         next_node do |response|
           if response == "yes"
-            question :how_many_children_part_year?
+            question "child_benefit_#{child_number}_stop?".to_sym
           else
-            question :income_details?
-          end
-        end
-      end
-
-      # Q3a
-      value_question :how_many_children_part_year?, parse: Integer do
-        on_response do |response|
-          calculator.part_year_children_count = response
-        end
-
-        validate(:valid_number_of_part_year_children) do
-          calculator.valid_number_of_part_year_children?
-        end
-
-        next_node do
-          question :child_benefit_1_start?
-        end
-      end
-
-      (1..Calculators::ChildBenefitTaxCalculator::MAX_CHILDREN).each do |child_number|
-        # Q3b
-        date_question "child_benefit_#{child_number}_start?".to_sym do
-          template_name "child_benefit_start"
-
-          on_response do |response|
-            calculator.store_date(:start_date, response)
-          end
-
-          validate(:valid_within_tax_year) do
-            calculator.valid_within_tax_year?(:start_date)
-          end
-
-          next_node do
-            question "add_child_benefit_#{child_number}_stop?".to_sym
-          end
-        end
-
-        # Q3c
-        radio "add_child_benefit_#{child_number}_stop?".to_sym do
-          template_name "add_child_benefit_stop"
-
-          option :yes
-          option :no
-
-          next_node do |response|
-            if response == "yes"
-              question "child_benefit_#{child_number}_stop?".to_sym
-            else
-              calculator.child_number = child_number + 1
-              if calculator.child_number <= calculator.part_year_children_count
-                question "child_benefit_#{calculator.child_number}_start?".to_sym
-              else
-                question :income_details?
-              end
-            end
-          end
-        end
-
-        # Q3d
-        date_question "child_benefit_#{child_number}_stop?".to_sym do
-          template_name "child_benefit_stop"
-
-          on_response do |response|
-            calculator.store_date(:end_date, response)
-          end
-
-          validate(:valid_within_tax_year) do
-            calculator.valid_within_tax_year?(:end_date)
-          end
-
-          validate(:valid_end_date) do
-            calculator.valid_end_date?
-          end
-
-          next_node do
             calculator.child_number = child_number + 1
             if calculator.child_number <= calculator.part_year_children_count
               question "child_benefit_#{calculator.child_number}_start?".to_sym
@@ -131,67 +103,93 @@ module SmartAnswer
         end
       end
 
-      # Q4
-      money_question :income_details? do
+      # Q3d
+      date_question "child_benefit_#{child_number}_stop?".to_sym do
+        template_name "child_benefit_stop"
+
         on_response do |response|
-          calculator.income_details = response
+          calculator.store_date(:end_date, response)
+        end
+
+        validate(:valid_within_tax_year) do
+          calculator.valid_within_tax_year?(:end_date)
+        end
+
+        validate(:valid_end_date) do
+          calculator.valid_end_date?
         end
 
         next_node do
-          question :add_allowable_deductions?
-        end
-      end
-
-      # Q5
-      radio :add_allowable_deductions? do
-        option :yes
-        option :no
-
-        next_node do |response|
-          if response == "yes"
-            question :allowable_deductions?
+          calculator.child_number = child_number + 1
+          if calculator.child_number <= calculator.part_year_children_count
+            question "child_benefit_#{calculator.child_number}_start?".to_sym
           else
-            outcome :results
+            question :income_details?
           end
         end
       end
+    end
 
-      # Q5a
-      money_question :allowable_deductions? do
-        on_response do |response|
-          calculator.allowable_deductions = response
-        end
-
-        next_node do
-          question :add_other_allowable_deductions?
-        end
+    # Q4
+    money_question :income_details? do
+      on_response do |response|
+        calculator.income_details = response
       end
 
-      # Q6
-      radio :add_other_allowable_deductions? do
-        option :yes
-        option :no
-
-        next_node do |response|
-          if response == "yes"
-            question :other_allowable_deductions?
-          else
-            outcome :results
-          end
-        end
+      next_node do
+        question :add_allowable_deductions?
       end
+    end
 
-      # Q6a
-      money_question :other_allowable_deductions? do
-        on_response do |response|
-          calculator.other_allowable_deductions = response
-        end
-        next_node do
+    # Q5
+    radio :add_allowable_deductions? do
+      option :yes
+      option :no
+
+      next_node do |response|
+        if response == "yes"
+          question :allowable_deductions?
+        else
           outcome :results
         end
       end
-
-      outcome :results
     end
+
+    # Q5a
+    money_question :allowable_deductions? do
+      on_response do |response|
+        calculator.allowable_deductions = response
+      end
+
+      next_node do
+        question :add_other_allowable_deductions?
+      end
+    end
+
+    # Q6
+    radio :add_other_allowable_deductions? do
+      option :yes
+      option :no
+
+      next_node do |response|
+        if response == "yes"
+          question :other_allowable_deductions?
+        else
+          outcome :results
+        end
+      end
+    end
+
+    # Q6a
+    money_question :other_allowable_deductions? do
+      on_response do |response|
+        calculator.other_allowable_deductions = response
+      end
+      next_node do
+        outcome :results
+      end
+    end
+
+    outcome :results
   end
 end

--- a/lib/smart_answer_flows/childcare-costs-for-tax-credits.rb
+++ b/lib/smart_answer_flows/childcare-costs-for-tax-credits.rb
@@ -1,339 +1,337 @@
-module SmartAnswer
-  class ChildcareCostsForTaxCreditsFlow < Flow
-    def define
-      content_id "f8c575b7-d7a2-41a4-9911-069a06f1a2cc"
-      name "childcare-costs-for-tax-credits"
-      status :published
+class ChildcareCostsForTaxCreditsFlow < SmartAnswer::Flow
+  def define
+    content_id "f8c575b7-d7a2-41a4-9911-069a06f1a2cc"
+    name "childcare-costs-for-tax-credits"
+    status :published
 
-      # Q1
-      radio :currently_claiming? do
-        option :yes
-        option :no
+    # Q1
+    radio :currently_claiming? do
+      option :yes
+      option :no
 
-        on_response do
-          self.calculator = Calculators::ChildcareCostCalculator.new
-        end
-
-        next_node do |response|
-          case response
-          when "yes"
-            question :have_costs_changed? # Q3
-          when "no"
-            question :how_often_use_childcare? # Q2
-          end
-        end
+      on_response do
+        self.calculator = SmartAnswer::Calculators::ChildcareCostCalculator.new
       end
 
-      # Q2
-      radio :how_often_use_childcare? do
-        option :regularly_less_than_year
-        option :regularly_more_than_year
-        option :only_short_while
-
-        next_node do |response|
-          case response
-          when "regularly_less_than_year"
-            question :how_often_pay_1? # Q4
-          when "regularly_more_than_year"
-            question :pay_same_each_time? # Q11
-          when "only_short_while"
-            outcome :call_helpline_detailed # O1
-          end
+      next_node do |response|
+        case response
+        when "yes"
+          question :have_costs_changed? # Q3
+        when "no"
+          question :how_often_use_childcare? # Q2
         end
       end
-
-      # Q3
-      radio :have_costs_changed? do
-        option :yes
-        option :no
-
-        next_node do |response|
-          case response
-          when "yes"
-            question :how_often_pay_2? # Q5
-          when "no"
-            outcome :no_change # O2
-          end
-        end
-      end
-
-      # Q4
-      radio :how_often_pay_1? do
-        option :weekly_same_amount
-        option :weekly_diff_amount
-        option :monthly_same_amount
-        option :monthly_diff_amount
-        option :other
-
-        next_node do |response|
-          case response
-          when "weekly_same_amount"
-            question :round_up_weekly # O3
-          when "weekly_diff_amount"
-            question :how_much_52_weeks_1? # Q7
-          when "monthly_same_amount"
-            question :how_much_each_month? # Q10
-          when "monthly_diff_amount", "other"
-            question :how_much_12_months_1? # Q6
-          end
-        end
-      end
-
-      # Q5
-      radio :how_often_pay_2? do
-        option :weekly_same_amount
-        option :weekly_diff_amount
-        option :monthly_same_amount
-        option :monthly_diff_amount
-        option :other
-
-        next_node do |response|
-          case response
-          when "weekly_same_amount"
-            question :new_weekly_costs? # Q17
-          when "weekly_diff_amount", "other"
-            question :how_much_52_weeks_2? # Q8
-          when "monthly_same_amount"
-            question :new_monthly_cost? # Q19
-          when "monthly_diff_amount"
-            question :how_much_12_months_2? # Q9
-          end
-        end
-      end
-
-      # Q6
-      money_question :how_much_12_months_1? do
-        on_response do |response|
-          calculator.weekly_cost = calculator.weekly_cost_from_annual(response)
-        end
-
-        next_node do
-          outcome :weekly_costs_are_x # O4
-        end
-      end
-
-      # Q7
-      money_question :how_much_52_weeks_1? do
-        on_response do |response|
-          calculator.weekly_cost = calculator.weekly_cost_from_annual(response)
-        end
-        next_node do
-          outcome :weekly_costs_are_x # O4
-        end
-      end
-
-      # Q8
-      money_question :how_much_52_weeks_2? do
-        on_response do |response|
-          calculator.weekly_cost = calculator.weekly_cost_from_annual(response)
-        end
-
-        next_node do |response|
-          amount = SmartAnswer::Money.new(response)
-          amount == 0 ? outcome(:no_longer_paying) : question(:old_weekly_amount_1?) # rubocop:disable Style/NumericPredicate
-        end
-      end
-
-      # Q9
-      money_question :how_much_12_months_2? do
-        on_response do |response|
-          calculator.new_weekly_costs = calculator.weekly_cost_from_annual(response)
-        end
-
-        next_node do |response|
-          amount = SmartAnswer::Money.new(response)
-          amount == 0 ? outcome(:no_longer_paying) : question(:old_monthly_amount?) # rubocop:disable Style/NumericPredicate
-        end
-      end
-
-      # Q10
-      money_question :how_much_each_month? do
-        on_response do |response|
-          calculator.weekly_cost = calculator.weekly_cost_from_monthly(response)
-        end
-        next_node do
-          outcome :weekly_costs_are_x # O4
-        end
-      end
-
-      # Q11
-      radio :pay_same_each_time? do
-        option :yes
-        option :no
-
-        next_node do |response|
-          case response
-          when "yes"
-            question :how_often_pay_providers? # Q12
-          when "no"
-            question :how_much_spent_last_12_months? # Q16
-          end
-        end
-      end
-
-      # Q12
-      radio :how_often_pay_providers? do
-        option :weekly
-        option :fortnightly
-        option :every_4_weeks
-        option :every_month
-        option :termly
-        option :yearly
-        option :other
-
-        next_node do |response|
-          case response
-          when "weekly"
-            outcome :round_up_weekly # O3
-          when "fortnightly"
-            question :how_much_fortnightly? # Q13
-          when "every_4_weeks"
-            question :how_much_4_weeks? # Q14
-          when "every_month"
-            question :how_much_each_month? # Q10
-          when "termly", "other"
-            outcome :call_helpline_plain # O5
-          when "yearly"
-            question :how_much_yearly? # Q15
-          end
-        end
-      end
-
-      # Q13
-      money_question :how_much_fortnightly? do
-        on_response do |response|
-          calculator.weekly_cost = calculator.weekly_cost_from_fortnightly(response)
-        end
-
-        next_node do
-          outcome :weekly_costs_are_x # O4
-        end
-      end
-
-      # Q14
-      money_question :how_much_4_weeks? do
-        on_response do |response|
-          calculator.weekly_cost = calculator.weekly_cost_from_four_weekly(response)
-        end
-        next_node do
-          outcome :weekly_costs_are_x # 04
-        end
-      end
-
-      # Q15
-      money_question :how_much_yearly? do
-        on_response do |response|
-          calculator.weekly_cost = calculator.weekly_cost_from_annual(response)
-        end
-        next_node do
-          outcome :weekly_costs_are_x # O4
-        end
-      end
-
-      # Q16
-      money_question :how_much_spent_last_12_months? do
-        on_response do |response|
-          calculator.weekly_cost = calculator.weekly_cost_from_annual(response)
-        end
-        next_node do
-          outcome :weekly_costs_are_x # O4
-        end
-      end
-
-      # Q17
-      money_question :new_weekly_costs? do
-        on_response do |response|
-          calculator.new_weekly_costs = Float(response).ceil
-        end
-
-        next_node do |response|
-          amount = SmartAnswer::Money.new(response)
-          amount == 0 ? outcome(:no_longer_paying) : question(:old_weekly_amount_2?) # rubocop:disable Style/NumericPredicate
-        end
-      end
-
-      # Q18
-      money_question :old_weekly_amount_1? do
-        # get weekly amount from Q8 or Q9 (whichever the user answered)
-        # calculate different using input from Q18
-        on_response do |response|
-          calculator.old_weekly_costs = Float(response).ceil
-          calculator.weekly_difference = calculator.cost_change(
-            calculator.weekly_cost,
-            calculator.old_weekly_costs,
-          )
-        end
-
-        next_node do
-          outcome :cost_changed
-        end
-      end
-
-      # Q19
-      money_question :new_monthly_cost? do
-        on_response do |response|
-          calculator.new_weekly_costs = calculator.weekly_cost_from_monthly(response)
-        end
-
-        next_node do |response|
-          amount = SmartAnswer::Money.new(response)
-          amount == 0 ? outcome(:no_longer_paying) : question(:old_monthly_amount?) # rubocop:disable Style/NumericPredicate
-        end
-      end
-
-      # Q20
-      money_question :old_weekly_amount_2? do
-        on_response do |response|
-          calculator.old_weekly_costs = Float(response).ceil
-          calculator.weekly_difference = calculator.cost_change(
-            calculator.new_weekly_costs,
-            calculator.old_weekly_costs,
-          )
-          calculator.cost_change_4_weeks = true
-        end
-
-        next_node do
-          outcome :cost_changed
-        end
-      end
-
-      # Q21
-      money_question :old_monthly_amount? do
-        on_response do |response|
-          calculator.old_weekly_costs = calculator.weekly_cost_from_monthly(response)
-          calculator.weekly_difference = calculator.cost_change(
-            calculator.new_weekly_costs,
-            calculator.old_weekly_costs,
-          )
-        end
-
-        next_node do
-          outcome :cost_changed
-        end
-      end
-
-      ### Outcomes
-
-      # O1
-      outcome :call_helpline_detailed
-
-      # O5
-      outcome :call_helpline_plain
-
-      # O2
-      outcome :no_change
-
-      # O3
-      outcome :round_up_weekly
-
-      # O4
-      outcome :weekly_costs_are_x
-
-      # O6, 7, 8
-      outcome :cost_changed
-
-      # O9
-      outcome :no_longer_paying
     end
+
+    # Q2
+    radio :how_often_use_childcare? do
+      option :regularly_less_than_year
+      option :regularly_more_than_year
+      option :only_short_while
+
+      next_node do |response|
+        case response
+        when "regularly_less_than_year"
+          question :how_often_pay_1? # Q4
+        when "regularly_more_than_year"
+          question :pay_same_each_time? # Q11
+        when "only_short_while"
+          outcome :call_helpline_detailed # O1
+        end
+      end
+    end
+
+    # Q3
+    radio :have_costs_changed? do
+      option :yes
+      option :no
+
+      next_node do |response|
+        case response
+        when "yes"
+          question :how_often_pay_2? # Q5
+        when "no"
+          outcome :no_change # O2
+        end
+      end
+    end
+
+    # Q4
+    radio :how_often_pay_1? do
+      option :weekly_same_amount
+      option :weekly_diff_amount
+      option :monthly_same_amount
+      option :monthly_diff_amount
+      option :other
+
+      next_node do |response|
+        case response
+        when "weekly_same_amount"
+          question :round_up_weekly # O3
+        when "weekly_diff_amount"
+          question :how_much_52_weeks_1? # Q7
+        when "monthly_same_amount"
+          question :how_much_each_month? # Q10
+        when "monthly_diff_amount", "other"
+          question :how_much_12_months_1? # Q6
+        end
+      end
+    end
+
+    # Q5
+    radio :how_often_pay_2? do
+      option :weekly_same_amount
+      option :weekly_diff_amount
+      option :monthly_same_amount
+      option :monthly_diff_amount
+      option :other
+
+      next_node do |response|
+        case response
+        when "weekly_same_amount"
+          question :new_weekly_costs? # Q17
+        when "weekly_diff_amount", "other"
+          question :how_much_52_weeks_2? # Q8
+        when "monthly_same_amount"
+          question :new_monthly_cost? # Q19
+        when "monthly_diff_amount"
+          question :how_much_12_months_2? # Q9
+        end
+      end
+    end
+
+    # Q6
+    money_question :how_much_12_months_1? do
+      on_response do |response|
+        calculator.weekly_cost = calculator.weekly_cost_from_annual(response)
+      end
+
+      next_node do
+        outcome :weekly_costs_are_x # O4
+      end
+    end
+
+    # Q7
+    money_question :how_much_52_weeks_1? do
+      on_response do |response|
+        calculator.weekly_cost = calculator.weekly_cost_from_annual(response)
+      end
+      next_node do
+        outcome :weekly_costs_are_x # O4
+      end
+    end
+
+    # Q8
+    money_question :how_much_52_weeks_2? do
+      on_response do |response|
+        calculator.weekly_cost = calculator.weekly_cost_from_annual(response)
+      end
+
+      next_node do |response|
+        amount = SmartAnswer::Money.new(response)
+        amount == 0 ? outcome(:no_longer_paying) : question(:old_weekly_amount_1?) # rubocop:disable Style/NumericPredicate
+      end
+    end
+
+    # Q9
+    money_question :how_much_12_months_2? do
+      on_response do |response|
+        calculator.new_weekly_costs = calculator.weekly_cost_from_annual(response)
+      end
+
+      next_node do |response|
+        amount = SmartAnswer::Money.new(response)
+        amount == 0 ? outcome(:no_longer_paying) : question(:old_monthly_amount?) # rubocop:disable Style/NumericPredicate
+      end
+    end
+
+    # Q10
+    money_question :how_much_each_month? do
+      on_response do |response|
+        calculator.weekly_cost = calculator.weekly_cost_from_monthly(response)
+      end
+      next_node do
+        outcome :weekly_costs_are_x # O4
+      end
+    end
+
+    # Q11
+    radio :pay_same_each_time? do
+      option :yes
+      option :no
+
+      next_node do |response|
+        case response
+        when "yes"
+          question :how_often_pay_providers? # Q12
+        when "no"
+          question :how_much_spent_last_12_months? # Q16
+        end
+      end
+    end
+
+    # Q12
+    radio :how_often_pay_providers? do
+      option :weekly
+      option :fortnightly
+      option :every_4_weeks
+      option :every_month
+      option :termly
+      option :yearly
+      option :other
+
+      next_node do |response|
+        case response
+        when "weekly"
+          outcome :round_up_weekly # O3
+        when "fortnightly"
+          question :how_much_fortnightly? # Q13
+        when "every_4_weeks"
+          question :how_much_4_weeks? # Q14
+        when "every_month"
+          question :how_much_each_month? # Q10
+        when "termly", "other"
+          outcome :call_helpline_plain # O5
+        when "yearly"
+          question :how_much_yearly? # Q15
+        end
+      end
+    end
+
+    # Q13
+    money_question :how_much_fortnightly? do
+      on_response do |response|
+        calculator.weekly_cost = calculator.weekly_cost_from_fortnightly(response)
+      end
+
+      next_node do
+        outcome :weekly_costs_are_x # O4
+      end
+    end
+
+    # Q14
+    money_question :how_much_4_weeks? do
+      on_response do |response|
+        calculator.weekly_cost = calculator.weekly_cost_from_four_weekly(response)
+      end
+      next_node do
+        outcome :weekly_costs_are_x # 04
+      end
+    end
+
+    # Q15
+    money_question :how_much_yearly? do
+      on_response do |response|
+        calculator.weekly_cost = calculator.weekly_cost_from_annual(response)
+      end
+      next_node do
+        outcome :weekly_costs_are_x # O4
+      end
+    end
+
+    # Q16
+    money_question :how_much_spent_last_12_months? do
+      on_response do |response|
+        calculator.weekly_cost = calculator.weekly_cost_from_annual(response)
+      end
+      next_node do
+        outcome :weekly_costs_are_x # O4
+      end
+    end
+
+    # Q17
+    money_question :new_weekly_costs? do
+      on_response do |response|
+        calculator.new_weekly_costs = Float(response).ceil
+      end
+
+      next_node do |response|
+        amount = SmartAnswer::Money.new(response)
+        amount == 0 ? outcome(:no_longer_paying) : question(:old_weekly_amount_2?) # rubocop:disable Style/NumericPredicate
+      end
+    end
+
+    # Q18
+    money_question :old_weekly_amount_1? do
+      # get weekly amount from Q8 or Q9 (whichever the user answered)
+      # calculate different using input from Q18
+      on_response do |response|
+        calculator.old_weekly_costs = Float(response).ceil
+        calculator.weekly_difference = calculator.cost_change(
+          calculator.weekly_cost,
+          calculator.old_weekly_costs,
+        )
+      end
+
+      next_node do
+        outcome :cost_changed
+      end
+    end
+
+    # Q19
+    money_question :new_monthly_cost? do
+      on_response do |response|
+        calculator.new_weekly_costs = calculator.weekly_cost_from_monthly(response)
+      end
+
+      next_node do |response|
+        amount = SmartAnswer::Money.new(response)
+        amount == 0 ? outcome(:no_longer_paying) : question(:old_monthly_amount?) # rubocop:disable Style/NumericPredicate
+      end
+    end
+
+    # Q20
+    money_question :old_weekly_amount_2? do
+      on_response do |response|
+        calculator.old_weekly_costs = Float(response).ceil
+        calculator.weekly_difference = calculator.cost_change(
+          calculator.new_weekly_costs,
+          calculator.old_weekly_costs,
+        )
+        calculator.cost_change_4_weeks = true
+      end
+
+      next_node do
+        outcome :cost_changed
+      end
+    end
+
+    # Q21
+    money_question :old_monthly_amount? do
+      on_response do |response|
+        calculator.old_weekly_costs = calculator.weekly_cost_from_monthly(response)
+        calculator.weekly_difference = calculator.cost_change(
+          calculator.new_weekly_costs,
+          calculator.old_weekly_costs,
+        )
+      end
+
+      next_node do
+        outcome :cost_changed
+      end
+    end
+
+    ### Outcomes
+
+    # O1
+    outcome :call_helpline_detailed
+
+    # O5
+    outcome :call_helpline_plain
+
+    # O2
+    outcome :no_change
+
+    # O3
+    outcome :round_up_weekly
+
+    # O4
+    outcome :weekly_costs_are_x
+
+    # O6, 7, 8
+    outcome :cost_changed
+
+    # O9
+    outcome :no_longer_paying
   end
 end

--- a/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
+++ b/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
@@ -1,89 +1,87 @@
-module SmartAnswer
-  class EstimateSelfAssessmentPenaltiesFlow < Flow
-    def define
-      content_id "32b54f44-fca1-4480-b13b-ddeb0b0238e1"
-      name "estimate-self-assessment-penalties"
-      status :published
+class EstimateSelfAssessmentPenaltiesFlow < SmartAnswer::Flow
+  def define
+    content_id "32b54f44-fca1-4480-b13b-ddeb0b0238e1"
+    name "estimate-self-assessment-penalties"
+    status :published
 
-      radio :which_year? do
-        option :"2013-14"
-        option :"2014-15"
-        option :"2015-16"
-        option :"2016-17"
-        option :"2017-18"
-        option :"2018-19"
-        option :"2019-20"
+    radio :which_year? do
+      option :"2013-14"
+      option :"2014-15"
+      option :"2015-16"
+      option :"2016-17"
+      option :"2017-18"
+      option :"2018-19"
+      option :"2019-20"
 
-        on_response do |response|
-          self.calculator = Calculators::SelfAssessmentPenalties.new
-          calculator.tax_year = response
-        end
-
-        next_node do
-          question :how_submitted?
-        end
+      on_response do |response|
+        self.calculator = SmartAnswer::Calculators::SelfAssessmentPenalties.new
+        calculator.tax_year = response
       end
 
-      radio :how_submitted? do
-        option :online
-        option :paper
-
-        on_response do |response|
-          calculator.submission_method = response
-        end
-
-        next_node do
-          question :when_submitted?
-        end
+      next_node do
+        question :how_submitted?
       end
-
-      date_question :when_submitted? do
-        from { 3.years.ago(Time.zone.today) }
-        to { 2.years.since(Time.zone.today) }
-
-        on_response do |response|
-          calculator.filing_date = response
-        end
-
-        validate { calculator.valid_filing_date? }
-
-        next_node do
-          question :when_paid?
-        end
-      end
-
-      date_question :when_paid? do
-        from { 3.years.ago(Time.zone.today) }
-        to { 2.years.since(Time.zone.today) }
-
-        on_response do |response|
-          calculator.payment_date = response
-        end
-
-        validate { calculator.valid_payment_date? }
-
-        next_node do
-          if calculator.paid_on_time?
-            outcome :filed_and_paid_on_time
-          else
-            question :how_much_tax?
-          end
-        end
-      end
-
-      money_question :how_much_tax? do
-        on_response do |response|
-          calculator.estimated_bill = response
-        end
-
-        next_node do
-          outcome :late
-        end
-      end
-
-      outcome :late
-
-      outcome :filed_and_paid_on_time
     end
+
+    radio :how_submitted? do
+      option :online
+      option :paper
+
+      on_response do |response|
+        calculator.submission_method = response
+      end
+
+      next_node do
+        question :when_submitted?
+      end
+    end
+
+    date_question :when_submitted? do
+      from { 3.years.ago(Time.zone.today) }
+      to { 2.years.since(Time.zone.today) }
+
+      on_response do |response|
+        calculator.filing_date = response
+      end
+
+      validate { calculator.valid_filing_date? }
+
+      next_node do
+        question :when_paid?
+      end
+    end
+
+    date_question :when_paid? do
+      from { 3.years.ago(Time.zone.today) }
+      to { 2.years.since(Time.zone.today) }
+
+      on_response do |response|
+        calculator.payment_date = response
+      end
+
+      validate { calculator.valid_payment_date? }
+
+      next_node do
+        if calculator.paid_on_time?
+          outcome :filed_and_paid_on_time
+        else
+          question :how_much_tax?
+        end
+      end
+    end
+
+    money_question :how_much_tax? do
+      on_response do |response|
+        calculator.estimated_bill = response
+      end
+
+      next_node do
+        outcome :late
+      end
+    end
+
+    outcome :late
+
+    outcome :filed_and_paid_on_time
   end
 end

--- a/lib/smart_answer_flows/find-coronavirus-support.rb
+++ b/lib/smart_answer_flows/find-coronavirus-support.rb
@@ -1,253 +1,251 @@
-module SmartAnswer
-  class FindCoronavirusSupportFlow < Flow
-    def define
-      name "find-coronavirus-support"
-      content_id "d67f2c92-d0f0-438b-9c81-c0059dd71baf"
-      status :published
-      response_store :session
-      use_hide_this_page true
-      hide_previous_answers_on_results_page true
+class FindCoronavirusSupportFlow < SmartAnswer::Flow
+  def define
+    name "find-coronavirus-support"
+    content_id "d67f2c92-d0f0-438b-9c81-c0059dd71baf"
+    status :published
+    response_store :session
+    use_hide_this_page true
+    hide_previous_answers_on_results_page true
 
-      # ======================================================================
-      # What do you need help with because of coronavirus?
-      # ======================================================================
-      checkbox_question :need_help_with do
-        option :feeling_unsafe
-        option :paying_bills
-        option :getting_food
-        option :being_unemployed
-        option :going_to_work
-        option :self_isolating
-        option :somewhere_to_live
-        option :mental_health
-        none_option
+    # ======================================================================
+    # What do you need help with because of coronavirus?
+    # ======================================================================
+    checkbox_question :need_help_with do
+      option :feeling_unsafe
+      option :paying_bills
+      option :getting_food
+      option :being_unemployed
+      option :going_to_work
+      option :self_isolating
+      option :somewhere_to_live
+      option :mental_health
+      none_option
 
-        on_response do |response|
-          self.calculator = Calculators::FindCoronavirusSupportCalculator.new
-          calculator.need_help_with = response
-        end
-
-        next_node do
-          question calculator.next_question(:need_help_with)
-        end
+      on_response do |response|
+        self.calculator = SmartAnswer::Calculators::FindCoronavirusSupportCalculator.new
+        calculator.need_help_with = response
       end
 
-      # ======================================================================
-      # Do you feel safe where you live?
-      # ======================================================================
-      radio :feel_unsafe do
-        option :yes
-        option :concerned_about_others
-        option :no
-        option :not_sure
-
-        on_response do |response|
-          calculator.feel_unsafe = response
-        end
-
-        next_node do
-          question calculator.next_question(:feel_unsafe)
-        end
+      next_node do
+        question calculator.next_question(:need_help_with)
       end
-
-      # ======================================================================
-      # Are you finding it hard to afford rent, your mortgage or bills?
-      # ======================================================================
-      radio :afford_rent_mortgage_bills do
-        option :yes
-        option :no
-        option :not_sure
-
-        on_response do |response|
-          calculator.afford_rent_mortgage_bills = response
-        end
-
-        next_node do
-          question calculator.next_question(:afford_rent_mortgage_bills)
-        end
-      end
-
-      # ======================================================================
-      # Are you finding it hard to afford food?
-      # ======================================================================
-      radio :afford_food do
-        option :yes
-        option :no
-        option :not_sure
-
-        on_response do |response|
-          calculator.afford_food = response
-        end
-
-        next_node do
-          question :get_food
-        end
-      end
-
-      # ======================================================================
-      # Are your able to get food?
-      # ======================================================================
-      radio :get_food do
-        option :yes
-        option :no
-        option :not_sure
-
-        on_response do |response|
-          calculator.get_food = response
-        end
-
-        next_node do
-          question calculator.next_question(:get_food)
-        end
-      end
-
-      # ======================================================================
-      # Are you self-employed or a sole trader?
-      # ======================================================================
-      radio :self_employed do
-        option :yes
-        option :no
-        option :not_sure
-
-        on_response do |response|
-          calculator.self_employed = response
-        end
-
-        next_node do
-          if calculator.self_employed == "yes"
-            question calculator.next_question(:have_you_been_made_unemployed)
-          else
-            question :have_you_been_made_unemployed
-          end
-        end
-      end
-
-      # ======================================================================
-      # Have you been told to stop working?
-      # ======================================================================
-      radio :have_you_been_made_unemployed do
-        option :yes_i_have_been_made_unemployed
-        option :yes_i_have_been_put_on_furlough
-        option :no
-        option :not_sure
-
-        on_response do |response|
-          calculator.have_you_been_made_unemployed = response
-        end
-
-        next_node do
-          question calculator.next_question(:have_you_been_made_unemployed)
-        end
-      end
-
-      # ======================================================================
-      # Are you worried about going in to work?
-      # ======================================================================
-      radio :worried_about_work do
-        option :yes
-        option :no
-        option :not_sure
-
-        on_response do |response|
-          calculator.worried_about_work = response
-        end
-
-        next_node do
-          question calculator.next_question(:worried_about_work)
-        end
-      end
-
-      # ======================================================================
-      # Are you worried about self-isolating?
-      # ======================================================================
-      radio :worried_about_self_isolating do
-        option :yes
-        option :no
-
-        on_response do |response|
-          calculator.worried_about_self_isolating = response
-        end
-
-        next_node do
-          question calculator.next_question(:worried_about_self_isolating)
-        end
-      end
-
-      # ======================================================================
-      # Do you have somewhere to live?
-      # ======================================================================
-      radio :have_somewhere_to_live do
-        option :yes
-        option :yes_but_i_might_lose_it
-        option :no
-        option :not_sure
-
-        on_response do |response|
-          calculator.have_somewhere_to_live = response
-        end
-
-        next_node do
-          question :have_you_been_evicted
-        end
-      end
-
-      # ======================================================================
-      # Have you been evicted?
-      # ======================================================================
-      radio :have_you_been_evicted do
-        option :yes
-        option :yes_i_might_be_soon
-        option :no
-        option :not_sure
-
-        on_response do |response|
-          calculator.have_you_been_evicted = response
-        end
-
-        next_node do
-          question calculator.next_question(:have_you_been_evicted)
-        end
-      end
-
-      # ======================================================================
-      # Are you worries about your mental health or someone else's mental health?
-      # ======================================================================
-      radio :mental_health_worries do
-        option :yes
-        option :no
-        option :not_sure
-
-        on_response do |response|
-          calculator.mental_health_worries = response
-        end
-
-        next_node do
-          question :nation
-        end
-      end
-
-      # ======================================================================
-      # Where do you live?
-      # ======================================================================
-      radio :nation do
-        option :england
-        option :scotland
-        option :wales
-        option :northern_ireland
-
-        on_response do |response|
-          calculator.nation = response
-        end
-
-        next_node do
-          outcome :results
-        end
-      end
-
-      # ======================================================================
-      # Results
-      # ======================================================================
-      outcome :results
     end
+
+    # ======================================================================
+    # Do you feel safe where you live?
+    # ======================================================================
+    radio :feel_unsafe do
+      option :yes
+      option :concerned_about_others
+      option :no
+      option :not_sure
+
+      on_response do |response|
+        calculator.feel_unsafe = response
+      end
+
+      next_node do
+        question calculator.next_question(:feel_unsafe)
+      end
+    end
+
+    # ======================================================================
+    # Are you finding it hard to afford rent, your mortgage or bills?
+    # ======================================================================
+    radio :afford_rent_mortgage_bills do
+      option :yes
+      option :no
+      option :not_sure
+
+      on_response do |response|
+        calculator.afford_rent_mortgage_bills = response
+      end
+
+      next_node do
+        question calculator.next_question(:afford_rent_mortgage_bills)
+      end
+    end
+
+    # ======================================================================
+    # Are you finding it hard to afford food?
+    # ======================================================================
+    radio :afford_food do
+      option :yes
+      option :no
+      option :not_sure
+
+      on_response do |response|
+        calculator.afford_food = response
+      end
+
+      next_node do
+        question :get_food
+      end
+    end
+
+    # ======================================================================
+    # Are your able to get food?
+    # ======================================================================
+    radio :get_food do
+      option :yes
+      option :no
+      option :not_sure
+
+      on_response do |response|
+        calculator.get_food = response
+      end
+
+      next_node do
+        question calculator.next_question(:get_food)
+      end
+    end
+
+    # ======================================================================
+    # Are you self-employed or a sole trader?
+    # ======================================================================
+    radio :self_employed do
+      option :yes
+      option :no
+      option :not_sure
+
+      on_response do |response|
+        calculator.self_employed = response
+      end
+
+      next_node do
+        if calculator.self_employed == "yes"
+          question calculator.next_question(:have_you_been_made_unemployed)
+        else
+          question :have_you_been_made_unemployed
+        end
+      end
+    end
+
+    # ======================================================================
+    # Have you been told to stop working?
+    # ======================================================================
+    radio :have_you_been_made_unemployed do
+      option :yes_i_have_been_made_unemployed
+      option :yes_i_have_been_put_on_furlough
+      option :no
+      option :not_sure
+
+      on_response do |response|
+        calculator.have_you_been_made_unemployed = response
+      end
+
+      next_node do
+        question calculator.next_question(:have_you_been_made_unemployed)
+      end
+    end
+
+    # ======================================================================
+    # Are you worried about going in to work?
+    # ======================================================================
+    radio :worried_about_work do
+      option :yes
+      option :no
+      option :not_sure
+
+      on_response do |response|
+        calculator.worried_about_work = response
+      end
+
+      next_node do
+        question calculator.next_question(:worried_about_work)
+      end
+    end
+
+    # ======================================================================
+    # Are you worried about self-isolating?
+    # ======================================================================
+    radio :worried_about_self_isolating do
+      option :yes
+      option :no
+
+      on_response do |response|
+        calculator.worried_about_self_isolating = response
+      end
+
+      next_node do
+        question calculator.next_question(:worried_about_self_isolating)
+      end
+    end
+
+    # ======================================================================
+    # Do you have somewhere to live?
+    # ======================================================================
+    radio :have_somewhere_to_live do
+      option :yes
+      option :yes_but_i_might_lose_it
+      option :no
+      option :not_sure
+
+      on_response do |response|
+        calculator.have_somewhere_to_live = response
+      end
+
+      next_node do
+        question :have_you_been_evicted
+      end
+    end
+
+    # ======================================================================
+    # Have you been evicted?
+    # ======================================================================
+    radio :have_you_been_evicted do
+      option :yes
+      option :yes_i_might_be_soon
+      option :no
+      option :not_sure
+
+      on_response do |response|
+        calculator.have_you_been_evicted = response
+      end
+
+      next_node do
+        question calculator.next_question(:have_you_been_evicted)
+      end
+    end
+
+    # ======================================================================
+    # Are you worries about your mental health or someone else's mental health?
+    # ======================================================================
+    radio :mental_health_worries do
+      option :yes
+      option :no
+      option :not_sure
+
+      on_response do |response|
+        calculator.mental_health_worries = response
+      end
+
+      next_node do
+        question :nation
+      end
+    end
+
+    # ======================================================================
+    # Where do you live?
+    # ======================================================================
+    radio :nation do
+      option :england
+      option :scotland
+      option :wales
+      option :northern_ireland
+
+      on_response do |response|
+        calculator.nation = response
+      end
+
+      next_node do
+        outcome :results
+      end
+    end
+
+    # ======================================================================
+    # Results
+    # ======================================================================
+    outcome :results
   end
 end

--- a/lib/smart_answer_flows/help-if-you-are-arrested-abroad.rb
+++ b/lib/smart_answer_flows/help-if-you-are-arrested-abroad.rb
@@ -1,35 +1,33 @@
-module SmartAnswer
-  class HelpIfYouAreArrestedAbroadFlow < Flow
-    def define
-      content_id "cb62c931-a0fa-4363-b33d-12ac06d6232a"
-      name "help-if-you-are-arrested-abroad"
-      status :published
+class HelpIfYouAreArrestedAbroadFlow < SmartAnswer::Flow
+  def define
+    content_id "cb62c931-a0fa-4363-b33d-12ac06d6232a"
+    name "help-if-you-are-arrested-abroad"
+    status :published
 
-      exclude_countries = %w[holy-see british-antarctic-territory]
-      british_overseas_territories = %w[anguilla bermuda british-indian-ocean-territory british-virgin-islands cayman-islands falkland-islands gibraltar montserrat pitcairn-island st-helena-ascension-and-tristan-da-cunha south-georgia-and-the-south-sandwich-islands turks-and-caicos-islands]
+    exclude_countries = %w[holy-see british-antarctic-territory]
+    british_overseas_territories = %w[anguilla bermuda british-indian-ocean-territory british-virgin-islands cayman-islands falkland-islands gibraltar montserrat pitcairn-island st-helena-ascension-and-tristan-da-cunha south-georgia-and-the-south-sandwich-islands turks-and-caicos-islands]
 
-      # Q1
-      country_select :which_country?, exclude_countries: exclude_countries do
-        on_response do |response|
-          self.calculator = Calculators::ArrestedAbroad.new(response)
-        end
-
-        next_node do |response|
-          if response == "syria"
-            outcome :answer_three_syria
-          elsif british_overseas_territories.include?(response)
-            outcome :answer_three_british_overseas_territories
-          else
-            outcome :answer_one_generic
-          end
-        end
+    # Q1
+    country_select :which_country?, exclude_countries: exclude_countries do
+      on_response do |response|
+        self.calculator = SmartAnswer::Calculators::ArrestedAbroad.new(response)
       end
 
-      outcome :answer_one_generic
-
-      outcome :answer_three_syria
-
-      outcome :answer_three_british_overseas_territories
+      next_node do |response|
+        if response == "syria"
+          outcome :answer_three_syria
+        elsif british_overseas_territories.include?(response)
+          outcome :answer_three_british_overseas_territories
+        else
+          outcome :answer_one_generic
+        end
+      end
     end
+
+    outcome :answer_one_generic
+
+    outcome :answer_three_syria
+
+    outcome :answer_three_british_overseas_territories
   end
 end

--- a/lib/smart_answer_flows/inherits-someone-dies-without-will.rb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will.rb
@@ -1,417 +1,415 @@
-module SmartAnswer
-  class InheritsSomeoneDiesWithoutWillFlow < Flow
-    def define
-      content_id "1f75de31-1f07-4c68-b1ab-8330b1ee8670"
-      name "inherits-someone-dies-without-will"
-      status :published
+class InheritsSomeoneDiesWithoutWillFlow < SmartAnswer::Flow
+  def define
+    content_id "1f75de31-1f07-4c68-b1ab-8330b1ee8670"
+    name "inherits-someone-dies-without-will"
+    status :published
 
-      # The case & if blocks in this file are organised to be read in the same order
-      # as the flow chart rather than to minimise repetition.
+    # The case & if blocks in this file are organised to be read in the same order
+    # as the flow chart rather than to minimise repetition.
 
-      # Q1
-      radio :region? do
-        option :"england-and-wales"
-        option :scotland
-        option :"northern-ireland"
+    # Q1
+    radio :region? do
+      option :"england-and-wales"
+      option :scotland
+      option :"northern-ireland"
 
-        on_response do |response|
-          self.calculator = Calculators::InheritsSomeoneDiesWithoutWillCalculator.new
-          calculator.region = response
-          calculator.next_steps = %i[wills_link inheritance_link]
-        end
-
-        next_node do
-          question :partner?
-        end
+      on_response do |response|
+        self.calculator = SmartAnswer::Calculators::InheritsSomeoneDiesWithoutWillCalculator.new
+        calculator.region = response
+        calculator.next_steps = %i[wills_link inheritance_link]
       end
 
-      # Q2
-      radio :partner? do
-        option :yes
-        option :no
+      next_node do
+        question :partner?
+      end
+    end
 
-        on_response do |response|
-          calculator.partner = response
-        end
+    # Q2
+    radio :partner? do
+      option :yes
+      option :no
 
-        next_node do
-          case calculator.region
-          when "england-and-wales", "northern-ireland"
-            if calculator.partner?
-              case calculator.region
-              when "england-and-wales"
-                question :estate_over_270000?
-              when "northern-ireland"
-                question :estate_over_250000?
-              end
-            else
-              question :children?
+      on_response do |response|
+        calculator.partner = response
+      end
+
+      next_node do
+        case calculator.region
+        when "england-and-wales", "northern-ireland"
+          if calculator.partner?
+            case calculator.region
+            when "england-and-wales"
+              question :estate_over_270000?
+            when "northern-ireland"
+              question :estate_over_250000?
             end
-          when "scotland"
-            question :children?
-          end
-        end
-      end
-
-      # Q3 (Ireland)
-      radio :estate_over_250000? do
-        option :yes
-        option :no
-
-        on_response do |response|
-          calculator.estate_over_250000 = response
-          calculator.next_steps = [:wills_link] unless calculator.estate_over_250000?
-        end
-
-        next_node do
-          if calculator.estate_over_250000?
-            question :children?
           else
-            outcome :outcome_60
-          end
-        end
-      end
-
-      # Q3 (England and Wales)
-      radio :estate_over_270000? do
-        option :yes
-        option :no
-
-        on_response do |response|
-          calculator.estate_over_270000 = response
-          calculator.next_steps = [:wills_link] unless calculator.estate_over_270000?
-        end
-
-        next_node do
-          if calculator.estate_over_270000?
             question :children?
+          end
+        when "scotland"
+          question :children?
+        end
+      end
+    end
+
+    # Q3 (Ireland)
+    radio :estate_over_250000? do
+      option :yes
+      option :no
+
+      on_response do |response|
+        calculator.estate_over_250000 = response
+        calculator.next_steps = [:wills_link] unless calculator.estate_over_250000?
+      end
+
+      next_node do
+        if calculator.estate_over_250000?
+          question :children?
+        else
+          outcome :outcome_60
+        end
+      end
+    end
+
+    # Q3 (England and Wales)
+    radio :estate_over_270000? do
+      option :yes
+      option :no
+
+      on_response do |response|
+        calculator.estate_over_270000 = response
+        calculator.next_steps = [:wills_link] unless calculator.estate_over_270000?
+      end
+
+      next_node do
+        if calculator.estate_over_270000?
+          question :children?
+        else
+          outcome :outcome_1
+        end
+      end
+    end
+
+    # Q4
+    radio :children? do
+      option :yes
+      option :no
+
+      on_response do |response|
+        calculator.children = response
+      end
+
+      next_node do
+        case calculator.region
+        when "england-and-wales"
+          if calculator.partner?
+            if calculator.children?
+              outcome :outcome_20
+            else
+              outcome :outcome_1
+            end
+          elsif calculator.children?
+            outcome :outcome_2
           else
-            outcome :outcome_1
+            question :parents?
+          end
+        when "scotland"
+          if calculator.partner?
+            if calculator.children?
+              outcome :outcome_40
+            else
+              question :parents?
+            end
+          elsif calculator.children?
+            outcome :outcome_2
+          else
+            question :parents?
+          end
+        when "northern-ireland"
+          if calculator.partner?
+            if calculator.children?
+              question :more_than_one_child?
+            else
+              question :parents?
+            end
+          elsif calculator.children?
+            outcome :outcome_66
+          else
+            question :parents?
           end
         end
       end
+    end
 
-      # Q4
-      radio :children? do
-        option :yes
-        option :no
+    # Q5
+    radio :parents? do
+      option :yes
+      option :no
 
-        on_response do |response|
-          calculator.children = response
-        end
-
-        next_node do
-          case calculator.region
-          when "england-and-wales"
-            if calculator.partner?
-              if calculator.children?
-                outcome :outcome_20
-              else
-                outcome :outcome_1
-              end
-            elsif calculator.children?
-              outcome :outcome_2
-            else
-              question :parents?
-            end
-          when "scotland"
-            if calculator.partner?
-              if calculator.children?
-                outcome :outcome_40
-              else
-                question :parents?
-              end
-            elsif calculator.children?
-              outcome :outcome_2
-            else
-              question :parents?
-            end
-          when "northern-ireland"
-            if calculator.partner?
-              if calculator.children?
-                question :more_than_one_child?
-              else
-                question :parents?
-              end
-            elsif calculator.children?
-              outcome :outcome_66
-            else
-              question :parents?
-            end
-          end
-        end
+      on_response do |response|
+        calculator.parents = response
       end
 
-      # Q5
-      radio :parents? do
-        option :yes
-        option :no
-
-        on_response do |response|
-          calculator.parents = response
-        end
-
-        next_node do
-          case calculator.region
-          when "england-and-wales"
-            if calculator.parents?
-              outcome :outcome_3
-            else
-              question :siblings?
-            end
-          when "scotland"
+      next_node do
+        case calculator.region
+        when "england-and-wales"
+          if calculator.parents?
+            outcome :outcome_3
+          else
             question :siblings?
-          when "northern-ireland"
-            if calculator.partner?
-              if calculator.parents?
-                outcome :outcome_63
-              else
-                question :siblings_including_mixed_parents?
-              end
-            elsif calculator.parents?
-              outcome :outcome_3
+          end
+        when "scotland"
+          question :siblings?
+        when "northern-ireland"
+          if calculator.partner?
+            if calculator.parents?
+              outcome :outcome_63
             else
-              question :siblings?
+              question :siblings_including_mixed_parents?
             end
+          elsif calculator.parents?
+            outcome :outcome_3
+          else
+            question :siblings?
           end
         end
       end
+    end
 
-      # Q6
-      radio :siblings? do
-        option :yes
-        option :no
+    # Q6
+    radio :siblings? do
+      option :yes
+      option :no
 
-        on_response do |response|
-          calculator.siblings = response
-        end
+      on_response do |response|
+        calculator.siblings = response
+      end
 
-        next_node do
-          case calculator.region
-          when "england-and-wales"
-            if calculator.siblings?
-              outcome :outcome_4
-            else
-              question :half_siblings?
-            end
-          when "scotland"
-            if calculator.partner?
-              if calculator.parents?
-                if calculator.siblings?
-                  outcome :outcome_43
-                else
-                  outcome :outcome_42
-                end
-              elsif calculator.siblings?
-                outcome :outcome_41
-              else
-                outcome :outcome_1
-              end
-            elsif calculator.parents?
+      next_node do
+        case calculator.region
+        when "england-and-wales"
+          if calculator.siblings?
+            outcome :outcome_4
+          else
+            question :half_siblings?
+          end
+        when "scotland"
+          if calculator.partner?
+            if calculator.parents?
               if calculator.siblings?
-                outcome :outcome_44
+                outcome :outcome_43
               else
-                outcome :outcome_3
+                outcome :outcome_42
               end
             elsif calculator.siblings?
-              outcome :outcome_4
+              outcome :outcome_41
             else
-              question :aunts_or_uncles?
+              outcome :outcome_1
             end
-          when "northern-ireland"
+          elsif calculator.parents?
             if calculator.siblings?
-              outcome :outcome_4
+              outcome :outcome_44
             else
-              question :grandparents?
+              outcome :outcome_3
             end
-          end
-        end
-      end
-
-      # Q61
-      radio :siblings_including_mixed_parents? do
-        option :yes
-        option :no
-
-        on_response do |response|
-          calculator.siblings_including_mixed_parents = response
-        end
-
-        next_node do
-          if calculator.siblings_including_mixed_parents?
-            outcome :outcome_64
+          elsif calculator.siblings?
+            outcome :outcome_4
           else
-            outcome :outcome_65
+            question :aunts_or_uncles?
           end
-        end
-      end
-
-      # Q7
-      radio :grandparents? do
-        option :yes
-        option :no
-
-        on_response do |response|
-          calculator.grandparents = response
-        end
-
-        next_node do
-          case calculator.region
-          when "england-and-wales"
-            if calculator.grandparents?
-              outcome :outcome_5
-            else
-              question :aunts_or_uncles?
-            end
-          when "scotland"
-            if calculator.grandparents?
-              outcome :outcome_5
-            else
-              question :great_aunts_or_uncles?
-            end
-          when "northern-ireland"
-            if calculator.grandparents?
-              outcome :outcome_5
-            else
-              question :aunts_or_uncles?
-            end
-          end
-        end
-      end
-
-      # Q8
-      radio :aunts_or_uncles? do
-        option :yes
-        option :no
-
-        on_response do |response|
-          calculator.aunts_or_uncles = response
-        end
-
-        next_node do
-          case calculator.region
-          when "england-and-wales"
-            if calculator.aunts_or_uncles?
-              outcome :outcome_6
-            else
-              question :half_aunts_or_uncles?
-            end
-          when "scotland"
-            if calculator.aunts_or_uncles?
-              outcome :outcome_6
-            else
-              question :grandparents?
-            end
-          when "northern-ireland"
-            if calculator.aunts_or_uncles?
-              outcome :outcome_6
-            else
-              outcome :outcome_67
-            end
-          end
-        end
-      end
-
-      # Q20
-      radio :half_siblings? do
-        option :yes
-        option :no
-
-        on_response do |response|
-          calculator.half_siblings = response
-        end
-
-        next_node do
-          if calculator.half_siblings?
-            outcome :outcome_23
+        when "northern-ireland"
+          if calculator.siblings?
+            outcome :outcome_4
           else
             question :grandparents?
           end
         end
       end
-
-      # Q21
-      radio :half_aunts_or_uncles? do
-        option :yes
-        option :no
-
-        on_response do |response|
-          calculator.half_aunts_or_uncles = response
-        end
-
-        next_node do
-          if calculator.half_aunts_or_uncles?
-            outcome :outcome_24
-          else
-            outcome :outcome_25
-          end
-        end
-      end
-
-      # Q40
-      radio :great_aunts_or_uncles? do
-        option :yes
-        option :no
-
-        on_response do |response|
-          calculator.great_aunts_or_uncles = response
-        end
-
-        next_node do
-          if calculator.great_aunts_or_uncles?
-            outcome :outcome_45
-          else
-            outcome :outcome_46
-          end
-        end
-      end
-
-      # Q60
-      radio :more_than_one_child? do
-        option :yes
-        option :no
-
-        on_response do |response|
-          calculator.more_than_one_child = response
-        end
-
-        next_node do
-          if calculator.more_than_one_child?
-            outcome :outcome_61
-          else
-            outcome :outcome_62
-          end
-        end
-      end
-
-      outcome :outcome_1
-      outcome :outcome_2
-      outcome :outcome_3
-      outcome :outcome_4
-      outcome :outcome_5
-      outcome :outcome_6
-
-      outcome :outcome_20
-      outcome :outcome_23
-      outcome :outcome_24
-      outcome :outcome_25
-
-      outcome :outcome_40
-      outcome :outcome_41
-      outcome :outcome_42
-      outcome :outcome_43
-      outcome :outcome_44
-      outcome :outcome_45
-      outcome :outcome_46
-
-      outcome :outcome_60
-      outcome :outcome_61
-      outcome :outcome_62
-      outcome :outcome_63
-      outcome :outcome_64
-      outcome :outcome_65
-      outcome :outcome_66
-      outcome :outcome_67
     end
+
+    # Q61
+    radio :siblings_including_mixed_parents? do
+      option :yes
+      option :no
+
+      on_response do |response|
+        calculator.siblings_including_mixed_parents = response
+      end
+
+      next_node do
+        if calculator.siblings_including_mixed_parents?
+          outcome :outcome_64
+        else
+          outcome :outcome_65
+        end
+      end
+    end
+
+    # Q7
+    radio :grandparents? do
+      option :yes
+      option :no
+
+      on_response do |response|
+        calculator.grandparents = response
+      end
+
+      next_node do
+        case calculator.region
+        when "england-and-wales"
+          if calculator.grandparents?
+            outcome :outcome_5
+          else
+            question :aunts_or_uncles?
+          end
+        when "scotland"
+          if calculator.grandparents?
+            outcome :outcome_5
+          else
+            question :great_aunts_or_uncles?
+          end
+        when "northern-ireland"
+          if calculator.grandparents?
+            outcome :outcome_5
+          else
+            question :aunts_or_uncles?
+          end
+        end
+      end
+    end
+
+    # Q8
+    radio :aunts_or_uncles? do
+      option :yes
+      option :no
+
+      on_response do |response|
+        calculator.aunts_or_uncles = response
+      end
+
+      next_node do
+        case calculator.region
+        when "england-and-wales"
+          if calculator.aunts_or_uncles?
+            outcome :outcome_6
+          else
+            question :half_aunts_or_uncles?
+          end
+        when "scotland"
+          if calculator.aunts_or_uncles?
+            outcome :outcome_6
+          else
+            question :grandparents?
+          end
+        when "northern-ireland"
+          if calculator.aunts_or_uncles?
+            outcome :outcome_6
+          else
+            outcome :outcome_67
+          end
+        end
+      end
+    end
+
+    # Q20
+    radio :half_siblings? do
+      option :yes
+      option :no
+
+      on_response do |response|
+        calculator.half_siblings = response
+      end
+
+      next_node do
+        if calculator.half_siblings?
+          outcome :outcome_23
+        else
+          question :grandparents?
+        end
+      end
+    end
+
+    # Q21
+    radio :half_aunts_or_uncles? do
+      option :yes
+      option :no
+
+      on_response do |response|
+        calculator.half_aunts_or_uncles = response
+      end
+
+      next_node do
+        if calculator.half_aunts_or_uncles?
+          outcome :outcome_24
+        else
+          outcome :outcome_25
+        end
+      end
+    end
+
+    # Q40
+    radio :great_aunts_or_uncles? do
+      option :yes
+      option :no
+
+      on_response do |response|
+        calculator.great_aunts_or_uncles = response
+      end
+
+      next_node do
+        if calculator.great_aunts_or_uncles?
+          outcome :outcome_45
+        else
+          outcome :outcome_46
+        end
+      end
+    end
+
+    # Q60
+    radio :more_than_one_child? do
+      option :yes
+      option :no
+
+      on_response do |response|
+        calculator.more_than_one_child = response
+      end
+
+      next_node do
+        if calculator.more_than_one_child?
+          outcome :outcome_61
+        else
+          outcome :outcome_62
+        end
+      end
+    end
+
+    outcome :outcome_1
+    outcome :outcome_2
+    outcome :outcome_3
+    outcome :outcome_4
+    outcome :outcome_5
+    outcome :outcome_6
+
+    outcome :outcome_20
+    outcome :outcome_23
+    outcome :outcome_24
+    outcome :outcome_25
+
+    outcome :outcome_40
+    outcome :outcome_41
+    outcome :outcome_42
+    outcome :outcome_43
+    outcome :outcome_44
+    outcome :outcome_45
+    outcome :outcome_46
+
+    outcome :outcome_60
+    outcome :outcome_61
+    outcome :outcome_62
+    outcome :outcome_63
+    outcome :outcome_64
+    outcome :outcome_65
+    outcome :outcome_66
+    outcome :outcome_67
   end
 end

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -6,107 +6,104 @@
 # IOM - Isle Of Man
 # OS - Opposite Sex
 # SS - Same Sex
+class MarriageAbroadFlow < SmartAnswer::Flow
+  def define
+    content_id "d0a95767-f6ab-432a-aebc-096e37fb3039"
+    name "marriage-abroad"
+    status :published
 
-module SmartAnswer
-  class MarriageAbroadFlow < Flow
-    def define
-      content_id "d0a95767-f6ab-432a-aebc-096e37fb3039"
-      name "marriage-abroad"
-      status :published
+    exclude_countries = %w[samoa mali holy-see british-antarctic-territory the-occupied-palestinian-territories]
 
-      exclude_countries = %w[samoa mali holy-see british-antarctic-territory the-occupied-palestinian-territories]
-
-      # Q1
-      country_select :country_of_ceremony?, exclude_countries: exclude_countries do
-        on_response do |response|
-          self.calculator = Calculators::MarriageAbroadCalculator.new
-          calculator.ceremony_country = response
-        end
-
-        validate do
-          calculator.valid_ceremony_country?
-        end
-
-        next_node do
-          if calculator.two_questions_country?
-            question :partner_opposite_or_same_sex?
-          elsif calculator.ceremony_country_offers_pacs?
-            question :marriage_or_pacs?
-          elsif calculator.ceremony_country_is_french_overseas_territory?
-            outcome :outcome_marriage_abroad_in_country
-          else
-            question :legal_residency?
-          end
-        end
+    # Q1
+    country_select :country_of_ceremony?, exclude_countries: exclude_countries do
+      on_response do |response|
+        self.calculator = SmartAnswer::Calculators::MarriageAbroadCalculator.new
+        calculator.ceremony_country = response
       end
 
-      # Q2
-      radio :legal_residency? do
-        option :uk
-        option :ceremony_country
-        option :third_country
-
-        on_response do |response|
-          calculator.resident_of = response
-        end
-
-        next_node do
-          if calculator.outcome_ceremony_location_country?
-            outcome :outcome_marriage_abroad_in_country
-          elsif calculator.three_questions_country?
-            question :partner_opposite_or_same_sex?
-          else
-            question :what_is_your_partners_nationality?
-          end
-        end
+      validate do
+        calculator.valid_ceremony_country?
       end
 
-      # Q3a
-      radio :marriage_or_pacs? do
-        option :marriage
-        option :pacs
-
-        on_response do |response|
-          calculator.marriage_or_pacs = response
+      next_node do
+        if calculator.two_questions_country?
+          question :partner_opposite_or_same_sex?
+        elsif calculator.ceremony_country_offers_pacs?
+          question :marriage_or_pacs?
+        elsif calculator.ceremony_country_is_french_overseas_territory?
+          outcome :outcome_marriage_abroad_in_country
+        else
+          question :legal_residency?
         end
+      end
+    end
 
-        next_node do
+    # Q2
+    radio :legal_residency? do
+      option :uk
+      option :ceremony_country
+      option :third_country
+
+      on_response do |response|
+        calculator.resident_of = response
+      end
+
+      next_node do
+        if calculator.outcome_ceremony_location_country?
+          outcome :outcome_marriage_abroad_in_country
+        elsif calculator.three_questions_country?
+          question :partner_opposite_or_same_sex?
+        else
+          question :what_is_your_partners_nationality?
+        end
+      end
+    end
+
+    # Q3a
+    radio :marriage_or_pacs? do
+      option :marriage
+      option :pacs
+
+      on_response do |response|
+        calculator.marriage_or_pacs = response
+      end
+
+      next_node do
+        outcome :outcome_marriage_abroad_in_country
+      end
+    end
+
+    # Q4
+    radio :what_is_your_partners_nationality? do
+      option :partner_british
+      option :partner_local
+      option :partner_other
+
+      on_response do |response|
+        calculator.partner_nationality = response
+      end
+
+      next_node do
+        question :partner_opposite_or_same_sex?
+      end
+    end
+
+    # Q5
+    radio :partner_opposite_or_same_sex? do
+      option :opposite_sex
+      option :same_sex
+
+      on_response do |response|
+        calculator.sex_of_your_partner = response
+      end
+
+      next_node do
+        if calculator.has_outcome_per_path?
           outcome :outcome_marriage_abroad_in_country
         end
       end
-
-      # Q4
-      radio :what_is_your_partners_nationality? do
-        option :partner_british
-        option :partner_local
-        option :partner_other
-
-        on_response do |response|
-          calculator.partner_nationality = response
-        end
-
-        next_node do
-          question :partner_opposite_or_same_sex?
-        end
-      end
-
-      # Q5
-      radio :partner_opposite_or_same_sex? do
-        option :opposite_sex
-        option :same_sex
-
-        on_response do |response|
-          calculator.sex_of_your_partner = response
-        end
-
-        next_node do
-          if calculator.has_outcome_per_path?
-            outcome :outcome_marriage_abroad_in_country
-          end
-        end
-      end
-
-      outcome :outcome_marriage_abroad_in_country
     end
+
+    outcome :outcome_marriage_abroad_in_country
   end
 end

--- a/lib/smart_answer_flows/maternity-paternity-calculator.rb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator.rb
@@ -1,8 +1,3 @@
-require "smart_answer_flows/maternity-paternity-calculator/adoption_calculator_flow"
-require "smart_answer_flows/maternity-paternity-calculator/paternity_calculator_flow"
-require "smart_answer_flows/maternity-paternity-calculator/maternity_calculator_flow"
-require "smart_answer_flows/maternity-paternity-calculator/shared_adoption_maternity_paternity_flow"
-
 class MaternityPaternityCalculatorFlow < SmartAnswer::Flow
   def define
     content_id "05d5412d-455b-485e-a570-020c9176a46e"

--- a/lib/smart_answer_flows/maternity-paternity-calculator.rb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator.rb
@@ -3,47 +3,45 @@ require "smart_answer_flows/maternity-paternity-calculator/paternity_calculator_
 require "smart_answer_flows/maternity-paternity-calculator/maternity_calculator_flow"
 require "smart_answer_flows/maternity-paternity-calculator/shared_adoption_maternity_paternity_flow"
 
-module SmartAnswer
-  class MaternityPaternityCalculatorFlow < Flow
-    def define
-      content_id "05d5412d-455b-485e-a570-020c9176a46e"
-      name "maternity-paternity-calculator"
-      status :published
+class MaternityPaternityCalculatorFlow < SmartAnswer::Flow
+  def define
+    content_id "05d5412d-455b-485e-a570-020c9176a46e"
+    name "maternity-paternity-calculator"
+    status :published
 
-      ## Q1
-      radio :what_type_of_leave? do
-        option :maternity
-        option :paternity
-        option :adoption
+    ## Q1
+    radio :what_type_of_leave? do
+      option :maternity
+      option :paternity
+      option :adoption
 
-        on_response do |response|
-          self.leave_type = response
+      on_response do |response|
+        self.leave_type = response
 
-          self.leave_spp_claim_link = nil
-          self.notice_of_leave_deadline = nil
-          self.monthly_pay_method = nil
-          self.period_calculation_method = nil
-          self.paternity_adoption = nil
-          self.has_contract = nil
-          self.paternity_employment_start = nil
-        end
-
-        next_node do
-          case leave_type
-          when "maternity"
-            question :baby_due_date_maternity?
-          when "paternity"
-            question :leave_or_pay_for_adoption?
-          when "adoption"
-            question :taking_paternity_or_maternity_leave_for_adoption?
-          end
-        end
+        self.leave_spp_claim_link = nil
+        self.notice_of_leave_deadline = nil
+        self.monthly_pay_method = nil
+        self.period_calculation_method = nil
+        self.paternity_adoption = nil
+        self.has_contract = nil
+        self.paternity_employment_start = nil
       end
 
-      append(AdoptionCalculatorFlow.build)
-      append(PaternityCalculatorFlow.build)
-      append(MaternityCalculatorFlow.build)
-      append(SharedAdoptionMaternityPaternityFlow.build)
+      next_node do
+        case leave_type
+        when "maternity"
+          question :baby_due_date_maternity?
+        when "paternity"
+          question :leave_or_pay_for_adoption?
+        when "adoption"
+          question :taking_paternity_or_maternity_leave_for_adoption?
+        end
+      end
     end
+
+    append(AdoptionCalculatorFlow.build)
+    append(PaternityCalculatorFlow.build)
+    append(MaternityCalculatorFlow.build)
+    append(SharedAdoptionMaternityPaternityFlow.build)
   end
 end

--- a/lib/smart_answer_flows/maternity-paternity-calculator/adoption_calculator_flow.rb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/adoption_calculator_flow.rb
@@ -1,259 +1,257 @@
-module SmartAnswer
-  class MaternityPaternityCalculatorFlow < Flow
-    class AdoptionCalculatorFlow < Flow
-      def define
-        radio :taking_paternity_or_maternity_leave_for_adoption? do
-          option :paternity
-          option :maternity
+class MaternityPaternityCalculatorFlow < SmartAnswer::Flow
+  class AdoptionCalculatorFlow < SmartAnswer::Flow
+    def define
+      radio :taking_paternity_or_maternity_leave_for_adoption? do
+        option :paternity
+        option :maternity
 
-          next_node do |response|
-            case response
-            when "paternity"
-              question :employee_date_matched_paternity_adoption?
-            when "maternity"
-              question :adoption_is_from_overseas?
-            end
+        next_node do |response|
+          case response
+          when "paternity"
+            question :employee_date_matched_paternity_adoption?
+          when "maternity"
+            question :adoption_is_from_overseas?
           end
         end
-
-        radio :adoption_is_from_overseas? do
-          option :yes
-          option :no
-
-          on_response do |response|
-            self.adoption_is_from_overseas = (response == "yes")
-          end
-
-          next_node do
-            question :date_of_adoption_match?
-          end
-        end
-
-        date_question :date_of_adoption_match? do
-          on_response do |response|
-            self.match_date = response
-            self.calculator = Calculators::AdoptionPayCalculator.new(match_date)
-          end
-
-          next_node do
-            question :date_of_adoption_placement?
-          end
-        end
-
-        date_question :date_of_adoption_placement? do
-          on_response do |response|
-            self.adoption_placement_date = response
-            calculator.adoption_placement_date = adoption_placement_date
-
-            self.a_leave_earliest_start = calculator.leave_earliest_start_date(adoption_is_from_overseas: adoption_is_from_overseas)
-            self.a_leave_earliest_start_formatted = calculator.format_date(a_leave_earliest_start)
-
-            self.a_leave_latest_start = calculator.leave_latest_start_date(adoption_is_from_overseas: adoption_is_from_overseas)
-            self.a_leave_latest_start_formatted = calculator.format_date(a_leave_latest_start)
-
-            self.employment_start = calculator.a_employment_start
-            self.qualifying_week_start = calculator.adoption_qualifying_start
-          end
-
-          validate :error_message do
-            adoption_placement_date >= match_date
-          end
-
-          next_node do
-            if adoption_is_from_overseas
-              question :adoption_date_leave_starts?
-            else
-              question :adoption_did_the_employee_work_for_you?
-            end
-          end
-        end
-
-        radio :adoption_did_the_employee_work_for_you? do
-          option :yes
-          option :no
-
-          next_node do |response|
-            case response
-            when "yes"
-              if adoption_is_from_overseas
-                question :adoption_is_the_employee_on_your_payroll?
-              else
-                question :adoption_employment_contract?
-              end
-            when "no"
-              outcome :adoption_not_entitled_to_leave_or_pay
-            end
-          end
-        end
-
-        radio :adoption_employment_contract? do
-          option :yes
-          option :no
-
-          on_response do |response|
-            calculator.employee_has_contract_adoption = response
-          end
-
-          next_node do
-            if adoption_is_from_overseas
-              question :adoption_did_the_employee_work_for_you?
-            else
-              question :adoption_is_the_employee_on_your_payroll?
-            end
-          end
-        end
-
-        radio :adoption_is_the_employee_on_your_payroll? do
-          option :yes
-          option :no
-
-          on_response do |response|
-            calculator.on_payroll = response
-            self.to_saturday = calculator.matched_week.last
-            self.to_saturday_formatted = calculator.format_date_day(to_saturday)
-          end
-
-          next_node do
-            if calculator.no_contract_not_on_payroll?
-              outcome :adoption_not_entitled_to_leave_or_pay
-            elsif adoption_is_from_overseas
-              question :last_normal_payday_adoption?
-            else
-              question :adoption_date_leave_starts?
-            end
-          end
-        end
-
-        date_question :adoption_date_leave_starts? do
-          on_response do |response|
-            self.leave_start_date = response
-            calculator.leave_start_date = leave_start_date
-            self.leave_end_date = calculator.leave_end_date
-            self.pay_start_date = calculator.pay_start_date
-            self.pay_end_date = calculator.pay_end_date
-            self.a_notice_leave = calculator.a_notice_leave.to_s(:govuk_date) if calculator.a_notice_leave
-            self.overseas_adoption_leave_employment_threshold = calculator.overseas_adoption_leave_employment_threshold
-          end
-
-          validate :error_leave_starts_too_early do
-            leave_start_date >= a_leave_earliest_start
-          end
-
-          validate :error_leave_starts_too_late do
-            leave_start_date <= a_leave_latest_start
-          end
-
-          next_node do
-            if adoption_is_from_overseas
-              question :adoption_employment_contract?
-            elsif calculator.has_contract_not_on_payroll?
-              outcome :adoption_leave_and_pay
-            else
-              question :last_normal_payday_adoption?
-            end
-          end
-        end
-
-        date_question :last_normal_payday_adoption? do
-          from { 2.years.ago(Time.zone.today) }
-          to { 2.years.since(Time.zone.today) }
-
-          on_response do |response|
-            self.last_payday = response
-            calculator.last_payday = last_payday
-            self.payday_offset = calculator.payday_offset
-            self.payday_offset_formatted = calculator.format_date(payday_offset)
-          end
-
-          validate :error_message do
-            last_payday <= to_saturday
-          end
-
-          next_node do
-            question :payday_eight_weeks_adoption?
-          end
-        end
-
-        date_question :payday_eight_weeks_adoption? do
-          from { 2.years.ago(Time.zone.today) }
-          to { 2.years.since(Time.zone.today) }
-
-          on_response do |response|
-            self.last_payday_eight_weeks = response + 1.day
-            calculator.pre_offset_payday = last_payday_eight_weeks
-            self.relevant_period = calculator.formatted_relevant_period
-          end
-
-          validate :error_message do
-            calculator.payday_offset >= last_payday_eight_weeks
-          end
-
-          next_node do
-            question :pay_frequency_adoption?
-          end
-        end
-
-        radio :pay_frequency_adoption? do
-          option :weekly
-          option :every_2_weeks
-          option :every_4_weeks
-          option :monthly
-
-          on_response do |response|
-            self.pay_pattern = response
-            calculator.pay_pattern = pay_pattern
-          end
-
-          next_node do
-            question :earnings_for_pay_period_adoption?
-          end
-        end
-
-        money_question :earnings_for_pay_period_adoption? do
-          on_response do |response|
-            calculator.earnings_for_pay_period = response
-            self.lower_earning_limit = sprintf("%.2f", calculator.lower_earning_limit)
-          end
-
-          next_node do
-            if calculator.average_weekly_earnings_under_lower_earning_limit?
-              outcome :adoption_leave_and_pay
-            elsif calculator.weekly?
-              question :how_many_payments_weekly? # See SharedAdoptionMaternityPaternityFlow for definition
-            elsif calculator.every_2_weeks?
-              question :how_many_payments_every_2_weeks? # See SharedAdoptionMaternityPaternityFlow for definition
-            elsif calculator.every_4_weeks?
-              question :how_many_payments_every_4_weeks? # See SharedAdoptionMaternityPaternityFlow for definition
-            elsif calculator.monthly?
-              question :how_many_payments_monthly? # See SharedAdoptionMaternityPaternityFlow for definition
-            else
-              question :how_do_you_want_the_sap_calculated?
-            end
-          end
-        end
-
-        radio :how_do_you_want_the_sap_calculated? do
-          option :weekly_starting
-          option :usual_paydates
-
-          on_response do |response|
-            calculator.period_calculation_method = response
-          end
-
-          next_node do
-            if calculator.period_calculation_method == "weekly_starting"
-              outcome :adoption_leave_and_pay
-            elsif calculator.pay_pattern == "monthly"
-              question :monthly_pay_paternity?
-            else
-              question :next_pay_day_paternity?
-            end
-          end
-        end
-
-        outcome :adoption_leave_and_pay
-        outcome :adoption_not_entitled_to_leave_or_pay
       end
+
+      radio :adoption_is_from_overseas? do
+        option :yes
+        option :no
+
+        on_response do |response|
+          self.adoption_is_from_overseas = (response == "yes")
+        end
+
+        next_node do
+          question :date_of_adoption_match?
+        end
+      end
+
+      date_question :date_of_adoption_match? do
+        on_response do |response|
+          self.match_date = response
+          self.calculator = SmartAnswer::Calculators::AdoptionPayCalculator.new(match_date)
+        end
+
+        next_node do
+          question :date_of_adoption_placement?
+        end
+      end
+
+      date_question :date_of_adoption_placement? do
+        on_response do |response|
+          self.adoption_placement_date = response
+          calculator.adoption_placement_date = adoption_placement_date
+
+          self.a_leave_earliest_start = calculator.leave_earliest_start_date(adoption_is_from_overseas: adoption_is_from_overseas)
+          self.a_leave_earliest_start_formatted = calculator.format_date(a_leave_earliest_start)
+
+          self.a_leave_latest_start = calculator.leave_latest_start_date(adoption_is_from_overseas: adoption_is_from_overseas)
+          self.a_leave_latest_start_formatted = calculator.format_date(a_leave_latest_start)
+
+          self.employment_start = calculator.a_employment_start
+          self.qualifying_week_start = calculator.adoption_qualifying_start
+        end
+
+        validate :error_message do
+          adoption_placement_date >= match_date
+        end
+
+        next_node do
+          if adoption_is_from_overseas
+            question :adoption_date_leave_starts?
+          else
+            question :adoption_did_the_employee_work_for_you?
+          end
+        end
+      end
+
+      radio :adoption_did_the_employee_work_for_you? do
+        option :yes
+        option :no
+
+        next_node do |response|
+          case response
+          when "yes"
+            if adoption_is_from_overseas
+              question :adoption_is_the_employee_on_your_payroll?
+            else
+              question :adoption_employment_contract?
+            end
+          when "no"
+            outcome :adoption_not_entitled_to_leave_or_pay
+          end
+        end
+      end
+
+      radio :adoption_employment_contract? do
+        option :yes
+        option :no
+
+        on_response do |response|
+          calculator.employee_has_contract_adoption = response
+        end
+
+        next_node do
+          if adoption_is_from_overseas
+            question :adoption_did_the_employee_work_for_you?
+          else
+            question :adoption_is_the_employee_on_your_payroll?
+          end
+        end
+      end
+
+      radio :adoption_is_the_employee_on_your_payroll? do
+        option :yes
+        option :no
+
+        on_response do |response|
+          calculator.on_payroll = response
+          self.to_saturday = calculator.matched_week.last
+          self.to_saturday_formatted = calculator.format_date_day(to_saturday)
+        end
+
+        next_node do
+          if calculator.no_contract_not_on_payroll?
+            outcome :adoption_not_entitled_to_leave_or_pay
+          elsif adoption_is_from_overseas
+            question :last_normal_payday_adoption?
+          else
+            question :adoption_date_leave_starts?
+          end
+        end
+      end
+
+      date_question :adoption_date_leave_starts? do
+        on_response do |response|
+          self.leave_start_date = response
+          calculator.leave_start_date = leave_start_date
+          self.leave_end_date = calculator.leave_end_date
+          self.pay_start_date = calculator.pay_start_date
+          self.pay_end_date = calculator.pay_end_date
+          self.a_notice_leave = calculator.a_notice_leave.to_s(:govuk_date) if calculator.a_notice_leave
+          self.overseas_adoption_leave_employment_threshold = calculator.overseas_adoption_leave_employment_threshold
+        end
+
+        validate :error_leave_starts_too_early do
+          leave_start_date >= a_leave_earliest_start
+        end
+
+        validate :error_leave_starts_too_late do
+          leave_start_date <= a_leave_latest_start
+        end
+
+        next_node do
+          if adoption_is_from_overseas
+            question :adoption_employment_contract?
+          elsif calculator.has_contract_not_on_payroll?
+            outcome :adoption_leave_and_pay
+          else
+            question :last_normal_payday_adoption?
+          end
+        end
+      end
+
+      date_question :last_normal_payday_adoption? do
+        from { 2.years.ago(Time.zone.today) }
+        to { 2.years.since(Time.zone.today) }
+
+        on_response do |response|
+          self.last_payday = response
+          calculator.last_payday = last_payday
+          self.payday_offset = calculator.payday_offset
+          self.payday_offset_formatted = calculator.format_date(payday_offset)
+        end
+
+        validate :error_message do
+          last_payday <= to_saturday
+        end
+
+        next_node do
+          question :payday_eight_weeks_adoption?
+        end
+      end
+
+      date_question :payday_eight_weeks_adoption? do
+        from { 2.years.ago(Time.zone.today) }
+        to { 2.years.since(Time.zone.today) }
+
+        on_response do |response|
+          self.last_payday_eight_weeks = response + 1.day
+          calculator.pre_offset_payday = last_payday_eight_weeks
+          self.relevant_period = calculator.formatted_relevant_period
+        end
+
+        validate :error_message do
+          calculator.payday_offset >= last_payday_eight_weeks
+        end
+
+        next_node do
+          question :pay_frequency_adoption?
+        end
+      end
+
+      radio :pay_frequency_adoption? do
+        option :weekly
+        option :every_2_weeks
+        option :every_4_weeks
+        option :monthly
+
+        on_response do |response|
+          self.pay_pattern = response
+          calculator.pay_pattern = pay_pattern
+        end
+
+        next_node do
+          question :earnings_for_pay_period_adoption?
+        end
+      end
+
+      money_question :earnings_for_pay_period_adoption? do
+        on_response do |response|
+          calculator.earnings_for_pay_period = response
+          self.lower_earning_limit = sprintf("%.2f", calculator.lower_earning_limit)
+        end
+
+        next_node do
+          if calculator.average_weekly_earnings_under_lower_earning_limit?
+            outcome :adoption_leave_and_pay
+          elsif calculator.weekly?
+            question :how_many_payments_weekly? # See SharedAdoptionMaternityPaternityFlow for definition
+          elsif calculator.every_2_weeks?
+            question :how_many_payments_every_2_weeks? # See SharedAdoptionMaternityPaternityFlow for definition
+          elsif calculator.every_4_weeks?
+            question :how_many_payments_every_4_weeks? # See SharedAdoptionMaternityPaternityFlow for definition
+          elsif calculator.monthly?
+            question :how_many_payments_monthly? # See SharedAdoptionMaternityPaternityFlow for definition
+          else
+            question :how_do_you_want_the_sap_calculated?
+          end
+        end
+      end
+
+      radio :how_do_you_want_the_sap_calculated? do
+        option :weekly_starting
+        option :usual_paydates
+
+        on_response do |response|
+          calculator.period_calculation_method = response
+        end
+
+        next_node do
+          if calculator.period_calculation_method == "weekly_starting"
+            outcome :adoption_leave_and_pay
+          elsif calculator.pay_pattern == "monthly"
+            question :monthly_pay_paternity?
+          else
+            question :next_pay_day_paternity?
+          end
+        end
+      end
+
+      outcome :adoption_leave_and_pay
+      outcome :adoption_not_entitled_to_leave_or_pay
     end
   end
 end

--- a/lib/smart_answer_flows/maternity-paternity-calculator/maternity_calculator_flow.rb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/maternity_calculator_flow.rb
@@ -1,284 +1,282 @@
-module SmartAnswer
-  class MaternityPaternityCalculatorFlow < Flow
-    class MaternityCalculatorFlow < Flow
-      def define
-        days_of_the_week = Calculators::MaternityPayCalculator::DAYS_OF_THE_WEEK
+class MaternityPaternityCalculatorFlow < SmartAnswer::Flow
+  class MaternityCalculatorFlow < SmartAnswer::Flow
+    def define
+      days_of_the_week = SmartAnswer::Calculators::MaternityPayCalculator::DAYS_OF_THE_WEEK
 
-        ## QM1
-        date_question :baby_due_date_maternity? do
-          from { 1.year.ago(Time.zone.today) }
-          to { 2.years.since(Time.zone.today) }
+      ## QM1
+      date_question :baby_due_date_maternity? do
+        from { 1.year.ago(Time.zone.today) }
+        to { 2.years.since(Time.zone.today) }
 
-          on_response do |response|
-            self.calculator = Calculators::MaternityPayCalculator.new(response)
-          end
-
-          next_node do
-            question :date_leave_starts?
-          end
+        on_response do |response|
+          self.calculator = SmartAnswer::Calculators::MaternityPayCalculator.new(response)
         end
 
-        ## QM2
-        date_question :date_leave_starts? do
-          from { 2.years.ago(Time.zone.today) }
-          to { 2.years.since(Time.zone.today) }
-
-          on_response do |response|
-            self.leave_start_date = response
-            calculator.leave_start_date = leave_start_date
-            self.leave_end_date = calculator.leave_end_date
-            self.notice_of_leave_deadline = calculator.notice_of_leave_deadline
-            self.pay_start_date = calculator.pay_start_date
-            self.pay_end_date = calculator.pay_end_date
-            self.employment_start = calculator.employment_start
-            self.qualifying_week_start = calculator.qualifying_week.first
-            self.ssp_stop = calculator.ssp_stop
-          end
-
-          validate :error_message do
-            leave_start_date >= calculator.leave_earliest_start_date
-          end
-
-          next_node do
-            question :did_the_employee_work_for_you_between?
-          end
+        next_node do
+          question :date_leave_starts?
         end
-
-        ## QM3
-        radio :did_the_employee_work_for_you_between? do
-          option :yes
-          option :no
-
-          on_response do |response|
-            self.has_employment_contract_between_dates = response
-            calculator.not_entitled_to_pay_reason = response == "no" ? :not_worked_long_enough_and_not_on_payroll : nil
-            self.to_saturday = calculator.qualifying_week.last
-            self.to_saturday_formatted = calculator.format_date_day(to_saturday)
-          end
-
-          next_node do
-            case has_employment_contract_between_dates
-            when "yes"
-              question :last_normal_payday?
-            when "no"
-              question :does_the_employee_work_for_you_now?
-            end
-          end
-        end
-
-        ## QM4
-        radio :does_the_employee_work_for_you_now? do
-          option :yes
-          option :no
-
-          on_response do |response|
-            self.has_employment_contract_now = response
-          end
-
-          next_node do
-            outcome :maternity_leave_and_pay_result
-          end
-        end
-
-        ## QM5
-        date_question :last_normal_payday? do
-          from { 2.years.ago(Time.zone.today) }
-          to { 2.years.since(Time.zone.today) }
-
-          on_response do |response|
-            self.last_payday = response
-            calculator.last_payday = last_payday
-          end
-
-          validate :error_message do
-            calculator.last_payday <= to_saturday
-          end
-
-          next_node do
-            question :payday_eight_weeks?
-          end
-        end
-
-        ## QM6
-        date_question :payday_eight_weeks? do
-          from { 2.years.ago(Time.zone.today) }
-          to { 2.years.since(Time.zone.today) }
-
-          on_response do |response|
-            self.last_payday_eight_weeks = 1.day.after(response)
-            calculator.pre_offset_payday = last_payday_eight_weeks
-            self.relevant_period = calculator.formatted_relevant_period
-          end
-
-          validate :error_message do
-            last_payday_eight_weeks <= calculator.payday_offset
-          end
-
-          next_node do
-            question :pay_frequency?
-          end
-        end
-
-        ## QM7
-        radio :pay_frequency? do
-          option :weekly
-          option :every_2_weeks
-          option :every_4_weeks
-          option :monthly
-
-          on_response do |response|
-            calculator.pay_pattern = response
-          end
-
-          next_node do
-            question :earnings_for_pay_period?
-          end
-        end
-
-        ## QM8
-        money_question :earnings_for_pay_period? do
-          on_response do |response|
-            calculator.earnings_for_pay_period = response
-          end
-
-          next_node do
-            if calculator.weekly?
-              question :how_many_payments_weekly? # See SharedAdoptionMaternityPaternityFlow for definition
-            elsif calculator.every_2_weeks?
-              question :how_many_payments_every_2_weeks? # See SharedAdoptionMaternityPaternityFlow for definition
-            elsif calculator.every_4_weeks?
-              question :how_many_payments_every_4_weeks? # See SharedAdoptionMaternityPaternityFlow for definition
-            elsif calculator.monthly?
-              question :how_many_payments_monthly? # See SharedAdoptionMaternityPaternityFlow for definition
-            else
-              question :how_do_you_want_the_smp_calculated?
-            end
-          end
-        end
-
-        ## QM9
-        radio :how_do_you_want_the_smp_calculated? do
-          option :weekly_starting
-          option :usual_paydates
-
-          on_response do |response|
-            calculator.period_calculation_method = response
-          end
-
-          next_node do
-            if calculator.period_calculation_method != "usual_paydates"
-              outcome :maternity_leave_and_pay_result
-            elsif calculator.pay_pattern == "monthly"
-              question :when_in_the_month_is_the_employee_paid?
-            else
-              question :when_is_your_employees_next_pay_day?
-            end
-          end
-        end
-
-        ## QM10
-        date_question :when_is_your_employees_next_pay_day? do
-          on_response do |response|
-            self.next_pay_day = response
-            calculator.pay_date = next_pay_day
-          end
-
-          next_node do
-            outcome :maternity_leave_and_pay_result
-          end
-        end
-
-        ## QM11
-        radio :when_in_the_month_is_the_employee_paid? do
-          option :first_day_of_the_month
-          option :last_day_of_the_month
-          option :specific_date_each_month
-          option :last_working_day_of_the_month
-          option :a_certain_week_day_each_month
-
-          on_response do |response|
-            calculator.monthly_pay_method = response
-          end
-
-          next_node do
-            case calculator.monthly_pay_method
-            when "first_day_of_the_month", "last_day_of_the_month"
-              outcome :maternity_leave_and_pay_result
-            when "specific_date_each_month"
-              question :what_specific_date_each_month_is_the_employee_paid?
-            when "last_working_day_of_the_month"
-              question :what_days_does_the_employee_work?
-            when "a_certain_week_day_each_month"
-              question :what_particular_day_of_the_month_is_the_employee_paid?
-            end
-          end
-        end
-
-        ## QM12
-        value_question :what_specific_date_each_month_is_the_employee_paid?, parse: :to_i do
-          on_response do |response|
-            self.pay_day_in_month = response
-            calculator.pay_day_in_month = pay_day_in_month
-          end
-
-          validate :error_message do
-            pay_day_in_month.positive? && pay_day_in_month < 32
-          end
-
-          next_node do
-            outcome :maternity_leave_and_pay_result
-          end
-        end
-
-        ## QM13
-        checkbox_question :what_days_does_the_employee_work? do
-          (0...days_of_the_week.size).each { |i| option i.to_s.to_sym }
-
-          on_response do |response|
-            self.last_day_in_week_worked = response
-            calculator.work_days = last_day_in_week_worked.split(",").map(&:to_i)
-            calculator.pay_day_in_week = calculator.work_days.max
-          end
-
-          next_node do
-            outcome :maternity_leave_and_pay_result
-          end
-        end
-
-        ## QM14
-        radio :what_particular_day_of_the_month_is_the_employee_paid? do
-          days_of_the_week.each { |d| option d.to_sym }
-
-          on_response do |response|
-            self.pay_day_in_week = response
-            calculator.pay_day_in_week = days_of_the_week.index(pay_day_in_week)
-          end
-
-          next_node do
-            question :which_week_in_month_is_the_employee_paid?
-          end
-        end
-
-        ## QM15
-        radio :which_week_in_month_is_the_employee_paid? do
-          option :first
-          option :second
-          option :third
-          option :fourth
-          option :last
-
-          on_response do |response|
-            self.pay_week_in_month = response
-            calculator.pay_week_in_month = pay_week_in_month
-          end
-          next_node do
-            outcome :maternity_leave_and_pay_result
-          end
-        end
-
-        ## Maternity outcomes
-        outcome :maternity_leave_and_pay_result
       end
+
+      ## QM2
+      date_question :date_leave_starts? do
+        from { 2.years.ago(Time.zone.today) }
+        to { 2.years.since(Time.zone.today) }
+
+        on_response do |response|
+          self.leave_start_date = response
+          calculator.leave_start_date = leave_start_date
+          self.leave_end_date = calculator.leave_end_date
+          self.notice_of_leave_deadline = calculator.notice_of_leave_deadline
+          self.pay_start_date = calculator.pay_start_date
+          self.pay_end_date = calculator.pay_end_date
+          self.employment_start = calculator.employment_start
+          self.qualifying_week_start = calculator.qualifying_week.first
+          self.ssp_stop = calculator.ssp_stop
+        end
+
+        validate :error_message do
+          leave_start_date >= calculator.leave_earliest_start_date
+        end
+
+        next_node do
+          question :did_the_employee_work_for_you_between?
+        end
+      end
+
+      ## QM3
+      radio :did_the_employee_work_for_you_between? do
+        option :yes
+        option :no
+
+        on_response do |response|
+          self.has_employment_contract_between_dates = response
+          calculator.not_entitled_to_pay_reason = response == "no" ? :not_worked_long_enough_and_not_on_payroll : nil
+          self.to_saturday = calculator.qualifying_week.last
+          self.to_saturday_formatted = calculator.format_date_day(to_saturday)
+        end
+
+        next_node do
+          case has_employment_contract_between_dates
+          when "yes"
+            question :last_normal_payday?
+          when "no"
+            question :does_the_employee_work_for_you_now?
+          end
+        end
+      end
+
+      ## QM4
+      radio :does_the_employee_work_for_you_now? do
+        option :yes
+        option :no
+
+        on_response do |response|
+          self.has_employment_contract_now = response
+        end
+
+        next_node do
+          outcome :maternity_leave_and_pay_result
+        end
+      end
+
+      ## QM5
+      date_question :last_normal_payday? do
+        from { 2.years.ago(Time.zone.today) }
+        to { 2.years.since(Time.zone.today) }
+
+        on_response do |response|
+          self.last_payday = response
+          calculator.last_payday = last_payday
+        end
+
+        validate :error_message do
+          calculator.last_payday <= to_saturday
+        end
+
+        next_node do
+          question :payday_eight_weeks?
+        end
+      end
+
+      ## QM6
+      date_question :payday_eight_weeks? do
+        from { 2.years.ago(Time.zone.today) }
+        to { 2.years.since(Time.zone.today) }
+
+        on_response do |response|
+          self.last_payday_eight_weeks = 1.day.after(response)
+          calculator.pre_offset_payday = last_payday_eight_weeks
+          self.relevant_period = calculator.formatted_relevant_period
+        end
+
+        validate :error_message do
+          last_payday_eight_weeks <= calculator.payday_offset
+        end
+
+        next_node do
+          question :pay_frequency?
+        end
+      end
+
+      ## QM7
+      radio :pay_frequency? do
+        option :weekly
+        option :every_2_weeks
+        option :every_4_weeks
+        option :monthly
+
+        on_response do |response|
+          calculator.pay_pattern = response
+        end
+
+        next_node do
+          question :earnings_for_pay_period?
+        end
+      end
+
+      ## QM8
+      money_question :earnings_for_pay_period? do
+        on_response do |response|
+          calculator.earnings_for_pay_period = response
+        end
+
+        next_node do
+          if calculator.weekly?
+            question :how_many_payments_weekly? # See SharedAdoptionMaternityPaternityFlow for definition
+          elsif calculator.every_2_weeks?
+            question :how_many_payments_every_2_weeks? # See SharedAdoptionMaternityPaternityFlow for definition
+          elsif calculator.every_4_weeks?
+            question :how_many_payments_every_4_weeks? # See SharedAdoptionMaternityPaternityFlow for definition
+          elsif calculator.monthly?
+            question :how_many_payments_monthly? # See SharedAdoptionMaternityPaternityFlow for definition
+          else
+            question :how_do_you_want_the_smp_calculated?
+          end
+        end
+      end
+
+      ## QM9
+      radio :how_do_you_want_the_smp_calculated? do
+        option :weekly_starting
+        option :usual_paydates
+
+        on_response do |response|
+          calculator.period_calculation_method = response
+        end
+
+        next_node do
+          if calculator.period_calculation_method != "usual_paydates"
+            outcome :maternity_leave_and_pay_result
+          elsif calculator.pay_pattern == "monthly"
+            question :when_in_the_month_is_the_employee_paid?
+          else
+            question :when_is_your_employees_next_pay_day?
+          end
+        end
+      end
+
+      ## QM10
+      date_question :when_is_your_employees_next_pay_day? do
+        on_response do |response|
+          self.next_pay_day = response
+          calculator.pay_date = next_pay_day
+        end
+
+        next_node do
+          outcome :maternity_leave_and_pay_result
+        end
+      end
+
+      ## QM11
+      radio :when_in_the_month_is_the_employee_paid? do
+        option :first_day_of_the_month
+        option :last_day_of_the_month
+        option :specific_date_each_month
+        option :last_working_day_of_the_month
+        option :a_certain_week_day_each_month
+
+        on_response do |response|
+          calculator.monthly_pay_method = response
+        end
+
+        next_node do
+          case calculator.monthly_pay_method
+          when "first_day_of_the_month", "last_day_of_the_month"
+            outcome :maternity_leave_and_pay_result
+          when "specific_date_each_month"
+            question :what_specific_date_each_month_is_the_employee_paid?
+          when "last_working_day_of_the_month"
+            question :what_days_does_the_employee_work?
+          when "a_certain_week_day_each_month"
+            question :what_particular_day_of_the_month_is_the_employee_paid?
+          end
+        end
+      end
+
+      ## QM12
+      value_question :what_specific_date_each_month_is_the_employee_paid?, parse: :to_i do
+        on_response do |response|
+          self.pay_day_in_month = response
+          calculator.pay_day_in_month = pay_day_in_month
+        end
+
+        validate :error_message do
+          pay_day_in_month.positive? && pay_day_in_month < 32
+        end
+
+        next_node do
+          outcome :maternity_leave_and_pay_result
+        end
+      end
+
+      ## QM13
+      checkbox_question :what_days_does_the_employee_work? do
+        (0...days_of_the_week.size).each { |i| option i.to_s.to_sym }
+
+        on_response do |response|
+          self.last_day_in_week_worked = response
+          calculator.work_days = last_day_in_week_worked.split(",").map(&:to_i)
+          calculator.pay_day_in_week = calculator.work_days.max
+        end
+
+        next_node do
+          outcome :maternity_leave_and_pay_result
+        end
+      end
+
+      ## QM14
+      radio :what_particular_day_of_the_month_is_the_employee_paid? do
+        days_of_the_week.each { |d| option d.to_sym }
+
+        on_response do |response|
+          self.pay_day_in_week = response
+          calculator.pay_day_in_week = days_of_the_week.index(pay_day_in_week)
+        end
+
+        next_node do
+          question :which_week_in_month_is_the_employee_paid?
+        end
+      end
+
+      ## QM15
+      radio :which_week_in_month_is_the_employee_paid? do
+        option :first
+        option :second
+        option :third
+        option :fourth
+        option :last
+
+        on_response do |response|
+          self.pay_week_in_month = response
+          calculator.pay_week_in_month = pay_week_in_month
+        end
+        next_node do
+          outcome :maternity_leave_and_pay_result
+        end
+      end
+
+      ## Maternity outcomes
+      outcome :maternity_leave_and_pay_result
     end
   end
 end

--- a/lib/smart_answer_flows/maternity-paternity-calculator/paternity_calculator_flow.rb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/paternity_calculator_flow.rb
@@ -1,478 +1,476 @@
-module SmartAnswer
-  class MaternityPaternityCalculatorFlow < Flow
-    class PaternityCalculatorFlow < Flow
-      def define
-        days_of_the_week = Calculators::MaternityPayCalculator::DAYS_OF_THE_WEEK
+class MaternityPaternityCalculatorFlow < SmartAnswer::Flow
+  class PaternityCalculatorFlow < SmartAnswer::Flow
+    def define
+      days_of_the_week = SmartAnswer::Calculators::MaternityPayCalculator::DAYS_OF_THE_WEEK
 
-        ## QP0
-        radio :leave_or_pay_for_adoption? do
-          option :yes
-          option :no
+      ## QP0
+      radio :leave_or_pay_for_adoption? do
+        option :yes
+        option :no
 
-          next_node do |response|
-            case response
-            when "yes"
-              question :employee_date_matched_paternity_adoption?
-            when "no"
-              question :baby_due_date_paternity?
-            end
+        next_node do |response|
+          case response
+          when "yes"
+            question :employee_date_matched_paternity_adoption?
+          when "no"
+            question :baby_due_date_paternity?
           end
         end
+      end
 
-        ## QP1
-        date_question :baby_due_date_paternity? do
-          on_response do |response|
-            self.due_date = response
-            self.calculator = Calculators::PaternityPayCalculator.new(due_date)
-          end
-
-          next_node do
-            question :baby_birth_date_paternity?
-          end
+      ## QP1
+      date_question :baby_due_date_paternity? do
+        on_response do |response|
+          self.due_date = response
+          self.calculator = SmartAnswer::Calculators::PaternityPayCalculator.new(due_date)
         end
 
-        ## QAP1 - Paternity Adoption
-        date_question :employee_date_matched_paternity_adoption? do
-          on_response do |response|
-            self.matched_date = response
-            self.calculator = Calculators::PaternityAdoptionPayCalculator.new(matched_date)
-            self.leave_type = "paternity_adoption"
-            self.paternity_adoption = true
-          end
+        next_node do
+          question :baby_birth_date_paternity?
+        end
+      end
 
-          next_node do
-            question :padoption_date_of_adoption_placement?
-          end
+      ## QAP1 - Paternity Adoption
+      date_question :employee_date_matched_paternity_adoption? do
+        on_response do |response|
+          self.matched_date = response
+          self.calculator = SmartAnswer::Calculators::PaternityAdoptionPayCalculator.new(matched_date)
+          self.leave_type = "paternity_adoption"
+          self.paternity_adoption = true
         end
 
-        ## QP2
-        date_question :baby_birth_date_paternity? do
-          on_response do |response|
-            self.date_of_birth = response
-            calculator.date_of_birth = date_of_birth
-          end
+        next_node do
+          question :padoption_date_of_adoption_placement?
+        end
+      end
 
-          next_node do
-            question :employee_responsible_for_upbringing?
-          end
+      ## QP2
+      date_question :baby_birth_date_paternity? do
+        on_response do |response|
+          self.date_of_birth = response
+          calculator.date_of_birth = date_of_birth
         end
 
-        ## QAP2 - Paternity Adoption
-        date_question :padoption_date_of_adoption_placement? do
-          on_response do |response|
-            self.ap_adoption_date = response
-            calculator.adoption_placement_date = ap_adoption_date
-            self.ap_adoption_date_formatted = calculator.format_date_day ap_adoption_date
-            self.matched_date_formatted = calculator.format_date_day matched_date
-          end
+        next_node do
+          question :employee_responsible_for_upbringing?
+        end
+      end
 
-          validate :error_message do
-            ap_adoption_date >= matched_date
-          end
-
-          next_node do
-            question :padoption_employee_responsible_for_upbringing?
-          end
+      ## QAP2 - Paternity Adoption
+      date_question :padoption_date_of_adoption_placement? do
+        on_response do |response|
+          self.ap_adoption_date = response
+          calculator.adoption_placement_date = ap_adoption_date
+          self.ap_adoption_date_formatted = calculator.format_date_day ap_adoption_date
+          self.matched_date_formatted = calculator.format_date_day matched_date
         end
 
-        ## QP3
-        radio :employee_responsible_for_upbringing? do
-          option :yes
-          option :no
-
-          on_response do |response|
-            self.paternity_responsible = response
-            self.employment_start = calculator.employment_start
-            self.employment_end = due_date
-            self.qualifying_week_start = calculator.qualifying_week.first
-            self.p_notice_leave = calculator.notice_of_leave_deadline
-          end
-
-          next_node do
-            case paternity_responsible
-            when "yes"
-              question :employee_work_before_employment_start?
-            when "no"
-              outcome :paternity_not_entitled_to_leave_or_pay
-            end
-          end
+        validate :error_message do
+          ap_adoption_date >= matched_date
         end
 
-        ## QAP3 - Paternity Adoption
-        radio :padoption_employee_responsible_for_upbringing? do
-          option :yes
-          option :no
+        next_node do
+          question :padoption_employee_responsible_for_upbringing?
+        end
+      end
 
-          on_response do |response|
-            self.paternity_responsible = response
-            self.employment_start = calculator.a_employment_start
-            self.employment_end = matched_date
-            self.qualifying_week_start = calculator.adoption_qualifying_start
-          end
+      ## QP3
+      radio :employee_responsible_for_upbringing? do
+        option :yes
+        option :no
 
-          next_node do
-            case paternity_responsible
-            when "yes"
-              question :employee_work_before_employment_start? # Combined flow
-            when "no"
-              outcome :paternity_not_entitled_to_leave_or_pay
-            end
-          end
+        on_response do |response|
+          self.paternity_responsible = response
+          self.employment_start = calculator.employment_start
+          self.employment_end = due_date
+          self.qualifying_week_start = calculator.qualifying_week.first
+          self.p_notice_leave = calculator.notice_of_leave_deadline
         end
 
-        ## QP4 - Shared flow onwards
-        radio :employee_work_before_employment_start? do
-          option :yes
-          option :no
-
-          on_response do |response|
-            self.paternity_employment_start = response
-          end
-
-          next_node do
-            case paternity_employment_start
-            when "yes"
-              question :employee_has_contract_paternity?
-            when "no"
-              outcome :paternity_not_entitled_to_leave_or_pay
-            end
+        next_node do
+          case paternity_responsible
+          when "yes"
+            question :employee_work_before_employment_start?
+          when "no"
+            outcome :paternity_not_entitled_to_leave_or_pay
           end
         end
+      end
 
-        ## QP5
-        radio :employee_has_contract_paternity? do
-          option :yes
-          option :no
+      ## QAP3 - Paternity Adoption
+      radio :padoption_employee_responsible_for_upbringing? do
+        option :yes
+        option :no
 
-          on_response do |response|
-            self.has_contract = response
-          end
-
-          next_node do
-            question :employee_on_payroll_paternity?
-          end
+        on_response do |response|
+          self.paternity_responsible = response
+          self.employment_start = calculator.a_employment_start
+          self.employment_end = matched_date
+          self.qualifying_week_start = calculator.adoption_qualifying_start
         end
 
-        ## QP6
-        radio :employee_on_payroll_paternity? do
-          option :yes
-          option :no
-
-          on_response do |response|
-            calculator.on_payroll = response
-
-            if paternity_adoption
-              self.leave_spp_claim_link = "adoption"
-              self.to_saturday = calculator.matched_week.last
-              self.still_employed_date = calculator.employment_end
-              self.start_leave_hint = ap_adoption_date_formatted
-            else
-              self.leave_spp_claim_link = "notice-period"
-              self.to_saturday = calculator.qualifying_week.last
-              self.still_employed_date = date_of_birth
-              self.start_leave_hint = date_of_birth
-            end
-
-            self.to_saturday_formatted = calculator.format_date_day to_saturday
-          end
-
-          next_node do
-            if calculator.on_payroll == "yes"
-              question :employee_still_employed_on_birth_date?
-            elsif has_contract == "no"
-              outcome :paternity_not_entitled_to_leave_or_pay
-            else
-              question :employee_start_paternity?
-            end
+        next_node do
+          case paternity_responsible
+          when "yes"
+            question :employee_work_before_employment_start? # Combined flow
+          when "no"
+            outcome :paternity_not_entitled_to_leave_or_pay
           end
         end
+      end
 
-        ## QP7
-        radio :employee_still_employed_on_birth_date? do
-          option :yes
-          option :no
+      ## QP4 - Shared flow onwards
+      radio :employee_work_before_employment_start? do
+        option :yes
+        option :no
 
-          on_response do |response|
-            self.employed_dob = response
-          end
-
-          next_node do
-            if has_contract == "no" && employed_dob == "no"
-              outcome :paternity_not_entitled_to_leave_or_pay
-            else
-              question :employee_start_paternity?
-            end
-          end
+        on_response do |response|
+          self.paternity_employment_start = response
         end
 
-        ## QP8
-        date_question :employee_start_paternity? do
-          from { 2.years.ago(Time.zone.today) }
-          to { 2.years.since(Time.zone.today) }
-
-          on_response do |response|
-            self.employee_leave_start = response
-            self.leave_start_date = employee_leave_start
-            calculator.leave_start_date = employee_leave_start
-            self.notice_of_leave_deadline = calculator.notice_of_leave_deadline
-          end
-
-          validate :error_message do
-            calculator.leave_start_date >= if paternity_adoption
-                                             ap_adoption_date
-                                           else
-                                             date_of_birth
-                                           end
-          end
-
-          next_node do
-            question :employee_paternity_length?
+        next_node do
+          case paternity_employment_start
+          when "yes"
+            question :employee_has_contract_paternity?
+          when "no"
+            outcome :paternity_not_entitled_to_leave_or_pay
           end
         end
+      end
 
-        ## QP9
-        radio :employee_paternity_length? do
-          option :one_week
-          option :two_weeks
+      ## QP5
+      radio :employee_has_contract_paternity? do
+        option :yes
+        option :no
 
-          on_response do |response|
-            self.leave_amount = response
-            calculator.paternity_leave_duration = leave_amount
-            self.leave_end_date = calculator.pay_end_date
-          end
-
-          next_node do
-            if has_contract == "yes" && (calculator.on_payroll == "no" || employed_dob == "no")
-              outcome :paternity_not_entitled_to_leave_or_pay
-            else
-              question :last_normal_payday_paternity?
-            end
-          end
+        on_response do |response|
+          self.has_contract = response
         end
 
-        ## QP10
-        date_question :last_normal_payday_paternity? do
-          from { 2.years.ago(Time.zone.today) }
-          to { 2.years.since(Time.zone.today) }
+        next_node do
+          question :employee_on_payroll_paternity?
+        end
+      end
 
-          on_response do |response|
-            calculator.last_payday = response
+      ## QP6
+      radio :employee_on_payroll_paternity? do
+        option :yes
+        option :no
+
+        on_response do |response|
+          calculator.on_payroll = response
+
+          if paternity_adoption
+            self.leave_spp_claim_link = "adoption"
+            self.to_saturday = calculator.matched_week.last
+            self.still_employed_date = calculator.employment_end
+            self.start_leave_hint = ap_adoption_date_formatted
+          else
+            self.leave_spp_claim_link = "notice-period"
+            self.to_saturday = calculator.qualifying_week.last
+            self.still_employed_date = date_of_birth
+            self.start_leave_hint = date_of_birth
           end
 
-          validate :error_message do
-            calculator.last_payday <= to_saturday
-          end
-
-          next_node do
-            question :payday_eight_weeks_paternity?
-          end
+          self.to_saturday_formatted = calculator.format_date_day to_saturday
         end
 
-        ## QP11
-        date_question :payday_eight_weeks_paternity? do
-          from { 2.years.ago(Time.zone.today) }
-          to { 2.years.since(Time.zone.today) }
-
-          on_response do |response|
-            calculator.pre_offset_payday = response + 1.day
-            self.relevant_period = calculator.formatted_relevant_period
-            self.payday_offset = calculator.payday_offset
-          end
-
-          validate :error_message do
-            calculator.pre_offset_payday <= calculator.payday_offset
-          end
-
-          next_node do
-            question :pay_frequency_paternity?
+        next_node do
+          if calculator.on_payroll == "yes"
+            question :employee_still_employed_on_birth_date?
+          elsif has_contract == "no"
+            outcome :paternity_not_entitled_to_leave_or_pay
+          else
+            question :employee_start_paternity?
           end
         end
+      end
 
-        ## QP12
-        radio :pay_frequency_paternity? do
-          option :weekly
-          option :every_2_weeks
-          option :every_4_weeks
-          option :monthly
+      ## QP7
+      radio :employee_still_employed_on_birth_date? do
+        option :yes
+        option :no
 
-          on_response do |response|
-            calculator.pay_pattern = response
-          end
-
-          next_node do
-            question :earnings_for_pay_period_paternity?
-          end
+        on_response do |response|
+          self.employed_dob = response
         end
 
-        ## QP13
-        money_question :earnings_for_pay_period_paternity? do
-          on_response do |response|
-            self.earnings = response
-            calculator.earnings_for_pay_period = earnings
-          end
-
-          next_node do
-            if calculator.average_weekly_earnings_under_lower_earning_limit?
-              outcome :paternity_leave_and_pay
-            elsif calculator.weekly?
-              question :how_many_payments_weekly? # See SharedAdoptionMaternityPaternityFlow for definition
-            elsif calculator.every_2_weeks?
-              question :how_many_payments_every_2_weeks? # See SharedAdoptionMaternityPaternityFlow for definition
-            elsif calculator.every_4_weeks?
-              question :how_many_payments_every_4_weeks? # See SharedAdoptionMaternityPaternityFlow for definition
-            elsif calculator.monthly?
-              question :how_many_payments_monthly? # See SharedAdoptionMaternityPaternityFlow for definition
-            else
-              question :how_do_you_want_the_spp_calculated?
-            end
+        next_node do
+          if has_contract == "no" && employed_dob == "no"
+            outcome :paternity_not_entitled_to_leave_or_pay
+          else
+            question :employee_start_paternity?
           end
         end
+      end
 
-        ## QP14
-        radio :how_do_you_want_the_spp_calculated? do
-          option :weekly_starting
-          option :usual_paydates
+      ## QP8
+      date_question :employee_start_paternity? do
+        from { 2.years.ago(Time.zone.today) }
+        to { 2.years.since(Time.zone.today) }
 
-          on_response do |response|
-            calculator.period_calculation_method = response
-          end
-
-          next_node do
-            if calculator.period_calculation_method == "weekly_starting"
-              outcome :paternity_leave_and_pay
-            elsif calculator.pay_pattern == "monthly"
-              question :monthly_pay_paternity?
-            else
-              question :next_pay_day_paternity?
-            end
-          end
+        on_response do |response|
+          self.employee_leave_start = response
+          self.leave_start_date = employee_leave_start
+          calculator.leave_start_date = employee_leave_start
+          self.notice_of_leave_deadline = calculator.notice_of_leave_deadline
         end
 
-        ## QP15 - Also shared with adoption calculator here onwards
-        date_question :next_pay_day_paternity? do
-          from { 2.years.ago(Time.zone.today) }
-          to { 2.years.since(Time.zone.today) }
+        validate :error_message do
+          calculator.leave_start_date >= if paternity_adoption
+                                           ap_adoption_date
+                                         else
+                                           date_of_birth
+                                         end
+        end
 
-          on_response do |response|
-            self.next_pay_day = response
-            calculator.pay_date = next_pay_day
+        next_node do
+          question :employee_paternity_length?
+        end
+      end
+
+      ## QP9
+      radio :employee_paternity_length? do
+        option :one_week
+        option :two_weeks
+
+        on_response do |response|
+          self.leave_amount = response
+          calculator.paternity_leave_duration = leave_amount
+          self.leave_end_date = calculator.pay_end_date
+        end
+
+        next_node do
+          if has_contract == "yes" && (calculator.on_payroll == "no" || employed_dob == "no")
+            outcome :paternity_not_entitled_to_leave_or_pay
+          else
+            question :last_normal_payday_paternity?
           end
+        end
+      end
 
-          next_node do
+      ## QP10
+      date_question :last_normal_payday_paternity? do
+        from { 2.years.ago(Time.zone.today) }
+        to { 2.years.since(Time.zone.today) }
+
+        on_response do |response|
+          calculator.last_payday = response
+        end
+
+        validate :error_message do
+          calculator.last_payday <= to_saturday
+        end
+
+        next_node do
+          question :payday_eight_weeks_paternity?
+        end
+      end
+
+      ## QP11
+      date_question :payday_eight_weeks_paternity? do
+        from { 2.years.ago(Time.zone.today) }
+        to { 2.years.since(Time.zone.today) }
+
+        on_response do |response|
+          calculator.pre_offset_payday = response + 1.day
+          self.relevant_period = calculator.formatted_relevant_period
+          self.payday_offset = calculator.payday_offset
+        end
+
+        validate :error_message do
+          calculator.pre_offset_payday <= calculator.payday_offset
+        end
+
+        next_node do
+          question :pay_frequency_paternity?
+        end
+      end
+
+      ## QP12
+      radio :pay_frequency_paternity? do
+        option :weekly
+        option :every_2_weeks
+        option :every_4_weeks
+        option :monthly
+
+        on_response do |response|
+          calculator.pay_pattern = response
+        end
+
+        next_node do
+          question :earnings_for_pay_period_paternity?
+        end
+      end
+
+      ## QP13
+      money_question :earnings_for_pay_period_paternity? do
+        on_response do |response|
+          self.earnings = response
+          calculator.earnings_for_pay_period = earnings
+        end
+
+        next_node do
+          if calculator.average_weekly_earnings_under_lower_earning_limit?
+            outcome :paternity_leave_and_pay
+          elsif calculator.weekly?
+            question :how_many_payments_weekly? # See SharedAdoptionMaternityPaternityFlow for definition
+          elsif calculator.every_2_weeks?
+            question :how_many_payments_every_2_weeks? # See SharedAdoptionMaternityPaternityFlow for definition
+          elsif calculator.every_4_weeks?
+            question :how_many_payments_every_4_weeks? # See SharedAdoptionMaternityPaternityFlow for definition
+          elsif calculator.monthly?
+            question :how_many_payments_monthly? # See SharedAdoptionMaternityPaternityFlow for definition
+          else
+            question :how_do_you_want_the_spp_calculated?
+          end
+        end
+      end
+
+      ## QP14
+      radio :how_do_you_want_the_spp_calculated? do
+        option :weekly_starting
+        option :usual_paydates
+
+        on_response do |response|
+          calculator.period_calculation_method = response
+        end
+
+        next_node do
+          if calculator.period_calculation_method == "weekly_starting"
+            outcome :paternity_leave_and_pay
+          elsif calculator.pay_pattern == "monthly"
+            question :monthly_pay_paternity?
+          else
+            question :next_pay_day_paternity?
+          end
+        end
+      end
+
+      ## QP15 - Also shared with adoption calculator here onwards
+      date_question :next_pay_day_paternity? do
+        from { 2.years.ago(Time.zone.today) }
+        to { 2.years.since(Time.zone.today) }
+
+        on_response do |response|
+          self.next_pay_day = response
+          calculator.pay_date = next_pay_day
+        end
+
+        next_node do
+          outcome :paternity_leave_and_pay
+        end
+      end
+
+      ## QP16
+      radio :monthly_pay_paternity? do
+        option :first_day_of_the_month
+        option :last_day_of_the_month
+        option :specific_date_each_month
+        option :last_working_day_of_the_month
+        option :a_certain_week_day_each_month
+
+        on_response do |response|
+          self.monthly_pay_method = response
+          calculator.monthly_pay_method = monthly_pay_method
+        end
+
+        next_node do
+          if monthly_pay_method == "specific_date_each_month"
+            question :specific_date_each_month_paternity?
+          elsif monthly_pay_method == "last_working_day_of_the_month"
+            question :days_of_the_week_paternity?
+          elsif monthly_pay_method == "a_certain_week_day_each_month"
+            question :day_of_the_month_paternity?
+          elsif leave_type == "adoption"
+            outcome :adoption_leave_and_pay
+          else
             outcome :paternity_leave_and_pay
           end
         end
-
-        ## QP16
-        radio :monthly_pay_paternity? do
-          option :first_day_of_the_month
-          option :last_day_of_the_month
-          option :specific_date_each_month
-          option :last_working_day_of_the_month
-          option :a_certain_week_day_each_month
-
-          on_response do |response|
-            self.monthly_pay_method = response
-            calculator.monthly_pay_method = monthly_pay_method
-          end
-
-          next_node do
-            if monthly_pay_method == "specific_date_each_month"
-              question :specific_date_each_month_paternity?
-            elsif monthly_pay_method == "last_working_day_of_the_month"
-              question :days_of_the_week_paternity?
-            elsif monthly_pay_method == "a_certain_week_day_each_month"
-              question :day_of_the_month_paternity?
-            elsif leave_type == "adoption"
-              outcome :adoption_leave_and_pay
-            else
-              outcome :paternity_leave_and_pay
-            end
-          end
-        end
-
-        ## QP17
-        value_question :specific_date_each_month_paternity?, parse: :to_i do
-          on_response do |response|
-            calculator.pay_day_in_month = response
-          end
-
-          validate :error_message do
-            calculator.pay_day_in_month.positive? && calculator.pay_day_in_month < 32
-          end
-
-          next_node do
-            if leave_type == "adoption"
-              outcome :adoption_leave_and_pay
-            else
-              outcome :paternity_leave_and_pay
-            end
-          end
-        end
-
-        ## QP18
-        checkbox_question :days_of_the_week_paternity? do
-          (0...days_of_the_week.size).each { |i| option i.to_s.to_sym }
-
-          on_response do |response|
-            calculator.work_days = response.split(",").map(&:to_i)
-            calculator.pay_day_in_week = response.split(",").max.to_i
-          end
-
-          next_node do
-            if leave_type == "adoption"
-              outcome :adoption_leave_and_pay
-            else
-              outcome :paternity_leave_and_pay
-            end
-          end
-        end
-
-        ## QP19
-        radio :day_of_the_month_paternity? do
-          option :"0"
-          option :"1"
-          option :"2"
-          option :"3"
-          option :"4"
-          option :"5"
-          option :"6"
-
-          on_response do |response|
-            calculator.pay_day_in_week = response.to_i
-            self.pay_day_in_week = days_of_the_week[calculator.pay_day_in_week]
-          end
-
-          next_node do
-            question :pay_date_options_paternity?
-          end
-        end
-
-        ## QP20
-        radio :pay_date_options_paternity? do
-          option :first
-          option :second
-          option :third
-          option :fourth
-          option :last
-
-          on_response do |response|
-            calculator.pay_week_in_month = response
-          end
-
-          next_node do
-            if leave_type == "adoption"
-              outcome :adoption_leave_and_pay
-            else
-              outcome :paternity_leave_and_pay
-            end
-          end
-        end
-
-        # Paternity outcomes
-        outcome :paternity_leave_and_pay
-        outcome :paternity_not_entitled_to_leave_or_pay
       end
+
+      ## QP17
+      value_question :specific_date_each_month_paternity?, parse: :to_i do
+        on_response do |response|
+          calculator.pay_day_in_month = response
+        end
+
+        validate :error_message do
+          calculator.pay_day_in_month.positive? && calculator.pay_day_in_month < 32
+        end
+
+        next_node do
+          if leave_type == "adoption"
+            outcome :adoption_leave_and_pay
+          else
+            outcome :paternity_leave_and_pay
+          end
+        end
+      end
+
+      ## QP18
+      checkbox_question :days_of_the_week_paternity? do
+        (0...days_of_the_week.size).each { |i| option i.to_s.to_sym }
+
+        on_response do |response|
+          calculator.work_days = response.split(",").map(&:to_i)
+          calculator.pay_day_in_week = response.split(",").max.to_i
+        end
+
+        next_node do
+          if leave_type == "adoption"
+            outcome :adoption_leave_and_pay
+          else
+            outcome :paternity_leave_and_pay
+          end
+        end
+      end
+
+      ## QP19
+      radio :day_of_the_month_paternity? do
+        option :"0"
+        option :"1"
+        option :"2"
+        option :"3"
+        option :"4"
+        option :"5"
+        option :"6"
+
+        on_response do |response|
+          calculator.pay_day_in_week = response.to_i
+          self.pay_day_in_week = days_of_the_week[calculator.pay_day_in_week]
+        end
+
+        next_node do
+          question :pay_date_options_paternity?
+        end
+      end
+
+      ## QP20
+      radio :pay_date_options_paternity? do
+        option :first
+        option :second
+        option :third
+        option :fourth
+        option :last
+
+        on_response do |response|
+          calculator.pay_week_in_month = response
+        end
+
+        next_node do
+          if leave_type == "adoption"
+            outcome :adoption_leave_and_pay
+          else
+            outcome :paternity_leave_and_pay
+          end
+        end
+      end
+
+      # Paternity outcomes
+      outcome :paternity_leave_and_pay
+      outcome :paternity_not_entitled_to_leave_or_pay
     end
   end
 end

--- a/lib/smart_answer_flows/maternity-paternity-calculator/shared_adoption_maternity_paternity_flow.rb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/shared_adoption_maternity_paternity_flow.rb
@@ -1,106 +1,104 @@
-module SmartAnswer
-  class MaternityPaternityCalculatorFlow < SmartAnswer::Flow
-    class SharedAdoptionMaternityPaternityFlow < SmartAnswer::Flow
-      def define
-        payment_options = SmartAnswer::Calculators::MaternityPayCalculator.payment_options
+class MaternityPaternityCalculatorFlow < SmartAnswer::Flow
+  class SharedAdoptionMaternityPaternityFlow < SmartAnswer::Flow
+    def define
+      payment_options = SmartAnswer::Calculators::MaternityPayCalculator.payment_options
 
-        # This question is being used in:
-        # QM8 in MaternityCalculatorFlow
-        # QP13 in PaternityCalculatorFlow
-        # QA10 in AdoptionCalculatorFlow
-        radio :how_many_payments_weekly? do
-          payment_options[:weekly].each_key do |payment_option|
-            option payment_option
-          end
-
-          on_response do |response|
-            calculator.payment_option = response
-          end
-
-          next_node do
-            case calculator.leave_type
-            when "adoption"
-              question :how_do_you_want_the_sap_calculated?
-            when "maternity"
-              question :how_do_you_want_the_smp_calculated?
-            else
-              question :how_do_you_want_the_spp_calculated?
-            end
-          end
+      # This question is being used in:
+      # QM8 in MaternityCalculatorFlow
+      # QP13 in PaternityCalculatorFlow
+      # QA10 in AdoptionCalculatorFlow
+      radio :how_many_payments_weekly? do
+        payment_options[:weekly].each_key do |payment_option|
+          option payment_option
         end
 
-        # This question is being used in:
-        # QM8 in MaternityCalculatorFlow
-        # QP13 in PaternityCalculatorFlow
-        # QA10 in AdoptionCalculatorFlow
-        radio :how_many_payments_every_2_weeks? do
-          payment_options[:every_2_weeks].each_key do |payment_option|
-            option payment_option
-          end
-
-          on_response do |response|
-            calculator.payment_option = response
-          end
-
-          next_node do
-            case calculator.leave_type
-            when "adoption"
-              question :how_do_you_want_the_sap_calculated?
-            when "maternity"
-              question :how_do_you_want_the_smp_calculated?
-            else
-              question :how_do_you_want_the_spp_calculated?
-            end
-          end
+        on_response do |response|
+          calculator.payment_option = response
         end
 
-        # This question is being used in:
-        # QM8 in MaternityCalculatorFlow
-        # QP13 in PaternityCalculatorFlow
-        # QA10 in AdoptionCalculatorFlow
-        radio :how_many_payments_every_4_weeks? do
-          payment_options[:every_4_weeks].each_key do |payment_option|
-            option payment_option
-          end
-
-          on_response do |response|
-            calculator.payment_option = response
-          end
-
-          next_node do
-            case calculator.leave_type
-            when "adoption"
-              question :how_do_you_want_the_sap_calculated?
-            when "maternity"
-              question :how_do_you_want_the_smp_calculated?
-            else
-              question :how_do_you_want_the_spp_calculated?
-            end
+        next_node do
+          case calculator.leave_type
+          when "adoption"
+            question :how_do_you_want_the_sap_calculated?
+          when "maternity"
+            question :how_do_you_want_the_smp_calculated?
+          else
+            question :how_do_you_want_the_spp_calculated?
           end
         end
+      end
 
-        # This question is being used in:
-        # QM8 in MaternityCalculatorFlow
-        # QP13 in PaternityCalculatorFlow
-        # QA10 in AdoptionCalculatorFlow
-        radio :how_many_payments_monthly? do
-          payment_options[:monthly].each_key do |payment_option|
-            option payment_option
+      # This question is being used in:
+      # QM8 in MaternityCalculatorFlow
+      # QP13 in PaternityCalculatorFlow
+      # QA10 in AdoptionCalculatorFlow
+      radio :how_many_payments_every_2_weeks? do
+        payment_options[:every_2_weeks].each_key do |payment_option|
+          option payment_option
+        end
+
+        on_response do |response|
+          calculator.payment_option = response
+        end
+
+        next_node do
+          case calculator.leave_type
+          when "adoption"
+            question :how_do_you_want_the_sap_calculated?
+          when "maternity"
+            question :how_do_you_want_the_smp_calculated?
+          else
+            question :how_do_you_want_the_spp_calculated?
           end
+        end
+      end
 
-          on_response do |response|
-            calculator.payment_option = response
+      # This question is being used in:
+      # QM8 in MaternityCalculatorFlow
+      # QP13 in PaternityCalculatorFlow
+      # QA10 in AdoptionCalculatorFlow
+      radio :how_many_payments_every_4_weeks? do
+        payment_options[:every_4_weeks].each_key do |payment_option|
+          option payment_option
+        end
+
+        on_response do |response|
+          calculator.payment_option = response
+        end
+
+        next_node do
+          case calculator.leave_type
+          when "adoption"
+            question :how_do_you_want_the_sap_calculated?
+          when "maternity"
+            question :how_do_you_want_the_smp_calculated?
+          else
+            question :how_do_you_want_the_spp_calculated?
           end
+        end
+      end
 
-          next_node do
-            case calculator.leave_type
-            when "adoption"
-              question :how_do_you_want_the_sap_calculated?
-            when "maternity"
-              question :how_do_you_want_the_smp_calculated?
-            else
-              question :how_do_you_want_the_spp_calculated?
-            end
+      # This question is being used in:
+      # QM8 in MaternityCalculatorFlow
+      # QP13 in PaternityCalculatorFlow
+      # QA10 in AdoptionCalculatorFlow
+      radio :how_many_payments_monthly? do
+        payment_options[:monthly].each_key do |payment_option|
+          option payment_option
+        end
+
+        on_response do |response|
+          calculator.payment_option = response
+        end
+
+        next_node do
+          case calculator.leave_type
+          when "adoption"
+            question :how_do_you_want_the_sap_calculated?
+          when "maternity"
+            question :how_do_you_want_the_smp_calculated?
+          else
+            question :how_do_you_want_the_spp_calculated?
           end
         end
       end

--- a/lib/smart_answer_flows/maternity-paternity-pay-leave.rb
+++ b/lib/smart_answer_flows/maternity-paternity-pay-leave.rb
@@ -1,69 +1,47 @@
-module SmartAnswer
-  class MaternityPaternityPayLeaveFlow < Flow
-    def define
-      content_id "1f6b4ecc-ce2c-488a-b9c7-b78b3bba5598"
-      name "maternity-paternity-pay-leave"
-      status :published
+class MaternityPaternityPayLeaveFlow < SmartAnswer::Flow
+  def define
+    content_id "1f6b4ecc-ce2c-488a-b9c7-b78b3bba5598"
+    name "maternity-paternity-pay-leave"
+    status :published
 
-      radio :two_carers do
-        option "yes"
-        option "no"
+    radio :two_carers do
+      option "yes"
+      option "no"
 
-        on_response do |response|
-          self.calculator = Calculators::MaternityPaternityPayLeaveCalculator.new
-          calculator.two_carers = response
-        end
-
-        next_node do
-          outcome :due_date
-        end
+      on_response do |response|
+        self.calculator = SmartAnswer::Calculators::MaternityPaternityPayLeaveCalculator.new
+        calculator.two_carers = response
       end
 
-      date_question :due_date do
-        on_response do |response|
-          calculator.due_date = response
-        end
+      next_node do
+        outcome :due_date
+      end
+    end
 
-        next_node do
-          outcome :employment_status_of_mother
-        end
+    date_question :due_date do
+      on_response do |response|
+        calculator.due_date = response
       end
 
-      radio :employment_status_of_mother do
-        option "employee"
-        option "worker"
-        option "self-employed"
-        option "unemployed"
+      next_node do
+        outcome :employment_status_of_mother
+      end
+    end
 
-        on_response do |response|
-          calculator.employment_status_of_mother = response
-        end
+    radio :employment_status_of_mother do
+      option "employee"
+      option "worker"
+      option "self-employed"
+      option "unemployed"
 
-        next_node do
-          if calculator.two_carers?
-            question :employment_status_of_partner
-          else
-            case calculator.employment_status_of_mother
-            when "employee", "worker"
-              question :mother_started_working_before_continuity_start_date
-            when "self-employed", "unemployed"
-              question :mother_worked_at_least_26_weeks
-            end
-          end
-        end
+      on_response do |response|
+        calculator.employment_status_of_mother = response
       end
 
-      radio :employment_status_of_partner do
-        option "employee"
-        option "worker"
-        option "self-employed"
-        option "unemployed"
-
-        on_response do |response|
-          calculator.employment_status_of_partner = response
-        end
-
-        next_node do
+      next_node do
+        if calculator.two_carers?
+          question :employment_status_of_partner
+        else
           case calculator.employment_status_of_mother
           when "employee", "worker"
             question :mother_started_working_before_continuity_start_date
@@ -72,130 +50,92 @@ module SmartAnswer
           end
         end
       end
+    end
 
-      radio :mother_started_working_before_continuity_start_date do
-        option "yes"
-        option "no"
+    radio :employment_status_of_partner do
+      option "employee"
+      option "worker"
+      option "self-employed"
+      option "unemployed"
 
-        on_response do |response|
-          calculator.mother_started_working_before_continuity_start_date = response
-        end
-
-        next_node do
-          outcome :mother_still_working_on_continuity_end_date
-        end
+      on_response do |response|
+        calculator.employment_status_of_partner = response
       end
 
-      radio :mother_still_working_on_continuity_end_date do
-        option "yes"
-        option "no"
-
-        on_response do |response|
-          calculator.mother_still_working_on_continuity_end_date = response
-        end
-
-        next_node do
-          outcome :mother_earned_more_than_lower_earnings_limit
+      next_node do
+        case calculator.employment_status_of_mother
+        when "employee", "worker"
+          question :mother_started_working_before_continuity_start_date
+        when "self-employed", "unemployed"
+          question :mother_worked_at_least_26_weeks
         end
       end
+    end
 
-      radio :mother_earned_more_than_lower_earnings_limit do
-        option "yes"
-        option "no"
+    radio :mother_started_working_before_continuity_start_date do
+      option "yes"
+      option "no"
 
-        on_response do |response|
-          calculator.mother_earned_more_than_lower_earnings_limit = response
-        end
+      on_response do |response|
+        calculator.mother_started_working_before_continuity_start_date = response
+      end
 
-        next_node do
-          if calculator.mother_continuity? && calculator.mother_lower_earnings?
-            if calculator.two_carers?
-              case calculator.employment_status_of_partner
-              when "employee", "worker"
-                question :partner_started_working_before_continuity_start_date
-              when "self-employed", "unemployed"
-                outcome :outcome_mat_leave_mat_pay
-              end
-            elsif calculator.employment_status_of_mother == "employee"
+      next_node do
+        outcome :mother_still_working_on_continuity_end_date
+      end
+    end
+
+    radio :mother_still_working_on_continuity_end_date do
+      option "yes"
+      option "no"
+
+      on_response do |response|
+        calculator.mother_still_working_on_continuity_end_date = response
+      end
+
+      next_node do
+        outcome :mother_earned_more_than_lower_earnings_limit
+      end
+    end
+
+    radio :mother_earned_more_than_lower_earnings_limit do
+      option "yes"
+      option "no"
+
+      on_response do |response|
+        calculator.mother_earned_more_than_lower_earnings_limit = response
+      end
+
+      next_node do
+        if calculator.mother_continuity? && calculator.mother_lower_earnings?
+          if calculator.two_carers?
+            case calculator.employment_status_of_partner
+            when "employee", "worker"
+              question :partner_started_working_before_continuity_start_date
+            when "self-employed", "unemployed"
               outcome :outcome_mat_leave_mat_pay
-            elsif calculator.employment_status_of_mother == "worker"
-              outcome :outcome_mat_pay
             end
-          else
-            question :mother_worked_at_least_26_weeks
+          elsif calculator.employment_status_of_mother == "employee"
+            outcome :outcome_mat_leave_mat_pay
+          elsif calculator.employment_status_of_mother == "worker"
+            outcome :outcome_mat_pay
           end
+        else
+          question :mother_worked_at_least_26_weeks
         end
       end
+    end
 
-      radio :mother_worked_at_least_26_weeks do
-        option "yes"
-        option "no"
+    radio :mother_worked_at_least_26_weeks do
+      option "yes"
+      option "no"
 
-        on_response do |response|
-          calculator.mother_worked_at_least_26_weeks = response
-        end
-
-        next_node do
-          if %w[employee self-employed].include?(calculator.employment_status_of_mother) && calculator.mother_worked_at_least_26_weeks == "no"
-            if calculator.two_carers?
-              if %w[employee worker].include?(calculator.employment_status_of_partner)
-                question :partner_started_working_before_continuity_start_date
-              elsif %w[self-employed unemployed].include?(calculator.employment_status_of_partner)
-                if calculator.employment_status_of_mother == "employee"
-                  if calculator.mother_continuity?
-                    if calculator.mother_lower_earnings?
-                      outcome :outcome_mat_leave_mat_pay
-                    else
-                      outcome :outcome_mat_leave
-                    end
-                  elsif calculator.mother_still_working_on_continuity_end_date == "yes"
-                    outcome :outcome_mat_leave
-                  elsif calculator.mother_still_working_on_continuity_end_date == "no"
-                    outcome :outcome_birth_nothing
-                  end
-                elsif calculator.employment_status_of_mother == "self-employed" || calculator.employment_status_of_partner == "unemployed"
-                  outcome :outcome_birth_nothing
-                elsif calculator.employment_status_of_partner == "self-employed"
-                  outcome :outcome_mat_allowance_14_weeks
-                end
-              end
-            elsif calculator.employment_status_of_mother == "employee"
-              case calculator.mother_still_working_on_continuity_end_date
-              when "yes"
-                outcome :outcome_mat_leave
-              when "no"
-                outcome :outcome_single_birth_nothing
-              end
-            elsif calculator.employment_status_of_mother == "self-employed"
-              outcome :outcome_single_birth_nothing
-            end
-          elsif calculator.employment_status_of_mother == "self-employed"
-            if calculator.two_carers?
-              if %w[employee worker].include?(calculator.employment_status_of_partner)
-                question :partner_started_working_before_continuity_start_date
-              else
-                outcome :outcome_mat_allowance
-              end
-            else
-              outcome :outcome_mat_allowance
-            end
-          elsif calculator.mother_worked_at_least_26_weeks == "no" && !calculator.two_carers?
-            outcome :outcome_single_birth_nothing
-          else
-            question :mother_earned_at_least_390
-          end
-        end
+      on_response do |response|
+        calculator.mother_worked_at_least_26_weeks = response
       end
 
-      radio :mother_earned_at_least_390 do
-        option "yes"
-        option "no"
-
-        on_response do |response|
-          calculator.mother_earned_at_least_390 = response
-        end
-
-        next_node do
+      next_node do
+        if %w[employee self-employed].include?(calculator.employment_status_of_mother) && calculator.mother_worked_at_least_26_weeks == "no"
           if calculator.two_carers?
             if %w[employee worker].include?(calculator.employment_status_of_partner)
               question :partner_started_working_before_continuity_start_date
@@ -204,28 +144,15 @@ module SmartAnswer
                 if calculator.mother_continuity?
                   if calculator.mother_lower_earnings?
                     outcome :outcome_mat_leave_mat_pay
-                  elsif calculator.mother_earnings_employment?
-                    outcome :outcome_mat_allowance_mat_leave
                   else
                     outcome :outcome_mat_leave
                   end
                 elsif calculator.mother_still_working_on_continuity_end_date == "yes"
-                  if calculator.mother_earnings_employment?
-                    outcome :outcome_mat_allowance_mat_leave
-                  else
-                    outcome :outcome_mat_leave
-                  end
+                  outcome :outcome_mat_leave
                 elsif calculator.mother_still_working_on_continuity_end_date == "no"
-                  if calculator.mother_earnings_employment?
-                    outcome :outcome_mat_allowance
-                  else
-                    outcome :outcome_birth_nothing
-                  end
+                  outcome :outcome_birth_nothing
                 end
-              elsif calculator.mother_earnings_employment?
-                outcome :outcome_mat_allowance
-              elsif %w[worker self-employed].include?(calculator.employment_status_of_mother) ||
-                  calculator.employment_status_of_partner == "unemployed"
+              elsif calculator.employment_status_of_mother == "self-employed" || calculator.employment_status_of_partner == "unemployed"
                 outcome :outcome_birth_nothing
               elsif calculator.employment_status_of_partner == "self-employed"
                 outcome :outcome_mat_allowance_14_weeks
@@ -234,252 +161,240 @@ module SmartAnswer
           elsif calculator.employment_status_of_mother == "employee"
             case calculator.mother_still_working_on_continuity_end_date
             when "yes"
-              if calculator.mother_earnings_employment?
-                outcome :outcome_mat_allowance_mat_leave
-              else
-                outcome :outcome_mat_leave
-              end
+              outcome :outcome_mat_leave
             when "no"
-              if calculator.mother_earnings_employment?
-                outcome :outcome_mat_allowance
-              else
-                outcome :outcome_single_birth_nothing
-              end
+              outcome :outcome_single_birth_nothing
             end
-          elsif %w[worker self-employed unemployed].include?(calculator.employment_status_of_mother)
+          elsif calculator.employment_status_of_mother == "self-employed"
+            outcome :outcome_single_birth_nothing
+          end
+        elsif calculator.employment_status_of_mother == "self-employed"
+          if calculator.two_carers?
+            if %w[employee worker].include?(calculator.employment_status_of_partner)
+              question :partner_started_working_before_continuity_start_date
+            else
+              outcome :outcome_mat_allowance
+            end
+          else
+            outcome :outcome_mat_allowance
+          end
+        elsif calculator.mother_worked_at_least_26_weeks == "no" && !calculator.two_carers?
+          outcome :outcome_single_birth_nothing
+        else
+          question :mother_earned_at_least_390
+        end
+      end
+    end
+
+    radio :mother_earned_at_least_390 do
+      option "yes"
+      option "no"
+
+      on_response do |response|
+        calculator.mother_earned_at_least_390 = response
+      end
+
+      next_node do
+        if calculator.two_carers?
+          if %w[employee worker].include?(calculator.employment_status_of_partner)
+            question :partner_started_working_before_continuity_start_date
+          elsif %w[self-employed unemployed].include?(calculator.employment_status_of_partner)
+            if calculator.employment_status_of_mother == "employee"
+              if calculator.mother_continuity?
+                if calculator.mother_lower_earnings?
+                  outcome :outcome_mat_leave_mat_pay
+                elsif calculator.mother_earnings_employment?
+                  outcome :outcome_mat_allowance_mat_leave
+                else
+                  outcome :outcome_mat_leave
+                end
+              elsif calculator.mother_still_working_on_continuity_end_date == "yes"
+                if calculator.mother_earnings_employment?
+                  outcome :outcome_mat_allowance_mat_leave
+                else
+                  outcome :outcome_mat_leave
+                end
+              elsif calculator.mother_still_working_on_continuity_end_date == "no"
+                if calculator.mother_earnings_employment?
+                  outcome :outcome_mat_allowance
+                else
+                  outcome :outcome_birth_nothing
+                end
+              end
+            elsif calculator.mother_earnings_employment?
+              outcome :outcome_mat_allowance
+            elsif %w[worker self-employed].include?(calculator.employment_status_of_mother) ||
+                calculator.employment_status_of_partner == "unemployed"
+              outcome :outcome_birth_nothing
+            elsif calculator.employment_status_of_partner == "self-employed"
+              outcome :outcome_mat_allowance_14_weeks
+            end
+          end
+        elsif calculator.employment_status_of_mother == "employee"
+          case calculator.mother_still_working_on_continuity_end_date
+          when "yes"
+            if calculator.mother_earnings_employment?
+              outcome :outcome_mat_allowance_mat_leave
+            else
+              outcome :outcome_mat_leave
+            end
+          when "no"
             if calculator.mother_earnings_employment?
               outcome :outcome_mat_allowance
             else
               outcome :outcome_single_birth_nothing
             end
           end
+        elsif %w[worker self-employed unemployed].include?(calculator.employment_status_of_mother)
+          if calculator.mother_earnings_employment?
+            outcome :outcome_mat_allowance
+          else
+            outcome :outcome_single_birth_nothing
+          end
         end
       end
+    end
 
-      radio :partner_started_working_before_continuity_start_date do
-        option "yes"
-        option "no"
+    radio :partner_started_working_before_continuity_start_date do
+      option "yes"
+      option "no"
 
-        on_response do |response|
-          calculator.partner_started_working_before_continuity_start_date = response
-        end
-
-        next_node do
-          outcome :partner_still_working_on_continuity_end_date
-        end
+      on_response do |response|
+        calculator.partner_started_working_before_continuity_start_date = response
       end
 
-      radio :partner_still_working_on_continuity_end_date do
-        option "yes"
-        option "no"
+      next_node do
+        outcome :partner_still_working_on_continuity_end_date
+      end
+    end
 
-        on_response do |response|
-          calculator.partner_still_working_on_continuity_end_date = response
-        end
+    radio :partner_still_working_on_continuity_end_date do
+      option "yes"
+      option "no"
 
-        next_node do
-          outcome :partner_earned_more_than_lower_earnings_limit
-        end
+      on_response do |response|
+        calculator.partner_still_working_on_continuity_end_date = response
       end
 
-      radio :partner_earned_more_than_lower_earnings_limit do
-        option "yes"
-        option "no"
+      next_node do
+        outcome :partner_earned_more_than_lower_earnings_limit
+      end
+    end
 
-        on_response do |response|
-          calculator.partner_earned_more_than_lower_earnings_limit = response
-        end
+    radio :partner_earned_more_than_lower_earnings_limit do
+      option "yes"
+      option "no"
 
-        next_node do
-          case calculator.employment_status_of_partner
-          when "employee"
-            if calculator.partner_continuity? && calculator.partner_lower_earnings?
-              if calculator.employment_status_of_mother == "employee"
-                if calculator.mother_continuity? && calculator.mother_lower_earnings?
-                  outcome :outcome_mat_leave_mat_pay_pat_leave_pat_pay
-                elsif calculator.mother_started_working_before_continuity_start_date == "yes" && calculator.mother_still_working_on_continuity_end_date == "yes"
-                  if calculator.mother_earnings_employment?
-                    outcome :outcome_mat_allowance_mat_leave_pat_leave_pat_pay
-                  elsif !calculator.mother_earnings_employment?
-                    outcome :outcome_mat_leave_pat_leave_pat_pay
-                  end
-                elsif calculator.mother_still_working_on_continuity_end_date == "yes"
-                  if calculator.mother_earnings_employment?
-                    outcome :outcome_mat_allowance_mat_leave_pat_leave_pat_pay
-                  elsif !calculator.mother_earnings_employment?
-                    outcome :outcome_mat_leave_pat_leave_pat_pay
-                  end
-                elsif calculator.mother_still_working_on_continuity_end_date == "no"
-                  if calculator.mother_earnings_employment?
-                    outcome :outcome_mat_allowance_pat_leave_pat_pay
-                  elsif !calculator.mother_earnings_employment?
-                    outcome :outcome_pat_leave_pat_pay
-                  end
+      on_response do |response|
+        calculator.partner_earned_more_than_lower_earnings_limit = response
+      end
+
+      next_node do
+        case calculator.employment_status_of_partner
+        when "employee"
+          if calculator.partner_continuity? && calculator.partner_lower_earnings?
+            if calculator.employment_status_of_mother == "employee"
+              if calculator.mother_continuity? && calculator.mother_lower_earnings?
+                outcome :outcome_mat_leave_mat_pay_pat_leave_pat_pay
+              elsif calculator.mother_started_working_before_continuity_start_date == "yes" && calculator.mother_still_working_on_continuity_end_date == "yes"
+                if calculator.mother_earnings_employment?
+                  outcome :outcome_mat_allowance_mat_leave_pat_leave_pat_pay
+                elsif !calculator.mother_earnings_employment?
+                  outcome :outcome_mat_leave_pat_leave_pat_pay
                 end
-              elsif calculator.employment_status_of_mother == "worker"
-                if calculator.mother_continuity? && calculator.mother_lower_earnings?
-                  outcome :outcome_mat_pay_pat_leave_pat_pay
-                elsif !calculator.mother_continuity? || !calculator.mother_lower_earnings?
-                  if calculator.mother_earnings_employment?
-                    outcome :outcome_mat_allowance_pat_leave_pat_pay
-                  elsif !calculator.mother_earnings_employment?
-                    outcome :outcome_pat_leave_pat_pay
-                  end
+              elsif calculator.mother_still_working_on_continuity_end_date == "yes"
+                if calculator.mother_earnings_employment?
+                  outcome :outcome_mat_allowance_mat_leave_pat_leave_pat_pay
+                elsif !calculator.mother_earnings_employment?
+                  outcome :outcome_mat_leave_pat_leave_pat_pay
                 end
-              elsif %w[unemployed self-employed].include?(calculator.employment_status_of_mother)
-                if !calculator.mother_earnings_employment?
-                  outcome :outcome_pat_leave_pat_pay
-                elsif calculator.mother_earnings_employment?
+              elsif calculator.mother_still_working_on_continuity_end_date == "no"
+                if calculator.mother_earnings_employment?
                   outcome :outcome_mat_allowance_pat_leave_pat_pay
+                elsif !calculator.mother_earnings_employment?
+                  outcome :outcome_pat_leave_pat_pay
                 end
               end
-            elsif calculator.partner_continuity?
-              if calculator.employment_status_of_mother == "employee"
-                if calculator.mother_continuity? && calculator.mother_lower_earnings?
-                  outcome :outcome_mat_leave_mat_pay_pat_leave
-                elsif calculator.mother_continuity?
+            elsif calculator.employment_status_of_mother == "worker"
+              if calculator.mother_continuity? && calculator.mother_lower_earnings?
+                outcome :outcome_mat_pay_pat_leave_pat_pay
+              elsif !calculator.mother_continuity? || !calculator.mother_lower_earnings?
+                if calculator.mother_earnings_employment?
+                  outcome :outcome_mat_allowance_pat_leave_pat_pay
+                elsif !calculator.mother_earnings_employment?
+                  outcome :outcome_pat_leave_pat_pay
+                end
+              end
+            elsif %w[unemployed self-employed].include?(calculator.employment_status_of_mother)
+              if !calculator.mother_earnings_employment?
+                outcome :outcome_pat_leave_pat_pay
+              elsif calculator.mother_earnings_employment?
+                outcome :outcome_mat_allowance_pat_leave_pat_pay
+              end
+            end
+          elsif calculator.partner_continuity?
+            if calculator.employment_status_of_mother == "employee"
+              if calculator.mother_continuity? && calculator.mother_lower_earnings?
+                outcome :outcome_mat_leave_mat_pay_pat_leave
+              elsif calculator.mother_continuity?
+                outcome :outcome_mat_leave_pat_leave
+              elsif calculator.mother_still_working_on_continuity_end_date == "yes"
+                if calculator.mother_earnings_employment?
+                  outcome :outcome_mat_allowance_mat_leave_pat_leave
+                elsif !calculator.mother_earnings_employment?
                   outcome :outcome_mat_leave_pat_leave
-                elsif calculator.mother_still_working_on_continuity_end_date == "yes"
-                  if calculator.mother_earnings_employment?
-                    outcome :outcome_mat_allowance_mat_leave_pat_leave
-                  elsif !calculator.mother_earnings_employment?
-                    outcome :outcome_mat_leave_pat_leave
-                  end
-                elsif calculator.mother_still_working_on_continuity_end_date == "no"
-                  if calculator.mother_earnings_employment?
-                    outcome :outcome_mat_allowance_pat_leave
-                  elsif !calculator.mother_earnings_employment?
-                    outcome :outcome_pat_leave
-                  end
                 end
-              elsif calculator.employment_status_of_mother == "worker"
-                if calculator.mother_continuity? && calculator.mother_lower_earnings?
-                  # TODO: Unsure about mat_pay
-                  outcome :outcome_mat_pay_pat_leave
-                elsif !calculator.mother_continuity? || !calculator.mother_lower_earnings?
-                  if calculator.mother_earnings_employment?
-                    outcome :outcome_mat_allowance_pat_leave
-                  elsif !calculator.mother_earnings_employment?
-                    outcome :outcome_pat_leave
-                  end
-                end
-              elsif %w[unemployed self-employed].include?(calculator.employment_status_of_mother)
+              elsif calculator.mother_still_working_on_continuity_end_date == "no"
                 if calculator.mother_earnings_employment?
                   outcome :outcome_mat_allowance_pat_leave
                 elsif !calculator.mother_earnings_employment?
                   outcome :outcome_pat_leave
                 end
               end
-            elsif !calculator.partner_continuity?
-              if calculator.employment_status_of_mother == "employee"
-                case calculator.mother_still_working_on_continuity_end_date
-                when "yes"
-                  if calculator.mother_continuity?
-                    outcome :outcome_mat_leave
-                  elsif calculator.mother_earnings_employment?
-                    outcome :outcome_mat_allowance_mat_leave
-                  elsif !calculator.mother_earnings_employment?
-                    outcome :outcome_mat_leave
-                  end
-                when "no"
-                  if calculator.mother_earnings_employment?
-                    outcome :outcome_mat_allowance
-                  elsif !calculator.mother_earnings_employment?
-                    outcome :outcome_birth_nothing
-                  end
+            elsif calculator.employment_status_of_mother == "worker"
+              if calculator.mother_continuity? && calculator.mother_lower_earnings?
+                # TODO: Unsure about mat_pay
+                outcome :outcome_mat_pay_pat_leave
+              elsif !calculator.mother_continuity? || !calculator.mother_lower_earnings?
+                if calculator.mother_earnings_employment?
+                  outcome :outcome_mat_allowance_pat_leave
+                elsif !calculator.mother_earnings_employment?
+                  outcome :outcome_pat_leave
                 end
-              elsif calculator.employment_status_of_mother == "worker"
-                if calculator.mother_continuity? && calculator.mother_lower_earnings?
-                  outcome :outcome_mat_pay
-                elsif !calculator.mother_continuity? || !calculator.mother_lower_earnings?
-                  if calculator.mother_earnings_employment?
-                    outcome :outcome_mat_allowance
-                  elsif !calculator.mother_earnings_employment?
-                    outcome :outcome_birth_nothing
-                  end
+              end
+            elsif %w[unemployed self-employed].include?(calculator.employment_status_of_mother)
+              if calculator.mother_earnings_employment?
+                outcome :outcome_mat_allowance_pat_leave
+              elsif !calculator.mother_earnings_employment?
+                outcome :outcome_pat_leave
+              end
+            end
+          elsif !calculator.partner_continuity?
+            if calculator.employment_status_of_mother == "employee"
+              case calculator.mother_still_working_on_continuity_end_date
+              when "yes"
+                if calculator.mother_continuity?
+                  outcome :outcome_mat_leave
+                elsif calculator.mother_earnings_employment?
+                  outcome :outcome_mat_allowance_mat_leave
+                elsif !calculator.mother_earnings_employment?
+                  outcome :outcome_mat_leave
                 end
-              elsif %w[unemployed self-employed].include?(calculator.employment_status_of_mother)
+              when "no"
                 if calculator.mother_earnings_employment?
                   outcome :outcome_mat_allowance
                 elsif !calculator.mother_earnings_employment?
                   outcome :outcome_birth_nothing
                 end
               end
-            end
-          when "worker"
-            if calculator.partner_continuity? && calculator.partner_lower_earnings?
-              if calculator.employment_status_of_mother == "employee"
-                if calculator.mother_continuity? && calculator.mother_lower_earnings?
-                  outcome :outcome_mat_leave_mat_pay_pat_pay
-                elsif calculator.mother_continuity?
-                  if calculator.mother_earnings_employment?
-                    outcome :outcome_mat_allowance_mat_leave_pat_pay
-                  elsif !calculator.mother_earnings_employment?
-                    outcome :outcome_mat_leave_pat_pay
-                  end
-                elsif calculator.mother_still_working_on_continuity_end_date == "yes"
-                  if !calculator.mother_earnings_employment?
-                    outcome :outcome_mat_leave_pat_pay
-                  else
-                    outcome :outcome_mat_allowance_mat_leave_pat_pay
-                  end
-                elsif calculator.mother_still_working_on_continuity_end_date == "no"
-                  if !calculator.mother_earnings_employment?
-                    outcome :outcome_pat_pay
-                  else
-                    outcome :outcome_mat_allowance_pat_pay
-                  end
-                end
-              elsif calculator.employment_status_of_mother == "worker"
-                if calculator.mother_continuity? && calculator.mother_lower_earnings?
-                  outcome :outcome_mat_pay_pat_pay
-                elsif !calculator.mother_continuity? || !calculator.mother_lower_earnings?
-                  if calculator.mother_earnings_employment?
-                    outcome :outcome_mat_allowance_pat_pay
-                  elsif !calculator.mother_earnings_employment?
-                    outcome :outcome_pat_pay
-                  end
-                end
-              elsif %w[unemployed self-employed].include?(calculator.employment_status_of_mother)
+            elsif calculator.employment_status_of_mother == "worker"
+              if calculator.mother_continuity? && calculator.mother_lower_earnings?
+                outcome :outcome_mat_pay
+              elsif !calculator.mother_continuity? || !calculator.mother_lower_earnings?
                 if calculator.mother_earnings_employment?
-                  outcome :outcome_mat_allowance_pat_pay
+                  outcome :outcome_mat_allowance
                 elsif !calculator.mother_earnings_employment?
-                  outcome :outcome_pat_pay
-                end
-              end
-            elsif calculator.partner_continuity?
-              case calculator.employment_status_of_mother
-              when "employee"
-                if calculator.mother_continuity? && calculator.mother_lower_earnings?
-                  outcome :outcome_mat_leave_mat_pay
-                elsif !calculator.mother_continuity? || !calculator.mother_lower_earnings?
-                  if calculator.mother_earnings_employment?
-                    outcome :outcome_mat_allowance_mat_leave
-                  else
-                    outcome :outcome_mat_leave
-                  end
-                elsif calculator.mother_still_working_on_continuity_end_date == "yes"
-                  if calculator.mother_earnings_employment?
-                    outcome :outcome_mat_allowance_mat_leave
-                  elsif !calculator.mother_earnings_employment?
-                    outcome :outcome_mat_leave
-                  end
-                elsif calculator.mother_still_working_on_continuity_end_date == "no"
-                  if calculator.mother_earnings_employment?
-                    outcome :outcome_mat_allowance
-                  elsif !calculator.mother_earnings_employment?
-                    outcome :outcome_birth_nothing
-                  end
-                end
-              when "worker"
-                if calculator.mother_continuity? && calculator.mother_lower_earnings?
-                  outcome :outcome_mat_pay
-                elsif !calculator.mother_continuity? || !calculator.mother_lower_earnings?
-                  if calculator.mother_earnings_employment?
-                    outcome :outcome_mat_allowance
-                  elsif !calculator.mother_earnings_employment?
-                    outcome :outcome_birth_nothing
-                  end
+                  outcome :outcome_birth_nothing
                 end
               end
             elsif %w[unemployed self-employed].include?(calculator.employment_status_of_mother)
@@ -488,42 +403,77 @@ module SmartAnswer
               elsif !calculator.mother_earnings_employment?
                 outcome :outcome_birth_nothing
               end
-            elsif !calculator.partner_continuity?
-              case calculator.employment_status_of_mother
-              when "employee"
-                case calculator.mother_still_working_on_continuity_end_date
-                when "yes"
-                  if calculator.mother_continuity?
-                    if calculator.mother_lower_earnings?
-                      outcome :outcome_mat_leave_mat_pay
-                    else
-                      outcome :outcome_mat_leave
-                    end
-                  elsif !calculator.mother_continuity?
-                    if calculator.mother_earnings_employment?
-                      outcome :outcome_mat_allowance_mat_leave
-                    elsif !calculator.mother_earnings_employment?
-                      outcome :outcome_mat_leave
-                    end
-                  end
-                when "no"
-                  if calculator.mother_earnings_employment?
-                    outcome :outcome_mat_allowance
-                  elsif !calculator.mother_earnings_employment?
-                    outcome :outcome_birth_nothing
-                  end
+            end
+          end
+        when "worker"
+          if calculator.partner_continuity? && calculator.partner_lower_earnings?
+            if calculator.employment_status_of_mother == "employee"
+              if calculator.mother_continuity? && calculator.mother_lower_earnings?
+                outcome :outcome_mat_leave_mat_pay_pat_pay
+              elsif calculator.mother_continuity?
+                if calculator.mother_earnings_employment?
+                  outcome :outcome_mat_allowance_mat_leave_pat_pay
+                elsif !calculator.mother_earnings_employment?
+                  outcome :outcome_mat_leave_pat_pay
                 end
-              when "worker"
-                if calculator.mother_continuity? && calculator.mother_lower_earnings?
-                  outcome :outcome_mat_pay
-                elsif !calculator.mother_continuity? || !calculator.mother_lower_earnings?
-                  if calculator.mother_earnings_employment?
-                    outcome :outcome_mat_allowance
-                  elsif !calculator.mother_earnings_employment?
-                    outcome :outcome_birth_nothing
-                  end
+              elsif calculator.mother_still_working_on_continuity_end_date == "yes"
+                if !calculator.mother_earnings_employment?
+                  outcome :outcome_mat_leave_pat_pay
+                else
+                  outcome :outcome_mat_allowance_mat_leave_pat_pay
                 end
-              when "unemployed", "self-employed"
+              elsif calculator.mother_still_working_on_continuity_end_date == "no"
+                if !calculator.mother_earnings_employment?
+                  outcome :outcome_pat_pay
+                else
+                  outcome :outcome_mat_allowance_pat_pay
+                end
+              end
+            elsif calculator.employment_status_of_mother == "worker"
+              if calculator.mother_continuity? && calculator.mother_lower_earnings?
+                outcome :outcome_mat_pay_pat_pay
+              elsif !calculator.mother_continuity? || !calculator.mother_lower_earnings?
+                if calculator.mother_earnings_employment?
+                  outcome :outcome_mat_allowance_pat_pay
+                elsif !calculator.mother_earnings_employment?
+                  outcome :outcome_pat_pay
+                end
+              end
+            elsif %w[unemployed self-employed].include?(calculator.employment_status_of_mother)
+              if calculator.mother_earnings_employment?
+                outcome :outcome_mat_allowance_pat_pay
+              elsif !calculator.mother_earnings_employment?
+                outcome :outcome_pat_pay
+              end
+            end
+          elsif calculator.partner_continuity?
+            case calculator.employment_status_of_mother
+            when "employee"
+              if calculator.mother_continuity? && calculator.mother_lower_earnings?
+                outcome :outcome_mat_leave_mat_pay
+              elsif !calculator.mother_continuity? || !calculator.mother_lower_earnings?
+                if calculator.mother_earnings_employment?
+                  outcome :outcome_mat_allowance_mat_leave
+                else
+                  outcome :outcome_mat_leave
+                end
+              elsif calculator.mother_still_working_on_continuity_end_date == "yes"
+                if calculator.mother_earnings_employment?
+                  outcome :outcome_mat_allowance_mat_leave
+                elsif !calculator.mother_earnings_employment?
+                  outcome :outcome_mat_leave
+                end
+              elsif calculator.mother_still_working_on_continuity_end_date == "no"
+                if calculator.mother_earnings_employment?
+                  outcome :outcome_mat_allowance
+                elsif !calculator.mother_earnings_employment?
+                  outcome :outcome_birth_nothing
+                end
+              end
+            when "worker"
+              if calculator.mother_continuity? && calculator.mother_lower_earnings?
+                outcome :outcome_mat_pay
+              elsif !calculator.mother_continuity? || !calculator.mother_lower_earnings?
                 if calculator.mother_earnings_employment?
                   outcome :outcome_mat_allowance
                 elsif !calculator.mother_earnings_employment?
@@ -531,36 +481,84 @@ module SmartAnswer
                 end
               end
             end
+          elsif %w[unemployed self-employed].include?(calculator.employment_status_of_mother)
+            if calculator.mother_earnings_employment?
+              outcome :outcome_mat_allowance
+            elsif !calculator.mother_earnings_employment?
+              outcome :outcome_birth_nothing
+            end
+          elsif !calculator.partner_continuity?
+            case calculator.employment_status_of_mother
+            when "employee"
+              case calculator.mother_still_working_on_continuity_end_date
+              when "yes"
+                if calculator.mother_continuity?
+                  if calculator.mother_lower_earnings?
+                    outcome :outcome_mat_leave_mat_pay
+                  else
+                    outcome :outcome_mat_leave
+                  end
+                elsif !calculator.mother_continuity?
+                  if calculator.mother_earnings_employment?
+                    outcome :outcome_mat_allowance_mat_leave
+                  elsif !calculator.mother_earnings_employment?
+                    outcome :outcome_mat_leave
+                  end
+                end
+              when "no"
+                if calculator.mother_earnings_employment?
+                  outcome :outcome_mat_allowance
+                elsif !calculator.mother_earnings_employment?
+                  outcome :outcome_birth_nothing
+                end
+              end
+            when "worker"
+              if calculator.mother_continuity? && calculator.mother_lower_earnings?
+                outcome :outcome_mat_pay
+              elsif !calculator.mother_continuity? || !calculator.mother_lower_earnings?
+                if calculator.mother_earnings_employment?
+                  outcome :outcome_mat_allowance
+                elsif !calculator.mother_earnings_employment?
+                  outcome :outcome_birth_nothing
+                end
+              end
+            when "unemployed", "self-employed"
+              if calculator.mother_earnings_employment?
+                outcome :outcome_mat_allowance
+              elsif !calculator.mother_earnings_employment?
+                outcome :outcome_birth_nothing
+              end
+            end
           end
         end
       end
-
-      outcome :outcome_birth_nothing
-      outcome :outcome_single_birth_nothing
-      outcome :outcome_mat_allowance
-      outcome :outcome_mat_allowance_14_weeks
-      outcome :outcome_mat_allowance_mat_leave
-      outcome :outcome_mat_allowance_mat_leave_pat_leave
-      outcome :outcome_mat_allowance_mat_leave_pat_leave_pat_pay
-      outcome :outcome_mat_allowance_mat_leave_pat_pay
-      outcome :outcome_mat_allowance_pat_leave
-      outcome :outcome_mat_allowance_pat_leave_pat_pay
-      outcome :outcome_mat_allowance_pat_pay
-      outcome :outcome_mat_leave
-      outcome :outcome_mat_leave_mat_pay
-      outcome :outcome_mat_leave_mat_pay_pat_leave
-      outcome :outcome_mat_leave_mat_pay_pat_leave_pat_pay
-      outcome :outcome_mat_leave_mat_pay_pat_pay
-      outcome :outcome_mat_leave_pat_leave
-      outcome :outcome_mat_leave_pat_leave_pat_pay
-      outcome :outcome_mat_leave_pat_pay
-      outcome :outcome_mat_pay
-      outcome :outcome_mat_pay_pat_leave
-      outcome :outcome_mat_pay_pat_leave_pat_pay
-      outcome :outcome_mat_pay_pat_pay
-      outcome :outcome_pat_leave
-      outcome :outcome_pat_leave_pat_pay
-      outcome :outcome_pat_pay
     end
+
+    outcome :outcome_birth_nothing
+    outcome :outcome_single_birth_nothing
+    outcome :outcome_mat_allowance
+    outcome :outcome_mat_allowance_14_weeks
+    outcome :outcome_mat_allowance_mat_leave
+    outcome :outcome_mat_allowance_mat_leave_pat_leave
+    outcome :outcome_mat_allowance_mat_leave_pat_leave_pat_pay
+    outcome :outcome_mat_allowance_mat_leave_pat_pay
+    outcome :outcome_mat_allowance_pat_leave
+    outcome :outcome_mat_allowance_pat_leave_pat_pay
+    outcome :outcome_mat_allowance_pat_pay
+    outcome :outcome_mat_leave
+    outcome :outcome_mat_leave_mat_pay
+    outcome :outcome_mat_leave_mat_pay_pat_leave
+    outcome :outcome_mat_leave_mat_pay_pat_leave_pat_pay
+    outcome :outcome_mat_leave_mat_pay_pat_pay
+    outcome :outcome_mat_leave_pat_leave
+    outcome :outcome_mat_leave_pat_leave_pat_pay
+    outcome :outcome_mat_leave_pat_pay
+    outcome :outcome_mat_pay
+    outcome :outcome_mat_pay_pat_leave
+    outcome :outcome_mat_pay_pat_leave_pat_pay
+    outcome :outcome_mat_pay_pat_pay
+    outcome :outcome_pat_leave
+    outcome :outcome_pat_leave_pat_pay
+    outcome :outcome_pat_pay
   end
 end

--- a/lib/smart_answer_flows/minimum-wage-calculator-employers.rb
+++ b/lib/smart_answer_flows/minimum-wage-calculator-employers.rb
@@ -1,5 +1,3 @@
-require "smart_answer_flows/shared/minimum_wage_flow"
-
 class MinimumWageCalculatorEmployersFlow < SmartAnswer::Flow
   def define
     content_id "cc25f6ca-0553-4400-9dba-a43294fee84b"

--- a/lib/smart_answer_flows/minimum-wage-calculator-employers.rb
+++ b/lib/smart_answer_flows/minimum-wage-calculator-employers.rb
@@ -1,50 +1,48 @@
 require "smart_answer_flows/shared/minimum_wage_flow"
 
-module SmartAnswer
-  class MinimumWageCalculatorEmployersFlow < Flow
-    def define
-      content_id "cc25f6ca-0553-4400-9dba-a43294fee84b"
-      name "minimum-wage-calculator-employers"
-      status :published
+class MinimumWageCalculatorEmployersFlow < SmartAnswer::Flow
+  def define
+    content_id "cc25f6ca-0553-4400-9dba-a43294fee84b"
+    name "minimum-wage-calculator-employers"
+    status :published
 
-      # Q1
-      radio :what_would_you_like_to_check? do
-        option "current_payment"
-        option "past_payment"
+    # Q1
+    radio :what_would_you_like_to_check? do
+      option "current_payment"
+      option "past_payment"
 
-        on_response do |response|
-          self.calculator = Calculators::MinimumWageCalculator.new
-          calculator.date = Date.parse("2020-04-01") if response == "past_payment"
-          self.accommodation_charge = nil
-        end
-
-        next_node do |response|
-          case response
-          when "current_payment"
-            question :are_you_an_apprentice?
-          when "past_payment"
-            question :were_you_an_apprentice?
-          end
-        end
+      on_response do |response|
+        self.calculator = SmartAnswer::Calculators::MinimumWageCalculator.new
+        calculator.date = Date.parse("2020-04-01") if response == "past_payment"
+        self.accommodation_charge = nil
       end
 
-      # Q3
-      value_question :how_old_are_you?, parse: Integer do
-        validate do |response|
-          calculator.valid_age?(response)
-        end
-
-        next_node do |response|
-          calculator.age = response
-          if calculator.under_school_leaving_age?
-            outcome :under_school_leaving_age
-          else
-            question :how_often_do_you_get_paid?
-          end
+      next_node do |response|
+        case response
+        when "current_payment"
+          question :are_you_an_apprentice?
+        when "past_payment"
+          question :were_you_an_apprentice?
         end
       end
-
-      append(Shared::MinimumWageFlow.build)
     end
+
+    # Q3
+    value_question :how_old_are_you?, parse: Integer do
+      validate do |response|
+        calculator.valid_age?(response)
+      end
+
+      next_node do |response|
+        calculator.age = response
+        if calculator.under_school_leaving_age?
+          outcome :under_school_leaving_age
+        else
+          question :how_often_do_you_get_paid?
+        end
+      end
+    end
+
+    append(MinimumWageFlow.build)
   end
 end

--- a/lib/smart_answer_flows/next-steps-for-your-business.rb
+++ b/lib/smart_answer_flows/next-steps-for-your-business.rb
@@ -1,104 +1,102 @@
-module SmartAnswer
-  class NextStepsForYourBusinessFlow < Flow
-    def define
-      name "next-steps-for-your-business"
-      content_id "4d7751b5-d860-4812-aa36-5b8c57253ff2"
-      status :published
-      response_store :query_parameters
+class NextStepsForYourBusinessFlow < SmartAnswer::Flow
+  def define
+    name "next-steps-for-your-business"
+    content_id "4d7751b5-d860-4812-aa36-5b8c57253ff2"
+    status :published
+    response_store :query_parameters
 
-      # ======================================================================
-      # Will your business take more than £85,000 in a 12 month period?
-      # ======================================================================
-      radio :annual_turnover_over_85k do
-        option :yes
-        option :no
-        option :not_sure
+    # ======================================================================
+    # Will your business take more than £85,000 in a 12 month period?
+    # ======================================================================
+    radio :annual_turnover_over_85k do
+      option :yes
+      option :no
+      option :not_sure
 
-        on_response do |response|
-          self.calculator = Calculators::NextStepsForYourBusinessCalculator.new
-          calculator.annual_turnover_over_85k = response
-        end
-
-        next_node do
-          question :employ_someone
-        end
+      on_response do |response|
+        self.calculator = SmartAnswer::Calculators::NextStepsForYourBusinessCalculator.new
+        calculator.annual_turnover_over_85k = response
       end
 
-      # ======================================================================
-      # Do you want to employ someone?
-      # ======================================================================
-      radio :employ_someone do
-        option :in_future
-        option :yes
-        option :no
-        option :not_sure
+      next_node do
+        question :employ_someone
+      end
+    end
 
-        on_response do |response|
-          calculator.employer = response
-        end
+    # ======================================================================
+    # Do you want to employ someone?
+    # ======================================================================
+    radio :employ_someone do
+      option :in_future
+      option :yes
+      option :no
+      option :not_sure
 
-        next_node do
-          question :activities
-        end
+      on_response do |response|
+        calculator.employer = response
       end
 
-      # ======================================================================
-      # Does your business do any of the following?
-      # ======================================================================
-      checkbox_question :activities do
-        option :import_goods
-        option :export_goods_or_services
-        none_option
+      next_node do
+        question :activities
+      end
+    end
 
-        on_response do |response|
-          calculator.activities = response.split(",")
-        end
+    # ======================================================================
+    # Does your business do any of the following?
+    # ======================================================================
+    checkbox_question :activities do
+      option :import_goods
+      option :export_goods_or_services
+      none_option
 
-        next_node do
-          question :financial_support
-        end
+      on_response do |response|
+        calculator.activities = response.split(",")
       end
 
-      # ======================================================================
-      # Are you looking for financial support for:
-      # ======================================================================
-      radio :financial_support do
-        option :yes
-        option :no
+      next_node do
+        question :financial_support
+      end
+    end
 
-        on_response do |response|
-          calculator.needs_financial_support = response
-        end
+    # ======================================================================
+    # Are you looking for financial support for:
+    # ======================================================================
+    radio :financial_support do
+      option :yes
+      option :no
 
-        next_node do
-          question :business_premises
-        end
+      on_response do |response|
+        calculator.needs_financial_support = response
       end
 
-      # ======================================================================
-      # Where are you running your business?
-      # ======================================================================
-      checkbox_question :business_premises do
-        option :home
-        option :rented
-        option :owned
-        none_option
+      next_node do
+        question :business_premises
+      end
+    end
 
-        on_response do |response|
-          calculator.business_premises = response.split(",")
-        end
+    # ======================================================================
+    # Where are you running your business?
+    # ======================================================================
+    checkbox_question :business_premises do
+      option :home
+      option :rented
+      option :owned
+      none_option
 
-        next_node do
-          outcome :results
-        end
+      on_response do |response|
+        calculator.business_premises = response.split(",")
       end
 
-      # ======================================================================
-      # Outcome
-      # ======================================================================
-      outcome :results do
-        view_template "smart_answers/custom_result"
+      next_node do
+        outcome :results
       end
+    end
+
+    # ======================================================================
+    # Outcome
+    # ======================================================================
+    outcome :results do
+      view_template "smart_answers/custom_result"
     end
   end
 end

--- a/lib/smart_answer_flows/part-year-profit-tax-credits.rb
+++ b/lib/smart_answer_flows/part-year-profit-tax-credits.rb
@@ -1,135 +1,133 @@
-module SmartAnswer
-  class PartYearProfitTaxCreditsFlow < Flow
-    def define
-      name "part-year-profit-tax-credits"
+class PartYearProfitTaxCreditsFlow < SmartAnswer::Flow
+  def define
+    name "part-year-profit-tax-credits"
 
-      status :published
-      content_id "de6723a5-7256-4bfd-aad3-82b04b06b73e"
+    status :published
+    content_id "de6723a5-7256-4bfd-aad3-82b04b06b73e"
 
-      date_question :when_did_your_tax_credits_award_end? do
-        from { Calculators::PartYearProfitTaxCreditsCalculator::TAX_CREDITS_AWARD_ENDS_EARLIEST_DATE }
-        to   { Calculators::PartYearProfitTaxCreditsCalculator::TAX_CREDITS_AWARD_ENDS_LATEST_DATE }
+    date_question :when_did_your_tax_credits_award_end? do
+      from { SmartAnswer::Calculators::PartYearProfitTaxCreditsCalculator::TAX_CREDITS_AWARD_ENDS_EARLIEST_DATE }
+      to   { SmartAnswer::Calculators::PartYearProfitTaxCreditsCalculator::TAX_CREDITS_AWARD_ENDS_LATEST_DATE }
 
-        on_response do |response|
-          self.calculator = Calculators::PartYearProfitTaxCreditsCalculator.new
-          calculator.tax_credits_award_ends_on = response
-        end
+      on_response do |response|
+        self.calculator = SmartAnswer::Calculators::PartYearProfitTaxCreditsCalculator.new
+        calculator.tax_credits_award_ends_on = response
+      end
 
-        next_node do
-          question :what_date_do_your_accounts_go_up_to?
+      next_node do
+        question :what_date_do_your_accounts_go_up_to?
+      end
+    end
+
+    date_question :what_date_do_your_accounts_go_up_to? do
+      default_year { 0 }
+
+      on_response do |response|
+        calculator.accounts_end_month_and_day = response
+      end
+
+      next_node do
+        question :have_you_stopped_trading?
+      end
+    end
+
+    radio :have_you_stopped_trading? do
+      option "yes"
+      option "no"
+
+      on_response do |response|
+        case response
+        when "yes"
+          calculator.stopped_trading = true
+        when "no"
+          calculator.stopped_trading = false
         end
       end
 
-      date_question :what_date_do_your_accounts_go_up_to? do
-        default_year { 0 }
-
-        on_response do |response|
-          calculator.accounts_end_month_and_day = response
-        end
-
-        next_node do
-          question :have_you_stopped_trading?
+      next_node do
+        if calculator.stopped_trading
+          question :did_you_start_trading_before_the_relevant_accounting_year?
+        else
+          question :do_your_accounts_cover_a_12_month_period?
         end
       end
+    end
 
-      radio :have_you_stopped_trading? do
-        option "yes"
-        option "no"
+    radio :did_you_start_trading_before_the_relevant_accounting_year? do
+      option "yes"
+      option "no"
 
-        on_response do |response|
-          case response
-          when "yes"
-            calculator.stopped_trading = true
-          when "no"
-            calculator.stopped_trading = false
-          end
-        end
-
-        next_node do
-          if calculator.stopped_trading
-            question :did_you_start_trading_before_the_relevant_accounting_year?
-          else
-            question :do_your_accounts_cover_a_12_month_period?
-          end
+      next_node do |response|
+        case response
+        when "yes"
+          question :when_did_you_stop_trading?
+        when "no"
+          question :when_did_you_start_trading?
         end
       end
+    end
 
-      radio :did_you_start_trading_before_the_relevant_accounting_year? do
-        option "yes"
-        option "no"
+    date_question :when_did_you_stop_trading? do
+      from { SmartAnswer::Calculators::PartYearProfitTaxCreditsCalculator::START_OR_STOP_TRADING_EARLIEST_DATE }
+      to   { SmartAnswer::Calculators::PartYearProfitTaxCreditsCalculator::START_OR_STOP_TRADING_LATEST_DATE }
 
-        next_node do |response|
-          case response
-          when "yes"
-            question :when_did_you_stop_trading?
-          when "no"
-            question :when_did_you_start_trading?
-          end
-        end
+      on_response do |response|
+        calculator.stopped_trading_on = response
       end
 
-      date_question :when_did_you_stop_trading? do
-        from { Calculators::PartYearProfitTaxCreditsCalculator::START_OR_STOP_TRADING_EARLIEST_DATE }
-        to   { Calculators::PartYearProfitTaxCreditsCalculator::START_OR_STOP_TRADING_LATEST_DATE }
+      validate(:error_not_in_tax_year) do
+        calculator.valid_stopped_trading_date?
+      end
 
-        on_response do |response|
-          calculator.stopped_trading_on = response
+      next_node do
+        question :what_is_your_taxable_profit?
+      end
+    end
+
+    radio :do_your_accounts_cover_a_12_month_period? do
+      option "yes"
+      option "no"
+
+      next_node do |response|
+        if response == "yes"
+          question :what_is_your_taxable_profit?
+        else
+          question :when_did_you_start_trading?
         end
+      end
+    end
 
-        validate(:error_not_in_tax_year) do
-          calculator.valid_stopped_trading_date?
-        end
+    date_question :when_did_you_start_trading? do
+      from { SmartAnswer::Calculators::PartYearProfitTaxCreditsCalculator::START_OR_STOP_TRADING_EARLIEST_DATE }
+      to   { SmartAnswer::Calculators::PartYearProfitTaxCreditsCalculator::START_OR_STOP_TRADING_LATEST_DATE }
 
-        next_node do
+      on_response do |response|
+        calculator.started_trading_on = response
+      end
+
+      validate(:error_invalid_start_trading_date) do
+        calculator.valid_start_trading_date?
+      end
+
+      next_node do
+        if calculator.stopped_trading
+          question :when_did_you_stop_trading?
+        else
           question :what_is_your_taxable_profit?
         end
       end
-
-      radio :do_your_accounts_cover_a_12_month_period? do
-        option "yes"
-        option "no"
-
-        next_node do |response|
-          if response == "yes"
-            question :what_is_your_taxable_profit?
-          else
-            question :when_did_you_start_trading?
-          end
-        end
-      end
-
-      date_question :when_did_you_start_trading? do
-        from { Calculators::PartYearProfitTaxCreditsCalculator::START_OR_STOP_TRADING_EARLIEST_DATE }
-        to   { Calculators::PartYearProfitTaxCreditsCalculator::START_OR_STOP_TRADING_LATEST_DATE }
-
-        on_response do |response|
-          calculator.started_trading_on = response
-        end
-
-        validate(:error_invalid_start_trading_date) do
-          calculator.valid_start_trading_date?
-        end
-
-        next_node do
-          if calculator.stopped_trading
-            question :when_did_you_stop_trading?
-          else
-            question :what_is_your_taxable_profit?
-          end
-        end
-      end
-
-      money_question :what_is_your_taxable_profit? do
-        on_response do |response|
-          calculator.taxable_profit = response
-        end
-
-        next_node do
-          outcome :result
-        end
-      end
-
-      outcome :result
     end
+
+    money_question :what_is_your_taxable_profit? do
+      on_response do |response|
+        calculator.taxable_profit = response
+      end
+
+      next_node do
+        outcome :result
+      end
+    end
+
+    outcome :result
   end
 end

--- a/lib/smart_answer_flows/plan-adoption-leave.rb
+++ b/lib/smart_answer_flows/plan-adoption-leave.rb
@@ -1,50 +1,48 @@
-module SmartAnswer
-  class PlanAdoptionLeaveFlow < Flow
-    def define
-      content_id "b0e80c8b-d19f-4a50-82f4-71ab08f88207"
-      name "plan-adoption-leave"
-      status :published
+class PlanAdoptionLeaveFlow < SmartAnswer::Flow
+  def define
+    content_id "b0e80c8b-d19f-4a50-82f4-71ab08f88207"
+    name "plan-adoption-leave"
+    status :published
 
-      date_question :child_match_date? do
-        on_response do |response|
-          self.calculator = Calculators::PlanAdoptionLeave.new
-          calculator.match_date = response
-        end
-
-        next_node do
-          question :child_arrival_date?
-        end
+    date_question :child_match_date? do
+      on_response do |response|
+        self.calculator = SmartAnswer::Calculators::PlanAdoptionLeave.new
+        calculator.match_date = response
       end
 
-      date_question :child_arrival_date? do
-        on_response do |response|
-          calculator.arrival_date = response
-        end
-
-        validate do
-          calculator.valid_arrival_date?
-        end
-
-        next_node do
-          question :leave_start?
-        end
+      next_node do
+        question :child_arrival_date?
       end
-
-      date_question :leave_start? do
-        on_response do |response|
-          calculator.start_date = response
-        end
-
-        validate do
-          calculator.valid_start_date?
-        end
-
-        next_node do
-          outcome :adoption_leave_details
-        end
-      end
-
-      outcome :adoption_leave_details
     end
+
+    date_question :child_arrival_date? do
+      on_response do |response|
+        calculator.arrival_date = response
+      end
+
+      validate do
+        calculator.valid_arrival_date?
+      end
+
+      next_node do
+        question :leave_start?
+      end
+    end
+
+    date_question :leave_start? do
+      on_response do |response|
+        calculator.start_date = response
+      end
+
+      validate do
+        calculator.valid_start_date?
+      end
+
+      next_node do
+        outcome :adoption_leave_details
+      end
+    end
+
+    outcome :adoption_leave_details
   end
 end

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -1,132 +1,130 @@
-module SmartAnswer
-  class RegisterABirthFlow < Flow
-    def define
-      content_id "bb68ca88-b56b-4df2-a33d-3aaec66a5098"
-      name "register-a-birth"
-      status :published
+class RegisterABirthFlow < SmartAnswer::Flow
+  def define
+    content_id "bb68ca88-b56b-4df2-a33d-3aaec66a5098"
+    name "register-a-birth"
+    status :published
 
-      # Q1
-      country_select :country_of_birth?, exclude_countries: Calculators::RegisterABirthCalculator::EXCLUDE_COUNTRIES do
-        on_response do |response|
-          self.calculator = Calculators::RegisterABirthCalculator.new
-          calculator.country_of_birth = response
-        end
-
-        next_node do
-          if calculator.country_has_no_embassy?
-            outcome :no_embassy_result
-          elsif calculator.responded_with_nonregistrable_country?
-            outcome :nonregistrable_result
-          else
-            question :who_has_british_nationality?
-          end
-        end
+    # Q1
+    country_select :country_of_birth?, exclude_countries: SmartAnswer::Calculators::RegisterABirthCalculator::EXCLUDE_COUNTRIES do
+      on_response do |response|
+        self.calculator = SmartAnswer::Calculators::RegisterABirthCalculator.new
+        calculator.country_of_birth = response
       end
 
-      # Q2
-      radio :who_has_british_nationality? do
-        option :mother
-        option :father
-        option :mother_and_father
-        option :neither
-
-        on_response do |response|
-          calculator.british_national_parent = response
-        end
-
-        next_node do
-          case calculator.british_national_parent
-          when "mother", "father", "mother_and_father"
-            question :married_couple_or_civil_partnership?
-          when "neither"
-            outcome :no_registration_result
-          end
+      next_node do
+        if calculator.country_has_no_embassy?
+          outcome :no_embassy_result
+        elsif calculator.responded_with_nonregistrable_country?
+          outcome :nonregistrable_result
+        else
+          question :who_has_british_nationality?
         end
       end
-
-      # Q3
-      radio :married_couple_or_civil_partnership? do
-        option :yes
-        option :no
-
-        on_response do |response|
-          calculator.married_couple_or_civil_partnership = response
-        end
-
-        next_node do
-          if calculator.paternity_declaration? && calculator.british_national_father?
-            question :childs_date_of_birth?
-          else
-            question :where_are_you_now?
-          end
-        end
-      end
-
-      # Q4
-      date_question :childs_date_of_birth? do
-        from { Time.zone.today.end_of_year }
-        to { 50.years.ago(Time.zone.today) }
-
-        on_response do |response|
-          calculator.childs_date_of_birth = response
-        end
-
-        next_node do
-          if calculator.before_july_2006?
-            outcome :homeoffice_result
-          else
-            question :where_are_you_now?
-          end
-        end
-      end
-
-      # Q5
-      radio :where_are_you_now? do
-        option :same_country
-        option :another_country
-        option :in_the_uk
-
-        on_response do |response|
-          calculator.current_location = response
-        end
-
-        next_node do
-          if calculator.no_birth_certificate_exception?
-            outcome :no_birth_certificate_result
-          elsif calculator.another_country?
-            question :which_country?
-          elsif calculator.same_country? && calculator.born_in_north_korea?
-            outcome :north_korea_result
-          else
-            outcome :oru_result
-          end
-        end
-      end
-
-      # Q6
-      country_select :which_country?, exclude_countries: Calculators::RegisterABirthCalculator::EXCLUDE_COUNTRIES do
-        on_response do |response|
-          calculator.current_country = response
-        end
-
-        next_node do
-          if calculator.currently_in_north_korea?
-            outcome :north_korea_result
-          else
-            outcome :oru_result
-          end
-        end
-      end
-
-      # Outcomes
-
-      outcome :north_korea_result
-      outcome :oru_result
-      outcome :nonregistrable_result
-      outcome :no_registration_result
-      outcome :no_embassy_result
-      outcome :homeoffice_result
-      outcome :no_birth_certificate_result
     end
+
+    # Q2
+    radio :who_has_british_nationality? do
+      option :mother
+      option :father
+      option :mother_and_father
+      option :neither
+
+      on_response do |response|
+        calculator.british_national_parent = response
+      end
+
+      next_node do
+        case calculator.british_national_parent
+        when "mother", "father", "mother_and_father"
+          question :married_couple_or_civil_partnership?
+        when "neither"
+          outcome :no_registration_result
+        end
+      end
+    end
+
+    # Q3
+    radio :married_couple_or_civil_partnership? do
+      option :yes
+      option :no
+
+      on_response do |response|
+        calculator.married_couple_or_civil_partnership = response
+      end
+
+      next_node do
+        if calculator.paternity_declaration? && calculator.british_national_father?
+          question :childs_date_of_birth?
+        else
+          question :where_are_you_now?
+        end
+      end
+    end
+
+    # Q4
+    date_question :childs_date_of_birth? do
+      from { Time.zone.today.end_of_year }
+      to { 50.years.ago(Time.zone.today) }
+
+      on_response do |response|
+        calculator.childs_date_of_birth = response
+      end
+
+      next_node do
+        if calculator.before_july_2006?
+          outcome :homeoffice_result
+        else
+          question :where_are_you_now?
+        end
+      end
+    end
+
+    # Q5
+    radio :where_are_you_now? do
+      option :same_country
+      option :another_country
+      option :in_the_uk
+
+      on_response do |response|
+        calculator.current_location = response
+      end
+
+      next_node do
+        if calculator.no_birth_certificate_exception?
+          outcome :no_birth_certificate_result
+        elsif calculator.another_country?
+          question :which_country?
+        elsif calculator.same_country? && calculator.born_in_north_korea?
+          outcome :north_korea_result
+        else
+          outcome :oru_result
+        end
+      end
+    end
+
+    # Q6
+    country_select :which_country?, exclude_countries: SmartAnswer::Calculators::RegisterABirthCalculator::EXCLUDE_COUNTRIES do
+      on_response do |response|
+        calculator.current_country = response
+      end
+
+      next_node do
+        if calculator.currently_in_north_korea?
+          outcome :north_korea_result
+        else
+          outcome :oru_result
+        end
+      end
+    end
+
+    # Outcomes
+
+    outcome :north_korea_result
+    outcome :oru_result
+    outcome :nonregistrable_result
+    outcome :no_registration_result
+    outcome :no_embassy_result
+    outcome :homeoffice_result
+    outcome :no_birth_certificate_result
   end
 end

--- a/lib/smart_answer_flows/register-a-death.rb
+++ b/lib/smart_answer_flows/register-a-death.rb
@@ -1,126 +1,124 @@
-module SmartAnswer
-  class RegisterADeathFlow < Flow
-    def define
-      content_id "9e3af3d4-f044-4ac5-830e-d604d701695b"
-      name "register-a-death"
-      status :published
+class RegisterADeathFlow < SmartAnswer::Flow
+  def define
+    content_id "9e3af3d4-f044-4ac5-830e-d604d701695b"
+    name "register-a-death"
+    status :published
 
-      # Q1
-      radio :where_did_the_death_happen? do
-        on_response do |response|
-          self.calculator = Calculators::RegisterADeathCalculator.new
-          calculator.location_of_death = response
-        end
+    # Q1
+    radio :where_did_the_death_happen? do
+      on_response do |response|
+        self.calculator = SmartAnswer::Calculators::RegisterADeathCalculator.new
+        calculator.location_of_death = response
+      end
 
-        option :england_wales
-        option :scotland
-        option :northern_ireland
-        option :overseas
+      option :england_wales
+      option :scotland
+      option :northern_ireland
+      option :overseas
 
-        next_node do
-          if calculator.died_in_uk?
-            case calculator.location_of_death
-            when "scotland"
-              outcome :scotland_result
-            when "northern_ireland"
-              outcome :northern_ireland_result
-            else
-              question :did_the_person_die_at_home_hospital?
-            end
+      next_node do
+        if calculator.died_in_uk?
+          case calculator.location_of_death
+          when "scotland"
+            outcome :scotland_result
+          when "northern_ireland"
+            outcome :northern_ireland_result
           else
-            question :which_country?
+            question :did_the_person_die_at_home_hospital?
           end
+        else
+          question :which_country?
         end
       end
-
-      # Q2
-      radio :did_the_person_die_at_home_hospital? do
-        option :at_home_hospital
-        option :elsewhere
-
-        on_response do |response|
-          calculator.death_location_type = response
-        end
-
-        next_node do
-          question :was_death_expected?
-        end
-      end
-
-      # Q3
-      radio :was_death_expected? do
-        option :yes
-        option :no
-
-        on_response do |response|
-          calculator.death_expected = response
-        end
-
-        next_node do
-          outcome :uk_result
-        end
-      end
-
-      # Q4
-      country_select :which_country?, exclude_countries: Calculators::RegisterADeathCalculator::EXCLUDE_COUNTRIES do
-        on_response do |response|
-          calculator.country_of_death = response
-        end
-
-        next_node do
-          if calculator.responded_with_nonregistrable_country?
-            outcome :nonregistrable_result
-          elsif calculator.country_has_no_embassy?
-            outcome :no_embassy_result
-          else
-            question :where_are_you_now?
-          end
-        end
-      end
-
-      # Q5
-      radio :where_are_you_now? do
-        option :same_country
-        option :another_country
-        option :in_the_uk
-
-        on_response do |response|
-          calculator.current_location = response
-        end
-
-        next_node do
-          if calculator.same_country? && calculator.died_in_north_korea?
-            outcome :north_korea_result
-          elsif calculator.another_country?
-            question :which_country_are_you_in_now?
-          else
-            outcome :oru_result
-          end
-        end
-      end
-
-      # Q6
-      country_select :which_country_are_you_in_now?, exclude_countries: Calculators::RegisterADeathCalculator::EXCLUDE_COUNTRIES do
-        on_response do |response|
-          calculator.current_country = response
-        end
-
-        next_node do
-          if calculator.currently_in_north_korea?
-            outcome :north_korea_result
-          else
-            outcome :oru_result
-          end
-        end
-      end
-
-      outcome :nonregistrable_result
-      outcome :no_embassy_result
-      outcome :uk_result
-      outcome :oru_result
-      outcome :north_korea_result
-      outcome :scotland_result
-      outcome :northern_ireland_result
     end
+
+    # Q2
+    radio :did_the_person_die_at_home_hospital? do
+      option :at_home_hospital
+      option :elsewhere
+
+      on_response do |response|
+        calculator.death_location_type = response
+      end
+
+      next_node do
+        question :was_death_expected?
+      end
+    end
+
+    # Q3
+    radio :was_death_expected? do
+      option :yes
+      option :no
+
+      on_response do |response|
+        calculator.death_expected = response
+      end
+
+      next_node do
+        outcome :uk_result
+      end
+    end
+
+    # Q4
+    country_select :which_country?, exclude_countries: SmartAnswer::Calculators::RegisterADeathCalculator::EXCLUDE_COUNTRIES do
+      on_response do |response|
+        calculator.country_of_death = response
+      end
+
+      next_node do
+        if calculator.responded_with_nonregistrable_country?
+          outcome :nonregistrable_result
+        elsif calculator.country_has_no_embassy?
+          outcome :no_embassy_result
+        else
+          question :where_are_you_now?
+        end
+      end
+    end
+
+    # Q5
+    radio :where_are_you_now? do
+      option :same_country
+      option :another_country
+      option :in_the_uk
+
+      on_response do |response|
+        calculator.current_location = response
+      end
+
+      next_node do
+        if calculator.same_country? && calculator.died_in_north_korea?
+          outcome :north_korea_result
+        elsif calculator.another_country?
+          question :which_country_are_you_in_now?
+        else
+          outcome :oru_result
+        end
+      end
+    end
+
+    # Q6
+    country_select :which_country_are_you_in_now?, exclude_countries: SmartAnswer::Calculators::RegisterADeathCalculator::EXCLUDE_COUNTRIES do
+      on_response do |response|
+        calculator.current_country = response
+      end
+
+      next_node do
+        if calculator.currently_in_north_korea?
+          outcome :north_korea_result
+        else
+          outcome :oru_result
+        end
+      end
+    end
+
+    outcome :nonregistrable_result
+    outcome :no_embassy_result
+    outcome :uk_result
+    outcome :oru_result
+    outcome :north_korea_result
+    outcome :scotland_result
+    outcome :northern_ireland_result
   end
 end

--- a/lib/smart_answer_flows/report-a-lost-or-stolen-passport.rb
+++ b/lib/smart_answer_flows/report-a-lost-or-stolen-passport.rb
@@ -1,26 +1,24 @@
-module SmartAnswer
-  class ReportALostOrStolenPassportFlow < Flow
-    def define
-      content_id "f02fc2c9-f5ff-4ea2-acc4-730bbda957bb"
-      name "report-a-lost-or-stolen-passport"
-      status :published
+class ReportALostOrStolenPassportFlow < SmartAnswer::Flow
+  def define
+    content_id "f02fc2c9-f5ff-4ea2-acc4-730bbda957bb"
+    name "report-a-lost-or-stolen-passport"
+    status :published
 
-      radio :where_was_the_passport_lost_or_stolen? do
-        option :in_the_uk
-        option :abroad
+    radio :where_was_the_passport_lost_or_stolen? do
+      option :in_the_uk
+      option :abroad
 
-        next_node do |response|
-          case response
-          when "in_the_uk"
-            outcome :report_lost_or_stolen_passport
-          when "abroad"
-            outcome :contact_the_embassy
-          end
+      next_node do |response|
+        case response
+        when "in_the_uk"
+          outcome :report_lost_or_stolen_passport
+        when "abroad"
+          outcome :contact_the_embassy
         end
       end
-
-      outcome :contact_the_embassy
-      outcome :report_lost_or_stolen_passport
     end
+
+    outcome :contact_the_embassy
+    outcome :report_lost_or_stolen_passport
   end
 end

--- a/lib/smart_answer_flows/shared/minimum_wage_flow.rb
+++ b/lib/smart_answer_flows/shared/minimum_wage_flow.rb
@@ -1,321 +1,317 @@
-module SmartAnswer
-  module Shared
-    class MinimumWageFlow < Flow
-      def define
-        # Q2
-        radio :are_you_an_apprentice? do
-          option "not_an_apprentice"
-          option "apprentice_under_19"
-          option "apprentice_over_19_first_year"
-          option "apprentice_over_19_second_year_onwards"
+class MinimumWageFlow < SmartAnswer::Flow
+  def define
+    # Q2
+    radio :are_you_an_apprentice? do
+      option "not_an_apprentice"
+      option "apprentice_under_19"
+      option "apprentice_over_19_first_year"
+      option "apprentice_over_19_second_year_onwards"
 
-          next_node do |response|
-            case response
-            when "not_an_apprentice", "apprentice_over_19_second_year_onwards"
-              calculator.is_apprentice = false
-              question :how_old_are_you?
-            when "apprentice_under_19", "apprentice_over_19_first_year"
-              calculator.is_apprentice = true
-              question :how_often_do_you_get_paid?
-            end
-          end
+      next_node do |response|
+        case response
+        when "not_an_apprentice", "apprentice_over_19_second_year_onwards"
+          calculator.is_apprentice = false
+          question :how_old_are_you?
+        when "apprentice_under_19", "apprentice_over_19_first_year"
+          calculator.is_apprentice = true
+          question :how_often_do_you_get_paid?
         end
-
-        # Q2 Past
-        radio :were_you_an_apprentice? do
-          option "no"
-          option "apprentice_under_19"
-          option "apprentice_over_19"
-
-          next_node do |response|
-            case response
-            when "no"
-              calculator.is_apprentice = false
-              question :how_old_were_you?
-            else
-              calculator.is_apprentice = true
-              question :how_often_did_you_get_paid?
-            end
-          end
-        end
-
-        # Q3 Past
-        value_question :how_old_were_you?, parse: Integer do
-          validate do |response|
-            calculator.valid_age?(response)
-          end
-
-          next_node do |response|
-            calculator.age = response
-            if calculator.under_school_leaving_age?
-              outcome :under_school_leaving_age_past
-            else
-              question :how_often_did_you_get_paid?
-            end
-          end
-        end
-
-        # Q4
-        value_question :how_often_do_you_get_paid?, parse: :to_i do
-          validate do |response|
-            calculator.valid_pay_frequency?(response)
-          end
-
-          next_node do |response|
-            calculator.pay_frequency = response
-            question :how_many_hours_do_you_work?
-          end
-        end
-
-        # Q4 Past
-        value_question :how_often_did_you_get_paid?, parse: :to_i do
-          validate do |response|
-            calculator.valid_pay_frequency?(response)
-          end
-
-          next_node do |response|
-            calculator.pay_frequency = response
-            question :how_many_hours_did_you_work?
-          end
-        end
-
-        # Q5
-        value_question :how_many_hours_do_you_work?, parse: Float do
-          validate(:error_hours) do |response|
-            calculator.valid_hours_worked?(response)
-          end
-
-          next_node do |response|
-            calculator.basic_hours = response
-            question :how_much_are_you_paid_during_pay_period?
-          end
-        end
-
-        # Q5 Past
-        value_question :how_many_hours_did_you_work?, parse: Float do
-          validate(:error_hours) do |response|
-            calculator.valid_hours_worked?(response)
-          end
-
-          next_node do |response|
-            calculator.basic_hours = response
-            question :how_much_were_you_paid_during_pay_period?
-          end
-        end
-
-        # Q6
-        money_question :how_much_are_you_paid_during_pay_period? do
-          next_node do |response|
-            calculator.basic_pay = Float(response)
-            question :is_provided_with_accommodation?
-          end
-        end
-
-        # Q6 Past
-        money_question :how_much_were_you_paid_during_pay_period? do
-          next_node do |response|
-            calculator.basic_pay = Float(response)
-            question :was_provided_with_accommodation?
-          end
-        end
-
-        # Q7
-        radio :is_provided_with_accommodation? do
-          option "no"
-          option "yes_free"
-          option "yes_charged"
-
-          next_node do |response|
-            case response
-            when "yes_free"
-              question :current_accommodation_usage?
-            when "yes_charged"
-              question :current_accommodation_charge?
-            else
-              question :does_employer_charge_for_job_requirements?
-            end
-          end
-        end
-
-        # Q7 Past
-        radio :was_provided_with_accommodation? do
-          option "no"
-          option "yes_free"
-          option "yes_charged"
-
-          next_node do |response|
-            case response
-            when "yes_free"
-              question :past_accommodation_usage?
-            when "yes_charged"
-              question :past_accommodation_charge?
-            else
-              question :did_employer_charge_for_job_requirements?
-            end
-          end
-        end
-
-        # Q7a
-        money_question :current_accommodation_charge? do
-          validate do |response|
-            calculator.valid_accommodation_charge?(response)
-          end
-
-          on_response do |response|
-            self.accommodation_charge = response
-          end
-
-          next_node do
-            question :current_accommodation_usage?
-          end
-        end
-
-        # Q7a Past
-        money_question :past_accommodation_charge? do
-          validate do |response|
-            calculator.valid_accommodation_charge?(response)
-          end
-
-          on_response do |response|
-            self.accommodation_charge = response
-          end
-
-          next_node do
-            question :past_accommodation_usage?
-          end
-        end
-
-        # Q7b
-        value_question :current_accommodation_usage?, parse: Integer do
-          validate do |response|
-            calculator.valid_accommodation_usage?(response)
-          end
-
-          next_node do |response|
-            calculator.accommodation_adjustment(accommodation_charge, response)
-            question :does_employer_charge_for_job_requirements?
-          end
-        end
-
-        # Q7b Past
-        value_question :past_accommodation_usage?, parse: Integer do
-          validate do |response|
-            calculator.valid_accommodation_usage?(response)
-          end
-
-          next_node do |response|
-            calculator.accommodation_adjustment(accommodation_charge, response)
-            question :did_employer_charge_for_job_requirements?
-          end
-        end
-
-        # Q8
-        radio :does_employer_charge_for_job_requirements? do
-          option "yes"
-          option "no"
-
-          next_node do |response|
-            calculator.job_requirements_charge = true if response == "yes"
-            question :current_additional_work_outside_shift?
-          end
-        end
-
-        # Q8 past
-        radio :did_employer_charge_for_job_requirements? do
-          option "yes"
-          option "no"
-
-          next_node do |response|
-            calculator.job_requirements_charge = true if response == "yes"
-            question :past_additional_work_outside_shift?
-          end
-        end
-
-        # Q9
-        radio :current_additional_work_outside_shift? do
-          option "yes"
-          option "no"
-
-          next_node do |response|
-            case response
-            when "yes"
-              question :current_paid_for_work_outside_shift?
-            when "no"
-              if calculator.minimum_wage_or_above?
-                outcome :current_payment_above
-              else
-                outcome :current_payment_below
-              end
-            end
-          end
-        end
-
-        # Q9 past
-        radio :past_additional_work_outside_shift? do
-          option "yes"
-          option "no"
-
-          next_node do |response|
-            case response
-            when "yes"
-              question :past_paid_for_work_outside_shift?
-            when "no"
-              if calculator.minimum_wage_or_above?
-                outcome :past_payment_above
-              else
-                outcome :past_payment_below
-              end
-            end
-          end
-        end
-
-        # Q9a
-        radio :current_paid_for_work_outside_shift? do
-          option "yes"
-          option "no"
-
-          next_node do |response|
-            case response
-            when "no"
-              calculator.unpaid_additional_hours = true
-            end
-
-            if calculator.minimum_wage_or_above?
-              outcome :current_payment_above
-            else
-              outcome :current_payment_below
-            end
-          end
-        end
-
-        # Q9a past
-        radio :past_paid_for_work_outside_shift? do
-          option "yes"
-          option "no"
-
-          next_node do |response|
-            case response
-            when "no"
-              calculator.unpaid_additional_hours = true
-            end
-
-            if calculator.minimum_wage_or_above?
-              outcome :past_payment_above
-            else
-              outcome :past_payment_below
-            end
-          end
-        end
-
-        outcome :current_payment_above
-        outcome :current_payment_below
-
-        outcome :past_payment_above
-        outcome :past_payment_below
-
-        outcome :under_school_leaving_age
-        outcome :under_school_leaving_age_past
       end
     end
+
+    # Q2 Past
+    radio :were_you_an_apprentice? do
+      option "no"
+      option "apprentice_under_19"
+      option "apprentice_over_19"
+
+      next_node do |response|
+        case response
+        when "no"
+          calculator.is_apprentice = false
+          question :how_old_were_you?
+        else
+          calculator.is_apprentice = true
+          question :how_often_did_you_get_paid?
+        end
+      end
+    end
+
+    # Q3 Past
+    value_question :how_old_were_you?, parse: Integer do
+      validate do |response|
+        calculator.valid_age?(response)
+      end
+
+      next_node do |response|
+        calculator.age = response
+        if calculator.under_school_leaving_age?
+          outcome :under_school_leaving_age_past
+        else
+          question :how_often_did_you_get_paid?
+        end
+      end
+    end
+
+    # Q4
+    value_question :how_often_do_you_get_paid?, parse: :to_i do
+      validate do |response|
+        calculator.valid_pay_frequency?(response)
+      end
+
+      next_node do |response|
+        calculator.pay_frequency = response
+        question :how_many_hours_do_you_work?
+      end
+    end
+
+    # Q4 Past
+    value_question :how_often_did_you_get_paid?, parse: :to_i do
+      validate do |response|
+        calculator.valid_pay_frequency?(response)
+      end
+
+      next_node do |response|
+        calculator.pay_frequency = response
+        question :how_many_hours_did_you_work?
+      end
+    end
+
+    # Q5
+    value_question :how_many_hours_do_you_work?, parse: Float do
+      validate(:error_hours) do |response|
+        calculator.valid_hours_worked?(response)
+      end
+
+      next_node do |response|
+        calculator.basic_hours = response
+        question :how_much_are_you_paid_during_pay_period?
+      end
+    end
+
+    # Q5 Past
+    value_question :how_many_hours_did_you_work?, parse: Float do
+      validate(:error_hours) do |response|
+        calculator.valid_hours_worked?(response)
+      end
+
+      next_node do |response|
+        calculator.basic_hours = response
+        question :how_much_were_you_paid_during_pay_period?
+      end
+    end
+
+    # Q6
+    money_question :how_much_are_you_paid_during_pay_period? do
+      next_node do |response|
+        calculator.basic_pay = Float(response)
+        question :is_provided_with_accommodation?
+      end
+    end
+
+    # Q6 Past
+    money_question :how_much_were_you_paid_during_pay_period? do
+      next_node do |response|
+        calculator.basic_pay = Float(response)
+        question :was_provided_with_accommodation?
+      end
+    end
+
+    # Q7
+    radio :is_provided_with_accommodation? do
+      option "no"
+      option "yes_free"
+      option "yes_charged"
+
+      next_node do |response|
+        case response
+        when "yes_free"
+          question :current_accommodation_usage?
+        when "yes_charged"
+          question :current_accommodation_charge?
+        else
+          question :does_employer_charge_for_job_requirements?
+        end
+      end
+    end
+
+    # Q7 Past
+    radio :was_provided_with_accommodation? do
+      option "no"
+      option "yes_free"
+      option "yes_charged"
+
+      next_node do |response|
+        case response
+        when "yes_free"
+          question :past_accommodation_usage?
+        when "yes_charged"
+          question :past_accommodation_charge?
+        else
+          question :did_employer_charge_for_job_requirements?
+        end
+      end
+    end
+
+    # Q7a
+    money_question :current_accommodation_charge? do
+      validate do |response|
+        calculator.valid_accommodation_charge?(response)
+      end
+
+      on_response do |response|
+        self.accommodation_charge = response
+      end
+
+      next_node do
+        question :current_accommodation_usage?
+      end
+    end
+
+    # Q7a Past
+    money_question :past_accommodation_charge? do
+      validate do |response|
+        calculator.valid_accommodation_charge?(response)
+      end
+
+      on_response do |response|
+        self.accommodation_charge = response
+      end
+
+      next_node do
+        question :past_accommodation_usage?
+      end
+    end
+
+    # Q7b
+    value_question :current_accommodation_usage?, parse: Integer do
+      validate do |response|
+        calculator.valid_accommodation_usage?(response)
+      end
+
+      next_node do |response|
+        calculator.accommodation_adjustment(accommodation_charge, response)
+        question :does_employer_charge_for_job_requirements?
+      end
+    end
+
+    # Q7b Past
+    value_question :past_accommodation_usage?, parse: Integer do
+      validate do |response|
+        calculator.valid_accommodation_usage?(response)
+      end
+
+      next_node do |response|
+        calculator.accommodation_adjustment(accommodation_charge, response)
+        question :did_employer_charge_for_job_requirements?
+      end
+    end
+
+    # Q8
+    radio :does_employer_charge_for_job_requirements? do
+      option "yes"
+      option "no"
+
+      next_node do |response|
+        calculator.job_requirements_charge = true if response == "yes"
+        question :current_additional_work_outside_shift?
+      end
+    end
+
+    # Q8 past
+    radio :did_employer_charge_for_job_requirements? do
+      option "yes"
+      option "no"
+
+      next_node do |response|
+        calculator.job_requirements_charge = true if response == "yes"
+        question :past_additional_work_outside_shift?
+      end
+    end
+
+    # Q9
+    radio :current_additional_work_outside_shift? do
+      option "yes"
+      option "no"
+
+      next_node do |response|
+        case response
+        when "yes"
+          question :current_paid_for_work_outside_shift?
+        when "no"
+          if calculator.minimum_wage_or_above?
+            outcome :current_payment_above
+          else
+            outcome :current_payment_below
+          end
+        end
+      end
+    end
+
+    # Q9 past
+    radio :past_additional_work_outside_shift? do
+      option "yes"
+      option "no"
+
+      next_node do |response|
+        case response
+        when "yes"
+          question :past_paid_for_work_outside_shift?
+        when "no"
+          if calculator.minimum_wage_or_above?
+            outcome :past_payment_above
+          else
+            outcome :past_payment_below
+          end
+        end
+      end
+    end
+
+    # Q9a
+    radio :current_paid_for_work_outside_shift? do
+      option "yes"
+      option "no"
+
+      next_node do |response|
+        case response
+        when "no"
+          calculator.unpaid_additional_hours = true
+        end
+
+        if calculator.minimum_wage_or_above?
+          outcome :current_payment_above
+        else
+          outcome :current_payment_below
+        end
+      end
+    end
+
+    # Q9a past
+    radio :past_paid_for_work_outside_shift? do
+      option "yes"
+      option "no"
+
+      next_node do |response|
+        case response
+        when "no"
+          calculator.unpaid_additional_hours = true
+        end
+
+        if calculator.minimum_wage_or_above?
+          outcome :past_payment_above
+        else
+          outcome :past_payment_below
+        end
+      end
+    end
+
+    outcome :current_payment_above
+    outcome :current_payment_below
+
+    outcome :past_payment_above
+    outcome :past_payment_below
+
+    outcome :under_school_leaving_age
+    outcome :under_school_leaving_age_past
   end
 end

--- a/lib/smart_answer_flows/shared/redundancy_pay_flow.rb
+++ b/lib/smart_answer_flows/shared/redundancy_pay_flow.rb
@@ -1,80 +1,76 @@
-module SmartAnswer
-  module Shared
-    class RedundancyPayFlow < Flow
-      def define
-        date_question :date_of_redundancy? do
-          from { Calculators::RedundancyCalculator.first_selectable_date }
-          to { Calculators::RedundancyCalculator.last_selectable_date }
-          validate_in_range
+class RedundancyPayFlow < SmartAnswer::Flow
+  def define
+    date_question :date_of_redundancy? do
+      from { SmartAnswer::Calculators::RedundancyCalculator.first_selectable_date }
+      to { SmartAnswer::Calculators::RedundancyCalculator.last_selectable_date }
+      validate_in_range
 
-          on_response do |response|
-            self.rates = Calculators::RedundancyCalculator.redundancy_rates(response)
-            self.ni_rates = Calculators::RedundancyCalculator.northern_ireland_redundancy_rates(response)
-            self.rate = rates.rate
-            self.ni_rate = ni_rates.rate
-            self.max_amount = rates.max
-            self.ni_max_amount = ni_rates.max
-          end
+      on_response do |response|
+        self.rates = SmartAnswer::Calculators::RedundancyCalculator.redundancy_rates(response)
+        self.ni_rates = SmartAnswer::Calculators::RedundancyCalculator.northern_ireland_redundancy_rates(response)
+        self.rate = rates.rate
+        self.ni_rate = ni_rates.rate
+        self.max_amount = rates.max
+        self.ni_max_amount = ni_rates.max
+      end
 
-          next_node do
-            question :age_of_employee?
-          end
-        end
-
-        value_question :age_of_employee?, parse: :to_i do
-          on_response do |response|
-            self.employee_age = response
-            self.years_available = employee_age - 15
-          end
-
-          validate do
-            employee_age.between?(16, 100)
-          end
-
-          next_node do
-            question :years_employed?
-          end
-        end
-
-        value_question :years_employed?, parse: Float do
-          on_response do |response|
-            self.years_employed = response.floor
-          end
-
-          validate do
-            years_employed.to_i <= years_available
-          end
-
-          next_node do |response|
-            if response.floor < 2
-              outcome :done_no_statutory
-            else
-              question :weekly_pay_before_tax?
-            end
-          end
-        end
-
-        money_question :weekly_pay_before_tax? do
-          on_response do |response|
-            self.calculator = Calculators::RedundancyCalculator.new(rate, employee_age, years_employed, response)
-            self.ni_calculator = Calculators::RedundancyCalculator.new(ni_rate, employee_age, years_employed, response)
-            self.statutory_redundancy_pay = calculator.format_money(calculator.pay.to_f)
-            self.statutory_redundancy_pay_ni = calculator.format_money(ni_calculator.pay.to_f)
-            self.number_of_weeks_entitlement = calculator.number_of_weeks_entitlement
-          end
-
-          next_node do
-            if years_employed < 2
-              outcome :done_no_statutory
-            else
-              outcome :done
-            end
-          end
-        end
-
-        outcome :done_no_statutory
-        outcome :done
+      next_node do
+        question :age_of_employee?
       end
     end
+
+    value_question :age_of_employee?, parse: :to_i do
+      on_response do |response|
+        self.employee_age = response
+        self.years_available = employee_age - 15
+      end
+
+      validate do
+        employee_age.between?(16, 100)
+      end
+
+      next_node do
+        question :years_employed?
+      end
+    end
+
+    value_question :years_employed?, parse: Float do
+      on_response do |response|
+        self.years_employed = response.floor
+      end
+
+      validate do
+        years_employed.to_i <= years_available
+      end
+
+      next_node do |response|
+        if response.floor < 2
+          outcome :done_no_statutory
+        else
+          question :weekly_pay_before_tax?
+        end
+      end
+    end
+
+    money_question :weekly_pay_before_tax? do
+      on_response do |response|
+        self.calculator = SmartAnswer::Calculators::RedundancyCalculator.new(rate, employee_age, years_employed, response)
+        self.ni_calculator = SmartAnswer::Calculators::RedundancyCalculator.new(ni_rate, employee_age, years_employed, response)
+        self.statutory_redundancy_pay = calculator.format_money(calculator.pay.to_f)
+        self.statutory_redundancy_pay_ni = calculator.format_money(ni_calculator.pay.to_f)
+        self.number_of_weeks_entitlement = calculator.number_of_weeks_entitlement
+      end
+
+      next_node do
+        if years_employed < 2
+          outcome :done_no_statutory
+        else
+          outcome :done
+        end
+      end
+    end
+
+    outcome :done_no_statutory
+    outcome :done
   end
 end

--- a/lib/smart_answer_flows/simplified-expenses-checker.rb
+++ b/lib/smart_answer_flows/simplified-expenses-checker.rb
@@ -1,295 +1,293 @@
-module SmartAnswer
-  class SimplifiedExpensesCheckerFlow < Flow
-    def define
-      content_id "8ad76560-8a27-42ee-9a99-8aaa8f0109a5"
-      name "simplified-expenses-checker"
-      status :published
+class SimplifiedExpensesCheckerFlow < SmartAnswer::Flow
+  def define
+    content_id "8ad76560-8a27-42ee-9a99-8aaa8f0109a5"
+    name "simplified-expenses-checker"
+    status :published
 
-      # Q1 - vehicle expense
-      radio :vehicle_expense? do
-        option :car
-        option :van
-        option :motorcycle
-        option :no_vehicle
+    # Q1 - vehicle expense
+    radio :vehicle_expense? do
+      option :car
+      option :van
+      option :motorcycle
+      option :no_vehicle
 
-        on_response do |response|
-          self.calculator = Calculators::SimplifiedExpensesCheckerCalculator.new
-          calculator.type_of_vehicle = response
-        end
-
-        next_node do
-          question :home_or_business_premises_expense?
-        end
+      on_response do |response|
+        self.calculator = SmartAnswer::Calculators::SimplifiedExpensesCheckerCalculator.new
+        calculator.type_of_vehicle = response
       end
 
-      # Q2 - home or business premises expense
-      radio :home_or_business_premises_expense? do
-        option :using_home_for_business
-        option :live_on_business_premises
-        option :no_expense
+      next_node do
+        question :home_or_business_premises_expense?
+      end
+    end
 
-        on_response do |response|
-          calculator.business_premises_expense = response
-        end
+    # Q2 - home or business premises expense
+    radio :home_or_business_premises_expense? do
+      option :using_home_for_business
+      option :live_on_business_premises
+      option :no_expense
 
-        next_node do |response|
-          calculator.business_premises_expense = response
-          if response == "no_expense" &&
-              calculator.type_of_vehicle == "no_vehicle"
-            outcome :you_cant_use_result
-          else
-            raise InvalidResponse if response =~ /live_on_business_premises.*?using_home_for_business/
-
-            if calculator.vehicle?
-              question :buying_new_vehicle?
-            elsif calculator.working_from_home?
-              question :hours_work_home?
-            elsif calculator.living_on_business_premises?
-              question :deduct_from_premises?
-            end
-          end
-        end
+      on_response do |response|
+        calculator.business_premises_expense = response
       end
 
-      # Q3 - buying new vehicle?
-      radio :buying_new_vehicle? do
-        option :new
-        option :used
-        option :no
+      next_node do |response|
+        calculator.business_premises_expense = response
+        if response == "no_expense" &&
+            calculator.type_of_vehicle == "no_vehicle"
+          outcome :you_cant_use_result
+        else
+          raise SmartAnswer::InvalidResponse if response =~ /live_on_business_premises.*?using_home_for_business/
 
-        on_response do |response|
-          calculator.new_or_used_vehicle = response
-        end
-
-        next_node do |response|
-          if %w[new used].include?(response)
-            question :how_much_expect_to_claim?
-          else
-            question :capital_allowances?
-          end
-        end
-      end
-
-      # Q4 - capital allowances claimed?
-      # if yes => go to Result 3 if in Q1 only [car_van] and/or [motorcylce] was selected
-      #
-      # if yes and other expenses apart from cars and/or motorbikes selected in Q1 store as capital_allowance_claimed and add text to result (see result 2) and go to questions for other expenses, ie don't go to Q4 & Q8
-      #
-      # if no go to Q4
-      radio :capital_allowances? do
-        option :capital_allowance
-        option :simplified_expenses
-        option :no
-
-        on_response do |response|
-          calculator.selected_allowance = response
-        end
-
-        next_node do |response|
-          calculator.selected_allowance = response
-          if calculator.capital_allowance?
-            if calculator.vehicle_only?
-              outcome :capital_allowance_result
-            elsif calculator.home?
-              question :hours_work_home?
-            elsif calculator.business_premises?
-              question :deduct_from_premises?
-            end
-          elsif calculator.simplified_expenses?
-            if calculator.vehicle_only?
-              outcome :you_cant_claim_capital_allowance
-            elsif calculator.home?
-              question :hours_work_home?
-            elsif calculator.business_premises?
-              question :deduct_from_premises?
-            end
-          elsif calculator.no_allowance?
-            if calculator.van? || calculator.motorcycle?
-              question :how_much_expect_to_claim?
-            elsif calculator.car?
-              question :car_status_before_usage?
-            end
-          end
-        end
-      end
-
-      # Q5 - Was your car new or second-hand when you started using it for your business?
-      radio :car_status_before_usage? do
-        option :new
-        option :used
-
-        on_response do |response|
-          calculator.car_status_before_usage = response
-        end
-
-        next_node do
-          question :how_much_expect_to_claim?
-        end
-      end
-
-      # Q6 - claim vehicle expenses
-      money_question :how_much_expect_to_claim? do
-        on_response do |response|
-          calculator.vehicle_costs = response
-        end
-
-        next_node do
-          if calculator.car?
-            question :is_vehicle_green?
-          elsif calculator.van? || calculator.motorcycle?
-            question :price_of_vehicle?
-          end
-        end
-      end
-
-      # Q7 - is vehicle green?
-      radio :is_vehicle_green? do
-        option :low
-        option :medium
-        option :high
-
-        on_response do |response|
-          calculator.vehicle_emission = case response
-                                        when "low"
-                                          if calculator.new_car?
-                                            response
-                                          else
-                                            "medium"
-                                          end
-                                        else
-                                          response
-                                        end
-        end
-
-        next_node do
-          question :price_of_vehicle?
-        end
-      end
-
-      # Q8 - price of vehicle
-      money_question :price_of_vehicle? do
-        on_response do |response|
-          calculator.vehicle_price = response
-        end
-
-        next_node do
-          question :vehicle_business_use_time?
-        end
-      end
-
-      # Q9 - vehicle private use time
-      value_question :vehicle_business_use_time?, parse: :to_f do
-        # deduct percentage amount from [green_cost] or [dirty_cost] and store as [green_write_off] or [dirty_write_off]
-
-        on_response do |response|
-          calculator.business_use_percent = response
-        end
-
-        next_node do |response|
-          raise InvalidResponse if response.to_i > 100
-
-          if calculator.car? || calculator.van?
-            question :drive_business_miles_car_van?
-          else
-            question :drive_business_miles_motorcycle?
-          end
-        end
-      end
-
-      # Q10 - miles to drive for business car_or_van
-      value_question :drive_business_miles_car_van? do
-        on_response do |response|
-          calculator.business_miles_car_van = response
-        end
-
-        next_node do
-          if calculator.motorcycle?
-            question :drive_business_miles_motorcycle?
+          if calculator.vehicle?
+            question :buying_new_vehicle?
           elsif calculator.working_from_home?
             question :hours_work_home?
           elsif calculator.living_on_business_premises?
             question :deduct_from_premises?
-          else
-            outcome :you_can_use_result
           end
         end
       end
+    end
 
-      # Q11 - miles to drive for business motorcycle
-      value_question :drive_business_miles_motorcycle? do
-        on_response do |response|
-          calculator.business_miles_motorcycle = response
+    # Q3 - buying new vehicle?
+    radio :buying_new_vehicle? do
+      option :new
+      option :used
+      option :no
+
+      on_response do |response|
+        calculator.new_or_used_vehicle = response
+      end
+
+      next_node do |response|
+        if %w[new used].include?(response)
+          question :how_much_expect_to_claim?
+        else
+          question :capital_allowances?
         end
+      end
+    end
 
-        next_node do
-          if calculator.working_from_home?
+    # Q4 - capital allowances claimed?
+    # if yes => go to Result 3 if in Q1 only [car_van] and/or [motorcylce] was selected
+    #
+    # if yes and other expenses apart from cars and/or motorbikes selected in Q1 store as capital_allowance_claimed and add text to result (see result 2) and go to questions for other expenses, ie don't go to Q4 & Q8
+    #
+    # if no go to Q4
+    radio :capital_allowances? do
+      option :capital_allowance
+      option :simplified_expenses
+      option :no
+
+      on_response do |response|
+        calculator.selected_allowance = response
+      end
+
+      next_node do |response|
+        calculator.selected_allowance = response
+        if calculator.capital_allowance?
+          if calculator.vehicle_only?
+            outcome :capital_allowance_result
+          elsif calculator.home?
             question :hours_work_home?
-          elsif calculator.living_on_business_premises?
+          elsif calculator.business_premises?
             question :deduct_from_premises?
-          else
-            outcome :you_can_use_result
           end
-        end
-      end
-
-      # Q12 - hours for home work
-      value_question :hours_work_home? do
-        on_response do |response|
-          calculator.hours_worked_home = response
-        end
-
-        next_node do |response|
-          if response.to_f < 1
-            raise SmartAnswer::InvalidResponse
-          elsif response.to_f < 25
-            outcome :you_cant_use_result
-          else
-            question :current_claim_amount_home?
-          end
-        end
-      end
-
-      # Q13 - how much do you claim?
-      money_question :current_claim_amount_home? do
-        on_response do |response|
-          calculator.home_costs = response
-        end
-
-        next_node do
-          if calculator.living_on_business_premises?
+        elsif calculator.simplified_expenses?
+          if calculator.vehicle_only?
+            outcome :you_cant_claim_capital_allowance
+          elsif calculator.home?
+            question :hours_work_home?
+          elsif calculator.business_premises?
             question :deduct_from_premises?
-          else
-            outcome :you_can_use_result
+          end
+        elsif calculator.no_allowance?
+          if calculator.van? || calculator.motorcycle?
+            question :how_much_expect_to_claim?
+          elsif calculator.car?
+            question :car_status_before_usage?
           end
         end
       end
+    end
 
-      # Q14 = how much do you deduct from premises for private use?
-      money_question :deduct_from_premises? do
-        on_response do |response|
-          calculator.business_premises_cost = response
-        end
+    # Q5 - Was your car new or second-hand when you started using it for your business?
+    radio :car_status_before_usage? do
+      option :new
+      option :used
 
-        next_node do
-          question :people_live_on_premises?
-        end
+      on_response do |response|
+        calculator.car_status_before_usage = response
       end
 
-      # Q15 - people who live on business premises?
-      value_question :people_live_on_premises?, parse: :to_i do
-        on_response do |response|
-          calculator.hours_lived_on_business_premises = response
-        end
+      next_node do
+        question :how_much_expect_to_claim?
+      end
+    end
 
-        next_node do
+    # Q6 - claim vehicle expenses
+    money_question :how_much_expect_to_claim? do
+      on_response do |response|
+        calculator.vehicle_costs = response
+      end
+
+      next_node do
+        if calculator.car?
+          question :is_vehicle_green?
+        elsif calculator.van? || calculator.motorcycle?
+          question :price_of_vehicle?
+        end
+      end
+    end
+
+    # Q7 - is vehicle green?
+    radio :is_vehicle_green? do
+      option :low
+      option :medium
+      option :high
+
+      on_response do |response|
+        calculator.vehicle_emission = case response
+                                      when "low"
+                                        if calculator.new_car?
+                                          response
+                                        else
+                                          "medium"
+                                        end
+                                      else
+                                        response
+                                      end
+      end
+
+      next_node do
+        question :price_of_vehicle?
+      end
+    end
+
+    # Q8 - price of vehicle
+    money_question :price_of_vehicle? do
+      on_response do |response|
+        calculator.vehicle_price = response
+      end
+
+      next_node do
+        question :vehicle_business_use_time?
+      end
+    end
+
+    # Q9 - vehicle private use time
+    value_question :vehicle_business_use_time?, parse: :to_f do
+      # deduct percentage amount from [green_cost] or [dirty_cost] and store as [green_write_off] or [dirty_write_off]
+
+      on_response do |response|
+        calculator.business_use_percent = response
+      end
+
+      next_node do |response|
+        raise SmartAnswer::InvalidResponse if response.to_i > 100
+
+        if calculator.car? || calculator.van?
+          question :drive_business_miles_car_van?
+        else
+          question :drive_business_miles_motorcycle?
+        end
+      end
+    end
+
+    # Q10 - miles to drive for business car_or_van
+    value_question :drive_business_miles_car_van? do
+      on_response do |response|
+        calculator.business_miles_car_van = response
+      end
+
+      next_node do
+        if calculator.motorcycle?
+          question :drive_business_miles_motorcycle?
+        elsif calculator.working_from_home?
+          question :hours_work_home?
+        elsif calculator.living_on_business_premises?
+          question :deduct_from_premises?
+        else
           outcome :you_can_use_result
         end
       end
-
-      outcome :you_cant_use_result
-      outcome :you_can_use_result
-      outcome :capital_allowance_result
-      outcome :you_cant_claim_capital_allowance
     end
+
+    # Q11 - miles to drive for business motorcycle
+    value_question :drive_business_miles_motorcycle? do
+      on_response do |response|
+        calculator.business_miles_motorcycle = response
+      end
+
+      next_node do
+        if calculator.working_from_home?
+          question :hours_work_home?
+        elsif calculator.living_on_business_premises?
+          question :deduct_from_premises?
+        else
+          outcome :you_can_use_result
+        end
+      end
+    end
+
+    # Q12 - hours for home work
+    value_question :hours_work_home? do
+      on_response do |response|
+        calculator.hours_worked_home = response
+      end
+
+      next_node do |response|
+        if response.to_f < 1
+          raise SmartAnswer::InvalidResponse
+        elsif response.to_f < 25
+          outcome :you_cant_use_result
+        else
+          question :current_claim_amount_home?
+        end
+      end
+    end
+
+    # Q13 - how much do you claim?
+    money_question :current_claim_amount_home? do
+      on_response do |response|
+        calculator.home_costs = response
+      end
+
+      next_node do
+        if calculator.living_on_business_premises?
+          question :deduct_from_premises?
+        else
+          outcome :you_can_use_result
+        end
+      end
+    end
+
+    # Q14 = how much do you deduct from premises for private use?
+    money_question :deduct_from_premises? do
+      on_response do |response|
+        calculator.business_premises_cost = response
+      end
+
+      next_node do
+        question :people_live_on_premises?
+      end
+    end
+
+    # Q15 - people who live on business premises?
+    value_question :people_live_on_premises?, parse: :to_i do
+      on_response do |response|
+        calculator.hours_lived_on_business_premises = response
+      end
+
+      next_node do
+        outcome :you_can_use_result
+      end
+    end
+
+    outcome :you_cant_use_result
+    outcome :you_can_use_result
+    outcome :capital_allowance_result
+    outcome :you_cant_claim_capital_allowance
   end
 end

--- a/lib/smart_answer_flows/state-pension-age.rb
+++ b/lib/smart_answer_flows/state-pension-age.rb
@@ -1,75 +1,73 @@
-module SmartAnswer
-  class StatePensionAgeFlow < Flow
-    def define
-      content_id "5491c439-1c83-4044-80d3-32cc3613b739"
-      name "state-pension-age"
-      status :published
+class StatePensionAgeFlow < SmartAnswer::Flow
+  def define
+    content_id "5491c439-1c83-4044-80d3-32cc3613b739"
+    name "state-pension-age"
+    status :published
 
-      # Q1
-      radio :which_calculation? do
-        option :age
-        option :bus_pass
+    # Q1
+    radio :which_calculation? do
+      option :age
+      option :bus_pass
 
-        on_response do |response|
-          self.which_calculation = response
-        end
-
-        next_node do
-          question :dob_age?
-        end
+      on_response do |response|
+        self.which_calculation = response
       end
 
-      # Q2:Age
-      date_question :dob_age? do
-        date_of_birth_defaults
+      next_node do
+        question :dob_age?
+      end
+    end
 
-        validate { |response| response <= Time.zone.today }
+    # Q2:Age
+    date_question :dob_age? do
+      date_of_birth_defaults
 
-        on_response do |response|
-          self.calculator = Calculators::StatePensionAgeCalculator.new(dob: response)
-        end
+      validate { |response| response <= Time.zone.today }
 
-        next_node do
-          if which_calculation == "age"
-            if calculator.pension_age_based_on_gender?
-              question :gender?
-            elsif calculator.before_state_pension_date?
-              outcome :not_yet_reached_sp_age
-            else
-              outcome :has_reached_sp_age
-            end
-          else
-            outcome :bus_pass_result
-          end
-        end
+      on_response do |response|
+        self.calculator = SmartAnswer::Calculators::StatePensionAgeCalculator.new(dob: response)
       end
 
-      # Q3
-      radio :gender? do
-        option :male
-        option :female
-        option :prefer_not_to_say
-
-        next_node do |response|
-          calculator.gender = response.to_sym
-
-          if calculator.non_binary?
-            outcome :has_reached_sp_age_non_binary
+      next_node do
+        if which_calculation == "age"
+          if calculator.pension_age_based_on_gender?
+            question :gender?
           elsif calculator.before_state_pension_date?
             outcome :not_yet_reached_sp_age
           else
             outcome :has_reached_sp_age
           end
+        else
+          outcome :bus_pass_result
         end
       end
-
-      outcome :bus_pass_result
-
-      outcome :not_yet_reached_sp_age
-
-      outcome :has_reached_sp_age
-
-      outcome :has_reached_sp_age_non_binary
     end
+
+    # Q3
+    radio :gender? do
+      option :male
+      option :female
+      option :prefer_not_to_say
+
+      next_node do |response|
+        calculator.gender = response.to_sym
+
+        if calculator.non_binary?
+          outcome :has_reached_sp_age_non_binary
+        elsif calculator.before_state_pension_date?
+          outcome :not_yet_reached_sp_age
+        else
+          outcome :has_reached_sp_age
+        end
+      end
+    end
+
+    outcome :bus_pass_result
+
+    outcome :not_yet_reached_sp_age
+
+    outcome :has_reached_sp_age
+
+    outcome :has_reached_sp_age_non_binary
   end
 end

--- a/lib/smart_answer_flows/state-pension-through-partner.rb
+++ b/lib/smart_answer_flows/state-pension-through-partner.rb
@@ -1,113 +1,111 @@
-module SmartAnswer
-  class StatePensionThroughPartnerFlow < Flow
-    def define
-      content_id "42a41808-b338-4e4b-a703-47195982f4c8"
-      name "state-pension-through-partner"
-      status :published
+class StatePensionThroughPartnerFlow < SmartAnswer::Flow
+  def define
+    content_id "42a41808-b338-4e4b-a703-47195982f4c8"
+    name "state-pension-through-partner"
+    status :published
 
-      # Q1
-      radio :what_is_your_marital_status? do
-        option :married
-        option :widowed
-        option :divorced
+    # Q1
+    radio :what_is_your_marital_status? do
+      option :married
+      option :widowed
+      option :divorced
 
-        on_response do |response|
-          self.calculator = Calculators::StatePensionThroughPartnerCalculator.new
-          calculator.marital_status = response
-        end
-
-        next_node do
-          if calculator.divorced?
-            question :what_is_your_gender?
-          else
-            question :when_will_you_reach_pension_age?
-          end
-        end
+      on_response do |response|
+        self.calculator = SmartAnswer::Calculators::StatePensionThroughPartnerCalculator.new
+        calculator.marital_status = response
       end
 
-      # Q2
-      radio :when_will_you_reach_pension_age? do
-        option :your_pension_age_before_specific_date
-        option :your_pension_age_after_specific_date
-
-        on_response do |response|
-          calculator.when_will_you_reach_pension_age = response
-        end
-
-        next_node do
-          if calculator.widow_and_new_pension?
-            question :what_is_your_gender?
-          elsif calculator.widow_and_old_pension?
-            outcome :widow_and_old_pension_outcome
-          else
-            question :when_will_your_partner_reach_pension_age?
-          end
+      next_node do
+        if calculator.divorced?
+          question :what_is_your_gender?
+        else
+          question :when_will_you_reach_pension_age?
         end
       end
-
-      # Q3
-      radio :when_will_your_partner_reach_pension_age? do
-        option :partner_pension_age_before_specific_date
-        option :partner_pension_age_after_specific_date
-
-        on_response do |response|
-          calculator.when_will_your_partner_reach_pension_age = response
-        end
-
-        next_node do
-          if calculator.current_rules_no_additional_pension?
-            outcome :current_rules_no_additional_pension_outcome
-          elsif calculator.current_rules_national_insurance_no_state_pension?
-            outcome :current_rules_national_insurance_no_state_pension_outcome
-          else
-            question :what_is_your_gender?
-          end
-        end
-      end
-
-      # Q4
-      radio :what_is_your_gender? do
-        option :male_gender
-        option :female_gender
-
-        on_response do |response|
-          calculator.gender = response
-        end
-
-        next_node do
-          if calculator.male?
-            if calculator.divorced?
-              outcome :impossibility_due_to_divorce_outcome
-            elsif calculator.widowed?
-              outcome :widow_male_reaching_pension_age
-            else
-              outcome :impossibility_to_increase_pension_outcome
-            end
-          elsif calculator.female?
-            if calculator.divorced?
-              outcome :age_dependent_pension_outcome
-            elsif calculator.widowed?
-              outcome :married_woman_and_state_pension_outcome
-            else
-              outcome :married_woman_no_state_pension_outcome
-            end
-          end
-        end
-      end
-
-      # Outcome list below. NB: outcomes 4 and 7 are not available
-      outcome :current_rules_no_additional_pension_outcome # Outcome 1
-      outcome :widow_and_old_pension_outcome # Outcome 2
-      outcome :current_rules_national_insurance_no_state_pension_outcome # Outcome 3
-
-      outcome :married_woman_no_state_pension_outcome # Outcome 5
-      outcome :married_woman_and_state_pension_outcome # Outcome 6
-
-      outcome :impossibility_to_increase_pension_outcome # Outcome 8a
-      outcome :widow_male_reaching_pension_age # Outcome 8b
-
-      outcome :impossibility_due_to_divorce_outcome # Outcome 9
-      outcome :age_dependent_pension_outcome # Outcome 10
     end
+
+    # Q2
+    radio :when_will_you_reach_pension_age? do
+      option :your_pension_age_before_specific_date
+      option :your_pension_age_after_specific_date
+
+      on_response do |response|
+        calculator.when_will_you_reach_pension_age = response
+      end
+
+      next_node do
+        if calculator.widow_and_new_pension?
+          question :what_is_your_gender?
+        elsif calculator.widow_and_old_pension?
+          outcome :widow_and_old_pension_outcome
+        else
+          question :when_will_your_partner_reach_pension_age?
+        end
+      end
+    end
+
+    # Q3
+    radio :when_will_your_partner_reach_pension_age? do
+      option :partner_pension_age_before_specific_date
+      option :partner_pension_age_after_specific_date
+
+      on_response do |response|
+        calculator.when_will_your_partner_reach_pension_age = response
+      end
+
+      next_node do
+        if calculator.current_rules_no_additional_pension?
+          outcome :current_rules_no_additional_pension_outcome
+        elsif calculator.current_rules_national_insurance_no_state_pension?
+          outcome :current_rules_national_insurance_no_state_pension_outcome
+        else
+          question :what_is_your_gender?
+        end
+      end
+    end
+
+    # Q4
+    radio :what_is_your_gender? do
+      option :male_gender
+      option :female_gender
+
+      on_response do |response|
+        calculator.gender = response
+      end
+
+      next_node do
+        if calculator.male?
+          if calculator.divorced?
+            outcome :impossibility_due_to_divorce_outcome
+          elsif calculator.widowed?
+            outcome :widow_male_reaching_pension_age
+          else
+            outcome :impossibility_to_increase_pension_outcome
+          end
+        elsif calculator.female?
+          if calculator.divorced?
+            outcome :age_dependent_pension_outcome
+          elsif calculator.widowed?
+            outcome :married_woman_and_state_pension_outcome
+          else
+            outcome :married_woman_no_state_pension_outcome
+          end
+        end
+      end
+    end
+
+    # Outcome list below. NB: outcomes 4 and 7 are not available
+    outcome :current_rules_no_additional_pension_outcome # Outcome 1
+    outcome :widow_and_old_pension_outcome # Outcome 2
+    outcome :current_rules_national_insurance_no_state_pension_outcome # Outcome 3
+
+    outcome :married_woman_no_state_pension_outcome # Outcome 5
+    outcome :married_woman_and_state_pension_outcome # Outcome 6
+
+    outcome :impossibility_to_increase_pension_outcome # Outcome 8a
+    outcome :widow_male_reaching_pension_age # Outcome 8b
+
+    outcome :impossibility_due_to_divorce_outcome # Outcome 9
+    outcome :age_dependent_pension_outcome # Outcome 10
   end
 end

--- a/lib/smart_answer_flows/student-finance-calculator.rb
+++ b/lib/smart_answer_flows/student-finance-calculator.rb
@@ -1,208 +1,206 @@
-module SmartAnswer
-  class StudentFinanceCalculatorFlow < Flow
-    def define
-      content_id "434b6eb5-33c8-4300-aba3-f5ead58600b8"
-      name "student-finance-calculator"
-      status :published
+class StudentFinanceCalculatorFlow < SmartAnswer::Flow
+  def define
+    content_id "434b6eb5-33c8-4300-aba3-f5ead58600b8"
+    name "student-finance-calculator"
+    status :published
 
-      # Q1
-      radio :when_does_your_course_start? do
-        option :"2020-2021"
-        option :"2021-2022"
+    # Q1
+    radio :when_does_your_course_start? do
+      option :"2020-2021"
+      option :"2021-2022"
 
-        on_response do |response|
-          self.calculator = Calculators::StudentFinanceCalculator.new
-          calculator.course_start = response
-        end
-
-        next_node do
-          question :what_type_of_student_are_you?
-        end
+      on_response do |response|
+        self.calculator = SmartAnswer::Calculators::StudentFinanceCalculator.new
+        calculator.course_start = response
       end
 
-      # Q2
-      radio :what_type_of_student_are_you? do
-        option :"uk-full-time"
-        option :"uk-part-time"
-        option :"eu-full-time"
-        option :"eu-part-time"
+      next_node do
+        question :what_type_of_student_are_you?
+      end
+    end
 
-        on_response do |response|
-          calculator.course_type = response
-        end
+    # Q2
+    radio :what_type_of_student_are_you? do
+      option :"uk-full-time"
+      option :"uk-part-time"
+      option :"eu-full-time"
+      option :"eu-part-time"
 
-        next_node do
-          question :how_much_are_your_tuition_fees_per_year?
-        end
+      on_response do |response|
+        calculator.course_type = response
       end
 
-      # Q3
-      money_question :how_much_are_your_tuition_fees_per_year? do
-        on_response do |response|
-          calculator.tuition_fee_amount = SmartAnswer::Money.new(response)
-        end
+      next_node do
+        question :how_much_are_your_tuition_fees_per_year?
+      end
+    end
 
-        validate do
-          calculator.valid_tuition_fee_amount?
-        end
-
-        next_node do
-          case calculator.course_type
-          when "uk-full-time"
-            question :where_will_you_live_while_studying?
-          when "uk-part-time"
-            question :where_will_you_live_while_studying?
-          when "eu-full-time", "eu-part-time"
-            outcome :outcome_eu_students
-          end
-        end
+    # Q3
+    money_question :how_much_are_your_tuition_fees_per_year? do
+      on_response do |response|
+        calculator.tuition_fee_amount = SmartAnswer::Money.new(response)
       end
 
-      # Q4
-      radio :where_will_you_live_while_studying? do
-        option :'at-home'
-        option :'away-outside-london'
-        option :'away-in-london'
-
-        on_response do |response|
-          calculator.residence = response
-        end
-
-        next_node do
-          question :whats_your_household_income?
-        end
+      validate do
+        calculator.valid_tuition_fee_amount?
       end
 
-      # Q5
-      money_question :whats_your_household_income? do
-        on_response do |response|
-          calculator.household_income = response
-        end
-
-        next_node do
-          case calculator.course_type
-          when "uk-full-time"
-            question :do_any_of_the_following_apply_uk_full_time_students_only?
-          when "uk-part-time"
-            question :how_many_credits_will_you_study?
-          end
+      next_node do
+        case calculator.course_type
+        when "uk-full-time"
+          question :where_will_you_live_while_studying?
+        when "uk-part-time"
+          question :where_will_you_live_while_studying?
+        when "eu-full-time", "eu-part-time"
+          outcome :outcome_eu_students
         end
       end
+    end
 
-      # Q6a
-      value_question :how_many_credits_will_you_study?, parse: Float do
-        on_response do |response|
-          calculator.part_time_credits = response
-        end
+    # Q4
+    radio :where_will_you_live_while_studying? do
+      option :'at-home'
+      option :'away-outside-london'
+      option :'away-in-london'
 
-        validate do
-          calculator.valid_credit_amount?
-        end
-
-        next_node do
-          question :how_many_credits_does_a_full_time_student_study?
-        end
+      on_response do |response|
+        calculator.residence = response
       end
 
-      # Q6b
-      value_question :how_many_credits_does_a_full_time_student_study?, parse: Float do
-        on_response do |response|
-          calculator.full_time_credits = response
-        end
+      next_node do
+        question :whats_your_household_income?
+      end
+    end
 
-        validate do
-          calculator.valid_full_time_credit_amount?
-        end
-
-        next_node do
-          question :do_any_of_the_following_apply_all_uk_students?
-        end
+    # Q5
+    money_question :whats_your_household_income? do
+      on_response do |response|
+        calculator.household_income = response
       end
 
-      # Q7a uk full-time students
-      checkbox_question :do_any_of_the_following_apply_uk_full_time_students_only? do
-        option :"children-under-17"
-        option :"dependant-adult"
-        option :"has-disability"
-        option :"low-income"
-        option :no
-
-        on_response do |response|
-          calculator.uk_ft_circumstances = response.split(",")
-        end
-
-        next_node do
-          question :what_course_are_you_studying?
+      next_node do
+        case calculator.course_type
+        when "uk-full-time"
+          question :do_any_of_the_following_apply_uk_full_time_students_only?
+        when "uk-part-time"
+          question :how_many_credits_will_you_study?
         end
       end
+    end
 
-      # Q7b uk students
-      checkbox_question :do_any_of_the_following_apply_all_uk_students? do
-        option :"has-disability"
-        option :"low-income"
-        option :no
-
-        on_response do |response|
-          calculator.uk_all_circumstances = response.split(",")
-        end
-
-        next_node do
-          question :what_course_are_you_studying?
-        end
+    # Q6a
+    value_question :how_many_credits_will_you_study?, parse: Float do
+      on_response do |response|
+        calculator.part_time_credits = response
       end
 
-      # Q8a
-      radio :what_course_are_you_studying? do
-        option :"teacher-training"
-        option :"dental-medical-healthcare"
-        option :"social-work"
-        option :"none-of-the-above"
-
-        on_response do |response|
-          calculator.course_studied = response
-        end
-
-        next_node do |response|
-          case calculator.course_type
-          when "uk-full-time"
-            if response == "dental-medical-healthcare"
-              question :are_you_a_doctor_or_dentist?
-            else
-              outcome :outcome_uk_full_time_students
-            end
-          when "uk-part-time"
-            outcome :outcome_uk_all_students
-          else
-            outcome :outcome_eu_students
-          end
-        end
+      validate do
+        calculator.valid_credit_amount?
       end
 
-      # Q8b
-      radio :are_you_a_doctor_or_dentist? do
-        option :yes
-        option :no
+      next_node do
+        question :how_many_credits_does_a_full_time_student_study?
+      end
+    end
 
-        on_response do |response|
-          calculator.doctor_or_dentist = (response == "yes")
-        end
+    # Q6b
+    value_question :how_many_credits_does_a_full_time_student_study?, parse: Float do
+      on_response do |response|
+        calculator.full_time_credits = response
+      end
 
-        next_node do |response|
-          if response == "yes"
-            outcome :outcome_uk_full_time_dental_medical_students
+      validate do
+        calculator.valid_full_time_credit_amount?
+      end
+
+      next_node do
+        question :do_any_of_the_following_apply_all_uk_students?
+      end
+    end
+
+    # Q7a uk full-time students
+    checkbox_question :do_any_of_the_following_apply_uk_full_time_students_only? do
+      option :"children-under-17"
+      option :"dependant-adult"
+      option :"has-disability"
+      option :"low-income"
+      option :no
+
+      on_response do |response|
+        calculator.uk_ft_circumstances = response.split(",")
+      end
+
+      next_node do
+        question :what_course_are_you_studying?
+      end
+    end
+
+    # Q7b uk students
+    checkbox_question :do_any_of_the_following_apply_all_uk_students? do
+      option :"has-disability"
+      option :"low-income"
+      option :no
+
+      on_response do |response|
+        calculator.uk_all_circumstances = response.split(",")
+      end
+
+      next_node do
+        question :what_course_are_you_studying?
+      end
+    end
+
+    # Q8a
+    radio :what_course_are_you_studying? do
+      option :"teacher-training"
+      option :"dental-medical-healthcare"
+      option :"social-work"
+      option :"none-of-the-above"
+
+      on_response do |response|
+        calculator.course_studied = response
+      end
+
+      next_node do |response|
+        case calculator.course_type
+        when "uk-full-time"
+          if response == "dental-medical-healthcare"
+            question :are_you_a_doctor_or_dentist?
           else
             outcome :outcome_uk_full_time_students
           end
+        when "uk-part-time"
+          outcome :outcome_uk_all_students
+        else
+          outcome :outcome_eu_students
         end
       end
-
-      outcome :outcome_uk_full_time_students
-
-      outcome :outcome_uk_all_students
-
-      outcome :outcome_eu_students
-
-      outcome :outcome_uk_full_time_dental_medical_students
     end
+
+    # Q8b
+    radio :are_you_a_doctor_or_dentist? do
+      option :yes
+      option :no
+
+      on_response do |response|
+        calculator.doctor_or_dentist = (response == "yes")
+      end
+
+      next_node do |response|
+        if response == "yes"
+          outcome :outcome_uk_full_time_dental_medical_students
+        else
+          outcome :outcome_uk_full_time_students
+        end
+      end
+    end
+
+    outcome :outcome_uk_full_time_students
+
+    outcome :outcome_uk_all_students
+
+    outcome :outcome_eu_students
+
+    outcome :outcome_uk_full_time_dental_medical_students
   end
 end

--- a/lib/smart_answer_flows/towing-rules.rb
+++ b/lib/smart_answer_flows/towing-rules.rb
@@ -1,309 +1,307 @@
-module SmartAnswer
-  class TowingRulesFlow < Flow
-    def define
-      content_id "7bab842c-a9aa-4369-b162-4e3e2a475245"
-      name "towing-rules"
-      status :published
+class TowingRulesFlow < SmartAnswer::Flow
+  def define
+    content_id "7bab842c-a9aa-4369-b162-4e3e2a475245"
+    name "towing-rules"
+    status :published
 
-      ## Cars and light vehicles
-      ##
-      ## Q1
-      radio :towing_vehicle_type? do
-        option "car-or-light-vehicle"
-        option "medium-sized-vehicle"
-        option "large-vehicle"
-        option "minibus"
-        option "bus"
+    ## Cars and light vehicles
+    ##
+    ## Q1
+    radio :towing_vehicle_type? do
+      option "car-or-light-vehicle"
+      option "medium-sized-vehicle"
+      option "large-vehicle"
+      option "minibus"
+      option "bus"
 
-        next_node do |response|
-          case response
-          when "car-or-light-vehicle"
-            question :existing_towing_entitlements? # Q2
-          when "medium-sized-vehicle"
-            question :medium_sized_vehicle_licenceholder? # Q8
-          when "large-vehicle"
-            question :existing_large_vehicle_licence? # Q20
-          when "minibus"
-            question :car_licence_before_jan_1997? # Q25
-          when "bus"
-            question :bus_licenceholder? # Q36
-          end
+      next_node do |response|
+        case response
+        when "car-or-light-vehicle"
+          question :existing_towing_entitlements? # Q2
+        when "medium-sized-vehicle"
+          question :medium_sized_vehicle_licenceholder? # Q8
+        when "large-vehicle"
+          question :existing_large_vehicle_licence? # Q20
+        when "minibus"
+          question :car_licence_before_jan_1997? # Q25
+        when "bus"
+          question :bus_licenceholder? # Q36
         end
       end
-
-      ## Q2
-      radio :existing_towing_entitlements? do
-        option :yes
-        option :no
-
-        next_node do |response|
-          case response
-          when "yes"
-            question :how_long_entitlements? # Q2A
-          when "no"
-            question :date_licence_was_issued? # Q5
-          end
-        end
-      end
-
-      ## Q2A
-      radio :how_long_entitlements? do
-        option "before-19-Jan-2013"
-        option "after-19-Jan-2013"
-
-        next_node do |response|
-          case response
-          when "before-19-Jan-2013"
-            outcome :car_light_vehicle_entitlement # A3
-          when "after-19-Jan-2013"
-            outcome :full_entitlement # A4
-          end
-        end
-      end
-
-      ## Q5
-      radio :date_licence_was_issued? do
-        option "licence-issued-before-19-Jan-2013"
-        option "licence-issued-after-19-Jan-2013"
-
-        next_node do |response|
-          case response
-          when "licence-issued-before-19-Jan-2013"
-            outcome :limited_trailer_entitlement # A6
-          when "licence-issued-after-19-Jan-2013"
-            outcome :limited_trailer_entitlement_2013 # A7
-          end
-        end
-      end
-
-      ## Medium sized vehicles
-      ##
-      ## Q8
-      radio :medium_sized_vehicle_licenceholder? do
-        option :yes
-        option :no
-
-        next_node do |response|
-          case response
-          when "yes"
-            question :how_old_are_you_msv? # Q9
-          when "no"
-            question :existing_large_vehicle_towing_entitlements? # Q12
-          end
-        end
-      end
-
-      ## Q9
-      radio :how_old_are_you_msv? do
-        option "under-21"
-        option "21-or-over"
-
-        next_node do |response|
-          case response
-          when "under-21"
-            outcome :limited_conditional_trailer_entitlement_msv # A10
-          when "21-or-over"
-            outcome :limited_trailer_entitlement_msv # A11
-          end
-        end
-      end
-
-      ## Q12
-      radio :existing_large_vehicle_towing_entitlements? do
-        option :yes
-        option :no
-
-        next_node do |response|
-          case response
-          when "yes"
-            outcome :included_entitlement_msv # A13
-          when "no"
-            question :date_licence_was_issued_msv? # Q14
-          end
-        end
-      end
-
-      ## Q14
-      radio :date_licence_was_issued_msv? do
-        option "before-jan-1997"
-        option "from-jan-1997"
-
-        next_node do |response|
-          case response
-          when "before-jan-1997"
-            outcome :full_entitlement_msv # A15
-          when "from-jan-1997"
-            question :how_old_are_you_msv_2? # Q16
-          end
-        end
-      end
-
-      ## Q16
-      radio :how_old_are_you_msv_2? do
-        option "under-18"
-        option "under-21"
-        option "21-or-over"
-
-        next_node do |response|
-          case response
-          when "under-18"
-            outcome :too_young_msv # A17
-          when "under-21"
-            outcome :apply_for_provisional_with_exceptions_msv # A18
-          when "21-or-over"
-            outcome :apply_for_provisional_msv # 19
-          end
-        end
-      end
-
-      ## Large vehicles
-      ##
-      ## Q20
-      radio :existing_large_vehicle_licence? do
-        option :yes
-        option :no
-
-        next_node do |response|
-          case response
-          when "yes"
-            outcome :full_cat_c_entitlement # A21
-          when "no"
-            question :how_old_are_you_lv? # Q22
-          end
-        end
-      end
-
-      ## Q22
-      radio :how_old_are_you_lv? do
-        option "under-21"
-        option "21-or-over"
-
-        next_node do |response|
-          case response
-          when "under-21"
-            outcome :not_old_enough_lv # A23
-          when "21-or-over"
-            outcome :apply_for_provisional_lv # A24
-          end
-        end
-      end
-
-      ## Minibuses
-      ##
-      ## Q25
-      radio :car_licence_before_jan_1997? do
-        option :yes
-        option :no
-
-        next_node do |response|
-          case response
-          when "yes"
-            outcome :full_entitlement_minibus # A26
-          when "no"
-            question :do_you_have_lv_or_bus_towing_entitlement? # Q27
-          end
-        end
-      end
-
-      ## Q27
-      radio :do_you_have_lv_or_bus_towing_entitlement? do
-        option :yes
-        option :no
-
-        next_node do |response|
-          case response
-          when "yes"
-            outcome :included_entitlement_minibus # A28
-          when "no"
-            question :full_minibus_licence? # Q29
-          end
-        end
-      end
-
-      ## Q29
-      radio :full_minibus_licence? do
-        option :yes
-        option :no
-
-        next_node do |response|
-          case response
-          when "yes"
-            outcome :limited_towing_entitlement_minibus # A30
-          when "no"
-            question :how_old_are_you_minibus? # Q31
-          end
-        end
-      end
-
-      ## Q31
-      radio :how_old_are_you_minibus? do
-        option "under-21"
-        option "21-or-over"
-
-        next_node do |response|
-          case response
-          when "under-21"
-            outcome :not_old_enough_minibus # A32
-          when "21-or-over"
-            outcome :limited_overall_entitlement_minibus # A34
-          end
-        end
-      end
-
-      ## Buses
-      ##
-      ## Q36
-      radio :bus_licenceholder? do
-        option :yes
-        option :no
-
-        next_node do |response|
-          case response
-          when "yes"
-            outcome :full_entitlement_bus # A37
-          when "no"
-            question :how_old_are_you_bus? # Q38
-          end
-        end
-      end
-
-      ## Q38
-      radio :how_old_are_you_bus? do
-        option "under-21"
-        option "21-or-over"
-
-        next_node do |response|
-          case response
-          when "under-21"
-            outcome :not_old_enough_bus # A39
-          when "21-or-over"
-            outcome :apply_for_provisional_bus # A40
-          end
-        end
-      end
-
-      outcome :car_light_vehicle_entitlement # A3
-      outcome :full_entitlement # A4
-      outcome :limited_trailer_entitlement # A6
-      outcome :limited_trailer_entitlement_2013 # A7
-      outcome :limited_conditional_trailer_entitlement_msv # A10
-      outcome :limited_trailer_entitlement_msv # A11
-      outcome :included_entitlement_msv # A13
-      outcome :full_entitlement_msv # A15
-      outcome :too_young_msv # A17
-      outcome :apply_for_provisional_with_exceptions_msv # A18
-      outcome :apply_for_provisional_msv # A19
-      outcome :full_cat_c_entitlement # A21
-      outcome :not_old_enough_lv # A23
-      outcome :apply_for_provisional_lv # A24
-      outcome :full_entitlement_minibus # A26
-      outcome :included_entitlement_minibus # A28
-      outcome :limited_towing_entitlement_minibus # A30
-      outcome :not_old_enough_minibus # A32
-      outcome :limited_overall_entitlement_minibus # A34
-      outcome :full_entitlement_bus # A37
-      outcome :not_old_enough_bus # A39
-      outcome :apply_for_provisional_bus # A40
     end
+
+    ## Q2
+    radio :existing_towing_entitlements? do
+      option :yes
+      option :no
+
+      next_node do |response|
+        case response
+        when "yes"
+          question :how_long_entitlements? # Q2A
+        when "no"
+          question :date_licence_was_issued? # Q5
+        end
+      end
+    end
+
+    ## Q2A
+    radio :how_long_entitlements? do
+      option "before-19-Jan-2013"
+      option "after-19-Jan-2013"
+
+      next_node do |response|
+        case response
+        when "before-19-Jan-2013"
+          outcome :car_light_vehicle_entitlement # A3
+        when "after-19-Jan-2013"
+          outcome :full_entitlement # A4
+        end
+      end
+    end
+
+    ## Q5
+    radio :date_licence_was_issued? do
+      option "licence-issued-before-19-Jan-2013"
+      option "licence-issued-after-19-Jan-2013"
+
+      next_node do |response|
+        case response
+        when "licence-issued-before-19-Jan-2013"
+          outcome :limited_trailer_entitlement # A6
+        when "licence-issued-after-19-Jan-2013"
+          outcome :limited_trailer_entitlement_2013 # A7
+        end
+      end
+    end
+
+    ## Medium sized vehicles
+    ##
+    ## Q8
+    radio :medium_sized_vehicle_licenceholder? do
+      option :yes
+      option :no
+
+      next_node do |response|
+        case response
+        when "yes"
+          question :how_old_are_you_msv? # Q9
+        when "no"
+          question :existing_large_vehicle_towing_entitlements? # Q12
+        end
+      end
+    end
+
+    ## Q9
+    radio :how_old_are_you_msv? do
+      option "under-21"
+      option "21-or-over"
+
+      next_node do |response|
+        case response
+        when "under-21"
+          outcome :limited_conditional_trailer_entitlement_msv # A10
+        when "21-or-over"
+          outcome :limited_trailer_entitlement_msv # A11
+        end
+      end
+    end
+
+    ## Q12
+    radio :existing_large_vehicle_towing_entitlements? do
+      option :yes
+      option :no
+
+      next_node do |response|
+        case response
+        when "yes"
+          outcome :included_entitlement_msv # A13
+        when "no"
+          question :date_licence_was_issued_msv? # Q14
+        end
+      end
+    end
+
+    ## Q14
+    radio :date_licence_was_issued_msv? do
+      option "before-jan-1997"
+      option "from-jan-1997"
+
+      next_node do |response|
+        case response
+        when "before-jan-1997"
+          outcome :full_entitlement_msv # A15
+        when "from-jan-1997"
+          question :how_old_are_you_msv_2? # Q16
+        end
+      end
+    end
+
+    ## Q16
+    radio :how_old_are_you_msv_2? do
+      option "under-18"
+      option "under-21"
+      option "21-or-over"
+
+      next_node do |response|
+        case response
+        when "under-18"
+          outcome :too_young_msv # A17
+        when "under-21"
+          outcome :apply_for_provisional_with_exceptions_msv # A18
+        when "21-or-over"
+          outcome :apply_for_provisional_msv # 19
+        end
+      end
+    end
+
+    ## Large vehicles
+    ##
+    ## Q20
+    radio :existing_large_vehicle_licence? do
+      option :yes
+      option :no
+
+      next_node do |response|
+        case response
+        when "yes"
+          outcome :full_cat_c_entitlement # A21
+        when "no"
+          question :how_old_are_you_lv? # Q22
+        end
+      end
+    end
+
+    ## Q22
+    radio :how_old_are_you_lv? do
+      option "under-21"
+      option "21-or-over"
+
+      next_node do |response|
+        case response
+        when "under-21"
+          outcome :not_old_enough_lv # A23
+        when "21-or-over"
+          outcome :apply_for_provisional_lv # A24
+        end
+      end
+    end
+
+    ## Minibuses
+    ##
+    ## Q25
+    radio :car_licence_before_jan_1997? do
+      option :yes
+      option :no
+
+      next_node do |response|
+        case response
+        when "yes"
+          outcome :full_entitlement_minibus # A26
+        when "no"
+          question :do_you_have_lv_or_bus_towing_entitlement? # Q27
+        end
+      end
+    end
+
+    ## Q27
+    radio :do_you_have_lv_or_bus_towing_entitlement? do
+      option :yes
+      option :no
+
+      next_node do |response|
+        case response
+        when "yes"
+          outcome :included_entitlement_minibus # A28
+        when "no"
+          question :full_minibus_licence? # Q29
+        end
+      end
+    end
+
+    ## Q29
+    radio :full_minibus_licence? do
+      option :yes
+      option :no
+
+      next_node do |response|
+        case response
+        when "yes"
+          outcome :limited_towing_entitlement_minibus # A30
+        when "no"
+          question :how_old_are_you_minibus? # Q31
+        end
+      end
+    end
+
+    ## Q31
+    radio :how_old_are_you_minibus? do
+      option "under-21"
+      option "21-or-over"
+
+      next_node do |response|
+        case response
+        when "under-21"
+          outcome :not_old_enough_minibus # A32
+        when "21-or-over"
+          outcome :limited_overall_entitlement_minibus # A34
+        end
+      end
+    end
+
+    ## Buses
+    ##
+    ## Q36
+    radio :bus_licenceholder? do
+      option :yes
+      option :no
+
+      next_node do |response|
+        case response
+        when "yes"
+          outcome :full_entitlement_bus # A37
+        when "no"
+          question :how_old_are_you_bus? # Q38
+        end
+      end
+    end
+
+    ## Q38
+    radio :how_old_are_you_bus? do
+      option "under-21"
+      option "21-or-over"
+
+      next_node do |response|
+        case response
+        when "under-21"
+          outcome :not_old_enough_bus # A39
+        when "21-or-over"
+          outcome :apply_for_provisional_bus # A40
+        end
+      end
+    end
+
+    outcome :car_light_vehicle_entitlement # A3
+    outcome :full_entitlement # A4
+    outcome :limited_trailer_entitlement # A6
+    outcome :limited_trailer_entitlement_2013 # A7
+    outcome :limited_conditional_trailer_entitlement_msv # A10
+    outcome :limited_trailer_entitlement_msv # A11
+    outcome :included_entitlement_msv # A13
+    outcome :full_entitlement_msv # A15
+    outcome :too_young_msv # A17
+    outcome :apply_for_provisional_with_exceptions_msv # A18
+    outcome :apply_for_provisional_msv # A19
+    outcome :full_cat_c_entitlement # A21
+    outcome :not_old_enough_lv # A23
+    outcome :apply_for_provisional_lv # A24
+    outcome :full_entitlement_minibus # A26
+    outcome :included_entitlement_minibus # A28
+    outcome :limited_towing_entitlement_minibus # A30
+    outcome :not_old_enough_minibus # A32
+    outcome :limited_overall_entitlement_minibus # A34
+    outcome :full_entitlement_bus # A37
+    outcome :not_old_enough_bus # A39
+    outcome :apply_for_provisional_bus # A40
   end
 end

--- a/lib/smart_answer_flows/uk-benefits-abroad.rb
+++ b/lib/smart_answer_flows/uk-benefits-abroad.rb
@@ -1,311 +1,257 @@
-module SmartAnswer
-  class UkBenefitsAbroadFlow < Flow
-    def define
-      content_id "e1eaf183-1211-4fd7-b439-5c94498814ef"
-      name "uk-benefits-abroad"
-      status :published
+class UkBenefitsAbroadFlow < SmartAnswer::Flow
+  def define
+    content_id "e1eaf183-1211-4fd7-b439-5c94498814ef"
+    name "uk-benefits-abroad"
+    status :published
 
-      exclude_countries = %w[british-antarctic-territory french-guiana guadeloupe holy-see martinique mayotte reunion st-maarten]
-      additional_countries = [
-        OpenStruct.new(slug: "jersey", name: "Jersey"),
-        OpenStruct.new(slug: "guernsey", name: "Guernsey"),
-      ]
+    exclude_countries = %w[british-antarctic-territory french-guiana guadeloupe holy-see martinique mayotte reunion st-maarten]
+    additional_countries = [
+      OpenStruct.new(slug: "jersey", name: "Jersey"),
+      OpenStruct.new(slug: "guernsey", name: "Guernsey"),
+    ]
 
-      # Q1
-      radio :going_or_already_abroad? do
-        option :going_abroad
-        option :already_abroad
+    # Q1
+    radio :going_or_already_abroad? do
+      option :going_abroad
+      option :already_abroad
 
-        on_response do |response|
-          self.calculator = Calculators::UkBenefitsAbroadCalculator.new
-          calculator.going_abroad = (response == "going_abroad")
-        end
-
-        next_node do
-          question :which_benefit?
-        end
+      on_response do |response|
+        self.calculator = SmartAnswer::Calculators::UkBenefitsAbroadCalculator.new
+        calculator.going_abroad = (response == "going_abroad")
       end
 
-      # Q2 going_abroad and Q3 already_abroad
-      radio :which_benefit? do
-        option :jsa
-        option :pension
-        option :winter_fuel_payment
-        option :maternity_benefits
-        option :child_benefit
-        option :iidb
-        option :ssp
-        option :esa
-        option :disability_benefits
-        option :bereavement_benefits
-        option :tax_credits
-        option :income_support
+      next_node do
+        question :which_benefit?
+      end
+    end
 
-        on_response do |response|
-          calculator.benefit = response
-        end
+    # Q2 going_abroad and Q3 already_abroad
+    radio :which_benefit? do
+      option :jsa
+      option :pension
+      option :winter_fuel_payment
+      option :maternity_benefits
+      option :child_benefit
+      option :iidb
+      option :ssp
+      option :esa
+      option :disability_benefits
+      option :bereavement_benefits
+      option :tax_credits
+      option :income_support
 
-        next_node do |response|
-          if %w[winter_fuel_payment maternity_benefits child_benefit ssp bereavement_benefits jsa].include?(response)
-            question :which_country?
-          elsif response == "iidb"
-            question :iidb_already_claiming?
-          elsif response == "esa"
-            question :esa_how_long_abroad?
-          elsif response == "disability_benefits"
-            question :db_how_long_abroad?
-          elsif response == "tax_credits"
-            question :eligible_for_tax_credits?
-          elsif calculator.going_abroad
-            case response
-            when "pension"
-              outcome :pension_going_abroad_outcome # A2 going_abroad
-            when "income_support"
-              question :is_how_long_abroad? # Q32 going_abroad
-            end
-          elsif calculator.already_abroad
-            case response
-            when "pension"
-              outcome :pension_already_abroad_outcome # A2 already_abroad
-            when "income_support"
-              outcome :is_already_abroad_outcome # A40 already_abroad
-            end
+      on_response do |response|
+        calculator.benefit = response
+      end
+
+      next_node do |response|
+        if %w[winter_fuel_payment maternity_benefits child_benefit ssp bereavement_benefits jsa].include?(response)
+          question :which_country?
+        elsif response == "iidb"
+          question :iidb_already_claiming?
+        elsif response == "esa"
+          question :esa_how_long_abroad?
+        elsif response == "disability_benefits"
+          question :db_how_long_abroad?
+        elsif response == "tax_credits"
+          question :eligible_for_tax_credits?
+        elsif calculator.going_abroad
+          case response
+          when "pension"
+            outcome :pension_going_abroad_outcome # A2 going_abroad
+          when "income_support"
+            question :is_how_long_abroad? # Q32 going_abroad
+          end
+        elsif calculator.already_abroad
+          case response
+          when "pension"
+            outcome :pension_already_abroad_outcome # A2 already_abroad
+          when "income_support"
+            outcome :is_already_abroad_outcome # A40 already_abroad
           end
         end
       end
+    end
 
-      ## Country Question - Shared
-      country_select :which_country?, additional_countries: additional_countries, exclude_countries: exclude_countries do
-        on_response do |response|
-          calculator.country = response
-          calculator.country_name = (WorldLocation.all + additional_countries).find { |c| c.slug == calculator.country }.name
-        end
+    ## Country Question - Shared
+    country_select :which_country?, additional_countries: additional_countries, exclude_countries: exclude_countries do
+      on_response do |response|
+        calculator.country = response
+        calculator.country_name = (WorldLocation.all + additional_countries).find { |c| c.slug == calculator.country }.name
+      end
 
-        next_node do |response|
-          case calculator.benefit
-          when "jsa"
-            if calculator.already_abroad && calculator.eea_country?
-              outcome :jsa_eea_already_abroad_outcome # A3 already_abroad
-            elsif calculator.already_abroad && calculator.social_security_countries_jsa?
-              outcome :jsa_social_security_already_abroad_outcome
-            elsif calculator.going_abroad && calculator.country == "ireland"
+      next_node do |response|
+        case calculator.benefit
+        when "jsa"
+          if calculator.already_abroad && calculator.eea_country?
+            outcome :jsa_eea_already_abroad_outcome # A3 already_abroad
+          elsif calculator.already_abroad && calculator.social_security_countries_jsa?
+            outcome :jsa_social_security_already_abroad_outcome
+          elsif calculator.going_abroad && calculator.country == "ireland"
+            question :is_british_or_irish?
+          elsif calculator.going_abroad && calculator.country == "gibraltar"
+            outcome :jsa_eea_going_abroad_maybe_outcome
+          elsif calculator.going_abroad && calculator.eea_country?
+            question :worked_in_eea_or_switzerland? # A5 going_abroad
+          elsif calculator.going_abroad && calculator.social_security_countries_jsa?
+            outcome :jsa_social_security_going_abroad_outcome
+          else
+            outcome :jsa_not_entitled_outcome # A7 calculator.going_abroad and A5 already_abroad
+          end
+        when "maternity_benefits"
+          if calculator.eea_country?
+            question :working_for_a_uk_employer? # Q8 going_abroad and Q7 already_abroad
+          else
+            question :employer_paying_ni? # Q10, Q11, Q16 going_abroad and Q9, Q10, Q15 already_abroad
+          end
+        when "winter_fuel_payment"
+          if calculator.country_eligible_for_winter_fuel_payment?
+            if calculator.country == "ireland"
               question :is_british_or_irish?
-            elsif calculator.going_abroad && calculator.country == "gibraltar"
-              outcome :jsa_eea_going_abroad_maybe_outcome
-            elsif calculator.going_abroad && calculator.eea_country?
-              question :worked_in_eea_or_switzerland? # A5 going_abroad
-            elsif calculator.going_abroad && calculator.social_security_countries_jsa?
-              outcome :jsa_social_security_going_abroad_outcome
             else
-              outcome :jsa_not_entitled_outcome # A7 calculator.going_abroad and A5 already_abroad
-            end
-          when "maternity_benefits"
-            if calculator.eea_country?
-              question :working_for_a_uk_employer? # Q8 going_abroad and Q7 already_abroad
-            else
-              question :employer_paying_ni? # Q10, Q11, Q16 going_abroad and Q9, Q10, Q15 already_abroad
-            end
-          when "winter_fuel_payment"
-            if calculator.country_eligible_for_winter_fuel_payment?
-              if calculator.country == "ireland"
-                question :is_british_or_irish?
-              else
-                question :worked_in_eea_or_switzerland? # A7 already_abroad
-              end
-            else
-              outcome :wfp_not_eligible_outcome # A8 going_abroad and A6 already_abroad
-            end
-          when "child_benefit"
-            if calculator.eea_country?
-              question :do_either_of_the_following_apply? # Q13 going_abroad and Q12 already_abroad
-            elsif calculator.former_yugoslavia?
-              if calculator.going_abroad
-                outcome :child_benefit_fy_going_abroad_outcome # A14 going_abroad
-              else
-                outcome :child_benefit_fy_already_abroad_outcome # A12 already_abroad
-              end
-            elsif %w[barbados canada guernsey israel jersey mauritius new-zealand].include?(response)
-              outcome :child_benefit_ss_outcome # A15 going_abroad and A13 already_abroad
-            elsif %w[jamaica turkey usa].include?(response)
-              outcome :child_benefit_jtu_outcome # A14 already_abroad
-            else
-              outcome :child_benefit_not_entitled_outcome # A18 going_abroad and A16 already_abroad
-            end
-          when "iidb"
-            if calculator.going_abroad
-              if calculator.eea_country? || !calculator.social_security_countries_iidb?
-                outcome :iidb_going_abroad_eea_outcome # A32 going_abroad
-              else
-                outcome :iidb_going_abroad_ss_outcome # A34 going_abroad
-              end
-            elsif calculator.already_abroad
-              if calculator.eea_country? || !calculator.social_security_countries_iidb?
-                outcome :iidb_already_abroad_eea_outcome # A31 already_abroad
-              else
-                outcome :iidb_already_abroad_ss_outcome # A33 already_abroad
-              end
-            end
-          when "disability_benefits"
-            if calculator.eea_country?
-              question :db_claiming_benefits? # Q30 going_abroad and Q29 already_abroad
-            elsif calculator.going_abroad
-              outcome :db_going_abroad_other_outcome # A36 going_abroad
-            else
-              outcome :db_already_abroad_other_outcome # A35 already_abroad
-            end
-          when "ssp"
-            if calculator.eea_country?
-              question :working_for_uk_employer_ssp? # Q15 going_abroad and Q14 already_abroad
-            else
-              question :employer_paying_ni? # Q10, Q11, Q16 going_abroad and Q9, Q10, Q15 already_abroad
-            end
-          when "tax_credits"
-            if calculator.eea_country?
-              question :tax_credits_currently_claiming? # Q20 already_abroad
-            else
-              outcome :tax_credits_unlikely_outcome # A21 already_abroad and A23 going_abroad
-            end
-          when "esa"
-            if calculator.going_abroad
-              if calculator.country == "ireland"
-                question :is_british_or_irish?
-              elsif calculator.former_yugoslavia?
-                outcome :esa_going_abroad_eea_outcome
-              elsif %w[barbados guernsey gibraltar israel jersey jamaica turkey usa].include?(response)
-                outcome :esa_going_abroad_eea_outcome
-              elsif calculator.eea_country?
-                question :worked_in_eea_or_switzerland?
-              else
-                outcome :esa_going_abroad_other_outcome # A30 going_abroad
-              end
-            elsif calculator.already_abroad
-              if calculator.country == "ireland"
-                question :is_british_or_irish?
-              elsif calculator.country == "gibraltar"
-                outcome :esa_already_abroad_eea_outcome
-              elsif calculator.eea_country?
-                question :worked_in_eea_or_switzerland?
-              elsif calculator.former_yugoslavia?
-                outcome :esa_already_abroad_ss_outcome # A28 already_abroad
-              elsif %w[barbados jersey guernsey jamaica turkey usa].include?(response)
-                outcome :esa_already_abroad_ss_outcome
-              else
-                outcome :esa_already_abroad_other_outcome # A29 already_abroad
-              end
-            end
-          when "bereavement_benefits"
-            if calculator.going_abroad
-              if calculator.eea_country?
-                outcome :bb_going_abroad_eea_outcome # A39 going_abroad
-              elsif calculator.social_security_countries_bereavement_benefits?
-                outcome :bb_going_abroad_ss_outcome # A40 going_abroad
-              else
-                outcome :bb_going_abroad_other_outcome # A38 going_abroad
-              end
-            elsif calculator.already_abroad
-              if calculator.eea_country?
-                outcome :bb_already_abroad_eea_outcome # A37 already_abroad
-              elsif calculator.social_security_countries_bereavement_benefits?
-                outcome :bb_already_abroad_ss_outcome # A38 already_abroad
-              else
-                outcome :bb_already_abroad_other_outcome # A39 already_abroad
-              end
-            end
-          end
-        end
-      end
-
-      # Q8 going_abroad and Q7 already_abroad
-      radio :working_for_a_uk_employer? do
-        option :yes
-        option :no
-
-        next_node do |response|
-          case response
-          when "yes"
-            question :eligible_for_smp? # Q9 going_abroad and Q8 already_abroad
-          when "no"
-            outcome :maternity_benefits_maternity_allowance_outcome # A10 going_abroad and A8 already_abroad
-          end
-        end
-      end
-
-      # Q9 going_abroad and Q8 already_abroad
-      radio :eligible_for_smp? do
-        option :yes
-        option :no
-
-        next_node do |response|
-          case response
-          when "yes"
-            outcome :maternity_benefits_eea_entitled_outcome # A11 going_abroad and A9 already_abroad
-          when "no"
-            outcome :maternity_benefits_maternity_allowance_outcome # A10 going_abroad and A8 already_abroad
-          end
-        end
-      end
-
-      # Q10, Q11, Q16 going_abroad and Q9, Q10, Q15 already_abroad
-      radio :employer_paying_ni? do
-        option :yes
-        option :no
-
-        next_node do |response|
-          # SSP benefits
-          if calculator.benefit == "ssp"
-            if calculator.going_abroad
-              if response == "yes"
-                outcome :ssp_going_abroad_entitled_outcome # A19 going_abroad
-              else
-                outcome :ssp_going_abroad_not_entitled_outcome # A20 going_abroad
-              end
-            elsif calculator.already_abroad
-              if response == "yes"
-                outcome :ssp_already_abroad_entitled_outcome # A17 already_abroad
-              else
-                outcome :ssp_already_abroad_not_entitled_outcome # A18 already_abroad
-              end
-            end
-          # not SSP benefits
-          elsif response == "yes"
-            question :eligible_for_smp? # Q9 going_abroad and Q8 already_abroad
-          elsif calculator.employer_paying_ni_not_ssp_country_entitled?
-            if calculator.already_abroad
-              outcome :maternity_benefits_social_security_already_abroad_outcome # A10 already_abroad
-            else
-              outcome :maternity_benefits_social_security_going_abroad_outcome # A12 going_abroad
+              question :worked_in_eea_or_switzerland? # A7 already_abroad
             end
           else
-            outcome :maternity_benefits_not_entitled_outcome # A13 going_abroad and A11 already_abroad
+            outcome :wfp_not_eligible_outcome # A8 going_abroad and A6 already_abroad
           end
-        end
-      end
-
-      # Q13 going_abroad and Q12 already_abroad
-      checkbox_question :do_either_of_the_following_apply? do
-        Calculators::UkBenefitsAbroadCalculator::STATE_BENEFITS.each_key do |benefit|
-          option benefit
-        end
-
-        on_response do |response|
-          calculator.benefits = response.split(",")
-        end
-
-        next_node do |_response|
-          if calculator.benefits?
-            outcome :child_benefit_entitled_outcome # A17 going_abroad and A15 already_abroad
+        when "child_benefit"
+          if calculator.eea_country?
+            question :do_either_of_the_following_apply? # Q13 going_abroad and Q12 already_abroad
+          elsif calculator.former_yugoslavia?
+            if calculator.going_abroad
+              outcome :child_benefit_fy_going_abroad_outcome # A14 going_abroad
+            else
+              outcome :child_benefit_fy_already_abroad_outcome # A12 already_abroad
+            end
+          elsif %w[barbados canada guernsey israel jersey mauritius new-zealand].include?(response)
+            outcome :child_benefit_ss_outcome # A15 going_abroad and A13 already_abroad
+          elsif %w[jamaica turkey usa].include?(response)
+            outcome :child_benefit_jtu_outcome # A14 already_abroad
           else
             outcome :child_benefit_not_entitled_outcome # A18 going_abroad and A16 already_abroad
           end
+        when "iidb"
+          if calculator.going_abroad
+            if calculator.eea_country? || !calculator.social_security_countries_iidb?
+              outcome :iidb_going_abroad_eea_outcome # A32 going_abroad
+            else
+              outcome :iidb_going_abroad_ss_outcome # A34 going_abroad
+            end
+          elsif calculator.already_abroad
+            if calculator.eea_country? || !calculator.social_security_countries_iidb?
+              outcome :iidb_already_abroad_eea_outcome # A31 already_abroad
+            else
+              outcome :iidb_already_abroad_ss_outcome # A33 already_abroad
+            end
+          end
+        when "disability_benefits"
+          if calculator.eea_country?
+            question :db_claiming_benefits? # Q30 going_abroad and Q29 already_abroad
+          elsif calculator.going_abroad
+            outcome :db_going_abroad_other_outcome # A36 going_abroad
+          else
+            outcome :db_already_abroad_other_outcome # A35 already_abroad
+          end
+        when "ssp"
+          if calculator.eea_country?
+            question :working_for_uk_employer_ssp? # Q15 going_abroad and Q14 already_abroad
+          else
+            question :employer_paying_ni? # Q10, Q11, Q16 going_abroad and Q9, Q10, Q15 already_abroad
+          end
+        when "tax_credits"
+          if calculator.eea_country?
+            question :tax_credits_currently_claiming? # Q20 already_abroad
+          else
+            outcome :tax_credits_unlikely_outcome # A21 already_abroad and A23 going_abroad
+          end
+        when "esa"
+          if calculator.going_abroad
+            if calculator.country == "ireland"
+              question :is_british_or_irish?
+            elsif calculator.former_yugoslavia?
+              outcome :esa_going_abroad_eea_outcome
+            elsif %w[barbados guernsey gibraltar israel jersey jamaica turkey usa].include?(response)
+              outcome :esa_going_abroad_eea_outcome
+            elsif calculator.eea_country?
+              question :worked_in_eea_or_switzerland?
+            else
+              outcome :esa_going_abroad_other_outcome # A30 going_abroad
+            end
+          elsif calculator.already_abroad
+            if calculator.country == "ireland"
+              question :is_british_or_irish?
+            elsif calculator.country == "gibraltar"
+              outcome :esa_already_abroad_eea_outcome
+            elsif calculator.eea_country?
+              question :worked_in_eea_or_switzerland?
+            elsif calculator.former_yugoslavia?
+              outcome :esa_already_abroad_ss_outcome # A28 already_abroad
+            elsif %w[barbados jersey guernsey jamaica turkey usa].include?(response)
+              outcome :esa_already_abroad_ss_outcome
+            else
+              outcome :esa_already_abroad_other_outcome # A29 already_abroad
+            end
+          end
+        when "bereavement_benefits"
+          if calculator.going_abroad
+            if calculator.eea_country?
+              outcome :bb_going_abroad_eea_outcome # A39 going_abroad
+            elsif calculator.social_security_countries_bereavement_benefits?
+              outcome :bb_going_abroad_ss_outcome # A40 going_abroad
+            else
+              outcome :bb_going_abroad_other_outcome # A38 going_abroad
+            end
+          elsif calculator.already_abroad
+            if calculator.eea_country?
+              outcome :bb_already_abroad_eea_outcome # A37 already_abroad
+            elsif calculator.social_security_countries_bereavement_benefits?
+              outcome :bb_already_abroad_ss_outcome # A38 already_abroad
+            else
+              outcome :bb_already_abroad_other_outcome # A39 already_abroad
+            end
+          end
         end
       end
+    end
 
-      # Q15 going_abroad and Q14 already_abroad
-      radio :working_for_uk_employer_ssp? do
-        option :yes
-        option :no
+    # Q8 going_abroad and Q7 already_abroad
+    radio :working_for_a_uk_employer? do
+      option :yes
+      option :no
 
-        next_node do |response|
+      next_node do |response|
+        case response
+        when "yes"
+          question :eligible_for_smp? # Q9 going_abroad and Q8 already_abroad
+        when "no"
+          outcome :maternity_benefits_maternity_allowance_outcome # A10 going_abroad and A8 already_abroad
+        end
+      end
+    end
+
+    # Q9 going_abroad and Q8 already_abroad
+    radio :eligible_for_smp? do
+      option :yes
+      option :no
+
+      next_node do |response|
+        case response
+        when "yes"
+          outcome :maternity_benefits_eea_entitled_outcome # A11 going_abroad and A9 already_abroad
+        when "no"
+          outcome :maternity_benefits_maternity_allowance_outcome # A10 going_abroad and A8 already_abroad
+        end
+      end
+    end
+
+    # Q10, Q11, Q16 going_abroad and Q9, Q10, Q15 already_abroad
+    radio :employer_paying_ni? do
+      option :yes
+      option :no
+
+      next_node do |response|
+        # SSP benefits
+        if calculator.benefit == "ssp"
           if calculator.going_abroad
             if response == "yes"
               outcome :ssp_going_abroad_entitled_outcome # A19 going_abroad
@@ -319,445 +265,497 @@ module SmartAnswer
               outcome :ssp_already_abroad_not_entitled_outcome # A18 already_abroad
             end
           end
-        end
-      end
-
-      # Q17 going_abroad and Q16 already_abroad
-      radio :eligible_for_tax_credits? do
-        option :crown_servant
-        option :cross_border_worker
-        option :none_of_the_above
-
-        next_node do |response|
-          case response
-          when "crown_servant"
-            outcome :tax_credits_crown_servant_outcome # A19 already_abroad
-          when "cross_border_worker"
-            outcome :tax_credits_cross_border_worker_outcome # A20 already_abroad
-          when "none_of_the_above"
-            question :tax_credits_how_long_abroad? # Q18 going_abroad and Q17 already_abroad
-          end
-        end
-      end
-
-      # Q19 going_abroad and Q18 already_abroad
-      radio :tax_credits_children? do
-        option :yes
-        option :no
-
-        next_node do |response|
-          case response
-          when "yes"
-            question :which_country? # Q17
-          when "no"
-            outcome :tax_credits_unlikely_outcome # A21 already_abroad and A23 going_abroad
-          end
-        end
-      end
-
-      # Q20 already_abroad
-      checkbox_question :tax_credits_currently_claiming? do
-        Calculators::UkBenefitsAbroadCalculator::TAX_CREDITS_BENEFITS.each_key do |credit|
-          option credit
-        end
-
-        on_response do |response|
-          calculator.tax_credits = response.split(",")
-        end
-
-        next_node do |_response|
-          if calculator.tax_credits?
-            outcome :tax_credits_eea_entitled_outcome # A22 already_abroad and A24 going_abroad
+        # not SSP benefits
+        elsif response == "yes"
+          question :eligible_for_smp? # Q9 going_abroad and Q8 already_abroad
+        elsif calculator.employer_paying_ni_not_ssp_country_entitled?
+          if calculator.already_abroad
+            outcome :maternity_benefits_social_security_already_abroad_outcome # A10 already_abroad
           else
-            outcome :tax_credits_unlikely_outcome # A21 already_abroad and A23 going_abroad
+            outcome :maternity_benefits_social_security_going_abroad_outcome # A12 going_abroad
           end
+        else
+          outcome :maternity_benefits_not_entitled_outcome # A13 going_abroad and A11 already_abroad
         end
       end
-
-      # Q23 going_abroad and Q22 already_abroad
-      radio :tax_credits_why_going_abroad? do
-        option :tax_credits_holiday
-        option :tax_credits_medical_treatment
-        option :tax_credits_death
-
-        next_node do |response|
-          case response
-          when "tax_credits_holiday"
-            outcome :tax_credits_holiday_outcome # A23 already_abroad and A25 going_abroad and A26 going_abroad
-          when "tax_credits_medical_treatment", "tax_credits_death"
-            outcome :tax_credits_medical_death_outcome # A24 already_abroad
-          end
-        end
-      end
-
-      # Q26 going_abroad and Q25 already_abroad
-      radio :iidb_already_claiming? do
-        option :yes
-        option :no
-
-        next_node do |response|
-          case response
-          when "yes"
-            question :which_country? # Shared question
-          when "no"
-            outcome :iidb_maybe_outcome # A30 already_abroad and A31 going_abroad
-          end
-        end
-      end
-
-      # Q30 going_abroad and Q29 already_abroad
-      radio :db_claiming_benefits? do
-        option :yes
-        option :no
-
-        next_node do |response|
-          if calculator.going_abroad
-            if response == "yes"
-              case calculator.country
-              when "ireland"
-                question :is_british_or_irish?
-              when "gibraltar"
-                outcome :db_going_abroad_gibraltar_outcome
-              else
-                question :worked_in_eea_or_switzerland? # A37 going_abroad
-              end
-            else
-              outcome :db_going_abroad_other_outcome # A36 going_abroad
-            end
-          elsif calculator.already_abroad
-            if response == "yes"
-              if calculator.country == "ireland"
-                question :is_british_or_irish?
-              elsif calculator.country == "gibraltar"
-                outcome :db_already_abroad_gibraltar_outcome
-              elsif calculator.eea_country?
-                question :worked_in_eea_or_switzerland? # A37 going_abroad
-              else
-                outcome :db_already_abroad_eea_outcome # A36 already_abroad
-              end
-            else
-              outcome :db_already_abroad_other_outcome # A35 already_abroad
-            end
-          end
-        end
-      end
-
-      # Q33 going_abroad
-      checkbox_question :is_claiming_benefits? do
-        Calculators::UkBenefitsAbroadCalculator::PREMIUMS.each_key do |premium|
-          option premium
-        end
-
-        on_response do |response|
-          calculator.partner_premiums = response.split(",")
-        end
-
-        next_node do |_response|
-          if calculator.partner_premiums?
-            outcome :is_claiming_benefits_outcome # A43 going_abroad
-          else
-            question :is_either_of_the_following? # Q34 going_abroad
-          end
-        end
-      end
-
-      # Q34 going_abroad
-      checkbox_question :is_either_of_the_following? do
-        Calculators::UkBenefitsAbroadCalculator::IMPAIRMENTS.each_key do |impairment|
-          option impairment
-        end
-
-        on_response do |response|
-          calculator.possible_impairments = response.split(",")
-        end
-
-        next_node do |_response|
-          if calculator.getting_income_support?
-            question :is_abroad_for_treatment? # Q35 going_abroad
-          else
-            question :is_any_of_the_following_apply? # Q37 going_abroad
-          end
-        end
-      end
-
-      # Q35 going_abroad
-      radio :is_abroad_for_treatment? do
-        option :yes
-        option :no
-
-        next_node do |response|
-          case response
-          when "yes"
-            outcome :is_abroad_for_treatment_outcome # A44 going_abroad
-          when "no"
-            question :is_work_or_sick_pay? # Q36 going_abroad
-          end
-        end
-      end
-
-      # Q36 going_abroad
-      checkbox_question :is_work_or_sick_pay? do
-        Calculators::UkBenefitsAbroadCalculator::PERIODS_OF_IMPAIRMENT.each_key do |period|
-          option period
-        end
-
-        on_response do |response|
-          calculator.impairment_periods = response.split(",")
-        end
-
-        next_node do |_response|
-          if calculator.not_getting_sick_pay?
-            outcome :is_abroad_for_treatment_outcome # A44 going_abroad
-          else
-            outcome :is_not_eligible_outcome # A45 going_abroad
-          end
-        end
-      end
-
-      # Q37 going_abroad
-      checkbox_question :is_any_of_the_following_apply? do
-        Calculators::UkBenefitsAbroadCalculator::DISPUTE_CRITERIA.each_key do |criterion|
-          option criterion
-        end
-
-        on_response do |response|
-          calculator.dispute_criteria = response.split(",")
-        end
-
-        next_node do |_response|
-          if calculator.dispute_criteria?
-            outcome :is_not_eligible_outcome # A45 going_abroad
-          else
-            outcome :is_abroad_for_treatment_outcome # A44 going_abroad
-          end
-        end
-      end
-
-      # Going abroad questions
-      # Going abroad Q18 (tax credits) and Q17 already_abroad
-      radio :tax_credits_how_long_abroad? do
-        option :tax_credits_up_to_a_year
-        option :tax_credits_more_than_a_year
-
-        next_node do |response|
-          case response
-          when "tax_credits_up_to_a_year"
-            question :tax_credits_why_going_abroad? # Q23 going_abroad and Q22 already_abroad
-          when "tax_credits_more_than_a_year"
-            question :tax_credits_children? # Q19 going_abroad and Q18 already_abroad
-          end
-        end
-      end
-
-      # Going abroad Q24 going_abroad (ESA) and Q23 already_abroad
-      radio :esa_how_long_abroad? do
-        option :esa_under_a_year_medical
-        option :esa_under_a_year_other
-        option :esa_more_than_a_year
-
-        next_node do |response|
-          if calculator.going_abroad && response == "esa_under_a_year_medical"
-            outcome :esa_going_abroad_under_a_year_medical_outcome # A27 going_abroad
-          elsif calculator.going_abroad && response == "esa_under_a_year_other"
-            outcome :esa_going_abroad_under_a_year_other_outcome # A28 going_abroad
-          elsif calculator.already_abroad && response == "esa_under_a_year_medical"
-            outcome :esa_already_abroad_under_a_year_medical_outcome # A25 already_abroad
-          elsif calculator.already_abroad && response == "esa_under_a_year_other"
-            outcome :esa_already_abroad_under_a_year_other_outcome # A26 already_abroad
-          else
-            question :which_country?
-          end
-        end
-      end
-
-      # Going abroad Q28 going_abroad (Disability Benefits) and Q27 already_abroad
-      radio :db_how_long_abroad? do
-        option :temporary
-        option :permanent
-
-        next_node do |response|
-          if response == "permanent"
-            question :which_country? # Q25
-          elsif calculator.going_abroad
-            outcome :db_going_abroad_temporary_outcome # A35 going_abroad
-          else
-            outcome :db_already_abroad_temporary_outcome # A34 already_abroad
-          end
-        end
-      end
-
-      # Going abroad Q32 going_abroad (Income Support)
-      radio :is_how_long_abroad? do
-        option :is_under_a_year_medical
-        option :is_under_a_year_other
-        option :is_more_than_a_year
-
-        next_node do |response|
-          case response
-          when "is_under_a_year_medical"
-            outcome :is_under_a_year_medical_outcome # A42 going_abroad
-          when "is_under_a_year_other"
-            question :is_claiming_benefits? # Q33 going_abroad
-          when "is_more_than_a_year"
-            outcome :is_more_than_a_year_outcome # A41 going_abroad
-          end
-        end
-      end
-
-      # Going abroad
-      radio :worked_in_eea_or_switzerland? do
-        option :before_jan_2021
-        option :after_jan_2021
-        option :no
-
-        next_node do |response|
-          case response
-          when "before_jan_2021"
-            case calculator.benefit
-            when "jsa"
-              outcome :jsa_eea_going_abroad_maybe_outcome
-            when "winter_fuel_payment"
-              outcome :wfp_going_abroad_eea_maybe_outcome
-            when "esa"
-              outcome(calculator.going_abroad ? :esa_going_abroad_eea_outcome : :esa_already_abroad_eea_outcome)
-            when "disability_benefits"
-              outcome(calculator.going_abroad ? :db_going_abroad_eea_outcome : :db_already_abroad_eea_outcome)
-            end
-          when "after_jan_2021", "no"
-            question :parents_lived_in_eea_or_switzerland?
-          end
-        end
-      end
-
-      radio :parents_lived_in_eea_or_switzerland? do
-        option :before_jan_2021
-        option :after_jan_2021
-        option :no
-
-        next_node do |response|
-          case response
-          when "before_jan_2021"
-            case calculator.benefit
-            when "jsa"
-              outcome :jsa_eea_going_abroad_maybe_outcome
-            when "winter_fuel_payment"
-              outcome :wfp_going_abroad_eea_maybe_outcome
-            when "esa"
-              outcome(calculator.going_abroad ? :esa_going_abroad_eea_outcome : :esa_already_abroad_eea_outcome)
-            when "disability_benefits"
-              outcome(calculator.going_abroad ? :db_going_abroad_eea_outcome : :db_already_abroad_eea_outcome)
-            end
-          when "after_jan_2021", "no"
-            case calculator.benefit
-            when "jsa"
-              outcome :jsa_not_entitled_outcome
-            when "winter_fuel_payment"
-              outcome :wfp_not_eligible_outcome
-            when "esa"
-              outcome(calculator.going_abroad ? :esa_going_abroad_other_outcome : :esa_already_abroad_other_outcome)
-            when "disability_benefits"
-              outcome(calculator.going_abroad ? :db_going_abroad_other_outcome : :db_already_abroad_other_outcome)
-            end
-          end
-        end
-      end
-
-      radio :is_british_or_irish? do
-        option :yes
-        option :no
-
-        next_node do |response|
-          case response
-          when "yes"
-            case calculator.benefit
-            when "jsa"
-              outcome :jsa_ireland_outcome
-            when "winter_fuel_payment"
-              outcome :wfp_ireland_outcome
-            when "esa"
-              outcome(calculator.going_abroad ? :esa_going_abroad_eea_outcome : :esa_already_abroad_eea_outcome)
-            when "disability_benefits"
-              outcome :db_going_abroad_ireland_outcome
-            end
-          when "no"
-            question :worked_in_eea_or_switzerland?
-          end
-        end
-      end
-
-      outcome :pension_going_abroad_outcome # A2 going_abroad
-      outcome :jsa_social_security_going_abroad_outcome # A6 going_abroad
-      outcome :jsa_not_entitled_outcome # A7 going_abroad and A5 already_abroad
-      outcome :wfp_not_eligible_outcome # A8 going_abroad and A6 already_abroad
-      outcome :maternity_benefits_maternity_allowance_outcome # A10 going_abroad and A8 already_abroad
-      outcome :maternity_benefits_social_security_going_abroad_outcome # A12 going_abroad
-      outcome :maternity_benefits_not_entitled_outcome # A13 going_abroad and A11 already_abroad
-      outcome :child_benefit_fy_going_abroad_outcome # A14 going_abroad
-      outcome :child_benefit_ss_outcome # A15 going_abroad and A13 already_abroad
-      outcome :child_benefit_entitled_outcome # A17 going_abroad and A15 already_abroad
-      outcome :child_benefit_not_entitled_outcome # A18 going_abroad and A16 already_abroad
-      outcome :ssp_going_abroad_entitled_outcome # A19 going_abroad
-      outcome :ssp_going_abroad_not_entitled_outcome # A20 going_abroad
-
-      outcome :jsa_eea_already_abroad_outcome # A3 already_abroad
-      outcome :jsa_social_security_already_abroad_outcome # A4 already_abroad
-      outcome :pension_already_abroad_outcome # A2 already_abroad
-      outcome :maternity_benefits_eea_entitled_outcome # A11 going_abroad and A9 already_abroad
-      outcome :maternity_benefits_social_security_already_abroad_outcome # A10 already_abroad
-      outcome :child_benefit_fy_already_abroad_outcome # A12 already_abroad
-      outcome :child_benefit_jtu_outcome # A14 already_abroad
-      outcome :ssp_already_abroad_entitled_outcome # A17 already_abroad
-      outcome :ssp_already_abroad_not_entitled_outcome # A18 already_abroad
-      outcome :tax_credits_crown_servant_outcome # A19 already_abroad
-      outcome :tax_credits_cross_border_worker_outcome # A20 already_abroad and A22 going_abroad
-      outcome :tax_credits_unlikely_outcome # A21 already_abroad and A23 going_abroad
-      outcome :tax_credits_eea_entitled_outcome # A22 already_abroad and A24 going_abroad
-      outcome :tax_credits_holiday_outcome # A23 already_abroad and A25 going_abroad and A26 going_abroad
-      outcome :esa_going_abroad_under_a_year_medical_outcome # A27 going_abroad
-      outcome :esa_going_abroad_under_a_year_other_outcome # A28 going_abroad
-      outcome :esa_going_abroad_eea_outcome # A29 going_abroad
-      outcome :esa_going_abroad_other_outcome # A30 going_abroad
-      outcome :iidb_going_abroad_eea_outcome # A32 going_abroad
-      outcome :iidb_going_abroad_ss_outcome # A33 going_abroad
-      outcome :db_going_abroad_temporary_outcome # A35 going_abroad
-      outcome :db_going_abroad_other_outcome # A36 going_abroad
-      outcome :db_going_abroad_eea_outcome # A37 going_abroad
-      outcome :bb_going_abroad_other_outcome # A38 going_abroad
-      outcome :bb_going_abroad_eea_outcome # A39 going_abroad
-      outcome :bb_going_abroad_ss_outcome # A40 going_abroad
-      outcome :is_more_than_a_year_outcome # A41 going_abroad
-      outcome :is_under_a_year_medical_outcome # A42 going_abroad
-      outcome :is_claiming_benefits_outcome # A43 going_abroad
-      outcome :is_abroad_for_treatment_outcome # A44 going_abroad
-      outcome :is_not_eligible_outcome # A45 going_abroad
-
-      outcome :tax_credits_medical_death_outcome # A24 already_abroad
-      outcome :esa_already_abroad_under_a_year_medical_outcome # A25 already_abroad
-      outcome :esa_already_abroad_under_a_year_other_outcome # A26 already_abroad
-      outcome :esa_already_abroad_eea_outcome # A27 already_abroad
-      outcome :esa_already_abroad_ss_outcome # A28 already_abroad
-      outcome :esa_already_abroad_other_outcome # A29 already_abroad
-      outcome :iidb_maybe_outcome # A 30 already_abroad and A31 going_abroad
-      outcome :iidb_already_abroad_eea_outcome # A31 already_abroad
-      outcome :iidb_already_abroad_ss_outcome # A32 already_abroad
-      outcome :iidb_already_abroad_other_outcome # A33 already_abroad
-      outcome :db_already_abroad_temporary_outcome # A34 already_abroad
-      outcome :db_already_abroad_other_outcome # A35 already_abroad
-      outcome :db_already_abroad_eea_outcome # A36 already_abroad
-      outcome :db_already_abroad_gibraltar_outcome
-      outcome :db_going_abroad_gibraltar_outcome
-      outcome :bb_already_abroad_eea_outcome # A37 already_abroad
-      outcome :bb_already_abroad_ss_outcome  # A38 already_abroad
-      outcome :bb_already_abroad_other_outcome # A39 already_abroad
-      outcome :is_already_abroad_outcome # A40 already_abroad
-
-      outcome :jsa_eea_going_abroad_maybe_outcome
-      outcome :jsa_ireland_outcome
-
-      outcome :wfp_going_abroad_eea_maybe_outcome
-      outcome :wfp_ireland_outcome
-
-      outcome :db_going_abroad_ireland_outcome
     end
+
+    # Q13 going_abroad and Q12 already_abroad
+    checkbox_question :do_either_of_the_following_apply? do
+      SmartAnswer::Calculators::UkBenefitsAbroadCalculator::STATE_BENEFITS.each_key do |benefit|
+        option benefit
+      end
+
+      on_response do |response|
+        calculator.benefits = response.split(",")
+      end
+
+      next_node do |_response|
+        if calculator.benefits?
+          outcome :child_benefit_entitled_outcome # A17 going_abroad and A15 already_abroad
+        else
+          outcome :child_benefit_not_entitled_outcome # A18 going_abroad and A16 already_abroad
+        end
+      end
+    end
+
+    # Q15 going_abroad and Q14 already_abroad
+    radio :working_for_uk_employer_ssp? do
+      option :yes
+      option :no
+
+      next_node do |response|
+        if calculator.going_abroad
+          if response == "yes"
+            outcome :ssp_going_abroad_entitled_outcome # A19 going_abroad
+          else
+            outcome :ssp_going_abroad_not_entitled_outcome # A20 going_abroad
+          end
+        elsif calculator.already_abroad
+          if response == "yes"
+            outcome :ssp_already_abroad_entitled_outcome # A17 already_abroad
+          else
+            outcome :ssp_already_abroad_not_entitled_outcome # A18 already_abroad
+          end
+        end
+      end
+    end
+
+    # Q17 going_abroad and Q16 already_abroad
+    radio :eligible_for_tax_credits? do
+      option :crown_servant
+      option :cross_border_worker
+      option :none_of_the_above
+
+      next_node do |response|
+        case response
+        when "crown_servant"
+          outcome :tax_credits_crown_servant_outcome # A19 already_abroad
+        when "cross_border_worker"
+          outcome :tax_credits_cross_border_worker_outcome # A20 already_abroad
+        when "none_of_the_above"
+          question :tax_credits_how_long_abroad? # Q18 going_abroad and Q17 already_abroad
+        end
+      end
+    end
+
+    # Q19 going_abroad and Q18 already_abroad
+    radio :tax_credits_children? do
+      option :yes
+      option :no
+
+      next_node do |response|
+        case response
+        when "yes"
+          question :which_country? # Q17
+        when "no"
+          outcome :tax_credits_unlikely_outcome # A21 already_abroad and A23 going_abroad
+        end
+      end
+    end
+
+    # Q20 already_abroad
+    checkbox_question :tax_credits_currently_claiming? do
+      SmartAnswer::Calculators::UkBenefitsAbroadCalculator::TAX_CREDITS_BENEFITS.each_key do |credit|
+        option credit
+      end
+
+      on_response do |response|
+        calculator.tax_credits = response.split(",")
+      end
+
+      next_node do |_response|
+        if calculator.tax_credits?
+          outcome :tax_credits_eea_entitled_outcome # A22 already_abroad and A24 going_abroad
+        else
+          outcome :tax_credits_unlikely_outcome # A21 already_abroad and A23 going_abroad
+        end
+      end
+    end
+
+    # Q23 going_abroad and Q22 already_abroad
+    radio :tax_credits_why_going_abroad? do
+      option :tax_credits_holiday
+      option :tax_credits_medical_treatment
+      option :tax_credits_death
+
+      next_node do |response|
+        case response
+        when "tax_credits_holiday"
+          outcome :tax_credits_holiday_outcome # A23 already_abroad and A25 going_abroad and A26 going_abroad
+        when "tax_credits_medical_treatment", "tax_credits_death"
+          outcome :tax_credits_medical_death_outcome # A24 already_abroad
+        end
+      end
+    end
+
+    # Q26 going_abroad and Q25 already_abroad
+    radio :iidb_already_claiming? do
+      option :yes
+      option :no
+
+      next_node do |response|
+        case response
+        when "yes"
+          question :which_country? # Shared question
+        when "no"
+          outcome :iidb_maybe_outcome # A30 already_abroad and A31 going_abroad
+        end
+      end
+    end
+
+    # Q30 going_abroad and Q29 already_abroad
+    radio :db_claiming_benefits? do
+      option :yes
+      option :no
+
+      next_node do |response|
+        if calculator.going_abroad
+          if response == "yes"
+            case calculator.country
+            when "ireland"
+              question :is_british_or_irish?
+            when "gibraltar"
+              outcome :db_going_abroad_gibraltar_outcome
+            else
+              question :worked_in_eea_or_switzerland? # A37 going_abroad
+            end
+          else
+            outcome :db_going_abroad_other_outcome # A36 going_abroad
+          end
+        elsif calculator.already_abroad
+          if response == "yes"
+            if calculator.country == "ireland"
+              question :is_british_or_irish?
+            elsif calculator.country == "gibraltar"
+              outcome :db_already_abroad_gibraltar_outcome
+            elsif calculator.eea_country?
+              question :worked_in_eea_or_switzerland? # A37 going_abroad
+            else
+              outcome :db_already_abroad_eea_outcome # A36 already_abroad
+            end
+          else
+            outcome :db_already_abroad_other_outcome # A35 already_abroad
+          end
+        end
+      end
+    end
+
+    # Q33 going_abroad
+    checkbox_question :is_claiming_benefits? do
+      SmartAnswer::Calculators::UkBenefitsAbroadCalculator::PREMIUMS.each_key do |premium|
+        option premium
+      end
+
+      on_response do |response|
+        calculator.partner_premiums = response.split(",")
+      end
+
+      next_node do |_response|
+        if calculator.partner_premiums?
+          outcome :is_claiming_benefits_outcome # A43 going_abroad
+        else
+          question :is_either_of_the_following? # Q34 going_abroad
+        end
+      end
+    end
+
+    # Q34 going_abroad
+    checkbox_question :is_either_of_the_following? do
+      SmartAnswer::Calculators::UkBenefitsAbroadCalculator::IMPAIRMENTS.each_key do |impairment|
+        option impairment
+      end
+
+      on_response do |response|
+        calculator.possible_impairments = response.split(",")
+      end
+
+      next_node do |_response|
+        if calculator.getting_income_support?
+          question :is_abroad_for_treatment? # Q35 going_abroad
+        else
+          question :is_any_of_the_following_apply? # Q37 going_abroad
+        end
+      end
+    end
+
+    # Q35 going_abroad
+    radio :is_abroad_for_treatment? do
+      option :yes
+      option :no
+
+      next_node do |response|
+        case response
+        when "yes"
+          outcome :is_abroad_for_treatment_outcome # A44 going_abroad
+        when "no"
+          question :is_work_or_sick_pay? # Q36 going_abroad
+        end
+      end
+    end
+
+    # Q36 going_abroad
+    checkbox_question :is_work_or_sick_pay? do
+      SmartAnswer::Calculators::UkBenefitsAbroadCalculator::PERIODS_OF_IMPAIRMENT.each_key do |period|
+        option period
+      end
+
+      on_response do |response|
+        calculator.impairment_periods = response.split(",")
+      end
+
+      next_node do |_response|
+        if calculator.not_getting_sick_pay?
+          outcome :is_abroad_for_treatment_outcome # A44 going_abroad
+        else
+          outcome :is_not_eligible_outcome # A45 going_abroad
+        end
+      end
+    end
+
+    # Q37 going_abroad
+    checkbox_question :is_any_of_the_following_apply? do
+      SmartAnswer::Calculators::UkBenefitsAbroadCalculator::DISPUTE_CRITERIA.each_key do |criterion|
+        option criterion
+      end
+
+      on_response do |response|
+        calculator.dispute_criteria = response.split(",")
+      end
+
+      next_node do |_response|
+        if calculator.dispute_criteria?
+          outcome :is_not_eligible_outcome # A45 going_abroad
+        else
+          outcome :is_abroad_for_treatment_outcome # A44 going_abroad
+        end
+      end
+    end
+
+    # Going abroad questions
+    # Going abroad Q18 (tax credits) and Q17 already_abroad
+    radio :tax_credits_how_long_abroad? do
+      option :tax_credits_up_to_a_year
+      option :tax_credits_more_than_a_year
+
+      next_node do |response|
+        case response
+        when "tax_credits_up_to_a_year"
+          question :tax_credits_why_going_abroad? # Q23 going_abroad and Q22 already_abroad
+        when "tax_credits_more_than_a_year"
+          question :tax_credits_children? # Q19 going_abroad and Q18 already_abroad
+        end
+      end
+    end
+
+    # Going abroad Q24 going_abroad (ESA) and Q23 already_abroad
+    radio :esa_how_long_abroad? do
+      option :esa_under_a_year_medical
+      option :esa_under_a_year_other
+      option :esa_more_than_a_year
+
+      next_node do |response|
+        if calculator.going_abroad && response == "esa_under_a_year_medical"
+          outcome :esa_going_abroad_under_a_year_medical_outcome # A27 going_abroad
+        elsif calculator.going_abroad && response == "esa_under_a_year_other"
+          outcome :esa_going_abroad_under_a_year_other_outcome # A28 going_abroad
+        elsif calculator.already_abroad && response == "esa_under_a_year_medical"
+          outcome :esa_already_abroad_under_a_year_medical_outcome # A25 already_abroad
+        elsif calculator.already_abroad && response == "esa_under_a_year_other"
+          outcome :esa_already_abroad_under_a_year_other_outcome # A26 already_abroad
+        else
+          question :which_country?
+        end
+      end
+    end
+
+    # Going abroad Q28 going_abroad (Disability Benefits) and Q27 already_abroad
+    radio :db_how_long_abroad? do
+      option :temporary
+      option :permanent
+
+      next_node do |response|
+        if response == "permanent"
+          question :which_country? # Q25
+        elsif calculator.going_abroad
+          outcome :db_going_abroad_temporary_outcome # A35 going_abroad
+        else
+          outcome :db_already_abroad_temporary_outcome # A34 already_abroad
+        end
+      end
+    end
+
+    # Going abroad Q32 going_abroad (Income Support)
+    radio :is_how_long_abroad? do
+      option :is_under_a_year_medical
+      option :is_under_a_year_other
+      option :is_more_than_a_year
+
+      next_node do |response|
+        case response
+        when "is_under_a_year_medical"
+          outcome :is_under_a_year_medical_outcome # A42 going_abroad
+        when "is_under_a_year_other"
+          question :is_claiming_benefits? # Q33 going_abroad
+        when "is_more_than_a_year"
+          outcome :is_more_than_a_year_outcome # A41 going_abroad
+        end
+      end
+    end
+
+    # Going abroad
+    radio :worked_in_eea_or_switzerland? do
+      option :before_jan_2021
+      option :after_jan_2021
+      option :no
+
+      next_node do |response|
+        case response
+        when "before_jan_2021"
+          case calculator.benefit
+          when "jsa"
+            outcome :jsa_eea_going_abroad_maybe_outcome
+          when "winter_fuel_payment"
+            outcome :wfp_going_abroad_eea_maybe_outcome
+          when "esa"
+            outcome(calculator.going_abroad ? :esa_going_abroad_eea_outcome : :esa_already_abroad_eea_outcome)
+          when "disability_benefits"
+            outcome(calculator.going_abroad ? :db_going_abroad_eea_outcome : :db_already_abroad_eea_outcome)
+          end
+        when "after_jan_2021", "no"
+          question :parents_lived_in_eea_or_switzerland?
+        end
+      end
+    end
+
+    radio :parents_lived_in_eea_or_switzerland? do
+      option :before_jan_2021
+      option :after_jan_2021
+      option :no
+
+      next_node do |response|
+        case response
+        when "before_jan_2021"
+          case calculator.benefit
+          when "jsa"
+            outcome :jsa_eea_going_abroad_maybe_outcome
+          when "winter_fuel_payment"
+            outcome :wfp_going_abroad_eea_maybe_outcome
+          when "esa"
+            outcome(calculator.going_abroad ? :esa_going_abroad_eea_outcome : :esa_already_abroad_eea_outcome)
+          when "disability_benefits"
+            outcome(calculator.going_abroad ? :db_going_abroad_eea_outcome : :db_already_abroad_eea_outcome)
+          end
+        when "after_jan_2021", "no"
+          case calculator.benefit
+          when "jsa"
+            outcome :jsa_not_entitled_outcome
+          when "winter_fuel_payment"
+            outcome :wfp_not_eligible_outcome
+          when "esa"
+            outcome(calculator.going_abroad ? :esa_going_abroad_other_outcome : :esa_already_abroad_other_outcome)
+          when "disability_benefits"
+            outcome(calculator.going_abroad ? :db_going_abroad_other_outcome : :db_already_abroad_other_outcome)
+          end
+        end
+      end
+    end
+
+    radio :is_british_or_irish? do
+      option :yes
+      option :no
+
+      next_node do |response|
+        case response
+        when "yes"
+          case calculator.benefit
+          when "jsa"
+            outcome :jsa_ireland_outcome
+          when "winter_fuel_payment"
+            outcome :wfp_ireland_outcome
+          when "esa"
+            outcome(calculator.going_abroad ? :esa_going_abroad_eea_outcome : :esa_already_abroad_eea_outcome)
+          when "disability_benefits"
+            outcome :db_going_abroad_ireland_outcome
+          end
+        when "no"
+          question :worked_in_eea_or_switzerland?
+        end
+      end
+    end
+
+    outcome :pension_going_abroad_outcome # A2 going_abroad
+    outcome :jsa_social_security_going_abroad_outcome # A6 going_abroad
+    outcome :jsa_not_entitled_outcome # A7 going_abroad and A5 already_abroad
+    outcome :wfp_not_eligible_outcome # A8 going_abroad and A6 already_abroad
+    outcome :maternity_benefits_maternity_allowance_outcome # A10 going_abroad and A8 already_abroad
+    outcome :maternity_benefits_social_security_going_abroad_outcome # A12 going_abroad
+    outcome :maternity_benefits_not_entitled_outcome # A13 going_abroad and A11 already_abroad
+    outcome :child_benefit_fy_going_abroad_outcome # A14 going_abroad
+    outcome :child_benefit_ss_outcome # A15 going_abroad and A13 already_abroad
+    outcome :child_benefit_entitled_outcome # A17 going_abroad and A15 already_abroad
+    outcome :child_benefit_not_entitled_outcome # A18 going_abroad and A16 already_abroad
+    outcome :ssp_going_abroad_entitled_outcome # A19 going_abroad
+    outcome :ssp_going_abroad_not_entitled_outcome # A20 going_abroad
+
+    outcome :jsa_eea_already_abroad_outcome # A3 already_abroad
+    outcome :jsa_social_security_already_abroad_outcome # A4 already_abroad
+    outcome :pension_already_abroad_outcome # A2 already_abroad
+    outcome :maternity_benefits_eea_entitled_outcome # A11 going_abroad and A9 already_abroad
+    outcome :maternity_benefits_social_security_already_abroad_outcome # A10 already_abroad
+    outcome :child_benefit_fy_already_abroad_outcome # A12 already_abroad
+    outcome :child_benefit_jtu_outcome # A14 already_abroad
+    outcome :ssp_already_abroad_entitled_outcome # A17 already_abroad
+    outcome :ssp_already_abroad_not_entitled_outcome # A18 already_abroad
+    outcome :tax_credits_crown_servant_outcome # A19 already_abroad
+    outcome :tax_credits_cross_border_worker_outcome # A20 already_abroad and A22 going_abroad
+    outcome :tax_credits_unlikely_outcome # A21 already_abroad and A23 going_abroad
+    outcome :tax_credits_eea_entitled_outcome # A22 already_abroad and A24 going_abroad
+    outcome :tax_credits_holiday_outcome # A23 already_abroad and A25 going_abroad and A26 going_abroad
+    outcome :esa_going_abroad_under_a_year_medical_outcome # A27 going_abroad
+    outcome :esa_going_abroad_under_a_year_other_outcome # A28 going_abroad
+    outcome :esa_going_abroad_eea_outcome # A29 going_abroad
+    outcome :esa_going_abroad_other_outcome # A30 going_abroad
+    outcome :iidb_going_abroad_eea_outcome # A32 going_abroad
+    outcome :iidb_going_abroad_ss_outcome # A33 going_abroad
+    outcome :db_going_abroad_temporary_outcome # A35 going_abroad
+    outcome :db_going_abroad_other_outcome # A36 going_abroad
+    outcome :db_going_abroad_eea_outcome # A37 going_abroad
+    outcome :bb_going_abroad_other_outcome # A38 going_abroad
+    outcome :bb_going_abroad_eea_outcome # A39 going_abroad
+    outcome :bb_going_abroad_ss_outcome # A40 going_abroad
+    outcome :is_more_than_a_year_outcome # A41 going_abroad
+    outcome :is_under_a_year_medical_outcome # A42 going_abroad
+    outcome :is_claiming_benefits_outcome # A43 going_abroad
+    outcome :is_abroad_for_treatment_outcome # A44 going_abroad
+    outcome :is_not_eligible_outcome # A45 going_abroad
+
+    outcome :tax_credits_medical_death_outcome # A24 already_abroad
+    outcome :esa_already_abroad_under_a_year_medical_outcome # A25 already_abroad
+    outcome :esa_already_abroad_under_a_year_other_outcome # A26 already_abroad
+    outcome :esa_already_abroad_eea_outcome # A27 already_abroad
+    outcome :esa_already_abroad_ss_outcome # A28 already_abroad
+    outcome :esa_already_abroad_other_outcome # A29 already_abroad
+    outcome :iidb_maybe_outcome # A 30 already_abroad and A31 going_abroad
+    outcome :iidb_already_abroad_eea_outcome # A31 already_abroad
+    outcome :iidb_already_abroad_ss_outcome # A32 already_abroad
+    outcome :iidb_already_abroad_other_outcome # A33 already_abroad
+    outcome :db_already_abroad_temporary_outcome # A34 already_abroad
+    outcome :db_already_abroad_other_outcome # A35 already_abroad
+    outcome :db_already_abroad_eea_outcome # A36 already_abroad
+    outcome :db_already_abroad_gibraltar_outcome
+    outcome :db_going_abroad_gibraltar_outcome
+    outcome :bb_already_abroad_eea_outcome # A37 already_abroad
+    outcome :bb_already_abroad_ss_outcome  # A38 already_abroad
+    outcome :bb_already_abroad_other_outcome # A39 already_abroad
+    outcome :is_already_abroad_outcome # A40 already_abroad
+
+    outcome :jsa_eea_going_abroad_maybe_outcome
+    outcome :jsa_ireland_outcome
+
+    outcome :wfp_going_abroad_eea_maybe_outcome
+    outcome :wfp_ireland_outcome
+
+    outcome :db_going_abroad_ireland_outcome
   end
 end

--- a/lib/smart_answer_flows/vat-payment-deadlines.rb
+++ b/lib/smart_answer_flows/vat-payment-deadlines.rb
@@ -1,67 +1,65 @@
-module SmartAnswer
-  class VatPaymentDeadlinesFlow < Flow
-    def define
-      content_id "dfa9a5c3-d52e-479c-8505-855f475dc338"
-      name "vat-payment-deadlines"
-      status :published
+class VatPaymentDeadlinesFlow < SmartAnswer::Flow
+  def define
+    content_id "dfa9a5c3-d52e-479c-8505-855f475dc338"
+    name "vat-payment-deadlines"
+    status :published
 
-      date_question :when_does_your_vat_accounting_period_end? do
-        default_day { -1 }
+    date_question :when_does_your_vat_accounting_period_end? do
+      default_day { -1 }
 
-        on_response do
-          self.calculator = Calculators::VatPaymentDeadlines.new
-        end
-
-        validate :error_message do |response|
-          response == response.end_of_month
-        end
-
-        next_node do |response|
-          calculator.period_end_date = response
-          question :how_do_you_want_to_pay?
-        end
+      on_response do
+        self.calculator = SmartAnswer::Calculators::VatPaymentDeadlines.new
       end
 
-      radio :how_do_you_want_to_pay? do
-        option "direct-debit"
-        option "online-telephone-banking"
-        option "online-debit-credit-card"
-        option "bacs-direct-credit"
-        option "bank-giro"
-        option "chaps"
-        option "cheque"
-
-        on_response do |response|
-          calculator.payment_method = response
-        end
-
-        next_node do |response|
-          case response
-          when "direct-debit"
-            outcome :result_direct_debit
-          when "online-telephone-banking"
-            outcome :result_online_telephone_banking
-          when "online-debit-credit-card"
-            outcome :result_online_debit_credit_card
-          when "bacs-direct-credit"
-            outcome :result_bacs_direct_credit
-          when "bank-giro"
-            outcome :result_bank_giro
-          when "chaps"
-            outcome :result_chaps
-          when "cheque"
-            outcome :result_cheque
-          end
-        end
+      validate :error_message do |response|
+        response == response.end_of_month
       end
 
-      outcome :result_direct_debit
-      outcome :result_online_telephone_banking
-      outcome :result_online_debit_credit_card
-      outcome :result_bacs_direct_credit
-      outcome :result_bank_giro
-      outcome :result_chaps
-      outcome :result_cheque
+      next_node do |response|
+        calculator.period_end_date = response
+        question :how_do_you_want_to_pay?
+      end
     end
+
+    radio :how_do_you_want_to_pay? do
+      option "direct-debit"
+      option "online-telephone-banking"
+      option "online-debit-credit-card"
+      option "bacs-direct-credit"
+      option "bank-giro"
+      option "chaps"
+      option "cheque"
+
+      on_response do |response|
+        calculator.payment_method = response
+      end
+
+      next_node do |response|
+        case response
+        when "direct-debit"
+          outcome :result_direct_debit
+        when "online-telephone-banking"
+          outcome :result_online_telephone_banking
+        when "online-debit-credit-card"
+          outcome :result_online_debit_credit_card
+        when "bacs-direct-credit"
+          outcome :result_bacs_direct_credit
+        when "bank-giro"
+          outcome :result_bank_giro
+        when "chaps"
+          outcome :result_chaps
+        when "cheque"
+          outcome :result_cheque
+        end
+      end
+    end
+
+    outcome :result_direct_debit
+    outcome :result_online_telephone_banking
+    outcome :result_online_debit_credit_card
+    outcome :result_bacs_direct_credit
+    outcome :result_bank_giro
+    outcome :result_chaps
+    outcome :result_cheque
   end
 end

--- a/spec/features/flows/am_i_getting_minimum_wage_spec.rb
+++ b/spec/features/flows/am_i_getting_minimum_wage_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature "SmartAnswer::AmIGettingMinimumWageFlow" do
+RSpec.feature "AmIGettingMinimumWageFlow" do
   let(:shared_headings) do
     # <question name>: <text_for :title from erb>
     {

--- a/spec/features/flows/business_coronavirus_support_finder_spec.rb
+++ b/spec/features/flows/business_coronavirus_support_finder_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature "SmartAnswer::BusinessCoronavirusSupportFinderFlow" do
+RSpec.feature "BusinessCoronavirusSupportFinderFlow" do
   let(:headings) do
     # <question name>: <text_for :title from erb>
     {

--- a/spec/features/flows/next_steps_for_your_business_flow_spec.rb
+++ b/spec/features/flows/next_steps_for_your_business_flow_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature "SmartAnswer::NextStepsForYourBusinessFlow" do
+RSpec.feature "NextStepsForYourBusinessFlow" do
   let(:headings) do
     # <question name>: <text_for :title from erb>
     {

--- a/spec/fixtures/flows/path-based.rb
+++ b/spec/fixtures/flows/path-based.rb
@@ -1,16 +1,14 @@
-module SmartAnswer
-  class PathBasedFlow < Flow
-    def define
-      name "path-based"
-      content_id "d26e566e-1550-4913-b945-9372c32256f1"
+class PathBasedFlow < SmartAnswer::Flow
+  def define
+    name "path-based"
+    content_id "d26e566e-1550-4913-b945-9372c32256f1"
 
-      value_question :question1 do
-        next_node do
-          outcome :results
-        end
+    value_question :question1 do
+      next_node do
+        outcome :results
       end
-
-      outcome :results
     end
+
+    outcome :results
   end
 end

--- a/spec/fixtures/flows/query-parameters-based.rb
+++ b/spec/fixtures/flows/query-parameters-based.rb
@@ -1,26 +1,24 @@
-module SmartAnswer
-  class QueryParametersBasedFlow < Flow
-    def define
-      name "query-parameters-based"
-      content_id "f26e566e-2557-4921-b944-9373c32255f1"
-      response_store :query_parameters
+class QueryParametersBasedFlow < SmartAnswer::Flow
+  def define
+    name "query-parameters-based"
+    content_id "f26e566e-2557-4921-b944-9373c32255f1"
+    response_store :query_parameters
 
-      radio :question1 do
-        option :response1
-        option :response2
+    radio :question1 do
+      option :response1
+      option :response2
 
-        next_node do
-          question :question2
-        end
+      next_node do
+        question :question2
       end
-
-      value_question :question2 do
-        next_node do
-          outcome :results
-        end
-      end
-
-      outcome :results
     end
+
+    value_question :question2 do
+      next_node do
+        outcome :results
+      end
+    end
+
+    outcome :results
   end
 end

--- a/spec/fixtures/flows/session-based.rb
+++ b/spec/fixtures/flows/session-based.rb
@@ -1,26 +1,24 @@
-module SmartAnswer
-  class SessionBasedFlow < Flow
-    def define
-      name "session-based"
-      content_id "f26e566e-2557-4921-b944-9373c32255f1"
-      response_store :session
+class SessionBasedFlow < SmartAnswer::Flow
+  def define
+    name "session-based"
+    content_id "f26e566e-2557-4921-b944-9373c32255f1"
+    response_store :session
 
-      radio :question1 do
-        option :response1
-        option :response2
+    radio :question1 do
+      option :response1
+      option :response2
 
-        next_node do
-          question :question2
-        end
+      next_node do
+        question :question2
       end
-
-      value_question :question2 do
-        next_node do
-          outcome :results
-        end
-      end
-
-      outcome :results
     end
+
+    value_question :question2 do
+      next_node do
+        outcome :results
+      end
+    end
+
+    outcome :results
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -71,9 +71,13 @@ RSpec.configure do |config|
   end
 
   config.before(:context, flow_dir: :fixture) do
+    fixture_load_path = Rails.root.join("spec/fixtures/flows")
+
+    Dir[fixture_load_path.join("*.rb")].map { |path| require path }
+
     SmartAnswer::FlowRegistry.reset_instance(
       preload_flows: false,
-      smart_answer_load_path: Rails.root.join("spec/fixtures/flows"),
+      smart_answer_load_path: fixture_load_path,
     )
   end
 

--- a/test/fixtures/smart_answer_flows/benchmarking-sample.rb
+++ b/test/fixtures/smart_answer_flows/benchmarking-sample.rb
@@ -1,7 +1,5 @@
-module SmartAnswer
-  class BenchmarkingSampleFlow < Flow
-    def define
-      name "benchmarking-sample"
-    end
+class BenchmarkingSampleFlow < SmartAnswer::Flow
+  def define
+    name "benchmarking-sample"
   end
 end

--- a/test/fixtures/smart_answer_flows/bridge-of-death.rb
+++ b/test/fixtures/smart_answer_flows/bridge-of-death.rb
@@ -1,60 +1,58 @@
-module SmartAnswer
-  class BridgeOfDeathFlow < Flow
-    def define
-      name "bridge-of-death"
-      status :draft
+class BridgeOfDeathFlow < SmartAnswer::Flow
+  def define
+    name "bridge-of-death"
+    status :draft
 
-      value_question :what_is_your_name? do
-        on_response do |response|
-          self.your_name = response
-        end
-
-        next_node do
-          question :what_is_your_quest?
-        end
+    value_question :what_is_your_name? do
+      on_response do |response|
+        self.your_name = response
       end
 
-      radio :what_is_your_quest? do
-        option :to_seek_the_holy_grail
-        option :to_rescue_the_princess
-        option :dunno
+      next_node do
+        question :what_is_your_quest?
+      end
+    end
 
-        next_node do |response|
-          if your_name =~ /robin/i && response == "to_seek_the_holy_grail"
-            question :what_is_the_capital_of_assyria?
-          else
-            question :what_is_your_favorite_colour?
-          end
+    radio :what_is_your_quest? do
+      option :to_seek_the_holy_grail
+      option :to_rescue_the_princess
+      option :dunno
+
+      next_node do |response|
+        if your_name =~ /robin/i && response == "to_seek_the_holy_grail"
+          question :what_is_the_capital_of_assyria?
+        else
+          question :what_is_your_favorite_colour?
         end
       end
+    end
 
-      value_question :what_is_the_capital_of_assyria? do
-        on_response do |response|
-          self.capital_of_assyria = response
-        end
+    value_question :what_is_the_capital_of_assyria? do
+      on_response do |response|
+        self.capital_of_assyria = response
+      end
 
-        next_node do
+      next_node do
+        outcome :auuuuuuuugh
+      end
+    end
+
+    radio :what_is_your_favorite_colour? do
+      option :blue
+      option :blue_no_yellow
+      option :red
+
+      next_node do |response|
+        case response
+        when "blue", "red"
+          outcome :done
+        when "blue_no_yellow"
           outcome :auuuuuuuugh
         end
       end
-
-      radio :what_is_your_favorite_colour? do
-        option :blue
-        option :blue_no_yellow
-        option :red
-
-        next_node do |response|
-          case response
-          when "blue", "red"
-            outcome :done
-          when "blue_no_yellow"
-            outcome :auuuuuuuugh
-          end
-        end
-      end
-
-      outcome :done
-      outcome :auuuuuuuugh
     end
+
+    outcome :done
+    outcome :auuuuuuuugh
   end
 end

--- a/test/fixtures/smart_answer_flows/checkbox-sample.rb
+++ b/test/fixtures/smart_answer_flows/checkbox-sample.rb
@@ -1,50 +1,48 @@
-module SmartAnswer
-  class CheckboxSampleFlow < Flow
-    def define
-      name "checkbox-sample"
-      status :draft
+class CheckboxSampleFlow < SmartAnswer::Flow
+  def define
+    name "checkbox-sample"
+    status :draft
 
-      checkbox_question :what_do_you_want_on_your_pizza? do
-        option :ham
-        option :peppers
-        option :ice_cream
-        option :pepperoni
+    checkbox_question :what_do_you_want_on_your_pizza? do
+      option :ham
+      option :peppers
+      option :ice_cream
+      option :pepperoni
 
-        on_response do |response|
-          self.toppings = response
-        end
+      on_response do |response|
+        self.toppings = response
+      end
 
-        next_node do |response|
-          if response == "none"
-            question :confirm_no_toppings?
+      next_node do |response|
+        if response == "none"
+          question :confirm_no_toppings?
+        else
+          toppings = response.split(",")
+          if toppings.include?("ice_cream")
+            outcome :no_way
           else
-            toppings = response.split(",")
-            if toppings.include?("ice_cream")
-              outcome :no_way
-            else
-              outcome :on_its_way
-            end
+            outcome :on_its_way
           end
         end
       end
-
-      checkbox_question :confirm_no_toppings? do
-        option :ask_me_again
-
-        none_option
-
-        next_node do |response|
-          if response == "none"
-            outcome :margherita
-          else
-            question :what_do_you_want_on_your_pizza?
-          end
-        end
-      end
-
-      outcome :margherita
-      outcome :on_its_way
-      outcome :no_way
     end
+
+    checkbox_question :confirm_no_toppings? do
+      option :ask_me_again
+
+      none_option
+
+      next_node do |response|
+        if response == "none"
+          outcome :margherita
+        else
+          question :what_do_you_want_on_your_pizza?
+        end
+      end
+    end
+
+    outcome :margherita
+    outcome :on_its_way
+    outcome :no_way
   end
 end

--- a/test/fixtures/smart_answer_flows/country-and-date-sample.rb
+++ b/test/fixtures/smart_answer_flows/country-and-date-sample.rb
@@ -1,44 +1,42 @@
-module SmartAnswer
-  class CountryAndDateSampleFlow < Flow
-    def define
-      name "country-and-date-sample"
-      status :draft
+class CountryAndDateSampleFlow < SmartAnswer::Flow
+  def define
+    name "country-and-date-sample"
+    status :draft
 
-      country_select :which_country_do_you_live_in? do
-        on_response do |response|
-          self.country = response
-        end
-
-        next_node do
-          question :what_date_did_you_move_there?
-        end
+    country_select :which_country_do_you_live_in? do
+      on_response do |response|
+        self.country = response
       end
 
-      date_question :what_date_did_you_move_there? do
-        from { Date.parse("1900-01-01") }
-        to { Time.zone.today }
-
-        on_response do |response|
-          self.years_there = ((Time.zone.today - response) / 365.25).to_i
-          self.date_moved = response
-        end
-
-        next_node do
-          question :which_country_were_you_born_in?
-        end
+      next_node do
+        question :what_date_did_you_move_there?
       end
-
-      country_select :which_country_were_you_born_in? do
-        on_response do |response|
-          self.birth_country = response
-        end
-
-        next_node do
-          outcome :ok
-        end
-      end
-
-      outcome :ok
     end
+
+    date_question :what_date_did_you_move_there? do
+      from { Date.parse("1900-01-01") }
+      to { Time.zone.today }
+
+      on_response do |response|
+        self.years_there = ((Time.zone.today - response) / 365.25).to_i
+        self.date_moved = response
+      end
+
+      next_node do
+        question :which_country_were_you_born_in?
+      end
+    end
+
+    country_select :which_country_were_you_born_in? do
+      on_response do |response|
+        self.birth_country = response
+      end
+
+      next_node do
+        outcome :ok
+      end
+    end
+
+    outcome :ok
   end
 end

--- a/test/fixtures/smart_answer_flows/custom-button.rb
+++ b/test/fixtures/smart_answer_flows/custom-button.rb
@@ -1,11 +1,9 @@
-module SmartAnswer
-  class CustomButtonFlow < Flow
-    def define
-      name "custom-button"
-      status :draft
+class CustomButtonFlow < SmartAnswer::Flow
+  def define
+    name "custom-button"
+    status :draft
 
-      value_question :user_input? do
-      end
+    value_question :user_input? do
     end
   end
 end

--- a/test/fixtures/smart_answer_flows/custom-errors-sample.rb
+++ b/test/fixtures/smart_answer_flows/custom-errors-sample.rb
@@ -1,18 +1,16 @@
-module SmartAnswer
-  class CustomErrorsSampleFlow < Flow
-    def define
-      name "custom-errors-sample"
-      status :draft
+class CustomErrorsSampleFlow < SmartAnswer::Flow
+  def define
+    name "custom-errors-sample"
+    status :draft
 
-      value_question :how_many_things_do_you_own? do
-        next_node do |response|
-          raise SmartAnswer::InvalidResponse, :error_custom unless response.to_i.positive?
+    value_question :how_many_things_do_you_own? do
+      next_node do |response|
+        raise SmartAnswer::InvalidResponse, :error_custom unless response.to_i.positive?
 
-          outcome :done
-        end
+        outcome :done
       end
-
-      outcome :done
     end
+
+    outcome :done
   end
 end

--- a/test/fixtures/smart_answer_flows/draft-flow-sample.rb
+++ b/test/fixtures/smart_answer_flows/draft-flow-sample.rb
@@ -1,8 +1,6 @@
-module SmartAnswer
-  class DraftFlowSampleFlow < Flow
-    def define
-      name "draft-flow-sample"
-      status :draft
-    end
+class DraftFlowSampleFlow < SmartAnswer::Flow
+  def define
+    name "draft-flow-sample"
+    status :draft
   end
 end

--- a/test/fixtures/smart_answer_flows/education-sample.rb
+++ b/test/fixtures/smart_answer_flows/education-sample.rb
@@ -1,19 +1,17 @@
-module SmartAnswer
-  class EducationSampleFlow < Flow
-    def define
-      name "education-sample"
+class EducationSampleFlow < SmartAnswer::Flow
+  def define
+    name "education-sample"
 
-      postcode_question :user_input? do
-        on_response do |response|
-          self.user_input = response
-        end
-
-        next_node do
-          outcome :outcome
-        end
+    postcode_question :user_input? do
+      on_response do |response|
+        self.user_input = response
       end
 
-      outcome :outcome
+      next_node do
+        outcome :outcome
+      end
     end
+
+    outcome :outcome
   end
 end

--- a/test/fixtures/smart_answer_flows/flow-sample.rb
+++ b/test/fixtures/smart_answer_flows/flow-sample.rb
@@ -1,40 +1,38 @@
-module SmartAnswer
-  class FlowSampleFlow < Flow
-    def define
-      name "flow-sample"
-      content_id "f26e566e-2557-4921-b944-9373c32255f1"
+class FlowSampleFlow < SmartAnswer::Flow
+  def define
+    name "flow-sample"
+    content_id "f26e566e-2557-4921-b944-9373c32255f1"
 
-      radio :hotter_or_colder? do
-        option :hotter
-        option :colder
+    radio :hotter_or_colder? do
+      option :hotter
+      option :colder
 
-        next_node do |response|
-          case response
-          when "hotter"
-            outcome :hot
-          when "colder"
-            question :frozen?
-          end
+      next_node do |response|
+        case response
+        when "hotter"
+          outcome :hot
+        when "colder"
+          question :frozen?
         end
       end
-
-      radio :frozen? do
-        option :yes
-        option :no
-
-        next_node do |response|
-          case response
-          when "yes"
-            outcome :frozen
-          when "no"
-            outcome :cold
-          end
-        end
-      end
-
-      outcome :hot
-      outcome :cold
-      outcome :frozen
     end
+
+    radio :frozen? do
+      option :yes
+      option :no
+
+      next_node do |response|
+        case response
+        when "yes"
+          outcome :frozen
+        when "no"
+          outcome :cold
+        end
+      end
+    end
+
+    outcome :hot
+    outcome :cold
+    outcome :frozen
   end
 end

--- a/test/fixtures/smart_answer_flows/graph.rb
+++ b/test/fixtures/smart_answer_flows/graph.rb
@@ -1,42 +1,40 @@
-module SmartAnswer
-  class GraphFlow < Flow
-    def define
-      name "graph"
-      status :draft
+class GraphFlow < SmartAnswer::Flow
+  def define
+    name "graph"
+    status :draft
 
-      radio :q1? do
-        option :yes
-        option :no
+    radio :q1? do
+      option :yes
+      option :no
 
-        next_node do
-          question :q2?
-        end
+      next_node do
+        question :q2?
       end
-
-      radio :q2? do
-        option :a
-        option :b
-
-        next_node do |response|
-          if response == "a"
-            outcome :done_a
-          else
-            question :q_with_interpolation?
-          end
-        end
-      end
-
-      radio :q_with_interpolation? do
-        option :x
-        option :y
-
-        next_node do
-          outcome :done_b
-        end
-      end
-
-      outcome :done_a
-      outcome :done_b
     end
+
+    radio :q2? do
+      option :a
+      option :b
+
+      next_node do |response|
+        if response == "a"
+          outcome :done_a
+        else
+          question :q_with_interpolation?
+        end
+      end
+    end
+
+    radio :q_with_interpolation? do
+      option :x
+      option :y
+
+      next_node do
+        outcome :done_b
+      end
+    end
+
+    outcome :done_a
+    outcome :done_b
   end
 end

--- a/test/fixtures/smart_answer_flows/money-and-salary-sample.rb
+++ b/test/fixtures/smart_answer_flows/money-and-salary-sample.rb
@@ -1,36 +1,34 @@
-module SmartAnswer
-  class MoneyAndSalarySampleFlow < Flow
-    def define
-      name "money-and-salary-sample"
-      status :draft
+class MoneyAndSalarySampleFlow < SmartAnswer::Flow
+  def define
+    name "money-and-salary-sample"
+    status :draft
 
-      salary_question :how_much_do_you_earn? do
-        on_response do |response|
-          self.salary = response
-          self.annual_salary = SmartAnswer::Money.new(response.per_week * 52)
-        end
-
-        next_node do
-          question :what_size_bonus_do_you_want?
-        end
+    salary_question :how_much_do_you_earn? do
+      on_response do |response|
+        self.salary = response
+        self.annual_salary = SmartAnswer::Money.new(response.per_week * 52)
       end
 
-      money_question :what_size_bonus_do_you_want? do
-        on_response do |response|
-          value = SmartAnswer::Money.new(response)
-          if value < annual_salary
-            raise InvalidResponse, "You can't request a bonus less than your annual salary.", caller
-          end
-
-          self.requested_bonus = value
-        end
-
-        next_node do
-          outcome :ok
-        end
+      next_node do
+        question :what_size_bonus_do_you_want?
       end
-
-      outcome :ok
     end
+
+    money_question :what_size_bonus_do_you_want? do
+      on_response do |response|
+        value = SmartAnswer::Money.new(response)
+        if value < annual_salary
+          raise SmartAnswer::InvalidResponse, "You can't request a bonus less than your annual salary.", caller
+        end
+
+        self.requested_bonus = value
+      end
+
+      next_node do
+        outcome :ok
+      end
+    end
+
+    outcome :ok
   end
 end

--- a/test/fixtures/smart_answer_flows/postcode-sample.rb
+++ b/test/fixtures/smart_answer_flows/postcode-sample.rb
@@ -1,20 +1,18 @@
-module SmartAnswer
-  class PostcodeSampleFlow < Flow
-    def define
-      name "postcode-sample"
-      status :draft
+class PostcodeSampleFlow < SmartAnswer::Flow
+  def define
+    name "postcode-sample"
+    status :draft
 
-      postcode_question :user_input? do
-        on_response do |response|
-          self.user_input = response
-        end
-
-        next_node do
-          outcome :outcome
-        end
+    postcode_question :user_input? do
+      on_response do |response|
+        self.user_input = response
       end
 
-      outcome :outcome
+      next_node do
+        outcome :outcome
+      end
     end
+
+    outcome :outcome
   end
 end

--- a/test/fixtures/smart_answer_flows/smart-answers-controller-sample-with-checkbox-question.rb
+++ b/test/fixtures/smart_answer_flows/smart-answers-controller-sample-with-checkbox-question.rb
@@ -1,14 +1,12 @@
-module SmartAnswer
-  class SmartAnswersControllerSampleWithCheckboxQuestionFlow < Flow
-    def define
-      name "smart-answers-controller-sample-with-checkbox-question"
-      checkbox_question :what? do
-        option :cheese
-        next_node do
-          outcome :done
-        end
+class SmartAnswersControllerSampleWithCheckboxQuestionFlow < SmartAnswer::Flow
+  def define
+    name "smart-answers-controller-sample-with-checkbox-question"
+    checkbox_question :what? do
+      option :cheese
+      next_node do
+        outcome :done
       end
-      outcome :done
     end
+    outcome :done
   end
 end

--- a/test/fixtures/smart_answer_flows/smart-answers-controller-sample-with-country-question.rb
+++ b/test/fixtures/smart_answer_flows/smart-answers-controller-sample-with-country-question.rb
@@ -1,13 +1,11 @@
-module SmartAnswer
-  class SmartAnswersControllerSampleWithCountryQuestionFlow < Flow
-    def define
-      name "smart-answers-controller-sample-with-country-question"
-      country_select :country? do
-        next_node do
-          outcome :done
-        end
+class SmartAnswersControllerSampleWithCountryQuestionFlow < SmartAnswer::Flow
+  def define
+    name "smart-answers-controller-sample-with-country-question"
+    country_select :country? do
+      next_node do
+        outcome :done
       end
-      outcome :done
     end
+    outcome :done
   end
 end

--- a/test/fixtures/smart_answer_flows/smart-answers-controller-sample-with-date-question.rb
+++ b/test/fixtures/smart_answer_flows/smart-answers-controller-sample-with-date-question.rb
@@ -1,14 +1,12 @@
-module SmartAnswer
-  class SmartAnswersControllerSampleWithDateQuestionFlow < Flow
-    def define
-      name "smart-answers-controller-sample-with-date-question"
+class SmartAnswersControllerSampleWithDateQuestionFlow < SmartAnswer::Flow
+  def define
+    name "smart-answers-controller-sample-with-date-question"
 
-      date_question :when? do
-        next_node do
-          outcome :done
-        end
+    date_question :when? do
+      next_node do
+        outcome :done
       end
-      outcome :done
     end
+    outcome :done
   end
 end

--- a/test/fixtures/smart_answer_flows/smart-answers-controller-sample-with-money-question.rb
+++ b/test/fixtures/smart_answer_flows/smart-answers-controller-sample-with-money-question.rb
@@ -1,18 +1,16 @@
-module SmartAnswer
-  class SmartAnswersControllerSampleWithMoneyQuestionFlow < Flow
-    def define
-      name "smart-answers-controller-sample-with-money-question"
-      money_question :how_much? do
-        next_node do
-          question :money_question_with_suffix_label?
-        end
+class SmartAnswersControllerSampleWithMoneyQuestionFlow < SmartAnswer::Flow
+  def define
+    name "smart-answers-controller-sample-with-money-question"
+    money_question :how_much? do
+      next_node do
+        question :money_question_with_suffix_label?
       end
-      money_question :money_question_with_suffix_label? do
-        next_node do
-          outcome :done
-        end
-      end
-      outcome :done
     end
+    money_question :money_question_with_suffix_label? do
+      next_node do
+        outcome :done
+      end
+    end
+    outcome :done
   end
 end

--- a/test/fixtures/smart_answer_flows/smart-answers-controller-sample-with-postcode-question.rb
+++ b/test/fixtures/smart_answer_flows/smart-answers-controller-sample-with-postcode-question.rb
@@ -1,13 +1,11 @@
-module SmartAnswer
-  class SmartAnswersControllerSampleWithPostcodeQuestionFlow < Flow
-    def define
-      name "smart-answers-controller-sample-with-postcode-question"
-      postcode_question :postcode? do
-        next_node do
-          outcome :done
-        end
+class SmartAnswersControllerSampleWithPostcodeQuestionFlow < SmartAnswer::Flow
+  def define
+    name "smart-answers-controller-sample-with-postcode-question"
+    postcode_question :postcode? do
+      next_node do
+        outcome :done
       end
-      outcome :done
     end
+    outcome :done
   end
 end

--- a/test/fixtures/smart_answer_flows/smart-answers-controller-sample-with-radio-question.rb
+++ b/test/fixtures/smart_answer_flows/smart-answers-controller-sample-with-radio-question.rb
@@ -1,14 +1,12 @@
-module SmartAnswer
-  class SmartAnswersControllerSampleWithRadioQuestionFlow < Flow
-    def define
-      name "smart-answers-controller-sample-with-radio-question"
-      radio :what? do
-        option :cheese
-        next_node do
-          outcome :done
-        end
+class SmartAnswersControllerSampleWithRadioQuestionFlow < SmartAnswer::Flow
+  def define
+    name "smart-answers-controller-sample-with-radio-question"
+    radio :what? do
+      option :cheese
+      next_node do
+        outcome :done
       end
-      outcome :done
     end
+    outcome :done
   end
 end

--- a/test/fixtures/smart_answer_flows/smart-answers-controller-sample-with-salary-question.rb
+++ b/test/fixtures/smart_answer_flows/smart-answers-controller-sample-with-salary-question.rb
@@ -1,18 +1,16 @@
-module SmartAnswer
-  class SmartAnswersControllerSampleWithSalaryQuestionFlow < Flow
-    def define
-      name "smart-answers-controller-sample-with-salary-question"
-      salary_question(:how_much?) do
-        next_node do
-          question :salary_question_with_error_message?
-        end
+class SmartAnswersControllerSampleWithSalaryQuestionFlow < SmartAnswer::Flow
+  def define
+    name "smart-answers-controller-sample-with-salary-question"
+    salary_question(:how_much?) do
+      next_node do
+        question :salary_question_with_error_message?
       end
-      salary_question(:salary_question_with_error_message?) do
-        next_node do
-          outcome :done
-        end
-      end
-      outcome :done
     end
+    salary_question(:salary_question_with_error_message?) do
+      next_node do
+        outcome :done
+      end
+    end
+    outcome :done
   end
 end

--- a/test/fixtures/smart_answer_flows/smart-answers-controller-sample-with-value-question.rb
+++ b/test/fixtures/smart_answer_flows/smart-answers-controller-sample-with-value-question.rb
@@ -1,25 +1,23 @@
-module SmartAnswer
-  class SmartAnswersControllerSampleWithValueQuestionFlow < Flow
-    def define
-      name "smart-answers-controller-sample-with-value-question"
+class SmartAnswersControllerSampleWithValueQuestionFlow < SmartAnswer::Flow
+  def define
+    name "smart-answers-controller-sample-with-value-question"
 
-      value_question :how_many_green_bottles? do
-        next_node do
-          question :value_question_with_label?
-        end
+    value_question :how_many_green_bottles? do
+      next_node do
+        question :value_question_with_label?
       end
-      value_question :value_question_with_label? do
-        next_node do
-          question :value_question_with_suffix_label?
-        end
-      end
-      value_question :value_question_with_suffix_label? do
-        next_node do
-          outcome :done
-        end
-      end
-
-      outcome :done
     end
+    value_question :value_question_with_label? do
+      next_node do
+        question :value_question_with_suffix_label?
+      end
+    end
+    value_question :value_question_with_suffix_label? do
+      next_node do
+        outcome :done
+      end
+    end
+
+    outcome :done
   end
 end

--- a/test/fixtures/smart_answer_flows/smart-answers-controller-sample.rb
+++ b/test/fixtures/smart_answer_flows/smart-answers-controller-sample.rb
@@ -1,38 +1,36 @@
-module SmartAnswer
-  class SmartAnswersControllerSampleFlow < Flow
-    def define
-      name "smart-answers-controller-sample"
+class SmartAnswersControllerSampleFlow < SmartAnswer::Flow
+  def define
+    name "smart-answers-controller-sample"
 
-      radio :do_you_like_chocolate? do
-        option :yes
-        option :no
+    radio :do_you_like_chocolate? do
+      option :yes
+      option :no
 
-        next_node do |response|
-          case response
-          when "yes"
-            outcome :you_have_a_sweet_tooth
-          when "no"
-            question :do_you_like_jam?
-          end
+      next_node do |response|
+        case response
+        when "yes"
+          outcome :you_have_a_sweet_tooth
+        when "no"
+          question :do_you_like_jam?
         end
       end
-
-      radio :do_you_like_jam? do
-        option :yes
-        option :no
-
-        next_node do |response|
-          case response
-          when "yes"
-            outcome :you_have_a_sweet_tooth
-          when "no"
-            outcome :you_have_a_savoury_tooth
-          end
-        end
-      end
-
-      outcome :you_have_a_savoury_tooth
-      outcome :you_have_a_sweet_tooth
     end
+
+    radio :do_you_like_jam? do
+      option :yes
+      option :no
+
+      next_node do |response|
+        case response
+        when "yes"
+          outcome :you_have_a_sweet_tooth
+        when "no"
+          outcome :you_have_a_savoury_tooth
+        end
+      end
+    end
+
+    outcome :you_have_a_savoury_tooth
+    outcome :you_have_a_sweet_tooth
   end
 end

--- a/test/fixtures/smart_answer_flows/value-sample.rb
+++ b/test/fixtures/smart_answer_flows/value-sample.rb
@@ -1,20 +1,18 @@
-module SmartAnswer
-  class ValueSampleFlow < Flow
-    def define
-      name "value-sample"
-      status :draft
+class ValueSampleFlow < SmartAnswer::Flow
+  def define
+    name "value-sample"
+    status :draft
 
-      value_question :user_input? do
-        on_response do |response|
-          self.user_input = response
-        end
-
-        next_node do
-          outcome :outcome_with_template
-        end
+    value_question :user_input? do
+      on_response do |response|
+        self.user_input = response
       end
 
-      outcome :outcome_with_template
+      next_node do
+        outcome :outcome_with_template
+      end
     end
+
+    outcome :outcome_with_template
   end
 end

--- a/test/helpers/content_item_helper_test.rb
+++ b/test/helpers/content_item_helper_test.rb
@@ -5,7 +5,7 @@ require File.expand_path("../fixtures/smart_answer_flows/flow-sample", __dir__)
 class ContentItemHelperTest < ActionView::TestCase
   def setup
     setup_fixture_flows
-    @flow = SmartAnswer::FlowSampleFlow.build
+    @flow = FlowSampleFlow.build
 
     node = SmartAnswer::StartNode.new(@flow, @flow.name.underscore.to_sym)
     @start_node = node.presenter

--- a/test/integration/smart_answer_flows/additional_commodity_code_test.rb
+++ b/test/integration/smart_answer_flows/additional_commodity_code_test.rb
@@ -1,8 +1,6 @@
 require_relative "../../test_helper"
 require_relative "flow_integration_test_helper"
 
-require "smart_answer_flows/additional-commodity-code"
-
 class AdditionalCommodityCodeTest < ActiveSupport::TestCase
   include FlowIntegrationTestHelper
 

--- a/test/integration/smart_answer_flows/additional_commodity_code_test.rb
+++ b/test/integration/smart_answer_flows/additional_commodity_code_test.rb
@@ -7,7 +7,7 @@ class AdditionalCommodityCodeTest < ActiveSupport::TestCase
   include FlowIntegrationTestHelper
 
   setup do
-    setup_for_testing_flow SmartAnswer::AdditionalCommodityCodeFlow
+    setup_for_testing_flow AdditionalCommodityCodeFlow
   end
   ## Q1
   should "ask how much starch glucose the product contains" do

--- a/test/integration/smart_answer_flows/adoption_calculator_test.rb
+++ b/test/integration/smart_answer_flows/adoption_calculator_test.rb
@@ -2,8 +2,6 @@ require_relative "../../test_helper"
 require_relative "flow_integration_test_helper"
 require_relative "../../../lib/smart_answer/date_helper"
 
-require "smart_answer_flows/maternity-paternity-calculator"
-
 class AdoptionCalculatorTest < ActiveSupport::TestCase
   include SmartAnswer::DateHelper
   include FlowIntegrationTestHelper

--- a/test/integration/smart_answer_flows/adoption_calculator_test.rb
+++ b/test/integration/smart_answer_flows/adoption_calculator_test.rb
@@ -9,7 +9,7 @@ class AdoptionCalculatorTest < ActiveSupport::TestCase
   include FlowIntegrationTestHelper
 
   setup do
-    setup_for_testing_flow SmartAnswer::MaternityPaternityCalculatorFlow
+    setup_for_testing_flow MaternityPaternityCalculatorFlow
   end
 
   ## Q1

--- a/test/integration/smart_answer_flows/am_i_getting_minimum_wage_test.rb
+++ b/test/integration/smart_answer_flows/am_i_getting_minimum_wage_test.rb
@@ -8,7 +8,7 @@ class AmIGettingMinimumWageTest < ActiveSupport::TestCase
 
   setup do
     Timecop.freeze(Date.parse("2015-01-01"))
-    setup_for_testing_flow SmartAnswer::AmIGettingMinimumWageFlow
+    setup_for_testing_flow AmIGettingMinimumWageFlow
   end
 
   # Q1
@@ -805,7 +805,7 @@ class AmIGettingMinimumWageTest < ActiveSupport::TestCase
   context "2020 scenarios" do
     setup do
       Timecop.freeze(Date.parse("2020-04-01"))
-      setup_for_testing_flow SmartAnswer::AmIGettingMinimumWageFlow
+      setup_for_testing_flow AmIGettingMinimumWageFlow
     end
 
     context "23 year old, 2nd year apprentice, paid additional work" do
@@ -1200,7 +1200,7 @@ class AmIGettingMinimumWageTest < ActiveSupport::TestCase
   context "2021 scenarios" do
     setup do
       Timecop.freeze(Date.parse("2021-04-01"))
-      setup_for_testing_flow SmartAnswer::AmIGettingMinimumWageFlow
+      setup_for_testing_flow AmIGettingMinimumWageFlow
     end
 
     context "27 year old, not apprentice, no additional charges" do

--- a/test/integration/smart_answer_flows/am_i_getting_minimum_wage_test.rb
+++ b/test/integration/smart_answer_flows/am_i_getting_minimum_wage_test.rb
@@ -1,8 +1,6 @@
 require_relative "../../test_helper"
 require_relative "flow_integration_test_helper"
 
-require "smart_answer_flows/am-i-getting-minimum-wage"
-
 class AmIGettingMinimumWageTest < ActiveSupport::TestCase
   include FlowIntegrationTestHelper
 

--- a/test/integration/smart_answer_flows/benefit_cap_calculator_test.rb
+++ b/test/integration/smart_answer_flows/benefit_cap_calculator_test.rb
@@ -1,8 +1,6 @@
 require_relative "../../test_helper"
 require_relative "flow_integration_test_helper"
 
-require "smart_answer_flows/benefit-cap-calculator"
-
 class BenefitCapCalculatorTest < ActiveSupport::TestCase
   include FlowIntegrationTestHelper
 

--- a/test/integration/smart_answer_flows/benefit_cap_calculator_test.rb
+++ b/test/integration/smart_answer_flows/benefit_cap_calculator_test.rb
@@ -7,7 +7,7 @@ class BenefitCapCalculatorTest < ActiveSupport::TestCase
   include FlowIntegrationTestHelper
 
   setup do
-    setup_for_testing_flow SmartAnswer::BenefitCapCalculatorFlow
+    setup_for_testing_flow BenefitCapCalculatorFlow
     stub_imminence_has_areas_for_postcode("WC2B%206SE", [{ type: "EUR", name: "London", country_name: "England" }])
     stub_imminence_has_areas_for_postcode("B1%201PW", [{ type: "EUR", name: "West Midlands", country_name: "England" }])
   end

--- a/test/integration/smart_answer_flows/calculate_agricultural_holiday_entitlement_test.rb
+++ b/test/integration/smart_answer_flows/calculate_agricultural_holiday_entitlement_test.rb
@@ -7,7 +7,7 @@ class CalculateAgriculturalHolidayEntitlementTest < ActiveSupport::TestCase
   include FlowIntegrationTestHelper
 
   setup do
-    setup_for_testing_flow SmartAnswer::CalculateAgriculturalHolidayEntitlementFlow
+    setup_for_testing_flow CalculateAgriculturalHolidayEntitlementFlow
   end
 
   should "ask what your days worked per week is" do

--- a/test/integration/smart_answer_flows/calculate_agricultural_holiday_entitlement_test.rb
+++ b/test/integration/smart_answer_flows/calculate_agricultural_holiday_entitlement_test.rb
@@ -1,8 +1,6 @@
 require_relative "../../test_helper"
 require_relative "flow_integration_test_helper"
 
-require "smart_answer_flows/calculate-agricultural-holiday-entitlement"
-
 class CalculateAgriculturalHolidayEntitlementTest < ActiveSupport::TestCase
   include FlowIntegrationTestHelper
 

--- a/test/integration/smart_answer_flows/calculate_employee_redundancy_pay_test.rb
+++ b/test/integration/smart_answer_flows/calculate_employee_redundancy_pay_test.rb
@@ -8,7 +8,7 @@ class CalculateEmployeeRedundancyPayTest < ActiveSupport::TestCase
 
   setup do
     Timecop.freeze("2019-08-31")
-    setup_for_testing_flow SmartAnswer::CalculateEmployeeRedundancyPayFlow
+    setup_for_testing_flow CalculateEmployeeRedundancyPayFlow
   end
 
   should "ask when the employee was made redundant" do

--- a/test/integration/smart_answer_flows/calculate_employee_redundancy_pay_test.rb
+++ b/test/integration/smart_answer_flows/calculate_employee_redundancy_pay_test.rb
@@ -1,8 +1,6 @@
 require_relative "../../test_helper"
 require_relative "flow_integration_test_helper"
 
-require "smart_answer_flows/calculate-employee-redundancy-pay"
-
 class CalculateEmployeeRedundancyPayTest < ActiveSupport::TestCase
   include FlowIntegrationTestHelper
 

--- a/test/integration/smart_answer_flows/calculate_married_couples_allowance_test.rb
+++ b/test/integration/smart_answer_flows/calculate_married_couples_allowance_test.rb
@@ -1,8 +1,6 @@
 require_relative "../../test_helper"
 require_relative "flow_integration_test_helper"
 
-require "smart_answer_flows/calculate-married-couples-allowance"
-
 class CalculateMarriedCouplesAllowanceTest < ActiveSupport::TestCase
   include FlowIntegrationTestHelper
 

--- a/test/integration/smart_answer_flows/calculate_married_couples_allowance_test.rb
+++ b/test/integration/smart_answer_flows/calculate_married_couples_allowance_test.rb
@@ -7,7 +7,7 @@ class CalculateMarriedCouplesAllowanceTest < ActiveSupport::TestCase
   include FlowIntegrationTestHelper
 
   setup do
-    setup_for_testing_flow SmartAnswer::CalculateMarriedCouplesAllowanceFlow
+    setup_for_testing_flow CalculateMarriedCouplesAllowanceFlow
   end
 
   should "ask if you or partner were born before April 1935" do

--- a/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
+++ b/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
@@ -1,8 +1,6 @@
 require_relative "../../test_helper"
 require_relative "flow_integration_test_helper"
 
-require "smart_answer_flows/calculate-statutory-sick-pay"
-
 class CalculateStatutorySickPayTest < ActiveSupport::TestCase
   include FlowIntegrationTestHelper
 

--- a/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
+++ b/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
@@ -7,7 +7,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
   include FlowIntegrationTestHelper
 
   setup do
-    setup_for_testing_flow SmartAnswer::CalculateStatutorySickPayFlow
+    setup_for_testing_flow CalculateStatutorySickPayFlow
   end
 
   context "Getting Statutory Maternity Pay" do

--- a/test/integration/smart_answer_flows/calculate_your_redundancy_pay_test.rb
+++ b/test/integration/smart_answer_flows/calculate_your_redundancy_pay_test.rb
@@ -1,8 +1,6 @@
 require_relative "../../test_helper"
 require_relative "flow_integration_test_helper"
 
-require "smart_answer_flows/calculate-your-redundancy-pay"
-
 class CalculateYourRedundancyPayTest < ActiveSupport::TestCase
   include FlowIntegrationTestHelper
 

--- a/test/integration/smart_answer_flows/calculate_your_redundancy_pay_test.rb
+++ b/test/integration/smart_answer_flows/calculate_your_redundancy_pay_test.rb
@@ -8,7 +8,7 @@ class CalculateYourRedundancyPayTest < ActiveSupport::TestCase
 
   setup do
     Timecop.freeze("2019-08-31")
-    setup_for_testing_flow SmartAnswer::CalculateYourRedundancyPayFlow
+    setup_for_testing_flow CalculateYourRedundancyPayFlow
   end
 
   should "ask when you were made redundant" do

--- a/test/integration/smart_answer_flows/check_uk_visa_test.rb
+++ b/test/integration/smart_answer_flows/check_uk_visa_test.rb
@@ -9,7 +9,7 @@ class CheckUkVisaTest < ActiveSupport::TestCase
   setup do
     @location_slugs = %w[andorra anguilla armenia austria bolivia canada china colombia croatia estonia hong-kong ireland latvia macao mexico south-africa stateless-or-refugee syria turkey democratic-republic-of-the-congo oman united-arab-emirates qatar taiwan venezuela afghanistan yemen]
     stub_worldwide_api_has_locations(@location_slugs)
-    setup_for_testing_flow SmartAnswer::CheckUkVisaFlow
+    setup_for_testing_flow CheckUkVisaFlow
   end
 
   context "hong-kong" do

--- a/test/integration/smart_answer_flows/check_uk_visa_test.rb
+++ b/test/integration/smart_answer_flows/check_uk_visa_test.rb
@@ -1,8 +1,6 @@
 require_relative "../../test_helper"
 require_relative "flow_integration_test_helper"
 
-require "smart_answer_flows/check-uk-visa"
-
 class CheckUkVisaTest < ActiveSupport::TestCase
   include FlowIntegrationTestHelper
 

--- a/test/integration/smart_answer_flows/child_benefit_tax_calculator_test.rb
+++ b/test/integration/smart_answer_flows/child_benefit_tax_calculator_test.rb
@@ -1,8 +1,6 @@
 require_relative "../../test_helper"
 require_relative "flow_integration_test_helper"
 
-require "smart_answer_flows/child-benefit-tax-calculator"
-
 class ChildBenefitTaxCalculatorTest < ActiveSupport::TestCase
   include FlowIntegrationTestHelper
 

--- a/test/integration/smart_answer_flows/child_benefit_tax_calculator_test.rb
+++ b/test/integration/smart_answer_flows/child_benefit_tax_calculator_test.rb
@@ -7,7 +7,7 @@ class ChildBenefitTaxCalculatorTest < ActiveSupport::TestCase
   include FlowIntegrationTestHelper
 
   setup do
-    setup_for_testing_flow SmartAnswer::ChildBenefitTaxCalculatorFlow
+    setup_for_testing_flow ChildBenefitTaxCalculatorFlow
   end
 
   context "Child Benefit tax calculator" do

--- a/test/integration/smart_answer_flows/childcare_costs_for_tax_credits_test.rb
+++ b/test/integration/smart_answer_flows/childcare_costs_for_tax_credits_test.rb
@@ -1,8 +1,6 @@
 require_relative "../../test_helper"
 require_relative "flow_integration_test_helper"
 
-require "smart_answer_flows/childcare-costs-for-tax-credits"
-
 class ChildcareCostsForTaxCreditsTest < ActiveSupport::TestCase
   include FlowIntegrationTestHelper
 

--- a/test/integration/smart_answer_flows/childcare_costs_for_tax_credits_test.rb
+++ b/test/integration/smart_answer_flows/childcare_costs_for_tax_credits_test.rb
@@ -7,7 +7,7 @@ class ChildcareCostsForTaxCreditsTest < ActiveSupport::TestCase
   include FlowIntegrationTestHelper
 
   setup do
-    setup_for_testing_flow SmartAnswer::ChildcareCostsForTaxCreditsFlow
+    setup_for_testing_flow ChildcareCostsForTaxCreditsFlow
   end
 
   context "answering Q1" do

--- a/test/integration/smart_answer_flows/estimate_self_assessment_penalties_test.rb
+++ b/test/integration/smart_answer_flows/estimate_self_assessment_penalties_test.rb
@@ -1,8 +1,6 @@
 require_relative "../../test_helper"
 require_relative "flow_integration_test_helper"
 
-require "smart_answer_flows/estimate-self-assessment-penalties"
-
 TEST_CALCULATOR_DATES = {
   online_filing_deadline: {
     "2013-14": Date.new(2015, 1, 31),

--- a/test/integration/smart_answer_flows/estimate_self_assessment_penalties_test.rb
+++ b/test/integration/smart_answer_flows/estimate_self_assessment_penalties_test.rb
@@ -21,7 +21,7 @@ class EstimateSelfAssessmentPenaltiesTest < ActiveSupport::TestCase
   include FlowIntegrationTestHelper
 
   setup do
-    setup_for_testing_flow SmartAnswer::EstimateSelfAssessmentPenaltiesFlow
+    setup_for_testing_flow EstimateSelfAssessmentPenaltiesFlow
   end
 
   should "ask which year you want to estimate" do

--- a/test/integration/smart_answer_flows/find_coronavirus_support_test.rb
+++ b/test/integration/smart_answer_flows/find_coronavirus_support_test.rb
@@ -7,7 +7,7 @@ class FindCoronavirusSupportFlowTest < ActiveSupport::TestCase
   include FlowIntegrationTestHelper
 
   setup do
-    setup_for_testing_flow SmartAnswer::FindCoronavirusSupportFlow
+    setup_for_testing_flow FindCoronavirusSupportFlow
   end
 
   context "specific outcomes" do

--- a/test/integration/smart_answer_flows/find_coronavirus_support_test.rb
+++ b/test/integration/smart_answer_flows/find_coronavirus_support_test.rb
@@ -1,8 +1,6 @@
 require_relative "../../test_helper"
 require_relative "flow_integration_test_helper"
 
-require "smart_answer_flows/find-coronavirus-support"
-
 class FindCoronavirusSupportFlowTest < ActiveSupport::TestCase
   include FlowIntegrationTestHelper
 

--- a/test/integration/smart_answer_flows/help_if_you_are_arrested_abroad_test.rb
+++ b/test/integration/smart_answer_flows/help_if_you_are_arrested_abroad_test.rb
@@ -9,7 +9,7 @@ class HelpIfYouAreArrestedAbroadTest < ActiveSupport::TestCase
   setup do
     @location_slugs = %w[aruba belgium bermuda greece iran syria democratic-republic-of-the-congo]
     stub_worldwide_api_has_locations(@location_slugs)
-    setup_for_testing_flow SmartAnswer::HelpIfYouAreArrestedAbroadFlow
+    setup_for_testing_flow HelpIfYouAreArrestedAbroadFlow
   end
 
   should "ask which country the arrest is in" do

--- a/test/integration/smart_answer_flows/help_if_you_are_arrested_abroad_test.rb
+++ b/test/integration/smart_answer_flows/help_if_you_are_arrested_abroad_test.rb
@@ -1,8 +1,6 @@
 require_relative "../../test_helper"
 require_relative "flow_integration_test_helper"
 
-require "smart_answer_flows/help-if-you-are-arrested-abroad"
-
 class HelpIfYouAreArrestedAbroadTest < ActiveSupport::TestCase
   include FlowIntegrationTestHelper
 

--- a/test/integration/smart_answer_flows/inherits_someone_dies_without_will_test.rb
+++ b/test/integration/smart_answer_flows/inherits_someone_dies_without_will_test.rb
@@ -1,8 +1,6 @@
 require_relative "../../test_helper"
 require_relative "flow_integration_test_helper"
 
-require "smart_answer_flows/inherits-someone-dies-without-will"
-
 class InheritsSomeoneDiesWithoutWillTest < ActiveSupport::TestCase
   include FlowIntegrationTestHelper
 

--- a/test/integration/smart_answer_flows/inherits_someone_dies_without_will_test.rb
+++ b/test/integration/smart_answer_flows/inherits_someone_dies_without_will_test.rb
@@ -7,7 +7,7 @@ class InheritsSomeoneDiesWithoutWillTest < ActiveSupport::TestCase
   include FlowIntegrationTestHelper
 
   setup do
-    setup_for_testing_flow SmartAnswer::InheritsSomeoneDiesWithoutWillFlow
+    setup_for_testing_flow InheritsSomeoneDiesWithoutWillFlow
   end
 
   context "england-and-wales" do

--- a/test/integration/smart_answer_flows/marriage_abroad_test.rb
+++ b/test/integration/smart_answer_flows/marriage_abroad_test.rb
@@ -1,8 +1,6 @@
 require_relative "../../test_helper"
 require_relative "flow_integration_test_helper"
 
-require "smart_answer_flows/marriage-abroad"
-
 class MarriageAbroadTest < ActiveSupport::TestCase
   include FlowIntegrationTestHelper
 

--- a/test/integration/smart_answer_flows/marriage_abroad_test.rb
+++ b/test/integration/smart_answer_flows/marriage_abroad_test.rb
@@ -21,7 +21,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
   setup do
     @location_slugs = FLATTEN_COUNTRIES
     stub_worldwide_api_has_locations(@location_slugs)
-    setup_for_testing_flow SmartAnswer::MarriageAbroadFlow
+    setup_for_testing_flow MarriageAbroadFlow
   end
 
   should "which country you want the ceremony to take place in" do

--- a/test/integration/smart_answer_flows/maternity_calculator_test.rb
+++ b/test/integration/smart_answer_flows/maternity_calculator_test.rb
@@ -11,7 +11,7 @@ class MaternityCalculatorTest < ActiveSupport::TestCase
   include MaternityCalculatorHelper
 
   setup do
-    setup_for_testing_flow SmartAnswer::MaternityPaternityCalculatorFlow
+    setup_for_testing_flow MaternityPaternityCalculatorFlow
   end
   ## Q1
   should "ask what type of leave or pay you want to check" do

--- a/test/integration/smart_answer_flows/maternity_calculator_test.rb
+++ b/test/integration/smart_answer_flows/maternity_calculator_test.rb
@@ -3,8 +3,6 @@ require_relative "flow_integration_test_helper"
 require_relative "maternity_calculator_helper"
 require_relative "../../../lib/smart_answer/date_helper"
 
-require "smart_answer_flows/maternity-paternity-calculator"
-
 class MaternityCalculatorTest < ActiveSupport::TestCase
   include SmartAnswer::DateHelper
   include FlowIntegrationTestHelper

--- a/test/integration/smart_answer_flows/maternity_paternity_pay_leave_test.rb
+++ b/test/integration/smart_answer_flows/maternity_paternity_pay_leave_test.rb
@@ -7,7 +7,7 @@ class MaternityPaternityPayLeaveTest < ActiveSupport::TestCase
   include FlowIntegrationTestHelper
 
   setup do
-    setup_for_testing_flow SmartAnswer::MaternityPaternityPayLeaveFlow
+    setup_for_testing_flow MaternityPaternityPayLeaveFlow
   end
 
   context "birth-singleparent" do

--- a/test/integration/smart_answer_flows/maternity_paternity_pay_leave_test.rb
+++ b/test/integration/smart_answer_flows/maternity_paternity_pay_leave_test.rb
@@ -1,8 +1,6 @@
 require_relative "../../test_helper"
 require_relative "flow_integration_test_helper"
 
-require "smart_answer_flows/maternity-paternity-pay-leave"
-
 class MaternityPaternityPayLeaveTest < ActiveSupport::TestCase
   include FlowIntegrationTestHelper
 

--- a/test/integration/smart_answer_flows/minimum_wage_calculator_employers_test.rb
+++ b/test/integration/smart_answer_flows/minimum_wage_calculator_employers_test.rb
@@ -10,7 +10,7 @@ class MinimumWageCalculatorEmployersTest < ActionDispatch::IntegrationTest
   include FlowIntegrationTestHelper
 
   setup do
-    setup_for_testing_flow SmartAnswer::MinimumWageCalculatorEmployersFlow
+    setup_for_testing_flow MinimumWageCalculatorEmployersFlow
   end
 
   should "complete flow for current payment under school age" do

--- a/test/integration/smart_answer_flows/minimum_wage_calculator_employers_test.rb
+++ b/test/integration/smart_answer_flows/minimum_wage_calculator_employers_test.rb
@@ -1,8 +1,6 @@
 require_relative "../../test_helper"
 require_relative "flow_integration_test_helper"
 
-require "smart_answer_flows/minimum-wage-calculator-employers"
-
 class MinimumWageCalculatorEmployersTest < ActionDispatch::IntegrationTest
   # This tests the parts of the flow defined within MinimumWageCalculatorEmployersFlow
   # Much of the user journey is through a shared flow Shared::MinimumWageFlow

--- a/test/integration/smart_answer_flows/part_year_profit_tax_credits_test.rb
+++ b/test/integration/smart_answer_flows/part_year_profit_tax_credits_test.rb
@@ -1,8 +1,6 @@
 require_relative "../../test_helper"
 require_relative "flow_integration_test_helper"
 
-require "smart_answer_flows/part-year-profit-tax-credits"
-
 class PartYearProfitTaxCreditsTest < ActiveSupport::TestCase
   include FlowIntegrationTestHelper
 

--- a/test/integration/smart_answer_flows/part_year_profit_tax_credits_test.rb
+++ b/test/integration/smart_answer_flows/part_year_profit_tax_credits_test.rb
@@ -7,7 +7,7 @@ class PartYearProfitTaxCreditsTest < ActiveSupport::TestCase
   include FlowIntegrationTestHelper
 
   setup do
-    setup_for_testing_flow SmartAnswer::PartYearProfitTaxCreditsFlow
+    setup_for_testing_flow PartYearProfitTaxCreditsFlow
   end
 
   context "when the business is still trading" do

--- a/test/integration/smart_answer_flows/paternity_calculator_test.rb
+++ b/test/integration/smart_answer_flows/paternity_calculator_test.rb
@@ -2,8 +2,6 @@ require_relative "../../test_helper"
 require_relative "flow_integration_test_helper"
 require_relative "../../../lib/smart_answer/date_helper"
 
-require "smart_answer_flows/maternity-paternity-calculator"
-
 class PaternityCalculatorTest < ActiveSupport::TestCase
   include SmartAnswer::DateHelper
   include FlowIntegrationTestHelper

--- a/test/integration/smart_answer_flows/paternity_calculator_test.rb
+++ b/test/integration/smart_answer_flows/paternity_calculator_test.rb
@@ -9,7 +9,7 @@ class PaternityCalculatorTest < ActiveSupport::TestCase
   include FlowIntegrationTestHelper
 
   setup do
-    setup_for_testing_flow SmartAnswer::MaternityPaternityCalculatorFlow
+    setup_for_testing_flow MaternityPaternityCalculatorFlow
   end
   ## Q1
   should "ask what type of leave or pay you want to check" do

--- a/test/integration/smart_answer_flows/plan_adoption_leave_test.rb
+++ b/test/integration/smart_answer_flows/plan_adoption_leave_test.rb
@@ -1,8 +1,6 @@
 require_relative "../../test_helper"
 require_relative "flow_integration_test_helper"
 
-require "smart_answer_flows/plan-adoption-leave"
-
 class PlanAdoptionLeaveTest < ActiveSupport::TestCase
   include FlowIntegrationTestHelper
 

--- a/test/integration/smart_answer_flows/plan_adoption_leave_test.rb
+++ b/test/integration/smart_answer_flows/plan_adoption_leave_test.rb
@@ -8,7 +8,7 @@ class PlanAdoptionLeaveTest < ActiveSupport::TestCase
 
   context "test basic flow" do
     setup do
-      setup_for_testing_flow SmartAnswer::PlanAdoptionLeaveFlow
+      setup_for_testing_flow PlanAdoptionLeaveFlow
     end
 
     should "start on the baby_due_date? question" do

--- a/test/integration/smart_answer_flows/register_a_birth_test.rb
+++ b/test/integration/smart_answer_flows/register_a_birth_test.rb
@@ -9,7 +9,7 @@ class RegisterABirthTest < ActiveSupport::TestCase
   setup do
     @location_slugs = %w[afghanistan algeria andorra australia bangladesh barbados belize cambodia cameroon democratic-republic-of-the-congo el-salvador estonia germany guatemala grenada india iran iraq israel laos libya maldives morocco netherlands north-korea pakistan philippines pitcairn-island saint-barthelemy serbia sierra-leone somalia spain sri-lanka st-kitts-and-nevis st-martin thailand turkey uganda united-arab-emirates venezuela]
     stub_worldwide_api_has_locations(@location_slugs)
-    setup_for_testing_flow SmartAnswer::RegisterABirthFlow
+    setup_for_testing_flow RegisterABirthFlow
   end
 
   should "ask which country the child was born in" do

--- a/test/integration/smart_answer_flows/register_a_birth_test.rb
+++ b/test/integration/smart_answer_flows/register_a_birth_test.rb
@@ -1,8 +1,6 @@
 require_relative "../../test_helper"
 require_relative "flow_integration_test_helper"
 
-require "smart_answer_flows/register-a-birth"
-
 class RegisterABirthTest < ActiveSupport::TestCase
   include FlowIntegrationTestHelper
 

--- a/test/integration/smart_answer_flows/register_a_death_test.rb
+++ b/test/integration/smart_answer_flows/register_a_death_test.rb
@@ -9,7 +9,7 @@ class RegisterADeathTest < ActiveSupport::TestCase
   setup do
     @location_slugs = %w[afghanistan algeria andorra argentina australia austria barbados belgium brazil cameroon democratic-republic-of-the-congo dominica egypt france germany grenada iran italy kenya libya morocco nigeria north-korea pakistan pitcairn-island poland saint-barthelemy serbia slovakia somalia spain st-kitts-and-nevis st-martin uganda]
     stub_worldwide_api_has_locations(@location_slugs)
-    setup_for_testing_flow SmartAnswer::RegisterADeathFlow
+    setup_for_testing_flow RegisterADeathFlow
   end
 
   should "ask where the death happened" do

--- a/test/integration/smart_answer_flows/register_a_death_test.rb
+++ b/test/integration/smart_answer_flows/register_a_death_test.rb
@@ -1,8 +1,6 @@
 require_relative "../../test_helper"
 require_relative "flow_integration_test_helper"
 
-require "smart_answer_flows/register-a-death"
-
 class RegisterADeathTest < ActiveSupport::TestCase
   include FlowIntegrationTestHelper
 

--- a/test/integration/smart_answer_flows/report_a_lost_or_stolen_passport_test.rb
+++ b/test/integration/smart_answer_flows/report_a_lost_or_stolen_passport_test.rb
@@ -9,7 +9,7 @@ class ReportALostOrStolenPassportTest < ActiveSupport::TestCase
   setup do
     @location_slugs = %w[azerbaijan canada]
     stub_worldwide_api_has_locations(@location_slugs)
-    setup_for_testing_flow SmartAnswer::ReportALostOrStolenPassportFlow
+    setup_for_testing_flow ReportALostOrStolenPassportFlow
   end
 
   should "ask where the passport was lost or stolen" do

--- a/test/integration/smart_answer_flows/report_a_lost_or_stolen_passport_test.rb
+++ b/test/integration/smart_answer_flows/report_a_lost_or_stolen_passport_test.rb
@@ -1,8 +1,6 @@
 require_relative "../../test_helper"
 require_relative "flow_integration_test_helper"
 
-require "smart_answer_flows/report-a-lost-or-stolen-passport"
-
 class ReportALostOrStolenPassportTest < ActiveSupport::TestCase
   include FlowIntegrationTestHelper
 

--- a/test/integration/smart_answer_flows/simplified_expenses_checker_test.rb
+++ b/test/integration/smart_answer_flows/simplified_expenses_checker_test.rb
@@ -7,7 +7,7 @@ class SimplifiedExpensesCheckerTest < ActiveSupport::TestCase
   include FlowIntegrationTestHelper
 
   setup do
-    setup_for_testing_flow SmartAnswer::SimplifiedExpensesCheckerFlow
+    setup_for_testing_flow SimplifiedExpensesCheckerFlow
   end
 
   context "you can't use simplified expenses result (Q1, Q2, result 1)" do

--- a/test/integration/smart_answer_flows/simplified_expenses_checker_test.rb
+++ b/test/integration/smart_answer_flows/simplified_expenses_checker_test.rb
@@ -1,8 +1,6 @@
 require_relative "../../test_helper"
 require_relative "flow_integration_test_helper"
 
-require "smart_answer_flows/simplified-expenses-checker"
-
 class SimplifiedExpensesCheckerTest < ActiveSupport::TestCase
   include FlowIntegrationTestHelper
 

--- a/test/integration/smart_answer_flows/state_pension_age_test.rb
+++ b/test/integration/smart_answer_flows/state_pension_age_test.rb
@@ -7,7 +7,7 @@ class StatePensionAgeTest < ActiveSupport::TestCase
   include FlowIntegrationTestHelper
 
   setup do
-    setup_for_testing_flow SmartAnswer::StatePensionAgeFlow
+    setup_for_testing_flow StatePensionAgeFlow
   end
 
   should "ask which calculation to perform" do

--- a/test/integration/smart_answer_flows/state_pension_age_test.rb
+++ b/test/integration/smart_answer_flows/state_pension_age_test.rb
@@ -1,8 +1,6 @@
 require_relative "../../test_helper"
 require_relative "flow_integration_test_helper"
 
-require "smart_answer_flows/state-pension-age"
-
 class StatePensionAgeTest < ActiveSupport::TestCase
   include FlowIntegrationTestHelper
 

--- a/test/integration/smart_answer_flows/state_pension_through_partner_test.rb
+++ b/test/integration/smart_answer_flows/state_pension_through_partner_test.rb
@@ -8,7 +8,7 @@ class StatePensionThroughPartnerTest < ActiveSupport::TestCase
   include FlowIntegrationTestHelper
 
   setup do
-    setup_for_testing_flow SmartAnswer::StatePensionThroughPartnerFlow
+    setup_for_testing_flow StatePensionThroughPartnerFlow
   end
 
   context "married (old1)" do

--- a/test/integration/smart_answer_flows/state_pension_through_partner_test.rb
+++ b/test/integration/smart_answer_flows/state_pension_through_partner_test.rb
@@ -2,8 +2,6 @@ require_relative "../../test_helper"
 require_relative "flow_integration_test_helper"
 require "gds_api/test_helpers/worldwide"
 
-require "smart_answer_flows/state-pension-through-partner"
-
 class StatePensionThroughPartnerTest < ActiveSupport::TestCase
   include FlowIntegrationTestHelper
 

--- a/test/integration/smart_answer_flows/student_finance_calculator_test.rb
+++ b/test/integration/smart_answer_flows/student_finance_calculator_test.rb
@@ -7,7 +7,7 @@ class StudentFinanceCalculatorTest < ActiveSupport::TestCase
   include FlowIntegrationTestHelper
 
   setup do
-    setup_for_testing_flow SmartAnswer::StudentFinanceCalculatorFlow
+    setup_for_testing_flow StudentFinanceCalculatorFlow
   end
 
   should "ask when your course starts" do

--- a/test/integration/smart_answer_flows/student_finance_calculator_test.rb
+++ b/test/integration/smart_answer_flows/student_finance_calculator_test.rb
@@ -1,8 +1,6 @@
 require_relative "../../test_helper"
 require_relative "flow_integration_test_helper"
 
-require "smart_answer_flows/student-finance-calculator"
-
 class StudentFinanceCalculatorTest < ActiveSupport::TestCase
   include FlowIntegrationTestHelper
 

--- a/test/integration/smart_answer_flows/towing_rules_test.rb
+++ b/test/integration/smart_answer_flows/towing_rules_test.rb
@@ -7,7 +7,7 @@ class TowingRulesTest < ActiveSupport::TestCase
   include FlowIntegrationTestHelper
 
   setup do
-    setup_for_testing_flow SmartAnswer::TowingRulesFlow
+    setup_for_testing_flow TowingRulesFlow
   end
   ## Cars and light vehicles
   ##

--- a/test/integration/smart_answer_flows/towing_rules_test.rb
+++ b/test/integration/smart_answer_flows/towing_rules_test.rb
@@ -1,8 +1,6 @@
 require_relative "../../test_helper"
 require_relative "flow_integration_test_helper"
 
-require "smart_answer_flows/towing-rules"
-
 class TowingRulesTest < ActiveSupport::TestCase
   include FlowIntegrationTestHelper
 

--- a/test/integration/smart_answer_flows/uk_benefits_abroad_test.rb
+++ b/test/integration/smart_answer_flows/uk_benefits_abroad_test.rb
@@ -1,8 +1,6 @@
 require_relative "../../test_helper"
 require_relative "flow_integration_test_helper"
 
-require "smart_answer_flows/uk-benefits-abroad"
-
 class UKBenefitsAbroadTest < ActiveSupport::TestCase
   include FlowIntegrationTestHelper
 

--- a/test/integration/smart_answer_flows/uk_benefits_abroad_test.rb
+++ b/test/integration/smart_answer_flows/uk_benefits_abroad_test.rb
@@ -7,7 +7,7 @@ class UKBenefitsAbroadTest < ActiveSupport::TestCase
   include FlowIntegrationTestHelper
 
   setup do
-    setup_for_testing_flow SmartAnswer::UkBenefitsAbroadFlow
+    setup_for_testing_flow UkBenefitsAbroadFlow
     stub_worldwide_api_has_locations(%w[albania austria canada gibraltar ireland jamaica jersey kosovo])
   end
 

--- a/test/integration/smart_answer_flows/vat_payment_deadlines_test.rb
+++ b/test/integration/smart_answer_flows/vat_payment_deadlines_test.rb
@@ -9,7 +9,7 @@ class VatPaymentDeadlinesTest < ActiveSupport::TestCase
   setup do
     WebMock.stub_request(:get, WorkingDays::BANK_HOLIDAYS_URL)
       .to_return(body: File.open(fixture_file("bank_holidays.json")))
-    setup_for_testing_flow SmartAnswer::VatPaymentDeadlinesFlow
+    setup_for_testing_flow VatPaymentDeadlinesFlow
   end
 
   should "ask when your VAT accounting period ends" do

--- a/test/integration/smart_answer_flows/vat_payment_deadlines_test.rb
+++ b/test/integration/smart_answer_flows/vat_payment_deadlines_test.rb
@@ -1,8 +1,6 @@
 require_relative "../../test_helper"
 require_relative "flow_integration_test_helper"
 
-require "smart_answer_flows/vat-payment-deadlines"
-
 class VatPaymentDeadlinesTest < ActiveSupport::TestCase
   include FlowIntegrationTestHelper
 

--- a/test/support/fixture_methods.rb
+++ b/test/support/fixture_methods.rb
@@ -12,6 +12,9 @@ module FixtureMethods
       .to_return(status: 404, body: {}.to_json)
 
     fixture_flows_path = Rails.root.join("test/fixtures/smart_answer_flows")
+    # require each of the flows since they're outside the autload path
+    Dir[fixture_flows_path.join("*.rb")].map { |path| require path }
+
     @preload_flows = SmartAnswer::FlowRegistry.instance.preloaded?
     SmartAnswer::FlowRegistry.reset_instance(
       preload_flows: false,

--- a/test/unit/graph_presenter_test.rb
+++ b/test/unit/graph_presenter_test.rb
@@ -5,7 +5,7 @@ module SmartAnswer
   class GraphPresenterTest < ActiveSupport::TestCase
     setup do
       setup_fixture_flows
-      @flow = SmartAnswer::GraphFlow.build
+      @flow = GraphFlow.build
       @presenter = GraphPresenter.new(@flow)
     end
 
@@ -38,7 +38,7 @@ module SmartAnswer
     end
 
     test "indicates does not define transitions in a way which can be visualised" do
-      p = GraphPresenter.new(SmartAnswer::GraphFlow.build)
+      p = GraphPresenter.new(GraphFlow.build)
       assert p.visualisable?, "'graph' should be visualisable"
     end
 

--- a/test/unit/smart_answer_flows/adoption_calculator_flow_test.rb
+++ b/test/unit/smart_answer_flows/adoption_calculator_flow_test.rb
@@ -2,8 +2,6 @@ require_relative "../../test_helper"
 require_relative "flow_unit_test_helper"
 require_relative "test_node"
 
-require "smart_answer_flows/maternity-paternity-calculator/adoption_calculator_flow"
-
 class AdoptionCalculatorFlowTest < ActiveSupport::TestCase
   include FlowUnitTestHelper
 

--- a/test/unit/smart_answer_flows/adoption_calculator_flow_test.rb
+++ b/test/unit/smart_answer_flows/adoption_calculator_flow_test.rb
@@ -4,400 +4,398 @@ require_relative "test_node"
 
 require "smart_answer_flows/maternity-paternity-calculator/adoption_calculator_flow"
 
-module SmartAnswer
-  class AdoptionCalculatorFlowTest < ActiveSupport::TestCase
-    include FlowUnitTestHelper
+class AdoptionCalculatorFlowTest < ActiveSupport::TestCase
+  include FlowUnitTestHelper
 
+  setup do
+    @flow = MaternityPaternityCalculatorFlow::AdoptionCalculatorFlow.build
+  end
+
+  should "start taking_paternity_or_maternity_leave_for_adoption? question" do
+    assert_equal :taking_paternity_or_maternity_leave_for_adoption?, @flow.questions.first.name
+  end
+
+  context "when answering taking_paternity_or_maternity_leave_for_adoption?" do
     setup do
-      @flow = MaternityPaternityCalculatorFlow::AdoptionCalculatorFlow.build
+      @question = TestNode.new(@flow, :taking_paternity_or_maternity_leave_for_adoption?)
+        .with_stubbed_calculator
     end
 
-    should "start taking_paternity_or_maternity_leave_for_adoption? question" do
-      assert_equal :taking_paternity_or_maternity_leave_for_adoption?, @flow.questions.first.name
+    should "respond to 'maternity' with adoption_is_from_overseas?" do
+      @question.answer_with("maternity")
+      assert_node_has_name(:adoption_is_from_overseas?, @question.next_node)
     end
 
-    context "when answering taking_paternity_or_maternity_leave_for_adoption?" do
+    should "respond to 'paternity' with employee_date_matched_paternity_adoption?" do
+      @question.answer_with("paternity")
+      assert_node_has_name(:employee_date_matched_paternity_adoption?, @question.next_node, belongs_to_another_flow: true)
+    end
+  end
+
+  context "when answering adoption_is_from_overseas?" do
+    setup do
+      @question = TestNode.new(@flow, :adoption_is_from_overseas?)
+    end
+
+    should "respond with date_of_adoption_match?" do
+      @question.answer_with("no")
+      assert_node_has_name(:date_of_adoption_match?, @question.next_node)
+    end
+
+    should "set adoption_is_from_overseas to true when answering with 'yes'" do
+      @question.answer_with("yes")
+      assert(@question.next_node.adoption_is_from_overseas)
+    end
+
+    should "set adoption_is_from_overseas to false when answering with 'no'" do
+      @question.answer_with("no")
+      assert_not(@question.next_node.adoption_is_from_overseas)
+    end
+  end
+
+  context "when answering date_of_adoption_match?" do
+    setup do
+      @question = TestNode.new(@flow, :date_of_adoption_match?)
+        .with_stubbed_calculator
+    end
+
+    should "ask date_of_adoption_placement? next" do
+      @question.answer_with(Time.zone.today)
+      assert_node_has_name(:date_of_adoption_placement?, @question.next_node)
+    end
+  end
+
+  context "when answering date_of_adoption_placement?" do
+    setup do
+      match_date = Date.parse("1 October 2017")
+      calculator = SmartAnswer::Calculators::AdoptionPayCalculator.new(match_date)
+      @question = TestNode.new(@flow, :date_of_adoption_placement?)
+        .with(
+          match_date: match_date,
+          calculator: calculator,
+        )
+    end
+
+    context "with an adoption from the UK" do
       setup do
-        @question = TestNode.new(@flow, :taking_paternity_or_maternity_leave_for_adoption?)
-          .with_stubbed_calculator
+        @question.with(adoption_is_from_overseas: false)
       end
 
-      should "respond to 'maternity' with adoption_is_from_overseas?" do
-        @question.answer_with("maternity")
-        assert_node_has_name(:adoption_is_from_overseas?, @question.next_node)
-      end
-
-      should "respond to 'paternity' with employee_date_matched_paternity_adoption?" do
-        @question.answer_with("paternity")
-        assert_node_has_name(:employee_date_matched_paternity_adoption?, @question.next_node, belongs_to_another_flow: true)
-      end
-    end
-
-    context "when answering adoption_is_from_overseas?" do
-      setup do
-        @question = TestNode.new(@flow, :adoption_is_from_overseas?)
-      end
-
-      should "respond with date_of_adoption_match?" do
-        @question.answer_with("no")
-        assert_node_has_name(:date_of_adoption_match?, @question.next_node)
-      end
-
-      should "set adoption_is_from_overseas to true when answering with 'yes'" do
-        @question.answer_with("yes")
-        assert(@question.next_node.adoption_is_from_overseas)
-      end
-
-      should "set adoption_is_from_overseas to false when answering with 'no'" do
-        @question.answer_with("no")
-        assert_not(@question.next_node.adoption_is_from_overseas)
-      end
-    end
-
-    context "when answering date_of_adoption_match?" do
-      setup do
-        @question = TestNode.new(@flow, :date_of_adoption_match?)
-          .with_stubbed_calculator
-      end
-
-      should "ask date_of_adoption_placement? next" do
+      should "ask adoption_did_the_employee_work_for_you? next" do
         @question.answer_with(Time.zone.today)
-        assert_node_has_name(:date_of_adoption_placement?, @question.next_node)
-      end
-    end
-
-    context "when answering date_of_adoption_placement?" do
-      setup do
-        match_date = Date.parse("1 October 2017")
-        calculator = Calculators::AdoptionPayCalculator.new(match_date)
-        @question = TestNode.new(@flow, :date_of_adoption_placement?)
-          .with(
-            match_date: match_date,
-            calculator: calculator,
-          )
+        assert_node_has_name(:adoption_did_the_employee_work_for_you?, @question.next_node)
       end
 
-      context "with an adoption from the UK" do
+      context "with a placement date of 15 November 2017" do
         setup do
-          @question.with(adoption_is_from_overseas: false)
+          @question.answer_with(Date.parse("15 November 2017"))
         end
 
-        should "ask adoption_did_the_employee_work_for_you? next" do
-          @question.answer_with(Time.zone.today)
-          assert_node_has_name(:adoption_did_the_employee_work_for_you?, @question.next_node)
-        end
-
-        context "with a placement date of 15 November 2017" do
-          setup do
-            @question.answer_with(Date.parse("15 November 2017"))
-          end
-
-          should "have an earliest leave start date 14 days prior" do
-            assert_equal(Date.parse("1 November 2017"), @question.next_node.a_leave_earliest_start)
-          end
-
-          should "have a latest start date 1 day after placement" do
-            assert_equal(Date.parse("16 November 2017"), @question.next_node.a_leave_latest_start)
-          end
-        end
-      end
-
-      context "with an adoption from overseas and the child entering the UK on 1 November 2017" do
-        setup do
-          @question.with(adoption_is_from_overseas: true)
-            .answer_with(Date.parse("1 November 2017"))
-        end
-
-        should "ask adoption_date_leave_starts next" do
-          assert_node_has_name(:adoption_date_leave_starts?, @question.next_node)
-        end
-
-        should "have an earliest start date of 1 November 2017" do
+        should "have an earliest leave start date 14 days prior" do
           assert_equal(Date.parse("1 November 2017"), @question.next_node.a_leave_earliest_start)
         end
 
-        should "have a latest start date of 28 November 2017" do
-          assert_equal(Date.parse("28 November 2017"), @question.next_node.a_leave_latest_start)
+        should "have a latest start date 1 day after placement" do
+          assert_equal(Date.parse("16 November 2017"), @question.next_node.a_leave_latest_start)
         end
       end
     end
 
-    context "when answering adoption_did_the_employee_work_for_you?" do
-      context "with an adoption from the uk" do
-        setup do
-          @question = TestNode.new(@flow, :adoption_did_the_employee_work_for_you?)
-          @question.with(adoption_is_from_overseas: false)
-        end
-
-        should "respond to 'yes' with adoption_employment_contract?" do
-          @question.answer_with("yes")
-          assert_node_has_name(:adoption_employment_contract?, @question.next_node)
-        end
-
-        should "respond to 'no' with adoption_not_entitled_to_leave_or_pay" do
-          @question.answer_with("no")
-          assert_node_has_name(:adoption_not_entitled_to_leave_or_pay, @question.next_node)
-        end
+    context "with an adoption from overseas and the child entering the UK on 1 November 2017" do
+      setup do
+        @question.with(adoption_is_from_overseas: true)
+          .answer_with(Date.parse("1 November 2017"))
       end
 
-      context "with an adoption from overseas" do
-        setup do
-          @question = TestNode.new(@flow, :adoption_did_the_employee_work_for_you?)
-          @question.with(adoption_is_from_overseas: true)
-        end
+      should "ask adoption_date_leave_starts next" do
+        assert_node_has_name(:adoption_date_leave_starts?, @question.next_node)
+      end
 
-        should "respond to 'yes' with adoption_is_the_employee_on_your_payroll?" do
-          @question.answer_with("yes")
-          assert_node_has_name(:adoption_is_the_employee_on_your_payroll?, @question.next_node)
-        end
+      should "have an earliest start date of 1 November 2017" do
+        assert_equal(Date.parse("1 November 2017"), @question.next_node.a_leave_earliest_start)
+      end
 
-        should "respond to 'no' with adoption_not_entitled_to_leave_or_pay" do
-          @question.answer_with("no")
-          assert_node_has_name(:adoption_not_entitled_to_leave_or_pay, @question.next_node)
-        end
+      should "have a latest start date of 28 November 2017" do
+        assert_equal(Date.parse("28 November 2017"), @question.next_node.a_leave_latest_start)
+      end
+    end
+  end
+
+  context "when answering adoption_did_the_employee_work_for_you?" do
+    context "with an adoption from the uk" do
+      setup do
+        @question = TestNode.new(@flow, :adoption_did_the_employee_work_for_you?)
+        @question.with(adoption_is_from_overseas: false)
+      end
+
+      should "respond to 'yes' with adoption_employment_contract?" do
+        @question.answer_with("yes")
+        assert_node_has_name(:adoption_employment_contract?, @question.next_node)
+      end
+
+      should "respond to 'no' with adoption_not_entitled_to_leave_or_pay" do
+        @question.answer_with("no")
+        assert_node_has_name(:adoption_not_entitled_to_leave_or_pay, @question.next_node)
       end
     end
 
-    context "when answering adoption_employment_contract?" do
+    context "with an adoption from overseas" do
+      setup do
+        @question = TestNode.new(@flow, :adoption_did_the_employee_work_for_you?)
+        @question.with(adoption_is_from_overseas: true)
+      end
+
+      should "respond to 'yes' with adoption_is_the_employee_on_your_payroll?" do
+        @question.answer_with("yes")
+        assert_node_has_name(:adoption_is_the_employee_on_your_payroll?, @question.next_node)
+      end
+
+      should "respond to 'no' with adoption_not_entitled_to_leave_or_pay" do
+        @question.answer_with("no")
+        assert_node_has_name(:adoption_not_entitled_to_leave_or_pay, @question.next_node)
+      end
+    end
+  end
+
+  context "when answering adoption_employment_contract?" do
+    context "with an adoption from the UK" do
+      setup do
+        @question = TestNode.new(@flow, :adoption_employment_contract?)
+          .with_stubbed_calculator
+        @question.with(adoption_is_from_overseas: false)
+      end
+
+      should "respond with adoption_is_the_employee_on_your_payroll?" do
+        @question.answer_with("yes")
+        assert_node_has_name(:adoption_is_the_employee_on_your_payroll?, @question.next_node)
+      end
+    end
+
+    context "with an adoption from overseas" do
+      setup do
+        @question = TestNode.new(@flow, :adoption_employment_contract?)
+          .with_stubbed_calculator
+        @question.with(adoption_is_from_overseas: true)
+      end
+
+      should "respond with adoption_did_the_employee_work_for_you?" do
+        @question.answer_with("yes")
+        assert_node_has_name(:adoption_did_the_employee_work_for_you?, @question.next_node)
+      end
+    end
+  end
+
+  context "when answering adoption_is_the_employee_on_your_payroll?" do
+    context "with an adoption from the UK" do
+      setup do
+        @question = TestNode.new(@flow, :adoption_is_the_employee_on_your_payroll?)
+          .with_stubbed_calculator(matched_week: [])
+        @question.with(adoption_is_from_overseas: false)
+      end
+
+      should "respond to no contract and not on the payroll with 'adoption_not_entitled_to_leave_or_pay'" do
+        @question
+          .with_stubbed_calculator(no_contract_not_on_payroll?: true)
+          .answer_with("no")
+
+        assert_node_has_name(:adoption_not_entitled_to_leave_or_pay, @question.next_node)
+      end
+
+      should "respond to no contract and is on the payroll with adoption_date_leave_starts?" do
+        @question
+          .with_stubbed_calculator(no_contract_not_on_payroll?: false)
+          .answer_with("yes")
+
+        assert_node_has_name(:adoption_date_leave_starts?, @question.next_node)
+      end
+    end
+
+    context "with an adoption from overseas" do
+      setup do
+        @question = TestNode.new(@flow, :adoption_is_the_employee_on_your_payroll?)
+          .with_stubbed_calculator(matched_week: [])
+        @question.with(adoption_is_from_overseas: true)
+      end
+
+      should "respond to no contract and not on the payroll with 'adoption_not_entitled_to_leave_or_pay'" do
+        @question
+          .with_stubbed_calculator(no_contract_not_on_payroll?: true)
+          .answer_with("no")
+
+        assert_node_has_name(:adoption_not_entitled_to_leave_or_pay, @question.next_node)
+      end
+
+      should "respond to no contract and is on the payroll with last_normal_payday_adoption?" do
+        @question
+          .with_stubbed_calculator(no_contract_not_on_payroll?: false)
+          .answer_with("yes")
+
+        assert_node_has_name(:last_normal_payday_adoption?, @question.next_node)
+      end
+    end
+  end
+
+  context "when answering adoption_date_leave_starts?" do
+    context "with valid dates" do
+      setup do
+        @question = TestNode.new(@flow, :adoption_date_leave_starts?)
+        @question
+            .with(a_leave_earliest_start: Date.parse("1 November 2017"))
+            .with(a_leave_latest_start: Date.parse("16 November 2017"))
+            .answer_with(Date.parse("15 November 2017"))
+      end
+
       context "with an adoption from the UK" do
         setup do
-          @question = TestNode.new(@flow, :adoption_employment_contract?)
-            .with_stubbed_calculator
           @question.with(adoption_is_from_overseas: false)
         end
 
-        should "respond with adoption_is_the_employee_on_your_payroll?" do
-          @question.answer_with("yes")
-          assert_node_has_name(:adoption_is_the_employee_on_your_payroll?, @question.next_node)
-        end
-      end
-
-      context "with an adoption from overseas" do
-        setup do
-          @question = TestNode.new(@flow, :adoption_employment_contract?)
-            .with_stubbed_calculator
-          @question.with(adoption_is_from_overseas: true)
+        should "respond to having a contract and not being on the payroll with adoption_leave_and_pay" do
+          @question.with_stubbed_calculator(has_contract_not_on_payroll?: true)
+          assert_node_has_name(:adoption_leave_and_pay, @question.next_node)
         end
 
-        should "respond with adoption_did_the_employee_work_for_you?" do
-          @question.answer_with("yes")
-          assert_node_has_name(:adoption_did_the_employee_work_for_you?, @question.next_node)
-        end
-      end
-    end
-
-    context "when answering adoption_is_the_employee_on_your_payroll?" do
-      context "with an adoption from the UK" do
-        setup do
-          @question = TestNode.new(@flow, :adoption_is_the_employee_on_your_payroll?)
-            .with_stubbed_calculator(matched_week: [])
-          @question.with(adoption_is_from_overseas: false)
-        end
-
-        should "respond to no contract and not on the payroll with 'adoption_not_entitled_to_leave_or_pay'" do
-          @question
-            .with_stubbed_calculator(no_contract_not_on_payroll?: true)
-            .answer_with("no")
-
-          assert_node_has_name(:adoption_not_entitled_to_leave_or_pay, @question.next_node)
-        end
-
-        should "respond to no contract and is on the payroll with adoption_date_leave_starts?" do
-          @question
-            .with_stubbed_calculator(no_contract_not_on_payroll?: false)
-            .answer_with("yes")
-
-          assert_node_has_name(:adoption_date_leave_starts?, @question.next_node)
-        end
-      end
-
-      context "with an adoption from overseas" do
-        setup do
-          @question = TestNode.new(@flow, :adoption_is_the_employee_on_your_payroll?)
-            .with_stubbed_calculator(matched_week: [])
-          @question.with(adoption_is_from_overseas: true)
-        end
-
-        should "respond to no contract and not on the payroll with 'adoption_not_entitled_to_leave_or_pay'" do
-          @question
-            .with_stubbed_calculator(no_contract_not_on_payroll?: true)
-            .answer_with("no")
-
-          assert_node_has_name(:adoption_not_entitled_to_leave_or_pay, @question.next_node)
-        end
-
-        should "respond to no contract and is on the payroll with last_normal_payday_adoption?" do
-          @question
-            .with_stubbed_calculator(no_contract_not_on_payroll?: false)
-            .answer_with("yes")
-
+        should "respond to having no contract and not being on the payroll with last_normal_payday_adoption?" do
+          @question.with_stubbed_calculator(has_contract_not_on_payroll?: false)
           assert_node_has_name(:last_normal_payday_adoption?, @question.next_node)
         end
       end
-    end
 
-    context "when answering adoption_date_leave_starts?" do
-      context "with valid dates" do
+      context "with an adoption from overseas" do
         setup do
-          @question = TestNode.new(@flow, :adoption_date_leave_starts?)
-          @question
-              .with(a_leave_earliest_start: Date.parse("1 November 2017"))
-              .with(a_leave_latest_start: Date.parse("16 November 2017"))
-              .answer_with(Date.parse("15 November 2017"))
-        end
-
-        context "with an adoption from the UK" do
-          setup do
-            @question.with(adoption_is_from_overseas: false)
-          end
-
-          should "respond to having a contract and not being on the payroll with adoption_leave_and_pay" do
-            @question.with_stubbed_calculator(has_contract_not_on_payroll?: true)
-            assert_node_has_name(:adoption_leave_and_pay, @question.next_node)
-          end
-
-          should "respond to having no contract and not being on the payroll with last_normal_payday_adoption?" do
-            @question.with_stubbed_calculator(has_contract_not_on_payroll?: false)
-            assert_node_has_name(:last_normal_payday_adoption?, @question.next_node)
-          end
-        end
-
-        context "with an adoption from overseas" do
-          setup do
-            @question.with(adoption_is_from_overseas: true)
-          end
-
-          should "respond with adoption_employment_contract" do
-            @question.with_stubbed_calculator(has_contract_not_on_payroll?: true)
-            assert_node_has_name(:adoption_employment_contract?, @question.next_node)
-          end
-        end
-      end
-
-      context "with invalid dates" do
-        setup do
-          @question = TestNode.new(@flow, :adoption_date_leave_starts?)
-          @question
-            .with_stubbed_calculator
-            .with(a_leave_earliest_start: Date.parse("2 November 2017"))
-            .with(a_leave_latest_start: Date.parse("29 November 2017"))
           @question.with(adoption_is_from_overseas: true)
         end
 
-        should "raise an InvalidResponse when leave starts before the earliest date" do
-          @question.answer_with(Date.parse("1 November 2017"))
-          error = assert_raises(SmartAnswer::InvalidResponse) { @question.next_node }
-          assert_equal "error_leave_starts_too_early", error.message
-        end
-
-        should "raise an InvalidResponse when leave starts after the latest date" do
-          @question.answer_with(Date.parse("30 November 2017"))
-          error = assert_raises(SmartAnswer::InvalidResponse) { @question.next_node }
-          assert_equal "error_leave_starts_too_late", error.message
+        should "respond with adoption_employment_contract" do
+          @question.with_stubbed_calculator(has_contract_not_on_payroll?: true)
+          assert_node_has_name(:adoption_employment_contract?, @question.next_node)
         end
       end
     end
 
-    context "when answering last_normal_payday_adoption?" do
+    context "with invalid dates" do
       setup do
-        @question = TestNode.new(@flow, :last_normal_payday_adoption?)
+        @question = TestNode.new(@flow, :adoption_date_leave_starts?)
+        @question
           .with_stubbed_calculator
-          .with(to_saturday: Time.zone.today)
+          .with(a_leave_earliest_start: Date.parse("2 November 2017"))
+          .with(a_leave_latest_start: Date.parse("29 November 2017"))
+        @question.with(adoption_is_from_overseas: true)
       end
 
-      should "ask payday_eight_weeks_adoption?" do
-        @question.answer_with(Date.yesterday)
-        assert_node_has_name(:payday_eight_weeks_adoption?, @question.next_node)
-      end
-    end
-
-    context "when answering payday_eight_weeks_adoption?" do
-      setup do
-        @question = TestNode.new(@flow, :payday_eight_weeks_adoption?)
-          .with_stubbed_calculator(payday_offset: Time.zone.today)
+      should "raise an InvalidResponse when leave starts before the earliest date" do
+        @question.answer_with(Date.parse("1 November 2017"))
+        error = assert_raises(SmartAnswer::InvalidResponse) { @question.next_node }
+        assert_equal "error_leave_starts_too_early", error.message
       end
 
-      should "ask pay_frequency_adoption?" do
-        @question.answer_with(Date.yesterday)
-        assert_node_has_name(:pay_frequency_adoption?, @question.next_node)
+      should "raise an InvalidResponse when leave starts after the latest date" do
+        @question.answer_with(Date.parse("30 November 2017"))
+        error = assert_raises(SmartAnswer::InvalidResponse) { @question.next_node }
+        assert_equal "error_leave_starts_too_late", error.message
       end
     end
+  end
 
-    context "when answering pay_frequency_adoption?" do
-      setup do
-        @question = TestNode.new(@flow, :pay_frequency_adoption?)
-          .with_stubbed_calculator
-      end
-
-      should "ask earnings_for_pay_period_adoption?" do
-        @question.answer_with("weekly")
-        assert_node_has_name(:earnings_for_pay_period_adoption?, @question.next_node)
-      end
+  context "when answering last_normal_payday_adoption?" do
+    setup do
+      @question = TestNode.new(@flow, :last_normal_payday_adoption?)
+        .with_stubbed_calculator
+        .with(to_saturday: Time.zone.today)
     end
 
-    context "when answering earnings_for_pay_period_adoption?" do
-      setup do
-        @question = TestNode.new(@flow, :earnings_for_pay_period_adoption?)
-          .answer_with(100)
-          .with_stubbed_calculator(lower_earning_limit: 200)
-      end
+    should "ask payday_eight_weeks_adoption?" do
+      @question.answer_with(Date.yesterday)
+      assert_node_has_name(:payday_eight_weeks_adoption?, @question.next_node)
+    end
+  end
 
-      should "respond to under the lower earning limit with adoption_leave_and_pay" do
-        @question.with_stubbed_calculator(average_weekly_earnings_under_lower_earning_limit?: true)
-        assert_node_has_name(:adoption_leave_and_pay, @question.next_node)
-      end
-
-      should "respond to weekly pay with how_many_payments_weekly?" do
-        @question.with_stubbed_calculator(weekly?: true)
-        assert_node_has_name(:how_many_payments_weekly?, @question.next_node, belongs_to_another_flow: true)
-      end
-
-      should "respond to fortnightly pay with how_many_payments_every_2_weeks?" do
-        @question.with_stubbed_calculator(every_2_weeks?: true)
-        assert_node_has_name(:how_many_payments_every_2_weeks?, @question.next_node, belongs_to_another_flow: true)
-      end
-
-      should "respond to pay every four weeks with how_many_payments_every_4_weeks?" do
-        @question.with_stubbed_calculator(every_4_weeks?: true)
-        assert_node_has_name(:how_many_payments_every_4_weeks?, @question.next_node, belongs_to_another_flow: true)
-      end
-
-      should "respond to monthly pay with how_many_payments_monthly?" do
-        @question.with_stubbed_calculator(monthly?: true)
-        assert_node_has_name(:how_many_payments_monthly?, @question.next_node, belongs_to_another_flow: true)
-      end
-
-      should "respond to other pay periods with how_do_you_want_the_sap_calculated?" do
-        assert_node_has_name(:how_do_you_want_the_sap_calculated?, @question.next_node)
-      end
+  context "when answering payday_eight_weeks_adoption?" do
+    setup do
+      @question = TestNode.new(@flow, :payday_eight_weeks_adoption?)
+        .with_stubbed_calculator(payday_offset: Time.zone.today)
     end
 
-    context "when answering how_do_you_want_the_sap_calculated?" do
+    should "ask pay_frequency_adoption?" do
+      @question.answer_with(Date.yesterday)
+      assert_node_has_name(:pay_frequency_adoption?, @question.next_node)
+    end
+  end
+
+  context "when answering pay_frequency_adoption?" do
+    setup do
+      @question = TestNode.new(@flow, :pay_frequency_adoption?)
+        .with_stubbed_calculator
+    end
+
+    should "ask earnings_for_pay_period_adoption?" do
+      @question.answer_with("weekly")
+      assert_node_has_name(:earnings_for_pay_period_adoption?, @question.next_node)
+    end
+  end
+
+  context "when answering earnings_for_pay_period_adoption?" do
+    setup do
+      @question = TestNode.new(@flow, :earnings_for_pay_period_adoption?)
+        .answer_with(100)
+        .with_stubbed_calculator(lower_earning_limit: 200)
+    end
+
+    should "respond to under the lower earning limit with adoption_leave_and_pay" do
+      @question.with_stubbed_calculator(average_weekly_earnings_under_lower_earning_limit?: true)
+      assert_node_has_name(:adoption_leave_and_pay, @question.next_node)
+    end
+
+    should "respond to weekly pay with how_many_payments_weekly?" do
+      @question.with_stubbed_calculator(weekly?: true)
+      assert_node_has_name(:how_many_payments_weekly?, @question.next_node, belongs_to_another_flow: true)
+    end
+
+    should "respond to fortnightly pay with how_many_payments_every_2_weeks?" do
+      @question.with_stubbed_calculator(every_2_weeks?: true)
+      assert_node_has_name(:how_many_payments_every_2_weeks?, @question.next_node, belongs_to_another_flow: true)
+    end
+
+    should "respond to pay every four weeks with how_many_payments_every_4_weeks?" do
+      @question.with_stubbed_calculator(every_4_weeks?: true)
+      assert_node_has_name(:how_many_payments_every_4_weeks?, @question.next_node, belongs_to_another_flow: true)
+    end
+
+    should "respond to monthly pay with how_many_payments_monthly?" do
+      @question.with_stubbed_calculator(monthly?: true)
+      assert_node_has_name(:how_many_payments_monthly?, @question.next_node, belongs_to_another_flow: true)
+    end
+
+    should "respond to other pay periods with how_do_you_want_the_sap_calculated?" do
+      assert_node_has_name(:how_do_you_want_the_sap_calculated?, @question.next_node)
+    end
+  end
+
+  context "when answering how_do_you_want_the_sap_calculated?" do
+    setup do
+      calculator = SmartAnswer::Calculators::AdoptionPayCalculator.new(Time.zone.now)
+      @question = TestNode.new(@flow, :how_do_you_want_the_sap_calculated?)
+        .with(calculator: calculator)
+    end
+
+    should "respond to 'weekly_starting' with adoption_leave_and_pay" do
+      @question.answer_with("weekly_starting")
+      assert_node_has_name(:adoption_leave_and_pay, @question.next_node)
+    end
+
+    context "answering with 'usual_paydates'" do
       setup do
-        calculator = Calculators::AdoptionPayCalculator.new(Time.zone.now)
-        @question = TestNode.new(@flow, :how_do_you_want_the_sap_calculated?)
-          .with(calculator: calculator)
+        @question.answer_with("usual_paydates")
       end
 
-      should "respond to 'weekly_starting' with adoption_leave_and_pay" do
-        @question.answer_with("weekly_starting")
-        assert_node_has_name(:adoption_leave_and_pay, @question.next_node)
+      should "respond to monthly pay with monthly_pay_paternity?" do
+        @question.with_stubbed_calculator(pay_pattern: "monthly")
+        assert_node_has_name(:monthly_pay_paternity?, @question.next_node, belongs_to_another_flow: true)
       end
 
-      context "answering with 'usual_paydates'" do
-        setup do
-          @question.answer_with("usual_paydates")
-        end
-
-        should "respond to monthly pay with monthly_pay_paternity?" do
-          @question.with_stubbed_calculator(pay_pattern: "monthly")
-          assert_node_has_name(:monthly_pay_paternity?, @question.next_node, belongs_to_another_flow: true)
-        end
-
-        should "respond to non-monthly pay with next_pay_day_paternity?" do
-          @question.with_stubbed_calculator(pay_pattern: "weekly")
-          assert_node_has_name(:next_pay_day_paternity?, @question.next_node, belongs_to_another_flow: true)
-        end
+      should "respond to non-monthly pay with next_pay_day_paternity?" do
+        @question.with_stubbed_calculator(pay_pattern: "weekly")
+        assert_node_has_name(:next_pay_day_paternity?, @question.next_node, belongs_to_another_flow: true)
       end
     end
   end

--- a/test/unit/smart_answer_flows/am_i_getting_minimum_wage_flow_test.rb
+++ b/test/unit/smart_answer_flows/am_i_getting_minimum_wage_flow_test.rb
@@ -2,186 +2,184 @@ require_relative "../../test_helper"
 
 require "smart_answer_flows/am-i-getting-minimum-wage"
 
-module SmartAnswer
-  class AmIGettingMinimumWageFlowTest < ActiveSupport::TestCase
-    setup do
-      @flow = AmIGettingMinimumWageFlow.build
+class AmIGettingMinimumWageFlowTest < ActiveSupport::TestCase
+  setup do
+    @flow = AmIGettingMinimumWageFlow.build
+  end
+
+  context "validation" do
+    %i[
+      how_old_are_you?
+      how_old_were_you?
+    ].each do |age_question_name|
+      context "for #{age_question_name}" do
+        setup do
+          @question = @flow.node(age_question_name)
+          @state = SmartAnswer::State.new(@question)
+          @calculator = stub(
+            "calculator",
+            :age= => nil,
+            :under_school_leaving_age? => nil,
+          )
+          @state.calculator = @calculator
+        end
+
+        should "raise if the calculator says the age is invalid" do
+          invalid_age = 0
+          @calculator.stubs(:valid_age?).with(invalid_age).returns(false)
+          assert_raise(SmartAnswer::InvalidResponse) do
+            @question.transition(@state, invalid_age)
+          end
+        end
+
+        should "not raise if the calculator says the age is valid" do
+          valid_age = 50
+          @calculator.stubs(:valid_age?).with(valid_age).returns(true)
+          assert_nothing_raised do
+            @question.transition(@state, valid_age)
+          end
+        end
+      end
     end
 
-    context "validation" do
-      %i[
-        how_old_are_you?
-        how_old_were_you?
-      ].each do |age_question_name|
-        context "for #{age_question_name}" do
-          setup do
-            @question = @flow.node(age_question_name)
-            @state = SmartAnswer::State.new(@question)
-            @calculator = stub(
-              "calculator",
-              :age= => nil,
-              :under_school_leaving_age? => nil,
-            )
-            @state.calculator = @calculator
-          end
+    %i[
+      how_often_do_you_get_paid?
+      how_often_did_you_get_paid?
+    ].each do |pay_frequency_question_name|
+      context "for #{pay_frequency_question_name}" do
+        setup do
+          @question = @flow.node(pay_frequency_question_name)
+          @state = SmartAnswer::State.new(@question)
+          @calculator = stub("calculator", :pay_frequency= => nil)
+          @state.calculator = @calculator
+        end
 
-          should "raise if the calculator says the age is invalid" do
-            invalid_age = 0
-            @calculator.stubs(:valid_age?).with(invalid_age).returns(false)
-            assert_raise(SmartAnswer::InvalidResponse) do
-              @question.transition(@state, invalid_age)
-            end
+        should "raise if the calculator says the pay_frequency is invalid" do
+          invalid_pay_frequency = 3
+          @calculator.stubs(:valid_pay_frequency?).with(invalid_pay_frequency).returns(false)
+          assert_raise(SmartAnswer::InvalidResponse) do
+            @question.transition(@state, invalid_pay_frequency)
           end
+        end
 
-          should "not raise if the calculator says the age is valid" do
-            valid_age = 50
-            @calculator.stubs(:valid_age?).with(valid_age).returns(true)
-            assert_nothing_raised do
-              @question.transition(@state, valid_age)
-            end
+        should "not raise if the calculator says the pay_frequency is valid" do
+          valid_pay_frequency = 4
+          @calculator.stubs(:valid_pay_frequency?).with(valid_pay_frequency).returns(true)
+          assert_nothing_raised do
+            @question.transition(@state, valid_pay_frequency)
           end
         end
       end
+    end
 
-      %i[
-        how_often_do_you_get_paid?
-        how_often_did_you_get_paid?
-      ].each do |pay_frequency_question_name|
-        context "for #{pay_frequency_question_name}" do
-          setup do
-            @question = @flow.node(pay_frequency_question_name)
-            @state = SmartAnswer::State.new(@question)
-            @calculator = stub("calculator", :pay_frequency= => nil)
-            @state.calculator = @calculator
+    %i[
+      how_many_hours_do_you_work?
+      how_many_hours_did_you_work?
+    ].each do |hours_question_name|
+      context "for #{hours_question_name}" do
+        setup do
+          @question = @flow.node(hours_question_name)
+          @state = SmartAnswer::State.new(@question)
+          @calculator = stub(
+            "calculator",
+            pay_frequency: 1,
+            :basic_hours= => nil,
+          )
+          @state.calculator = @calculator
+        end
+
+        should "use the error_hours error message" do
+          @calculator.stubs(:valid_hours_worked?).returns(false)
+          exception = assert_raise(SmartAnswer::InvalidResponse) do
+            @question.transition(@state, "0")
           end
+          assert_equal "error_hours", exception.message
+        end
 
-          should "raise if the calculator says the pay_frequency is invalid" do
-            invalid_pay_frequency = 3
-            @calculator.stubs(:valid_pay_frequency?).with(invalid_pay_frequency).returns(false)
-            assert_raise(SmartAnswer::InvalidResponse) do
-              @question.transition(@state, invalid_pay_frequency)
-            end
+        should "raise if the calculator says the hours_worked is invalid" do
+          invalid_hours_worked = 3
+          @calculator.stubs(:valid_hours_worked?).with(invalid_hours_worked).returns(false)
+
+          assert_raise(SmartAnswer::InvalidResponse) do
+            @question.transition(@state, invalid_hours_worked)
           end
+        end
 
-          should "not raise if the calculator says the pay_frequency is valid" do
-            valid_pay_frequency = 4
-            @calculator.stubs(:valid_pay_frequency?).with(valid_pay_frequency).returns(true)
-            assert_nothing_raised do
-              @question.transition(@state, valid_pay_frequency)
-            end
+        should "not raise if the calculator says the hours_worked is valid" do
+          valid_hours_worked = 4
+          @calculator.stubs(:valid_hours_worked?).with(valid_hours_worked).returns(true)
+
+          assert_nothing_raised do
+            @question.transition(@state, valid_hours_worked)
           end
         end
       end
+    end
 
-      %i[
-        how_many_hours_do_you_work?
-        how_many_hours_did_you_work?
-      ].each do |hours_question_name|
-        context "for #{hours_question_name}" do
-          setup do
-            @question = @flow.node(hours_question_name)
-            @state = SmartAnswer::State.new(@question)
-            @calculator = stub(
-              "calculator",
-              pay_frequency: 1,
-              :basic_hours= => nil,
-            )
-            @state.calculator = @calculator
+    %i[
+      current_accommodation_charge?
+      past_accommodation_charge?
+    ].each do |accommodation_charge_question_name|
+      context "for #{accommodation_charge_question_name}" do
+        setup do
+          @question = @flow.node(accommodation_charge_question_name)
+          @state = SmartAnswer::State.new(@question)
+          @calculator = stub("calculator")
+          @state.calculator = @calculator
+        end
+
+        should "raise if the calculator says the accommodation_charge is invalid" do
+          invalid_accommodation_charge = 3
+          @calculator.stubs(:valid_accommodation_charge?).with(invalid_accommodation_charge).returns(false)
+
+          assert_raise(SmartAnswer::InvalidResponse) do
+            @question.transition(@state, invalid_accommodation_charge)
           end
+        end
 
-          should "use the error_hours error message" do
-            @calculator.stubs(:valid_hours_worked?).returns(false)
-            exception = assert_raise(SmartAnswer::InvalidResponse) do
-              @question.transition(@state, "0")
-            end
-            assert_equal "error_hours", exception.message
-          end
+        should "not raise if the calculator says the accommodation_charge is valid" do
+          valid_accommodation_charge = 4
+          @calculator.stubs(:valid_accommodation_charge?).with(valid_accommodation_charge).returns(true)
 
-          should "raise if the calculator says the hours_worked is invalid" do
-            invalid_hours_worked = 3
-            @calculator.stubs(:valid_hours_worked?).with(invalid_hours_worked).returns(false)
-
-            assert_raise(SmartAnswer::InvalidResponse) do
-              @question.transition(@state, invalid_hours_worked)
-            end
-          end
-
-          should "not raise if the calculator says the hours_worked is valid" do
-            valid_hours_worked = 4
-            @calculator.stubs(:valid_hours_worked?).with(valid_hours_worked).returns(true)
-
-            assert_nothing_raised do
-              @question.transition(@state, valid_hours_worked)
-            end
+          assert_nothing_raised do
+            @question.transition(@state, valid_accommodation_charge)
           end
         end
       end
+    end
 
-      %i[
-        current_accommodation_charge?
-        past_accommodation_charge?
-      ].each do |accommodation_charge_question_name|
-        context "for #{accommodation_charge_question_name}" do
-          setup do
-            @question = @flow.node(accommodation_charge_question_name)
-            @state = SmartAnswer::State.new(@question)
-            @calculator = stub("calculator")
-            @state.calculator = @calculator
-          end
+    %i[
+      current_accommodation_usage?
+      past_accommodation_usage?
+    ].each do |accommodation_usage_question_name|
+      context "for #{accommodation_usage_question_name}" do
+        setup do
+          @question = @flow.node(accommodation_usage_question_name)
+          @state = SmartAnswer::State.new(@question)
+          @state.accommodation_charge = nil
+          @calculator = stub(
+            "calculator",
+            accommodation_adjustment: nil,
+            minimum_wage_or_above?: nil,
+          )
+          @state.calculator = @calculator
+        end
 
-          should "raise if the calculator says the accommodation_charge is invalid" do
-            invalid_accommodation_charge = 3
-            @calculator.stubs(:valid_accommodation_charge?).with(invalid_accommodation_charge).returns(false)
+        should "raise if the calculator says the accommodation_usage is invalid" do
+          invalid_accommodation_usage = 3
+          @calculator.stubs(:valid_accommodation_usage?).with(invalid_accommodation_usage).returns(false)
 
-            assert_raise(SmartAnswer::InvalidResponse) do
-              @question.transition(@state, invalid_accommodation_charge)
-            end
-          end
-
-          should "not raise if the calculator says the accommodation_charge is valid" do
-            valid_accommodation_charge = 4
-            @calculator.stubs(:valid_accommodation_charge?).with(valid_accommodation_charge).returns(true)
-
-            assert_nothing_raised do
-              @question.transition(@state, valid_accommodation_charge)
-            end
+          assert_raise(SmartAnswer::InvalidResponse) do
+            @question.transition(@state, invalid_accommodation_usage)
           end
         end
-      end
 
-      %i[
-        current_accommodation_usage?
-        past_accommodation_usage?
-      ].each do |accommodation_usage_question_name|
-        context "for #{accommodation_usage_question_name}" do
-          setup do
-            @question = @flow.node(accommodation_usage_question_name)
-            @state = SmartAnswer::State.new(@question)
-            @state.accommodation_charge = nil
-            @calculator = stub(
-              "calculator",
-              accommodation_adjustment: nil,
-              minimum_wage_or_above?: nil,
-            )
-            @state.calculator = @calculator
-          end
+        should "not raise if the calculator says the accommodation_usage is valid" do
+          valid_accommodation_usage = 4
+          @calculator.stubs(:valid_accommodation_usage?).with(valid_accommodation_usage).returns(true)
 
-          should "raise if the calculator says the accommodation_usage is invalid" do
-            invalid_accommodation_usage = 3
-            @calculator.stubs(:valid_accommodation_usage?).with(invalid_accommodation_usage).returns(false)
-
-            assert_raise(SmartAnswer::InvalidResponse) do
-              @question.transition(@state, invalid_accommodation_usage)
-            end
-          end
-
-          should "not raise if the calculator says the accommodation_usage is valid" do
-            valid_accommodation_usage = 4
-            @calculator.stubs(:valid_accommodation_usage?).with(valid_accommodation_usage).returns(true)
-
-            assert_nothing_raised do
-              @question.transition(@state, valid_accommodation_usage)
-            end
+          assert_nothing_raised do
+            @question.transition(@state, valid_accommodation_usage)
           end
         end
       end

--- a/test/unit/smart_answer_flows/am_i_getting_minimum_wage_flow_test.rb
+++ b/test/unit/smart_answer_flows/am_i_getting_minimum_wage_flow_test.rb
@@ -1,7 +1,5 @@
 require_relative "../../test_helper"
 
-require "smart_answer_flows/am-i-getting-minimum-wage"
-
 class AmIGettingMinimumWageFlowTest < ActiveSupport::TestCase
   setup do
     @flow = AmIGettingMinimumWageFlow.build

--- a/test/unit/smart_answer_flows/benefit_cap_calculator_flow_test.rb
+++ b/test/unit/smart_answer_flows/benefit_cap_calculator_flow_test.rb
@@ -1,37 +1,35 @@
 require_relative "../../test_helper"
 require "smart_answer_flows/benefit-cap-calculator"
 
-module SmartAnswer
-  class BenefitCapCalculatorFlowTest < ActiveSupport::TestCase
-    context BenefitCapCalculatorFlow do
-      setup do
-        @questions = {
-          first_benefit: :first_benefit_amount?,
-          second_benefit: :second_benefit_amount?,
-          third_benefit: :third_benefit_amount?,
-          fourth_benefit: :fourth_benefit_amount?,
-        }
+class BenefitCapCalculatorFlowTest < ActiveSupport::TestCase
+  context BenefitCapCalculatorFlow do
+    setup do
+      @questions = {
+        first_benefit: :first_benefit_amount?,
+        second_benefit: :second_benefit_amount?,
+        third_benefit: :third_benefit_amount?,
+        fourth_benefit: :fourth_benefit_amount?,
+      }
 
-        @selected_benefits = %i[second_benefit fourth_benefit]
-      end
+      @selected_benefits = %i[second_benefit fourth_benefit]
+    end
 
-      context "order of questions asked" do
-        should "ask the next benefit amount question in the selected_benefits list" do
-          # Should ask the first question in the selected benefits list
-          assert_equal :second_benefit_amount?,
-                       BenefitCapCalculatorFlow.next_benefit_amount_question(@questions, @selected_benefits)
+    context "order of questions asked" do
+      should "ask the next benefit amount question in the selected_benefits list" do
+        # Should ask the first question in the selected benefits list
+        assert_equal :second_benefit_amount?,
+                     BenefitCapCalculatorFlow.next_benefit_amount_question(@questions, @selected_benefits)
 
-          # The selected benefits list should only contain unasked questions
-          assert_equal [:fourth_benefit], @selected_benefits
+        # The selected benefits list should only contain unasked questions
+        assert_equal [:fourth_benefit], @selected_benefits
 
-          # Should ask the next question in the selected benefits list
-          assert_equal :fourth_benefit_amount?,
-                       BenefitCapCalculatorFlow.next_benefit_amount_question(@questions, @selected_benefits)
+        # Should ask the next question in the selected benefits list
+        assert_equal :fourth_benefit_amount?,
+                     BenefitCapCalculatorFlow.next_benefit_amount_question(@questions, @selected_benefits)
 
-          # After all questions have been asked, there should not be any unasked
-          # questions in selected_benefits
-          assert_equal [], @selected_benefits
-        end
+        # After all questions have been asked, there should not be any unasked
+        # questions in selected_benefits
+        assert_equal [], @selected_benefits
       end
     end
   end

--- a/test/unit/smart_answer_flows/benefit_cap_calculator_flow_test.rb
+++ b/test/unit/smart_answer_flows/benefit_cap_calculator_flow_test.rb
@@ -1,5 +1,4 @@
 require_relative "../../test_helper"
-require "smart_answer_flows/benefit-cap-calculator"
 
 class BenefitCapCalculatorFlowTest < ActiveSupport::TestCase
   context BenefitCapCalculatorFlow do

--- a/test/unit/smart_answer_flows/calculate_agricultural_holiday_entitlement_flow_test.rb
+++ b/test/unit/smart_answer_flows/calculate_agricultural_holiday_entitlement_flow_test.rb
@@ -3,83 +3,81 @@ require_relative "flow_unit_test_helper"
 
 require "smart_answer_flows/calculate-agricultural-holiday-entitlement"
 
-module SmartAnswer
-  class CalculateAgriculturalHolidayEntitlementFlowTest < ActiveSupport::TestCase
-    include FlowUnitTestHelper
+class CalculateAgriculturalHolidayEntitlementFlowTest < ActiveSupport::TestCase
+  include FlowUnitTestHelper
 
+  setup do
+    @calculator = SmartAnswer::Calculators::AgriculturalHolidayEntitlementCalculator.new
+    @flow = CalculateAgriculturalHolidayEntitlementFlow.build
+  end
+
+  context "when answering how_many_total_days? question" do
     setup do
-      @calculator = Calculators::AgriculturalHolidayEntitlementCalculator.new
-      @flow = CalculateAgriculturalHolidayEntitlementFlow.build
+      @calculator.stubs(:valid_total_days_worked?).returns(true)
+      setup_states_for_question(
+        :how_many_total_days?,
+        responding_with: "50",
+        initial_state: { calculator: @calculator },
+      )
     end
 
-    context "when answering how_many_total_days? question" do
+    should "store parsed response on calculator as total_days_worked" do
+      assert_equal 50, @calculator.total_days_worked
+    end
+
+    should "go to worked_for_same_employer? question" do
+      assert_equal :worked_for_same_employer?, @new_state.current_node_name
+      assert_node_exists :worked_for_same_employer?
+    end
+
+    context "responding with an invalid response" do
       setup do
-        @calculator.stubs(:valid_total_days_worked?).returns(true)
-        setup_states_for_question(
-          :how_many_total_days?,
-          responding_with: "50",
-          initial_state: { calculator: @calculator },
-        )
+        @calculator.stubs(:valid_total_days_worked?).returns(false)
       end
 
-      should "store parsed response on calculator as total_days_worked" do
-        assert_equal 50, @calculator.total_days_worked
-      end
-
-      should "go to worked_for_same_employer? question" do
-        assert_equal :worked_for_same_employer?, @new_state.current_node_name
-        assert_node_exists :worked_for_same_employer?
-      end
-
-      context "responding with an invalid response" do
-        setup do
-          @calculator.stubs(:valid_total_days_worked?).returns(false)
-        end
-
-        should "raise an exception" do
-          assert_raise(SmartAnswer::InvalidResponse) do
-            setup_states_for_question(
-              :how_many_total_days?,
-              responding_with: "500",
-              initial_state: { calculator: @calculator },
-            )
-          end
+      should "raise an exception" do
+        assert_raise(SmartAnswer::InvalidResponse) do
+          setup_states_for_question(
+            :how_many_total_days?,
+            responding_with: "500",
+            initial_state: { calculator: @calculator },
+          )
         end
       end
     end
+  end
 
-    context "when answering how_many_weeks_at_current_employer? question" do
+  context "when answering how_many_weeks_at_current_employer? question" do
+    setup do
+      @calculator.stubs(:valid_weeks_at_current_employer?).returns(true)
+      setup_states_for_question(
+        :how_many_weeks_at_current_employer?,
+        responding_with: "25",
+        initial_state: { calculator: @calculator },
+      )
+    end
+
+    should "store parsed response on calculator as weeks_at_current_employer" do
+      assert_equal 25, @calculator.weeks_at_current_employer
+    end
+
+    should "go to done_with_number_formatting outcomeuestion" do
+      assert_equal :done_with_number_formatting, @new_state.current_node_name
+      assert_node_exists :done_with_number_formatting
+    end
+
+    context "responding with an invalid response" do
       setup do
-        @calculator.stubs(:valid_weeks_at_current_employer?).returns(true)
-        setup_states_for_question(
-          :how_many_weeks_at_current_employer?,
-          responding_with: "25",
-          initial_state: { calculator: @calculator },
-        )
+        @calculator.stubs(:valid_weeks_at_current_employer?).returns(false)
       end
 
-      should "store parsed response on calculator as weeks_at_current_employer" do
-        assert_equal 25, @calculator.weeks_at_current_employer
-      end
-
-      should "go to done_with_number_formatting outcomeuestion" do
-        assert_equal :done_with_number_formatting, @new_state.current_node_name
-        assert_node_exists :done_with_number_formatting
-      end
-
-      context "responding with an invalid response" do
-        setup do
-          @calculator.stubs(:valid_weeks_at_current_employer?).returns(false)
-        end
-
-        should "raise an exception" do
-          assert_raise(SmartAnswer::InvalidResponse) do
-            setup_states_for_question(
-              :how_many_weeks_at_current_employer?,
-              responding_with: "55",
-              initial_state: { calculator: @calculator },
-            )
-          end
+      should "raise an exception" do
+        assert_raise(SmartAnswer::InvalidResponse) do
+          setup_states_for_question(
+            :how_many_weeks_at_current_employer?,
+            responding_with: "55",
+            initial_state: { calculator: @calculator },
+          )
         end
       end
     end

--- a/test/unit/smart_answer_flows/calculate_agricultural_holiday_entitlement_flow_test.rb
+++ b/test/unit/smart_answer_flows/calculate_agricultural_holiday_entitlement_flow_test.rb
@@ -1,8 +1,6 @@
 require_relative "../../test_helper"
 require_relative "flow_unit_test_helper"
 
-require "smart_answer_flows/calculate-agricultural-holiday-entitlement"
-
 class CalculateAgriculturalHolidayEntitlementFlowTest < ActiveSupport::TestCase
   include FlowUnitTestHelper
 

--- a/test/unit/smart_answer_flows/calculate_statutory_sick_pay_flow_test.rb
+++ b/test/unit/smart_answer_flows/calculate_statutory_sick_pay_flow_test.rb
@@ -3,111 +3,109 @@ require_relative "flow_unit_test_helper"
 
 require "smart_answer_flows/calculate-statutory-sick-pay"
 
-module SmartAnswer
-  class CalculateStatutorySickPayFlowTest < ActiveSupport::TestCase
-    include FlowUnitTestHelper
+class CalculateStatutorySickPayFlowTest < ActiveSupport::TestCase
+  include FlowUnitTestHelper
 
+  setup do
+    @calculator = SmartAnswer::Calculators::StatutorySickPayCalculator.new
+    @flow = CalculateStatutorySickPayFlow.build
+  end
+
+  context "when answering last_sick_day? question" do
     setup do
-      @calculator = Calculators::StatutorySickPayCalculator.new
-      @flow = CalculateStatutorySickPayFlow.build
+      @calculator.sick_start_date = Date.parse("2015-01-01")
     end
 
-    context "when answering last_sick_day? question" do
+    context "and sickness period is valid period of incapacity for work" do
       setup do
-        @calculator.sick_start_date = Date.parse("2015-01-01")
-      end
-
-      context "and sickness period is valid period of incapacity for work" do
-        setup do
-          @calculator.stubs(valid_period_of_incapacity_for_work?: true)
-          setup_states_for_question(
-            :last_sick_day?,
-            responding_with: "2015-01-03",
-            initial_state: { calculator: @calculator },
-          )
-        end
-
-        should "go to has_linked_sickness? question" do
-          assert_equal :has_linked_sickness?, @new_state.current_node_name
-          assert_node_exists :has_linked_sickness?
-        end
-      end
-
-      context "and sickness period is not valid period of incapacity for work" do
-        setup do
-          @calculator.stubs(valid_period_of_incapacity_for_work?: false)
-          setup_states_for_question(
-            :last_sick_day?,
-            responding_with: "2015-01-03",
-            initial_state: { calculator: @calculator },
-          )
-        end
-
-        should "go to must_be_sick_for_4_days outcome" do
-          assert_equal :must_be_sick_for_4_days, @new_state.current_node_name
-          assert_node_exists :must_be_sick_for_4_days
-        end
-      end
-    end
-
-    context "when answering linked_sickness_end_date? question" do
-      setup do
-        @calculator.stubs(
-          within_eight_weeks_of_current_sickness_period?: true,
-          at_least_1_day_before_first_sick_day?: true,
-          valid_linked_period_of_incapacity_for_work?: true,
+        @calculator.stubs(valid_period_of_incapacity_for_work?: true)
+        setup_states_for_question(
+          :last_sick_day?,
+          responding_with: "2015-01-03",
+          initial_state: { calculator: @calculator },
         )
       end
 
-      context "and linked sickness ends more than 8 weeks before sickness starts" do
-        setup do
-          @calculator.stubs(within_eight_weeks_of_current_sickness_period?: false)
-        end
+      should "go to has_linked_sickness? question" do
+        assert_equal :has_linked_sickness?, @new_state.current_node_name
+        assert_node_exists :has_linked_sickness?
+      end
+    end
 
-        should "raise an exception" do
-          exception = assert_raise(SmartAnswer::InvalidResponse) do
-            setup_states_for_question(
-              :linked_sickness_end_date?,
-              responding_with: "2015-01-07",
-              initial_state: { calculator: @calculator },
-            )
-          end
-          assert_equal "error_must_be_within_eight_weeks", exception.message
-        end
+    context "and sickness period is not valid period of incapacity for work" do
+      setup do
+        @calculator.stubs(valid_period_of_incapacity_for_work?: false)
+        setup_states_for_question(
+          :last_sick_day?,
+          responding_with: "2015-01-03",
+          initial_state: { calculator: @calculator },
+        )
       end
 
-      context "and linked sickness ends the day before sickness starts" do
-        setup do
-          @calculator.stubs(at_least_1_day_before_first_sick_day?: false)
-        end
+      should "go to must_be_sick_for_4_days outcome" do
+        assert_equal :must_be_sick_for_4_days, @new_state.current_node_name
+        assert_node_exists :must_be_sick_for_4_days
+      end
+    end
+  end
 
-        should "raise an exception" do
-          exception = assert_raise(SmartAnswer::InvalidResponse) do
-            setup_states_for_question(
-              :linked_sickness_end_date?,
-              responding_with: "2015-01-31",
-              initial_state: { calculator: @calculator },
-            )
-          end
-          assert_equal "error_must_be_at_least_1_day_before_first_sick_day", exception.message
-        end
+  context "when answering linked_sickness_end_date? question" do
+    setup do
+      @calculator.stubs(
+        within_eight_weeks_of_current_sickness_period?: true,
+        at_least_1_day_before_first_sick_day?: true,
+        valid_linked_period_of_incapacity_for_work?: true,
+      )
+    end
+
+    context "and linked sickness ends more than 8 weeks before sickness starts" do
+      setup do
+        @calculator.stubs(within_eight_weeks_of_current_sickness_period?: false)
       end
 
-      context "and linked sickness period is less than 4 calendar days long" do
-        setup do
-          @calculator.stubs(valid_linked_period_of_incapacity_for_work?: false)
+      should "raise an exception" do
+        exception = assert_raise(SmartAnswer::InvalidResponse) do
+          setup_states_for_question(
+            :linked_sickness_end_date?,
+            responding_with: "2015-01-07",
+            initial_state: { calculator: @calculator },
+          )
         end
+        assert_equal "error_must_be_within_eight_weeks", exception.message
+      end
+    end
 
-        should "raise an exception" do
-          exception = assert_raise(SmartAnswer::InvalidResponse) do
-            setup_states_for_question(
-              :linked_sickness_end_date?,
-              responding_with: "2015-01-03",
-              initial_state: { calculator: @calculator },
-            )
-          end
-          assert_equal "error_must_be_valid_period_of_incapacity_for_work", exception.message
+    context "and linked sickness ends the day before sickness starts" do
+      setup do
+        @calculator.stubs(at_least_1_day_before_first_sick_day?: false)
+      end
+
+      should "raise an exception" do
+        exception = assert_raise(SmartAnswer::InvalidResponse) do
+          setup_states_for_question(
+            :linked_sickness_end_date?,
+            responding_with: "2015-01-31",
+            initial_state: { calculator: @calculator },
+          )
         end
+        assert_equal "error_must_be_at_least_1_day_before_first_sick_day", exception.message
+      end
+    end
+
+    context "and linked sickness period is less than 4 calendar days long" do
+      setup do
+        @calculator.stubs(valid_linked_period_of_incapacity_for_work?: false)
+      end
+
+      should "raise an exception" do
+        exception = assert_raise(SmartAnswer::InvalidResponse) do
+          setup_states_for_question(
+            :linked_sickness_end_date?,
+            responding_with: "2015-01-03",
+            initial_state: { calculator: @calculator },
+          )
+        end
+        assert_equal "error_must_be_valid_period_of_incapacity_for_work", exception.message
       end
     end
   end

--- a/test/unit/smart_answer_flows/calculate_statutory_sick_pay_flow_test.rb
+++ b/test/unit/smart_answer_flows/calculate_statutory_sick_pay_flow_test.rb
@@ -1,8 +1,6 @@
 require_relative "../../test_helper"
 require_relative "flow_unit_test_helper"
 
-require "smart_answer_flows/calculate-statutory-sick-pay"
-
 class CalculateStatutorySickPayFlowTest < ActiveSupport::TestCase
   include FlowUnitTestHelper
 

--- a/test/unit/smart_answer_flows/calculate_statutory_sick_pay_view_test.rb
+++ b/test/unit/smart_answer_flows/calculate_statutory_sick_pay_view_test.rb
@@ -1,7 +1,5 @@
 require_relative "../../test_helper"
 
-require "smart_answer_flows/calculate-statutory-sick-pay"
-
 class CalculateStatutorySickPayViewTest < ActiveSupport::TestCase
   setup do
     @flow = CalculateStatutorySickPayFlow.build

--- a/test/unit/smart_answer_flows/calculate_statutory_sick_pay_view_test.rb
+++ b/test/unit/smart_answer_flows/calculate_statutory_sick_pay_view_test.rb
@@ -2,33 +2,31 @@ require_relative "../../test_helper"
 
 require "smart_answer_flows/calculate-statutory-sick-pay"
 
-module SmartAnswer
-  class CalculateStatutorySickPayViewTest < ActiveSupport::TestCase
+class CalculateStatutorySickPayViewTest < ActiveSupport::TestCase
+  setup do
+    @flow = CalculateStatutorySickPayFlow.build
+  end
+
+  context "when rendering linked_sickness_end_date? question" do
     setup do
-      @flow = CalculateStatutorySickPayFlow.build
+      question = @flow.node(:linked_sickness_end_date?)
+      @state = SmartAnswer::State.new(question)
+      @presenter = QuestionPresenter.new(question, nil, @state)
     end
 
-    context "when rendering linked_sickness_end_date? question" do
-      setup do
-        question = @flow.node(:linked_sickness_end_date?)
-        @state = SmartAnswer::State.new(question)
-        @presenter = QuestionPresenter.new(question, nil, @state)
-      end
+    should "have a must_be_within_eight_weeks error message" do
+      @state.error = "error_must_be_within_eight_weeks"
+      assert_equal "You need to enter a date within 8 weeks of the current period of sickness or it isn't a linked period of sickness.", @presenter.error
+    end
 
-      should "have a must_be_within_eight_weeks error message" do
-        @state.error = "error_must_be_within_eight_weeks"
-        assert_equal "You need to enter a date within 8 weeks of the current period of sickness or it isn't a linked period of sickness.", @presenter.error
-      end
+    should "have a must_be_at_least_1_day_before_first_sick_day error message" do
+      @state.error = "error_must_be_at_least_1_day_before_first_sick_day"
+      assert_equal "You need to enter a date at least 1 day before the start of the current period of sickness or it isn't a separate linked period of sickness.", @presenter.error
+    end
 
-      should "have a must_be_at_least_1_day_before_first_sick_day error message" do
-        @state.error = "error_must_be_at_least_1_day_before_first_sick_day"
-        assert_equal "You need to enter a date at least 1 day before the start of the current period of sickness or it isn't a separate linked period of sickness.", @presenter.error
-      end
-
-      should "have a start_before_end error message" do
-        @state.error = "error_must_be_valid_period_of_incapacity_for_work"
-        assert_equal "The linked period of sickness must be at least 4 calendar days long.", @presenter.error
-      end
+    should "have a start_before_end error message" do
+      @state.error = "error_must_be_valid_period_of_incapacity_for_work"
+      assert_equal "The linked period of sickness must be at least 4 calendar days long.", @presenter.error
     end
   end
 end

--- a/test/unit/smart_answer_flows/child_benefit_tax_calculator_flow_test.rb
+++ b/test/unit/smart_answer_flows/child_benefit_tax_calculator_flow_test.rb
@@ -1,8 +1,6 @@
 require_relative "../../test_helper"
 require_relative "flow_unit_test_helper"
 
-require "smart_answer_flows/child-benefit-tax-calculator"
-
 class ChildBenefitTaxCalculatorFlowTest < ActiveSupport::TestCase
   context ChildBenefitTaxCalculatorFlow do
     include FlowUnitTestHelper

--- a/test/unit/smart_answer_flows/child_benefit_tax_calculator_flow_test.rb
+++ b/test/unit/smart_answer_flows/child_benefit_tax_calculator_flow_test.rb
@@ -3,50 +3,123 @@ require_relative "flow_unit_test_helper"
 
 require "smart_answer_flows/child-benefit-tax-calculator"
 
-module SmartAnswer
-  class ChildBenefitTaxCalculatorFlowTest < ActiveSupport::TestCase
-    context ChildBenefitTaxCalculatorFlow do
-      include FlowUnitTestHelper
+class ChildBenefitTaxCalculatorFlowTest < ActiveSupport::TestCase
+  context ChildBenefitTaxCalculatorFlow do
+    include FlowUnitTestHelper
 
+    setup do
+      @calculator = SmartAnswer::Calculators::ChildBenefitTaxCalculator.new
+      @flow = ChildBenefitTaxCalculatorFlow.build
+    end
+
+    should "start with how_many_children? question" do
+      assert_equal :how_many_children?, @flow.questions.first.name
+    end
+
+    # Q1
+    context "when answering how_many_children? question" do
       setup do
-        @calculator = Calculators::ChildBenefitTaxCalculator.new
-        @flow = ChildBenefitTaxCalculatorFlow.build
+        SmartAnswer::Calculators::ChildBenefitTaxCalculator.stubs(:new).returns(@calculator)
+        setup_states_for_question(
+          :how_many_children?,
+          responding_with: "2",
+        )
       end
 
-      should "start with how_many_children? question" do
-        assert_equal :how_many_children?, @flow.questions.first.name
+      should "instantiate and store calculator" do
+        assert_same @calculator, @new_state.calculator
       end
 
-      # Q1
-      context "when answering how_many_children? question" do
+      should "store parsed response on calculator as children_count" do
+        assert_equal 2, @calculator.children_count
+      end
+
+      should "go to which_tax_year? question" do
+        assert_equal :which_tax_year?, @new_state.current_node_name
+        assert_node_exists :which_tax_year?
+      end
+    end
+
+    # Q2
+    context "when answering which_tax_year? question" do
+      setup do
+        setup_states_for_question(
+          :which_tax_year?,
+          responding_with: "2012",
+          initial_state: { calculator: @calculator },
+        )
+      end
+
+      should "instantiate and store calculator" do
+        assert_same @calculator, @new_state.calculator
+      end
+
+      should "store parsed response on calculator as tax_year" do
+        assert_equal "2012", @calculator.tax_year
+      end
+
+      should "go to is_part_year_claim? question" do
+        assert_equal :is_part_year_claim?, @new_state.current_node_name
+        assert_node_exists :is_part_year_claim?
+      end
+    end
+
+    # Q3
+    context "when answering is_part_year_claim? question" do
+      context "responding with yes" do
         setup do
-          Calculators::ChildBenefitTaxCalculator.stubs(:new).returns(@calculator)
           setup_states_for_question(
-            :how_many_children?,
+            :is_part_year_claim?,
+            responding_with: "yes",
+            initial_state: { calculator: @calculator },
+          )
+        end
+
+        should "instantiate and store calculator" do
+          assert_same @calculator, @new_state.calculator
+        end
+
+        should "go to how_many_children_part_year? question" do
+          assert_equal :how_many_children_part_year?, @new_state.current_node_name
+          assert_node_exists :how_many_children_part_year?
+        end
+      end
+
+      context "responding with no" do
+        setup do
+          setup_states_for_question(
+            :is_part_year_claim?,
+            responding_with: "no",
+            initial_state: { calculator: @calculator },
+          )
+        end
+
+        should "instantiate and store calculator" do
+          assert_same @calculator, @new_state.calculator
+        end
+
+        should "go to income_details? question" do
+          setup do
+            setup_states_for_question(
+              :is_part_year_claim?,
+              responding_with: "no",
+              initial_state: { calculator: @calculator },
+            )
+          end
+          assert_equal :income_details?, @new_state.current_node_name
+          assert_node_exists :income_details?
+        end
+      end
+    end
+
+    # Q3a
+    context "when answering how_many_children_part_year? question" do
+      context "when the number is valid" do
+        setup do
+          @calculator.children_count = 8
+          setup_states_for_question(
+            :how_many_children_part_year?,
             responding_with: "2",
-          )
-        end
-
-        should "instantiate and store calculator" do
-          assert_same @calculator, @new_state.calculator
-        end
-
-        should "store parsed response on calculator as children_count" do
-          assert_equal 2, @calculator.children_count
-        end
-
-        should "go to which_tax_year? question" do
-          assert_equal :which_tax_year?, @new_state.current_node_name
-          assert_node_exists :which_tax_year?
-        end
-      end
-
-      # Q2
-      context "when answering which_tax_year? question" do
-        setup do
-          setup_states_for_question(
-            :which_tax_year?,
-            responding_with: "2012",
             initial_state: { calculator: @calculator },
           )
         end
@@ -55,294 +128,61 @@ module SmartAnswer
           assert_same @calculator, @new_state.calculator
         end
 
-        should "store parsed response on calculator as tax_year" do
-          assert_equal "2012", @calculator.tax_year
-        end
-
-        should "go to is_part_year_claim? question" do
-          assert_equal :is_part_year_claim?, @new_state.current_node_name
-          assert_node_exists :is_part_year_claim?
+        should "go to child_benefit_1_start? question" do
+          assert_equal :child_benefit_1_start?, @new_state.current_node_name
+          assert_node_exists :child_benefit_1_start?
         end
       end
+    end
 
-      # Q3
-      context "when answering is_part_year_claim? question" do
-        context "responding with yes" do
-          setup do
-            setup_states_for_question(
-              :is_part_year_claim?,
-              responding_with: "yes",
-              initial_state: { calculator: @calculator },
-            )
-          end
-
-          should "instantiate and store calculator" do
-            assert_same @calculator, @new_state.calculator
-          end
-
-          should "go to how_many_children_part_year? question" do
-            assert_equal :how_many_children_part_year?, @new_state.current_node_name
-            assert_node_exists :how_many_children_part_year?
-          end
-        end
-
-        context "responding with no" do
-          setup do
-            setup_states_for_question(
-              :is_part_year_claim?,
-              responding_with: "no",
-              initial_state: { calculator: @calculator },
-            )
-          end
-
-          should "instantiate and store calculator" do
-            assert_same @calculator, @new_state.calculator
-          end
-
-          should "go to income_details? question" do
-            setup do
-              setup_states_for_question(
-                :is_part_year_claim?,
-                responding_with: "no",
-                initial_state: { calculator: @calculator },
-              )
-            end
-            assert_equal :income_details?, @new_state.current_node_name
-            assert_node_exists :income_details?
-          end
-        end
-      end
-
-      # Q3a
-      context "when answering how_many_children_part_year? question" do
-        context "when the number is valid" do
-          setup do
-            @calculator.children_count = 8
-            setup_states_for_question(
-              :how_many_children_part_year?,
-              responding_with: "2",
-              initial_state: { calculator: @calculator },
-            )
-          end
-
-          should "instantiate and store calculator" do
-            assert_same @calculator, @new_state.calculator
-          end
-
-          should "go to child_benefit_1_start? question" do
-            assert_equal :child_benefit_1_start?, @new_state.current_node_name
-            assert_node_exists :child_benefit_1_start?
-          end
-        end
-      end
-
-      # Q3b
-      context "when answering child_benefit_1_start? question" do
-        context "when the date is valid" do
-          setup do
-            @calculator.tax_year = "2015"
-            setup_states_for_question(
-              :child_benefit_1_start?,
-              responding_with: "2015-06-09",
-              initial_state: { calculator: @calculator },
-            )
-          end
-
-          should "instantiate and store calculator" do
-            assert_same @calculator, @new_state.calculator
-          end
-
-          should "go to add_child_benefit_1_stop? question" do
-            assert_equal :add_child_benefit_1_stop?, @new_state.current_node_name
-            assert_node_exists :add_child_benefit_1_stop?
-          end
-        end
-      end
-
-      context "when answering a later child_benefit_x_start? question" do
-        context "when the date is valid" do
-          setup do
-            @calculator.tax_year = "2015"
-            setup_states_for_question(
-              :child_benefit_2_start?,
-              responding_with: "2015-06-09",
-              initial_state: { calculator: @calculator },
-            )
-          end
-
-          should "go to the corresponding add_child_benefit_x_stop? question" do
-            assert_equal :add_child_benefit_2_stop?, @new_state.current_node_name
-            assert_node_exists :add_child_benefit_2_stop?
-          end
-        end
-      end
-
-      # Q3c
-      context "when answering add_child_benefit_1_stop? question" do
-        context "when answering yes" do
-          setup do
-            setup_states_for_question(
-              :add_child_benefit_1_stop?,
-              responding_with: "yes",
-              initial_state: { calculator: @calculator },
-            )
-          end
-
-          should "instantiate and store calculator" do
-            assert_same @calculator, @new_state.calculator
-          end
-
-          should "go to child_benefit_1_stop? question" do
-            assert_equal :child_benefit_1_stop?, @new_state.current_node_name
-            assert_node_exists :child_benefit_1_stop?
-          end
-        end
-
-        context "when answering no" do
-          setup do
-            setup_states_for_question(
-              :add_child_benefit_1_stop?,
-              responding_with: "no",
-              initial_state: { calculator: @calculator },
-            )
-          end
-
-          should "instantiate and store calculator" do
-            assert_same @calculator, @new_state.calculator
-          end
-
-          should "go to income_details? question" do
-            assert_equal :income_details?, @new_state.current_node_name
-            assert_node_exists :income_details?
-          end
-        end
-      end
-
-      context "when answering a later add_child_benefit_x_stop? question" do
-        context "when answering yes" do
-          setup do
-            setup_states_for_question(
-              :add_child_benefit_2_stop?,
-              responding_with: "yes",
-              initial_state: { calculator: @calculator },
-            )
-          end
-
-          should "go to the corresponding child_benefit_x_stop? question" do
-            assert_equal :child_benefit_2_stop?, @new_state.current_node_name
-            assert_node_exists :child_benefit_2_stop?
-          end
-        end
-
-        context "when answering no" do
-          setup do
-            setup_states_for_question(
-              :add_child_benefit_2_stop?,
-              responding_with: "no",
-              initial_state: { calculator: @calculator },
-            )
-          end
-
-          should "go to income_details? question" do
-            assert_equal :income_details?, @new_state.current_node_name
-            assert_node_exists :income_details?
-          end
-        end
-      end
-
-      # Q3d
-      context "when answering child_benefit_1_stop? question" do
+    # Q3b
+    context "when answering child_benefit_1_start? question" do
+      context "when the date is valid" do
         setup do
           @calculator.tax_year = "2015"
-          @calculator.stubs(:valid_end_date?).returns true
+          setup_states_for_question(
+            :child_benefit_1_start?,
+            responding_with: "2015-06-09",
+            initial_state: { calculator: @calculator },
+          )
         end
 
-        context "when there are more part year children" do
-          setup do
-            @calculator.child_number = 2
-            @calculator.part_year_children_count = 6
-            setup_states_for_question(
-              :child_benefit_1_stop?,
-              responding_with: "2015-06-09",
-              initial_state: { calculator: @calculator },
-            )
-          end
-
-          should "instantiate and store calculator" do
-            assert_same @calculator, @new_state.calculator
-          end
-
-          should "go to child_benefit_2_start? question" do
-            assert_equal :child_benefit_2_start?, @new_state.current_node_name
-            assert_node_exists :child_benefit_2_start?
-          end
+        should "instantiate and store calculator" do
+          assert_same @calculator, @new_state.calculator
         end
 
-        context "when the final part year child" do
-          setup do
-            setup_states_for_question(
-              :child_benefit_1_stop?,
-              responding_with: "2015-06-09",
-              initial_state: { calculator: @calculator },
-            )
-          end
-
-          should "instantiate and store calculator" do
-            assert_same @calculator, @new_state.calculator
-          end
-
-          should "go to income_details? question" do
-            assert_equal :income_details?, @new_state.current_node_name
-            assert_node_exists :income_details?
-          end
+        should "go to add_child_benefit_1_stop? question" do
+          assert_equal :add_child_benefit_1_stop?, @new_state.current_node_name
+          assert_node_exists :add_child_benefit_1_stop?
         end
       end
+    end
 
-      context "when answering a later child_benefit_x_stop? question" do
+    context "when answering a later child_benefit_x_start? question" do
+      context "when the date is valid" do
         setup do
           @calculator.tax_year = "2015"
-          @calculator.stubs(:valid_end_date?).returns true
+          setup_states_for_question(
+            :child_benefit_2_start?,
+            responding_with: "2015-06-09",
+            initial_state: { calculator: @calculator },
+          )
         end
 
-        context "when there are more part year children" do
-          setup do
-            @calculator.child_number = 3
-            @calculator.part_year_children_count = 6
-            setup_states_for_question(
-              :child_benefit_2_stop?,
-              responding_with: "2015-06-09",
-              initial_state: { calculator: @calculator },
-            )
-          end
-
-          should "go to the next child_benefit_x_start? question" do
-            assert_equal :child_benefit_3_start?, @new_state.current_node_name
-            assert_node_exists :child_benefit_3_start?
-          end
-        end
-
-        context "when the final part year child" do
-          setup do
-            setup_states_for_question(
-              :child_benefit_2_stop?,
-              responding_with: "2015-06-09",
-              initial_state: { calculator: @calculator },
-            )
-          end
-
-          should "go to income_details? question" do
-            assert_equal :income_details?, @new_state.current_node_name
-            assert_node_exists :income_details?
-          end
+        should "go to the corresponding add_child_benefit_x_stop? question" do
+          assert_equal :add_child_benefit_2_stop?, @new_state.current_node_name
+          assert_node_exists :add_child_benefit_2_stop?
         end
       end
+    end
 
-      # Q4
-      context "when answering income_details? question" do
+    # Q3c
+    context "when answering add_child_benefit_1_stop? question" do
+      context "when answering yes" do
         setup do
           setup_states_for_question(
-            :income_details?,
-            responding_with: "60000",
+            :add_child_benefit_1_stop?,
+            responding_with: "yes",
             initial_state: { calculator: @calculator },
           )
         end
@@ -351,63 +191,17 @@ module SmartAnswer
           assert_same @calculator, @new_state.calculator
         end
 
-        should "store parsed response on calculator as income_details" do
-          assert_equal 60_000, @calculator.income_details
-        end
-
-        should "go to add_allowable_deductions? question" do
-          assert_equal :add_allowable_deductions?, @new_state.current_node_name
-          assert_node_exists :add_allowable_deductions?
+        should "go to child_benefit_1_stop? question" do
+          assert_equal :child_benefit_1_stop?, @new_state.current_node_name
+          assert_node_exists :child_benefit_1_stop?
         end
       end
 
-      # Q5
-      context "when answering add_allowable_deductions? question" do
-        context "responding with yes" do
-          setup do
-            setup_states_for_question(
-              :add_allowable_deductions?,
-              responding_with: "yes",
-              initial_state: { calculator: @calculator },
-            )
-          end
-
-          should "instantiate and store calculator" do
-            assert_same @calculator, @new_state.calculator
-          end
-
-          should "go to allowable_deductions? question" do
-            assert_equal :allowable_deductions?, @new_state.current_node_name
-            assert_node_exists :allowable_deductions?
-          end
-        end
-
-        context "responding with no" do
-          setup do
-            setup_states_for_question(
-              :add_allowable_deductions?,
-              responding_with: "no",
-              initial_state: { calculator: @calculator },
-            )
-          end
-
-          should "instantiate and store calculator" do
-            assert_same @calculator, @new_state.calculator
-          end
-
-          should "go to outcome" do
-            assert_equal :results, @new_state.current_node_name
-            assert_node_exists :results
-          end
-        end
-      end
-
-      # Q5a
-      context "when answering allowable_deductions? question" do
+      context "when answering no" do
         setup do
           setup_states_for_question(
-            :allowable_deductions?,
-            responding_with: "8000",
+            :add_child_benefit_1_stop?,
+            responding_with: "no",
             initial_state: { calculator: @calculator },
           )
         end
@@ -416,63 +210,59 @@ module SmartAnswer
           assert_same @calculator, @new_state.calculator
         end
 
-        should "store parsed response on calculator as allowable_deductions" do
-          assert_equal SmartAnswer::Money.new(8000), @calculator.allowable_deductions
-        end
-
-        should "go to add_other_allowable_deductions? question" do
-          assert_equal :add_other_allowable_deductions?, @new_state.current_node_name
-          assert_node_exists :add_other_allowable_deductions?
+        should "go to income_details? question" do
+          assert_equal :income_details?, @new_state.current_node_name
+          assert_node_exists :income_details?
         end
       end
+    end
 
-      # Q6
-      context "when answering add_other_allowable_deductions? question" do
-        context "responding with yes" do
-          setup do
-            setup_states_for_question(
-              :add_other_allowable_deductions?,
-              responding_with: "yes",
-              initial_state: { calculator: @calculator },
-            )
-          end
-
-          should "instantiate and store calculator" do
-            assert_same @calculator, @new_state.calculator
-          end
-
-          should "go to other_allowable_deductions? question" do
-            assert_equal :other_allowable_deductions?, @new_state.current_node_name
-            assert_node_exists :other_allowable_deductions?
-          end
-        end
-
-        context "responding with no" do
-          setup do
-            setup_states_for_question(
-              :add_other_allowable_deductions?,
-              responding_with: "no",
-              initial_state: { calculator: @calculator },
-            )
-          end
-
-          should "instantiate and store calculator" do
-            assert_same @calculator, @new_state.calculator
-          end
-
-          should "go to outcome" do
-            assert_equal :results, @new_state.current_node_name
-            assert_node_exists :results
-          end
-        end
-      end
-
-      # Q6a
-      context "when answering other_allowable_deductions? question" do
+    context "when answering a later add_child_benefit_x_stop? question" do
+      context "when answering yes" do
         setup do
           setup_states_for_question(
-            :other_allowable_deductions?,
-            responding_with: "1000",
+            :add_child_benefit_2_stop?,
+            responding_with: "yes",
+            initial_state: { calculator: @calculator },
+          )
+        end
+
+        should "go to the corresponding child_benefit_x_stop? question" do
+          assert_equal :child_benefit_2_stop?, @new_state.current_node_name
+          assert_node_exists :child_benefit_2_stop?
+        end
+      end
+
+      context "when answering no" do
+        setup do
+          setup_states_for_question(
+            :add_child_benefit_2_stop?,
+            responding_with: "no",
+            initial_state: { calculator: @calculator },
+          )
+        end
+
+        should "go to income_details? question" do
+          assert_equal :income_details?, @new_state.current_node_name
+          assert_node_exists :income_details?
+        end
+      end
+    end
+
+    # Q3d
+    context "when answering child_benefit_1_stop? question" do
+      setup do
+        @calculator.tax_year = "2015"
+        @calculator.stubs(:valid_end_date?).returns true
+      end
+
+      context "when there are more part year children" do
+        setup do
+          @calculator.child_number = 2
+          @calculator.part_year_children_count = 6
+          setup_states_for_question(
+            :child_benefit_1_stop?,
+            responding_with: "2015-06-09",
             initial_state: { calculator: @calculator },
           )
         end
@@ -481,14 +271,222 @@ module SmartAnswer
           assert_same @calculator, @new_state.calculator
         end
 
-        should "store parsed response on calculator as other_allowable_deductions" do
-          assert_equal SmartAnswer::Money.new(1000), @calculator.other_allowable_deductions
+        should "go to child_benefit_2_start? question" do
+          assert_equal :child_benefit_2_start?, @new_state.current_node_name
+          assert_node_exists :child_benefit_2_start?
+        end
+      end
+
+      context "when the final part year child" do
+        setup do
+          setup_states_for_question(
+            :child_benefit_1_stop?,
+            responding_with: "2015-06-09",
+            initial_state: { calculator: @calculator },
+          )
         end
 
-        should "go to results page" do
+        should "instantiate and store calculator" do
+          assert_same @calculator, @new_state.calculator
+        end
+
+        should "go to income_details? question" do
+          assert_equal :income_details?, @new_state.current_node_name
+          assert_node_exists :income_details?
+        end
+      end
+    end
+
+    context "when answering a later child_benefit_x_stop? question" do
+      setup do
+        @calculator.tax_year = "2015"
+        @calculator.stubs(:valid_end_date?).returns true
+      end
+
+      context "when there are more part year children" do
+        setup do
+          @calculator.child_number = 3
+          @calculator.part_year_children_count = 6
+          setup_states_for_question(
+            :child_benefit_2_stop?,
+            responding_with: "2015-06-09",
+            initial_state: { calculator: @calculator },
+          )
+        end
+
+        should "go to the next child_benefit_x_start? question" do
+          assert_equal :child_benefit_3_start?, @new_state.current_node_name
+          assert_node_exists :child_benefit_3_start?
+        end
+      end
+
+      context "when the final part year child" do
+        setup do
+          setup_states_for_question(
+            :child_benefit_2_stop?,
+            responding_with: "2015-06-09",
+            initial_state: { calculator: @calculator },
+          )
+        end
+
+        should "go to income_details? question" do
+          assert_equal :income_details?, @new_state.current_node_name
+          assert_node_exists :income_details?
+        end
+      end
+    end
+
+    # Q4
+    context "when answering income_details? question" do
+      setup do
+        setup_states_for_question(
+          :income_details?,
+          responding_with: "60000",
+          initial_state: { calculator: @calculator },
+        )
+      end
+
+      should "instantiate and store calculator" do
+        assert_same @calculator, @new_state.calculator
+      end
+
+      should "store parsed response on calculator as income_details" do
+        assert_equal 60_000, @calculator.income_details
+      end
+
+      should "go to add_allowable_deductions? question" do
+        assert_equal :add_allowable_deductions?, @new_state.current_node_name
+        assert_node_exists :add_allowable_deductions?
+      end
+    end
+
+    # Q5
+    context "when answering add_allowable_deductions? question" do
+      context "responding with yes" do
+        setup do
+          setup_states_for_question(
+            :add_allowable_deductions?,
+            responding_with: "yes",
+            initial_state: { calculator: @calculator },
+          )
+        end
+
+        should "instantiate and store calculator" do
+          assert_same @calculator, @new_state.calculator
+        end
+
+        should "go to allowable_deductions? question" do
+          assert_equal :allowable_deductions?, @new_state.current_node_name
+          assert_node_exists :allowable_deductions?
+        end
+      end
+
+      context "responding with no" do
+        setup do
+          setup_states_for_question(
+            :add_allowable_deductions?,
+            responding_with: "no",
+            initial_state: { calculator: @calculator },
+          )
+        end
+
+        should "instantiate and store calculator" do
+          assert_same @calculator, @new_state.calculator
+        end
+
+        should "go to outcome" do
           assert_equal :results, @new_state.current_node_name
           assert_node_exists :results
         end
+      end
+    end
+
+    # Q5a
+    context "when answering allowable_deductions? question" do
+      setup do
+        setup_states_for_question(
+          :allowable_deductions?,
+          responding_with: "8000",
+          initial_state: { calculator: @calculator },
+        )
+      end
+
+      should "instantiate and store calculator" do
+        assert_same @calculator, @new_state.calculator
+      end
+
+      should "store parsed response on calculator as allowable_deductions" do
+        assert_equal SmartAnswer::Money.new(8000), @calculator.allowable_deductions
+      end
+
+      should "go to add_other_allowable_deductions? question" do
+        assert_equal :add_other_allowable_deductions?, @new_state.current_node_name
+        assert_node_exists :add_other_allowable_deductions?
+      end
+    end
+
+    # Q6
+    context "when answering add_other_allowable_deductions? question" do
+      context "responding with yes" do
+        setup do
+          setup_states_for_question(
+            :add_other_allowable_deductions?,
+            responding_with: "yes",
+            initial_state: { calculator: @calculator },
+          )
+        end
+
+        should "instantiate and store calculator" do
+          assert_same @calculator, @new_state.calculator
+        end
+
+        should "go to other_allowable_deductions? question" do
+          assert_equal :other_allowable_deductions?, @new_state.current_node_name
+          assert_node_exists :other_allowable_deductions?
+        end
+      end
+
+      context "responding with no" do
+        setup do
+          setup_states_for_question(
+            :add_other_allowable_deductions?,
+            responding_with: "no",
+            initial_state: { calculator: @calculator },
+          )
+        end
+
+        should "instantiate and store calculator" do
+          assert_same @calculator, @new_state.calculator
+        end
+
+        should "go to outcome" do
+          assert_equal :results, @new_state.current_node_name
+          assert_node_exists :results
+        end
+      end
+    end
+
+    # Q6a
+    context "when answering other_allowable_deductions? question" do
+      setup do
+        setup_states_for_question(
+          :other_allowable_deductions?,
+          responding_with: "1000",
+          initial_state: { calculator: @calculator },
+        )
+      end
+
+      should "instantiate and store calculator" do
+        assert_same @calculator, @new_state.calculator
+      end
+
+      should "store parsed response on calculator as other_allowable_deductions" do
+        assert_equal SmartAnswer::Money.new(1000), @calculator.other_allowable_deductions
+      end
+
+      should "go to results page" do
+        assert_equal :results, @new_state.current_node_name
+        assert_node_exists :results
       end
     end
   end

--- a/test/unit/smart_answer_flows/child_benefit_tax_calculator_view_test.rb
+++ b/test/unit/smart_answer_flows/child_benefit_tax_calculator_view_test.rb
@@ -1,5 +1,4 @@
 require_relative "../../test_helper"
-require "smart_answer_flows/child-benefit-tax-calculator"
 
 class ChildBenefitTaxCalculatorViewTest < ActiveSupport::TestCase
   include ERB::Util

--- a/test/unit/smart_answer_flows/child_benefit_tax_calculator_view_test.rb
+++ b/test/unit/smart_answer_flows/child_benefit_tax_calculator_view_test.rb
@@ -1,363 +1,361 @@
 require_relative "../../test_helper"
 require "smart_answer_flows/child-benefit-tax-calculator"
 
-module SmartAnswer
-  class ChildBenefitTaxCalculatorViewTest < ActiveSupport::TestCase
-    include ERB::Util
+class ChildBenefitTaxCalculatorViewTest < ActiveSupport::TestCase
+  include ERB::Util
 
+  setup do
+    @flow = ChildBenefitTaxCalculatorFlow.build
+  end
+
+  # Q1
+  context "when rendering how_many_children? question" do
     setup do
-      @flow = ChildBenefitTaxCalculatorFlow.build
+      question = @flow.node(:how_many_children?)
+      @state = SmartAnswer::State.new(question)
+      @presenter = ValueQuestionPresenter.new(question, nil, @state)
     end
 
-    # Q1
-    context "when rendering how_many_children? question" do
-      setup do
-        question = @flow.node(:how_many_children?)
-        @state = SmartAnswer::State.new(question)
-        @presenter = ValueQuestionPresenter.new(question, nil, @state)
-      end
-
-      should "display a useful error message when the number entered is bigger than 30" do
-        @state.error = "valid_number_of_children"
-        assert_equal "Please enter number of children you're claiming for", @presenter.error
-      end
-
-      should "display hint text" do
-        assert_equal "Number of children", @presenter.hint
-      end
-
-      should "have a default error message" do
-        @state.error = "error-message"
-        assert_equal "Please answer this question", @presenter.error
-      end
+    should "display a useful error message when the number entered is bigger than 30" do
+      @state.error = "valid_number_of_children"
+      assert_equal "Please enter number of children you're claiming for", @presenter.error
     end
 
-    # Q2
-    context "when rendering which_tax_year? question" do
-      setup do
-        question = @flow.node(:which_tax_year?)
-        @state = SmartAnswer::State.new(question)
-        @presenter = RadioQuestionPresenter.new(question, nil, @state)
-      end
-
-      should "have options with labels" do
-        assert_equal({ "2012" => "2012 to 2013",
-                       "2013" => "2013 to 2014",
-                       "2014" => "2014 to 2015",
-                       "2015" => "2015 to 2016",
-                       "2016" => "2016 to 2017",
-                       "2017" => "2017 to 2018",
-                       "2018" => "2018 to 2019",
-                       "2019" => "2019 to 2020",
-                       "2020" => "2020 to 2021",
-                       "2021" => "2021 to 2022" }, values_vs_labels(@presenter.options))
-      end
-
-      should "display hint text" do
-        assert_equal "Tax years run from 6 April to 5 April the following year.", @presenter.hint
-      end
-
-      should "have a default error message" do
-        @state.error = "error-message"
-        assert_equal "Select a tax year", @presenter.error
-      end
+    should "display hint text" do
+      assert_equal "Number of children", @presenter.hint
     end
 
-    # Q3
-    context "when rendering is_part_year_claim? question" do
-      setup do
-        question = @flow.node(:is_part_year_claim?)
-        @state = SmartAnswer::State.new(question)
-        @presenter = RadioQuestionPresenter.new(question, nil, @state)
-      end
+    should "have a default error message" do
+      @state.error = "error-message"
+      assert_equal "Please answer this question", @presenter.error
+    end
+  end
 
-      should "have options with labels" do
-        assert_equal({ "yes" => "Yes", "no" => "No" }, values_vs_labels(@presenter.options))
-      end
-
-      should "have a default error message" do
-        @state.error = "error-message"
-        assert_equal "Please answer this question", @presenter.error
-      end
+  # Q2
+  context "when rendering which_tax_year? question" do
+    setup do
+      question = @flow.node(:which_tax_year?)
+      @state = SmartAnswer::State.new(question)
+      @presenter = RadioQuestionPresenter.new(question, nil, @state)
     end
 
-    # Q3a
-    context "when rendering how_many_children_part_year? question" do
-      setup do
-        @question = @flow.node(:how_many_children_part_year?)
-        @state = SmartAnswer::State.new(@question)
-        @presenter = ValueQuestionPresenter.new(@question, nil, @state)
-      end
-
-      should "display hint text" do
-        assert_equal "Number of children", @presenter.hint
-      end
-
-      should "have a default error message" do
-        @state.error = "error-message"
-        assert_equal "Please enter a number", @presenter.error
-      end
-
-      should "display a useful error message when the number entered is negative, or bigger than the total number of children entered" do
-        @state.error = "valid_number_of_part_year_children"
-        assert_equal "Please enter a valid number. The number of children you're claiming a part year for can't be more than the total number of children you're claiming for", @presenter.error
-      end
+    should "have options with labels" do
+      assert_equal({ "2012" => "2012 to 2013",
+                     "2013" => "2013 to 2014",
+                     "2014" => "2014 to 2015",
+                     "2015" => "2015 to 2016",
+                     "2016" => "2016 to 2017",
+                     "2017" => "2017 to 2018",
+                     "2018" => "2018 to 2019",
+                     "2019" => "2019 to 2020",
+                     "2020" => "2020 to 2021",
+                     "2021" => "2021 to 2022" }, values_vs_labels(@presenter.options))
     end
 
-    # Q3b
-    context "when rendering child_benefit_x_start? questions" do
-      setup do
-        question = @flow.node(:child_benefit_1_start?)
-        calculator = Calculators::ChildBenefitTaxCalculator.new
-        @state = SmartAnswer::State.new(question)
-        @state.calculator = calculator
-        @presenter = DateQuestionPresenter.new(question, nil, @state)
-      end
-
-      should "render the child number" do
-        assert_match "Child 1", @presenter.body
-      end
-
-      should "have a default error message" do
-        @state.error = "error-message"
-        assert_equal "Please answer this question", @presenter.error
-      end
-
-      should "display a useful error message when the date entered is not within the tax year selected" do
-        @state.error = "valid_within_tax_year"
-        assert_equal "Child Benefit start date must be within the tax year selected", @presenter.error
-      end
-
-      context "when this question is presented for a later child" do
-        should "render the appropriate child number" do
-          question = @flow.node(:child_benefit_2_start?)
-          state = SmartAnswer::State.new(question)
-          state.calculator = Calculators::ChildBenefitTaxCalculator.new
-          state.calculator.child_number = 2
-          presenter = DateQuestionPresenter.new(question, nil, state)
-
-          assert_match "Child 2", presenter.body
-        end
-      end
+    should "display hint text" do
+      assert_equal "Tax years run from 6 April to 5 April the following year.", @presenter.hint
     end
 
-    # Q3c
-    context "when rendering add_child_benefit_x_stop? questions" do
-      setup do
-        question = @flow.node(:add_child_benefit_1_stop?)
-        calculator = Calculators::ChildBenefitTaxCalculator.new
-        @state = SmartAnswer::State.new(question)
-        @state.calculator = calculator
-        @presenter = RadioQuestionPresenter.new(question, nil, @state)
-      end
+    should "have a default error message" do
+      @state.error = "error-message"
+      assert_equal "Select a tax year", @presenter.error
+    end
+  end
 
-      should "have options with labels" do
-        assert_equal({ "yes" => "Yes", "no" => "No" }, values_vs_labels(@presenter.options))
-      end
-
-      should "have a default error message" do
-        @state.error = "error-message"
-        assert_equal "Please answer this question", @presenter.error
-      end
+  # Q3
+  context "when rendering is_part_year_claim? question" do
+    setup do
+      question = @flow.node(:is_part_year_claim?)
+      @state = SmartAnswer::State.new(question)
+      @presenter = RadioQuestionPresenter.new(question, nil, @state)
     end
 
-    # Q3d
-    context "when rendering child_benefit_x_stop? question" do
-      setup do
-        question = @flow.node(:child_benefit_1_stop?)
-        calculator = Calculators::ChildBenefitTaxCalculator.new
-        @state = SmartAnswer::State.new(question)
-        @state.calculator = calculator
-        @presenter = DateQuestionPresenter.new(question, nil, @state)
-      end
-
-      should "render the child number" do
-        assert_match "Child 1", @presenter.body
-      end
-
-      should "have a default error message" do
-        @state.error = "error-message"
-        assert_equal "Please answer this question", @presenter.error
-      end
-
-      should "display a useful error message when the date entered is not within the tax year selected" do
-        @state.error = "valid_within_tax_year"
-        assert_equal "Child Benefit stop date must be within the tax year selected", @presenter.error
-      end
-
-      context "when this question is presented for a later child" do
-        should "render the appropriate child number" do
-          question = @flow.node(:child_benefit_2_stop?)
-          state = SmartAnswer::State.new(question)
-          state.calculator = Calculators::ChildBenefitTaxCalculator.new
-          state.calculator.child_number = 2
-          presenter = DateQuestionPresenter.new(question, nil, state)
-
-          assert_match "Child 2", presenter.body
-        end
-      end
+    should "have options with labels" do
+      assert_equal({ "yes" => "Yes", "no" => "No" }, values_vs_labels(@presenter.options))
     end
 
-    # Q4
-    context "when rendering income_details? question" do
-      setup do
-        question = @flow.node(:income_details?)
-        @state = SmartAnswer::State.new(question)
-        @presenter = MoneyQuestionPresenter.new(question, nil, @state)
-      end
+    should "have a default error message" do
+      @state.error = "error-message"
+      assert_equal "Please answer this question", @presenter.error
+    end
+  end
 
-      should "have a default error message" do
-        @state.error = "error-message"
-        assert_equal "Please enter a number", @presenter.error
-      end
+  # Q3a
+  context "when rendering how_many_children_part_year? question" do
+    setup do
+      @question = @flow.node(:how_many_children_part_year?)
+      @state = SmartAnswer::State.new(@question)
+      @presenter = ValueQuestionPresenter.new(@question, nil, @state)
     end
 
-    # Q5
-    context "when rendering add_allowable_deductions? question" do
-      setup do
-        question = @flow.node(:add_allowable_deductions?)
-        @state = SmartAnswer::State.new(question)
-        @presenter = RadioQuestionPresenter.new(question, nil, @state)
-      end
-
-      should "have options with labels" do
-        assert_equal({ "yes" => "Yes", "no" => "No" }, values_vs_labels(@presenter.options))
-      end
-
-      should "have a default error message" do
-        @state.error = "error-message"
-        assert_equal "Please answer this question", @presenter.error
-      end
+    should "display hint text" do
+      assert_equal "Number of children", @presenter.hint
     end
 
-    # Q5a
-    context "when rendering allowable_deductions? question" do
-      setup do
-        question = @flow.node(:allowable_deductions?)
-        @state = SmartAnswer::State.new(question)
-        @presenter = MoneyQuestionPresenter.new(question, nil, @state)
-      end
-
-      should "have a default error message" do
-        @state.error = "error-message"
-        assert_equal "Please answer this question", @presenter.error
-      end
+    should "have a default error message" do
+      @state.error = "error-message"
+      assert_equal "Please enter a number", @presenter.error
     end
 
-    # Q6
-    context "when rendering add_other_allowable_deductions? question" do
-      setup do
-        question = @flow.node(:add_other_allowable_deductions?)
-        @state = SmartAnswer::State.new(question)
-        @presenter = RadioQuestionPresenter.new(question, nil, @state)
-      end
+    should "display a useful error message when the number entered is negative, or bigger than the total number of children entered" do
+      @state.error = "valid_number_of_part_year_children"
+      assert_equal "Please enter a valid number. The number of children you're claiming a part year for can't be more than the total number of children you're claiming for", @presenter.error
+    end
+  end
 
-      should "have options with labels" do
-        assert_equal({ "yes" => "Yes", "no" => "No" }, values_vs_labels(@presenter.options))
-      end
-
-      should "have a default error message" do
-        @state.error = "error-message"
-        assert_equal "Please answer this question", @presenter.error
-      end
+  # Q3b
+  context "when rendering child_benefit_x_start? questions" do
+    setup do
+      question = @flow.node(:child_benefit_1_start?)
+      calculator = SmartAnswer::Calculators::ChildBenefitTaxCalculator.new
+      @state = SmartAnswer::State.new(question)
+      @state.calculator = calculator
+      @presenter = DateQuestionPresenter.new(question, nil, @state)
     end
 
-    # Q6a
-    context "when rendering other_allowable_deductions? question" do
-      setup do
-        question = @flow.node(:other_allowable_deductions?)
-        @state = SmartAnswer::State.new(question)
-        @presenter = MoneyQuestionPresenter.new(question, nil, @state)
-      end
-
-      should "have a default error message" do
-        @state.error = "error-message"
-        assert_equal "Please answer this question", @presenter.error
-      end
+    should "render the child number" do
+      assert_match "Child 1", @presenter.body
     end
 
-    # outcome
-    context "when rendering results page" do
-      setup do
-        @outcome = @flow.node(:results)
-        @calculator = Calculators::ChildBenefitTaxCalculator.new(
-          tax_year: "2019",
-          children_count: 4,
-        )
-        @state = SmartAnswer::State.new(@outcome)
-        @state.calculator = @calculator
-      end
-
-      context "when tax year is incomplete" do
-        setup do
-          Timecop.freeze("2019-07-02")
-          @calculator.stubs(calculate_adjusted_net_income: SmartAnswer::Money.new(60_000))
-          @presenter = OutcomePresenter.new(@outcome, nil, @state)
-          @body = @presenter.body
-        end
-
-        should "say that it is an estimate" do
-          assert_match "This is an estimate based on your adjusted net income of £60,000", @body
-        end
-      end
-
-      context "when income is below £50,099" do
-        setup do
-          @calculator.stubs(calculate_adjusted_net_income: SmartAnswer::Money.new(50_098))
-          @presenter = OutcomePresenter.new(@outcome, nil, @state)
-          @body = @presenter.body
-        end
-
-        should "say no tax is owed" do
-          assert_match "There is no tax charge if your income is below £50,099.", @body
-        end
-      end
-
-      context "when income is above £50,100" do
-        setup do
-          @calculator.stubs(calculate_adjusted_net_income: SmartAnswer::Money.new(50_101))
-          @presenter = OutcomePresenter.new(@outcome, nil, @state)
-          @body = @presenter.body
-        end
-
-        should "say the amount of tax owed" do
-          assert_match "The estimated tax charge to pay is £32.00", @body
-        end
-      end
+    should "have a default error message" do
+      @state.error = "error-message"
+      assert_equal "Please answer this question", @presenter.error
     end
 
-    context "when the tax year is 2012" do
-      setup do
-        @outcome = @flow.node(:results)
-        @calculator = Calculators::ChildBenefitTaxCalculator.new(
-          tax_year: "2012",
-          children_count: 4,
-        )
+    should "display a useful error message when the date entered is not within the tax year selected" do
+      @state.error = "valid_within_tax_year"
+      assert_equal "Child Benefit start date must be within the tax year selected", @presenter.error
+    end
 
+    context "when this question is presented for a later child" do
+      should "render the appropriate child number" do
+        question = @flow.node(:child_benefit_2_start?)
+        state = SmartAnswer::State.new(question)
+        state.calculator = SmartAnswer::Calculators::ChildBenefitTaxCalculator.new
+        state.calculator.child_number = 2
+        presenter = DateQuestionPresenter.new(question, nil, state)
+
+        assert_match "Child 2", presenter.body
+      end
+    end
+  end
+
+  # Q3c
+  context "when rendering add_child_benefit_x_stop? questions" do
+    setup do
+      question = @flow.node(:add_child_benefit_1_stop?)
+      calculator = SmartAnswer::Calculators::ChildBenefitTaxCalculator.new
+      @state = SmartAnswer::State.new(question)
+      @state.calculator = calculator
+      @presenter = RadioQuestionPresenter.new(question, nil, @state)
+    end
+
+    should "have options with labels" do
+      assert_equal({ "yes" => "Yes", "no" => "No" }, values_vs_labels(@presenter.options))
+    end
+
+    should "have a default error message" do
+      @state.error = "error-message"
+      assert_equal "Please answer this question", @presenter.error
+    end
+  end
+
+  # Q3d
+  context "when rendering child_benefit_x_stop? question" do
+    setup do
+      question = @flow.node(:child_benefit_1_stop?)
+      calculator = SmartAnswer::Calculators::ChildBenefitTaxCalculator.new
+      @state = SmartAnswer::State.new(question)
+      @state.calculator = calculator
+      @presenter = DateQuestionPresenter.new(question, nil, @state)
+    end
+
+    should "render the child number" do
+      assert_match "Child 1", @presenter.body
+    end
+
+    should "have a default error message" do
+      @state.error = "error-message"
+      assert_equal "Please answer this question", @presenter.error
+    end
+
+    should "display a useful error message when the date entered is not within the tax year selected" do
+      @state.error = "valid_within_tax_year"
+      assert_equal "Child Benefit stop date must be within the tax year selected", @presenter.error
+    end
+
+    context "when this question is presented for a later child" do
+      should "render the appropriate child number" do
+        question = @flow.node(:child_benefit_2_stop?)
+        state = SmartAnswer::State.new(question)
+        state.calculator = SmartAnswer::Calculators::ChildBenefitTaxCalculator.new
+        state.calculator.child_number = 2
+        presenter = DateQuestionPresenter.new(question, nil, state)
+
+        assert_match "Child 2", presenter.body
+      end
+    end
+  end
+
+  # Q4
+  context "when rendering income_details? question" do
+    setup do
+      question = @flow.node(:income_details?)
+      @state = SmartAnswer::State.new(question)
+      @presenter = MoneyQuestionPresenter.new(question, nil, @state)
+    end
+
+    should "have a default error message" do
+      @state.error = "error-message"
+      assert_equal "Please enter a number", @presenter.error
+    end
+  end
+
+  # Q5
+  context "when rendering add_allowable_deductions? question" do
+    setup do
+      question = @flow.node(:add_allowable_deductions?)
+      @state = SmartAnswer::State.new(question)
+      @presenter = RadioQuestionPresenter.new(question, nil, @state)
+    end
+
+    should "have options with labels" do
+      assert_equal({ "yes" => "Yes", "no" => "No" }, values_vs_labels(@presenter.options))
+    end
+
+    should "have a default error message" do
+      @state.error = "error-message"
+      assert_equal "Please answer this question", @presenter.error
+    end
+  end
+
+  # Q5a
+  context "when rendering allowable_deductions? question" do
+    setup do
+      question = @flow.node(:allowable_deductions?)
+      @state = SmartAnswer::State.new(question)
+      @presenter = MoneyQuestionPresenter.new(question, nil, @state)
+    end
+
+    should "have a default error message" do
+      @state.error = "error-message"
+      assert_equal "Please answer this question", @presenter.error
+    end
+  end
+
+  # Q6
+  context "when rendering add_other_allowable_deductions? question" do
+    setup do
+      question = @flow.node(:add_other_allowable_deductions?)
+      @state = SmartAnswer::State.new(question)
+      @presenter = RadioQuestionPresenter.new(question, nil, @state)
+    end
+
+    should "have options with labels" do
+      assert_equal({ "yes" => "Yes", "no" => "No" }, values_vs_labels(@presenter.options))
+    end
+
+    should "have a default error message" do
+      @state.error = "error-message"
+      assert_equal "Please answer this question", @presenter.error
+    end
+  end
+
+  # Q6a
+  context "when rendering other_allowable_deductions? question" do
+    setup do
+      question = @flow.node(:other_allowable_deductions?)
+      @state = SmartAnswer::State.new(question)
+      @presenter = MoneyQuestionPresenter.new(question, nil, @state)
+    end
+
+    should "have a default error message" do
+      @state.error = "error-message"
+      assert_equal "Please answer this question", @presenter.error
+    end
+  end
+
+  # outcome
+  context "when rendering results page" do
+    setup do
+      @outcome = @flow.node(:results)
+      @calculator = SmartAnswer::Calculators::ChildBenefitTaxCalculator.new(
+        tax_year: "2019",
+        children_count: 4,
+      )
+      @state = SmartAnswer::State.new(@outcome)
+      @state.calculator = @calculator
+    end
+
+    context "when tax year is incomplete" do
+      setup do
+        Timecop.freeze("2019-07-02")
         @calculator.stubs(calculate_adjusted_net_income: SmartAnswer::Money.new(60_000))
-        @state = SmartAnswer::State.new(@outcome)
-        @state.calculator = @calculator
         @presenter = OutcomePresenter.new(@outcome, nil, @state)
         @body = @presenter.body
       end
 
-      should "give the dates the benefit is received for" do
-        assert_match "Received between 7 January and 5 April 2013.", @body
-      end
-
-      should "give the dates the tax is applied to" do
-        assert_match "The tax charge only applies to the Child Benefit received between 7 January and 5 April 2013", @body
-      end
-
-      should "state that this is only for part of the tax year" do
-        assert_match "Your result for the next tax year may be higher because the tax charge will apply to the whole tax year", @body
+      should "say that it is an estimate" do
+        assert_match "This is an estimate based on your adjusted net income of £60,000", @body
       end
     end
 
-  private
+    context "when income is below £50,099" do
+      setup do
+        @calculator.stubs(calculate_adjusted_net_income: SmartAnswer::Money.new(50_098))
+        @presenter = OutcomePresenter.new(@outcome, nil, @state)
+        @body = @presenter.body
+      end
 
-    def values_vs_labels(options)
-      options.each_with_object({}) { |o, h| h[o[:value]] = o[:label]; }
+      should "say no tax is owed" do
+        assert_match "There is no tax charge if your income is below £50,099.", @body
+      end
     end
+
+    context "when income is above £50,100" do
+      setup do
+        @calculator.stubs(calculate_adjusted_net_income: SmartAnswer::Money.new(50_101))
+        @presenter = OutcomePresenter.new(@outcome, nil, @state)
+        @body = @presenter.body
+      end
+
+      should "say the amount of tax owed" do
+        assert_match "The estimated tax charge to pay is £32.00", @body
+      end
+    end
+  end
+
+  context "when the tax year is 2012" do
+    setup do
+      @outcome = @flow.node(:results)
+      @calculator = SmartAnswer::Calculators::ChildBenefitTaxCalculator.new(
+        tax_year: "2012",
+        children_count: 4,
+      )
+
+      @calculator.stubs(calculate_adjusted_net_income: SmartAnswer::Money.new(60_000))
+      @state = SmartAnswer::State.new(@outcome)
+      @state.calculator = @calculator
+      @presenter = OutcomePresenter.new(@outcome, nil, @state)
+      @body = @presenter.body
+    end
+
+    should "give the dates the benefit is received for" do
+      assert_match "Received between 7 January and 5 April 2013.", @body
+    end
+
+    should "give the dates the tax is applied to" do
+      assert_match "The tax charge only applies to the Child Benefit received between 7 January and 5 April 2013", @body
+    end
+
+    should "state that this is only for part of the tax year" do
+      assert_match "Your result for the next tax year may be higher because the tax charge will apply to the whole tax year", @body
+    end
+  end
+
+private
+
+  def values_vs_labels(options)
+    options.each_with_object({}) { |o, h| h[o[:value]] = o[:label]; }
   end
 end

--- a/test/unit/smart_answer_flows/estimate_self_assessment_penalties_flow_test.rb
+++ b/test/unit/smart_answer_flows/estimate_self_assessment_penalties_flow_test.rb
@@ -3,84 +3,82 @@ require_relative "flow_unit_test_helper"
 
 require "smart_answer_flows/estimate-self-assessment-penalties"
 
-module SmartAnswer
-  class EstimateSelfAssessmentPenaltiesFlowTest < ActiveSupport::TestCase
-    include FlowUnitTestHelper
+class EstimateSelfAssessmentPenaltiesFlowTest < ActiveSupport::TestCase
+  include FlowUnitTestHelper
 
+  setup do
+    @calculator = SmartAnswer::Calculators::SelfAssessmentPenalties.new
+    @flow = EstimateSelfAssessmentPenaltiesFlow.build
+  end
+
+  context "when answering when_submitted? question" do
     setup do
-      @calculator = Calculators::SelfAssessmentPenalties.new
-      @flow = EstimateSelfAssessmentPenaltiesFlow.build
+      @calculator.stubs(:valid_filing_date?).returns(true)
+      setup_states_for_question(
+        :when_submitted?,
+        responding_with: "2017-05-01",
+        initial_state: { calculator: @calculator },
+      )
     end
 
-    context "when answering when_submitted? question" do
+    should "store parsed response on calculator as filing_date" do
+      assert_equal Date.parse("2017-05-01"), @calculator.filing_date
+    end
+
+    should "go to when_paid? question" do
+      assert_equal :when_paid?, @new_state.current_node_name
+      assert_node_exists :when_paid?
+    end
+
+    context "responding with an invalid response" do
       setup do
-        @calculator.stubs(:valid_filing_date?).returns(true)
-        setup_states_for_question(
-          :when_submitted?,
-          responding_with: "2017-05-01",
-          initial_state: { calculator: @calculator },
-        )
+        @calculator.stubs(:valid_filing_date?).returns(false)
       end
 
-      should "store parsed response on calculator as filing_date" do
-        assert_equal Date.parse("2017-05-01"), @calculator.filing_date
-      end
-
-      should "go to when_paid? question" do
-        assert_equal :when_paid?, @new_state.current_node_name
-        assert_node_exists :when_paid?
-      end
-
-      context "responding with an invalid response" do
-        setup do
-          @calculator.stubs(:valid_filing_date?).returns(false)
-        end
-
-        should "raise an exception" do
-          assert_raise(SmartAnswer::InvalidResponse) do
-            setup_states_for_question(
-              :when_submitted?,
-              responding_with: "2017-05-01",
-              initial_state: { calculator: @calculator },
-            )
-          end
+      should "raise an exception" do
+        assert_raise(SmartAnswer::InvalidResponse) do
+          setup_states_for_question(
+            :when_submitted?,
+            responding_with: "2017-05-01",
+            initial_state: { calculator: @calculator },
+          )
         end
       end
     end
+  end
 
-    context "when answering when_paid? question" do
+  context "when answering when_paid? question" do
+    setup do
+      @calculator.stubs(:paid_on_time?).returns(true)
+      @calculator.stubs(:valid_payment_date?).returns(true)
+      setup_states_for_question(
+        :when_paid?,
+        responding_with: "2017-05-01",
+        initial_state: { calculator: @calculator },
+      )
+    end
+
+    should "store parsed response on calculator as payment_date" do
+      assert_equal Date.parse("2017-05-01"), @calculator.payment_date
+    end
+
+    should "go to filed_and_paid_on_time outcome" do
+      assert_equal :filed_and_paid_on_time, @new_state.current_node_name
+      assert_node_exists :filed_and_paid_on_time
+    end
+
+    context "responding with an invalid response" do
       setup do
-        @calculator.stubs(:paid_on_time?).returns(true)
-        @calculator.stubs(:valid_payment_date?).returns(true)
-        setup_states_for_question(
-          :when_paid?,
-          responding_with: "2017-05-01",
-          initial_state: { calculator: @calculator },
-        )
+        @calculator.stubs(:valid_payment_date?).returns(false)
       end
 
-      should "store parsed response on calculator as payment_date" do
-        assert_equal Date.parse("2017-05-01"), @calculator.payment_date
-      end
-
-      should "go to filed_and_paid_on_time outcome" do
-        assert_equal :filed_and_paid_on_time, @new_state.current_node_name
-        assert_node_exists :filed_and_paid_on_time
-      end
-
-      context "responding with an invalid response" do
-        setup do
-          @calculator.stubs(:valid_payment_date?).returns(false)
-        end
-
-        should "raise an exception" do
-          assert_raise(SmartAnswer::InvalidResponse) do
-            setup_states_for_question(
-              :when_paid?,
-              responding_with: "2017-05-01",
-              initial_state: { calculator: @calculator },
-            )
-          end
+      should "raise an exception" do
+        assert_raise(SmartAnswer::InvalidResponse) do
+          setup_states_for_question(
+            :when_paid?,
+            responding_with: "2017-05-01",
+            initial_state: { calculator: @calculator },
+          )
         end
       end
     end

--- a/test/unit/smart_answer_flows/estimate_self_assessment_penalties_flow_test.rb
+++ b/test/unit/smart_answer_flows/estimate_self_assessment_penalties_flow_test.rb
@@ -1,8 +1,6 @@
 require_relative "../../test_helper"
 require_relative "flow_unit_test_helper"
 
-require "smart_answer_flows/estimate-self-assessment-penalties"
-
 class EstimateSelfAssessmentPenaltiesFlowTest < ActiveSupport::TestCase
   include FlowUnitTestHelper
 

--- a/test/unit/smart_answer_flows/flow_unit_test_helper.rb
+++ b/test/unit/smart_answer_flows/flow_unit_test_helper.rb
@@ -1,21 +1,19 @@
-module SmartAnswer
-  module FlowUnitTestHelper
-    def setup_states_for_question(key, responding_with:, initial_state: {})
-      @question = @flow.node(key)
-      @state = SmartAnswer::State.new(@question)
-      initial_state.each do |variable, value|
-        @state.send("#{variable}=", value)
-      end
-      @new_state = @question.transition(@state, responding_with)
+module FlowUnitTestHelper
+  def setup_states_for_question(key, responding_with:, initial_state: {})
+    @question = @flow.node(key)
+    @state = SmartAnswer::State.new(@question)
+    initial_state.each do |variable, value|
+      @state.send("#{variable}=", value)
     end
+    @new_state = @question.transition(@state, responding_with)
+  end
 
-    def assert_node_exists(key)
-      assert @flow.node_exists?(key), "Node #{key} does not exist."
-    end
+  def assert_node_exists(key)
+    assert @flow.node_exists?(key), "Node #{key} does not exist."
+  end
 
-    def assert_node_has_name(name, node, belongs_to_another_flow: false)
-      assert_equal(name, node.current_node_name)
-      assert_node_exists(name) unless belongs_to_another_flow
-    end
+  def assert_node_has_name(name, node, belongs_to_another_flow: false)
+    assert_equal(name, node.current_node_name)
+    assert_node_exists(name) unless belongs_to_another_flow
   end
 end

--- a/test/unit/smart_answer_flows/marriage_abroad_flow_test.rb
+++ b/test/unit/smart_answer_flows/marriage_abroad_flow_test.rb
@@ -1,8 +1,6 @@
 require_relative "../../test_helper"
 require_relative "flow_unit_test_helper"
 
-require "smart_answer_flows/marriage-abroad"
-
 class MarriageAbroadFlowTest < ActiveSupport::TestCase
   include FlowUnitTestHelper
 

--- a/test/unit/smart_answer_flows/marriage_abroad_flow_test.rb
+++ b/test/unit/smart_answer_flows/marriage_abroad_flow_test.rb
@@ -3,117 +3,115 @@ require_relative "flow_unit_test_helper"
 
 require "smart_answer_flows/marriage-abroad"
 
-module SmartAnswer
-  class MarriageAbroadFlowTest < ActiveSupport::TestCase
-    include FlowUnitTestHelper
+class MarriageAbroadFlowTest < ActiveSupport::TestCase
+  include FlowUnitTestHelper
 
+  setup do
+    @calculator = SmartAnswer::Calculators::MarriageAbroadCalculator.new
+    @flow = MarriageAbroadFlow.build
+    stub_worldwide_api_has_locations(%w[afghanistan])
+  end
+
+  should "start with the country_of_ceremony? question" do
+    assert_equal :country_of_ceremony?, @flow.questions.first.name
+  end
+
+  context "when answering country_of_ceremony? question" do
     setup do
-      @calculator = Calculators::MarriageAbroadCalculator.new
-      @flow = MarriageAbroadFlow.build
-      stub_worldwide_api_has_locations(%w[afghanistan])
+      SmartAnswer::Calculators::MarriageAbroadCalculator.stubs(:new).returns(@calculator)
+      setup_states_for_question(
+        :country_of_ceremony?,
+        responding_with: "afghanistan",
+      )
     end
 
-    should "start with the country_of_ceremony? question" do
-      assert_equal :country_of_ceremony?, @flow.questions.first.name
+    should "instantiate and store calculator" do
+      assert_same @calculator, @new_state.calculator
     end
 
-    context "when answering country_of_ceremony? question" do
+    should "store parsed response on calculator as ceremony_country" do
+      assert_equal "afghanistan", @calculator.ceremony_country
+    end
+
+    context "responding with an invalid ceremony country" do
       setup do
-        Calculators::MarriageAbroadCalculator.stubs(:new).returns(@calculator)
-        setup_states_for_question(
-          :country_of_ceremony?,
-          responding_with: "afghanistan",
-        )
+        @calculator.stubs(:valid_ceremony_country?).returns(false)
       end
 
-      should "instantiate and store calculator" do
-        assert_same @calculator, @new_state.calculator
-      end
-
-      should "store parsed response on calculator as ceremony_country" do
-        assert_equal "afghanistan", @calculator.ceremony_country
-      end
-
-      context "responding with an invalid ceremony country" do
-        setup do
-          @calculator.stubs(:valid_ceremony_country?).returns(false)
-        end
-
-        should "raise an exception" do
-          assert_raise(SmartAnswer::InvalidResponse) do
-            setup_states_for_question(
-              :country_of_ceremony?,
-              responding_with: "unknown-country",
-              initial_state: { calculator: @calculator },
-            )
-          end
+      should "raise an exception" do
+        assert_raise(SmartAnswer::InvalidResponse) do
+          setup_states_for_question(
+            :country_of_ceremony?,
+            responding_with: "unknown-country",
+            initial_state: { calculator: @calculator },
+          )
         end
       end
     end
+  end
 
-    context "when answering legal_residency? question" do
-      setup do
-        setup_states_for_question(
-          :legal_residency?,
-          responding_with: "uk",
-          initial_state: {
-            calculator: @calculator,
-          },
-        )
-      end
-
-      should "store parsed response on calculator as resident_of" do
-        assert_equal "uk", @calculator.instance_variable_get("@resident_of")
-      end
+  context "when answering legal_residency? question" do
+    setup do
+      setup_states_for_question(
+        :legal_residency?,
+        responding_with: "uk",
+        initial_state: {
+          calculator: @calculator,
+        },
+      )
     end
 
-    context "when answering what_is_your_partners_nationality? question" do
-      setup do
-        setup_states_for_question(
-          :what_is_your_partners_nationality?,
-          responding_with: "partner_british",
-          initial_state: {
-            calculator: @calculator,
-          },
-        )
-      end
+    should "store parsed response on calculator as resident_of" do
+      assert_equal "uk", @calculator.instance_variable_get("@resident_of")
+    end
+  end
 
-      should "store parsed response on calculator as partner_nationality" do
-        assert_equal "partner_british", @calculator.instance_variable_get("@partner_nationality")
-      end
+  context "when answering what_is_your_partners_nationality? question" do
+    setup do
+      setup_states_for_question(
+        :what_is_your_partners_nationality?,
+        responding_with: "partner_british",
+        initial_state: {
+          calculator: @calculator,
+        },
+      )
     end
 
-    context "when answering partner_opposite_or_same_sex? question" do
-      setup do
-        @calculator.ceremony_country = "france"
-        setup_states_for_question(
-          :partner_opposite_or_same_sex?,
-          responding_with: "same_sex",
-          initial_state: {
-            calculator: @calculator,
-          },
-        )
-      end
+    should "store parsed response on calculator as partner_nationality" do
+      assert_equal "partner_british", @calculator.instance_variable_get("@partner_nationality")
+    end
+  end
 
-      should "store parsed response on calculator as sex_of_your_partner" do
-        assert_equal "same_sex", @calculator.instance_variable_get("@sex_of_your_partner")
-      end
+  context "when answering partner_opposite_or_same_sex? question" do
+    setup do
+      @calculator.ceremony_country = "france"
+      setup_states_for_question(
+        :partner_opposite_or_same_sex?,
+        responding_with: "same_sex",
+        initial_state: {
+          calculator: @calculator,
+        },
+      )
     end
 
-    context "when answering marriage_or_pacs? question" do
-      setup do
-        setup_states_for_question(
-          :marriage_or_pacs?,
-          responding_with: "marriage",
-          initial_state: {
-            calculator: @calculator,
-          },
-        )
-      end
+    should "store parsed response on calculator as sex_of_your_partner" do
+      assert_equal "same_sex", @calculator.instance_variable_get("@sex_of_your_partner")
+    end
+  end
 
-      should "store parsed response on calculator as marriage_or_pacs" do
-        assert_equal "marriage", @calculator.instance_variable_get("@marriage_or_pacs")
-      end
+  context "when answering marriage_or_pacs? question" do
+    setup do
+      setup_states_for_question(
+        :marriage_or_pacs?,
+        responding_with: "marriage",
+        initial_state: {
+          calculator: @calculator,
+        },
+      )
+    end
+
+    should "store parsed response on calculator as marriage_or_pacs" do
+      assert_equal "marriage", @calculator.instance_variable_get("@marriage_or_pacs")
     end
   end
 end

--- a/test/unit/smart_answer_flows/part_year_profit_tax_credits_flow_test.rb
+++ b/test/unit/smart_answer_flows/part_year_profit_tax_credits_flow_test.rb
@@ -3,115 +3,124 @@ require_relative "flow_unit_test_helper"
 
 require "smart_answer_flows/part-year-profit-tax-credits"
 
-module SmartAnswer
-  class PartYearProfitTaxCreditsFlowTest < ActiveSupport::TestCase
-    include FlowUnitTestHelper
+class PartYearProfitTaxCreditsFlowTest < ActiveSupport::TestCase
+  include FlowUnitTestHelper
 
+  setup do
+    @calculator = SmartAnswer::Calculators::PartYearProfitTaxCreditsCalculator.new
+    @flow = PartYearProfitTaxCreditsFlow.build
+  end
+
+  should "start when_did_your_tax_credits_award_end? question" do
+    assert_equal :when_did_your_tax_credits_award_end?, @flow.questions.first.name
+  end
+
+  context "when answering when_did_your_tax_credits_award_end? question" do
     setup do
-      @calculator = Calculators::PartYearProfitTaxCreditsCalculator.new
-      @flow = PartYearProfitTaxCreditsFlow.build
+      SmartAnswer::Calculators::PartYearProfitTaxCreditsCalculator.stubs(:new).returns(@calculator)
+      setup_states_for_question(
+        :when_did_your_tax_credits_award_end?,
+        responding_with: "2016-02-20",
+      )
     end
 
-    should "start when_did_your_tax_credits_award_end? question" do
-      assert_equal :when_did_your_tax_credits_award_end?, @flow.questions.first.name
+    should "instantiate and store calculator" do
+      assert_same @calculator, @new_state.calculator
     end
 
-    context "when answering when_did_your_tax_credits_award_end? question" do
+    should "set the from date of the date select to the constant defined in the calculator" do
+      expected = SmartAnswer::Calculators::PartYearProfitTaxCreditsCalculator::TAX_CREDITS_AWARD_ENDS_EARLIEST_DATE
+      assert_equal expected, @question.range.begin
+    end
+
+    should "set the to date of the date select to the constant defined in the calculator" do
+      expected = SmartAnswer::Calculators::PartYearProfitTaxCreditsCalculator::TAX_CREDITS_AWARD_ENDS_LATEST_DATE
+      assert_equal expected, @question.range.end
+    end
+
+    should "store parsed response on calculator as tax_credits_award_ends_on" do
+      assert_equal Date.parse("2016-02-20"), @calculator.tax_credits_award_ends_on
+    end
+
+    should "go to what_date_do_your_accounts_go_up_to? question" do
+      assert_equal :what_date_do_your_accounts_go_up_to?, @new_state.current_node_name
+      assert_node_exists :what_date_do_your_accounts_go_up_to?
+    end
+  end
+
+  context "when answering what_date_do_your_accounts_go_up_to? question" do
+    setup do
+      setup_states_for_question(
+        :what_date_do_your_accounts_go_up_to?,
+        responding_with: "0000-04-06",
+        initial_state: { calculator: @calculator },
+      )
+    end
+
+    should "store parsed response on calculator as accounts_end_month_and_day" do
+      assert_equal Date.parse("0000-04-06"), @calculator.accounts_end_month_and_day
+    end
+
+    should "go to have_you_stopped_trading? question" do
+      assert_equal :have_you_stopped_trading?, @new_state.current_node_name
+      assert_node_exists :have_you_stopped_trading?
+    end
+  end
+
+  context "when answering have_you_stopped_trading? question" do
+    context "responding with yes" do
       setup do
-        Calculators::PartYearProfitTaxCreditsCalculator.stubs(:new).returns(@calculator)
         setup_states_for_question(
-          :when_did_your_tax_credits_award_end?,
-          responding_with: "2016-02-20",
-        )
-      end
-
-      should "instantiate and store calculator" do
-        assert_same @calculator, @new_state.calculator
-      end
-
-      should "set the from date of the date select to the constant defined in the calculator" do
-        expected = Calculators::PartYearProfitTaxCreditsCalculator::TAX_CREDITS_AWARD_ENDS_EARLIEST_DATE
-        assert_equal expected, @question.range.begin
-      end
-
-      should "set the to date of the date select to the constant defined in the calculator" do
-        expected = Calculators::PartYearProfitTaxCreditsCalculator::TAX_CREDITS_AWARD_ENDS_LATEST_DATE
-        assert_equal expected, @question.range.end
-      end
-
-      should "store parsed response on calculator as tax_credits_award_ends_on" do
-        assert_equal Date.parse("2016-02-20"), @calculator.tax_credits_award_ends_on
-      end
-
-      should "go to what_date_do_your_accounts_go_up_to? question" do
-        assert_equal :what_date_do_your_accounts_go_up_to?, @new_state.current_node_name
-        assert_node_exists :what_date_do_your_accounts_go_up_to?
-      end
-    end
-
-    context "when answering what_date_do_your_accounts_go_up_to? question" do
-      setup do
-        setup_states_for_question(
-          :what_date_do_your_accounts_go_up_to?,
-          responding_with: "0000-04-06",
+          :have_you_stopped_trading?,
+          responding_with: "yes",
           initial_state: { calculator: @calculator },
         )
       end
 
-      should "store parsed response on calculator as accounts_end_month_and_day" do
-        assert_equal Date.parse("0000-04-06"), @calculator.accounts_end_month_and_day
+      should "set stopped_trading to true on the calculator" do
+        assert_equal true, @calculator.stopped_trading
       end
 
-      should "go to have_you_stopped_trading? question" do
-        assert_equal :have_you_stopped_trading?, @new_state.current_node_name
-        assert_node_exists :have_you_stopped_trading?
-      end
-    end
-
-    context "when answering have_you_stopped_trading? question" do
-      context "responding with yes" do
-        setup do
-          setup_states_for_question(
-            :have_you_stopped_trading?,
-            responding_with: "yes",
-            initial_state: { calculator: @calculator },
-          )
-        end
-
-        should "set stopped_trading to true on the calculator" do
-          assert_equal true, @calculator.stopped_trading
-        end
-
-        should "go to did_you_start_trading_before_the_relevant_accounting_year? question" do
-          assert_equal :did_you_start_trading_before_the_relevant_accounting_year?, @new_state.current_node_name
-          assert_node_exists :did_you_start_trading_before_the_relevant_accounting_year?
-        end
-      end
-
-      context "responding with no" do
-        setup do
-          setup_states_for_question(
-            :have_you_stopped_trading?,
-            responding_with: "no",
-            initial_state: { calculator: @calculator },
-          )
-        end
-
-        should "set stopped_trading to false on the calculator" do
-          assert_equal false, @calculator.stopped_trading
-        end
-
-        should "go to do_your_accounts_cover_a_12_month_period? question" do
-          assert_equal :do_your_accounts_cover_a_12_month_period?, @new_state.current_node_name
-          assert_node_exists :do_your_accounts_cover_a_12_month_period?
-        end
+      should "go to did_you_start_trading_before_the_relevant_accounting_year? question" do
+        assert_equal :did_you_start_trading_before_the_relevant_accounting_year?, @new_state.current_node_name
+        assert_node_exists :did_you_start_trading_before_the_relevant_accounting_year?
       end
     end
 
-    context "when answering did_you_start_trading_before_the_relevant_accounting_year? question" do
+    context "responding with no" do
       setup do
-        accounting_year = YearRange.new(begins_on: Date.parse("2015-04-06"))
-        @calculator.stubs(accounting_year: accounting_year)
+        setup_states_for_question(
+          :have_you_stopped_trading?,
+          responding_with: "no",
+          initial_state: { calculator: @calculator },
+        )
+      end
+
+      should "set stopped_trading to false on the calculator" do
+        assert_equal false, @calculator.stopped_trading
+      end
+
+      should "go to do_your_accounts_cover_a_12_month_period? question" do
+        assert_equal :do_your_accounts_cover_a_12_month_period?, @new_state.current_node_name
+        assert_node_exists :do_your_accounts_cover_a_12_month_period?
+      end
+    end
+  end
+
+  context "when answering did_you_start_trading_before_the_relevant_accounting_year? question" do
+    setup do
+      accounting_year = SmartAnswer::YearRange.new(begins_on: Date.parse("2015-04-06"))
+      @calculator.stubs(accounting_year: accounting_year)
+      question = :did_you_start_trading_before_the_relevant_accounting_year?
+      setup_states_for_question(
+        question,
+        responding_with: "yes",
+        initial_state: { calculator: @calculator },
+      )
+    end
+
+    context "responding with yes" do
+      setup do
         question = :did_you_start_trading_before_the_relevant_accounting_year?
         setup_states_for_question(
           question,
@@ -120,220 +129,209 @@ module SmartAnswer
         )
       end
 
-      context "responding with yes" do
-        setup do
-          question = :did_you_start_trading_before_the_relevant_accounting_year?
-          setup_states_for_question(
-            question,
-            responding_with: "yes",
-            initial_state: { calculator: @calculator },
-          )
-        end
-
-        should "go to when_did_you_stop_trading? question" do
-          assert_equal :when_did_you_stop_trading?, @new_state.current_node_name
-          assert_node_exists :when_did_you_stop_trading?
-        end
-      end
-
-      context "responding with no" do
-        setup do
-          question = :did_you_start_trading_before_the_relevant_accounting_year?
-          setup_states_for_question(
-            question,
-            responding_with: "no",
-            initial_state: { calculator: @calculator },
-          )
-        end
-
-        should "go to when_did_you_start_trading question" do
-          assert_equal :when_did_you_start_trading?, @new_state.current_node_name
-          assert_node_exists :when_did_you_start_trading?
-        end
+      should "go to when_did_you_stop_trading? question" do
+        assert_equal :when_did_you_stop_trading?, @new_state.current_node_name
+        assert_node_exists :when_did_you_stop_trading?
       end
     end
 
-    context "when answering when_did_you_start_trading? question" do
+    context "responding with no" do
       setup do
-        award_period = DateRange.new(
-          begins_on: Date.parse("2015-04-06"),
-          ends_on: Date.parse("2015-08-01"),
+        question = :did_you_start_trading_before_the_relevant_accounting_year?
+        setup_states_for_question(
+          question,
+          responding_with: "no",
+          initial_state: { calculator: @calculator },
         )
-        @calculator.stubs(:award_period).returns(award_period)
+      end
+
+      should "go to when_did_you_start_trading question" do
+        assert_equal :when_did_you_start_trading?, @new_state.current_node_name
+        assert_node_exists :when_did_you_start_trading?
+      end
+    end
+  end
+
+  context "when answering when_did_you_start_trading? question" do
+    setup do
+      award_period = SmartAnswer::DateRange.new(
+        begins_on: Date.parse("2015-04-06"),
+        ends_on: Date.parse("2015-08-01"),
+      )
+      @calculator.stubs(:award_period).returns(award_period)
+      setup_states_for_question(
+        :when_did_you_start_trading?,
+        responding_with: "2015-02-01",
+        initial_state: { calculator: @calculator },
+      )
+    end
+
+    should "set the from date of the date select to constant defined in the calculator" do
+      expected = SmartAnswer::Calculators::PartYearProfitTaxCreditsCalculator::START_OR_STOP_TRADING_EARLIEST_DATE
+      assert_equal expected, @question.range.begin
+    end
+
+    should "set the to date of the date select to the constant defined in the calculator" do
+      expected = SmartAnswer::Calculators::PartYearProfitTaxCreditsCalculator::START_OR_STOP_TRADING_LATEST_DATE
+      assert_equal expected, @question.range.end
+    end
+
+    should "store parsed response on calculator as started_trading_on" do
+      assert_equal Date.parse("2015-02-01"), @calculator.started_trading_on
+    end
+
+    context "responding with an invalid start trading date" do
+      setup do
+        @calculator.stubs(:valid_start_trading_date?).returns(false)
+      end
+
+      should "raise an exception" do
+        exception = assert_raise(SmartAnswer::InvalidResponse) do
+          setup_states_for_question(
+            :when_did_you_start_trading?,
+            responding_with: "0000-01-01",
+            initial_state: { calculator: @calculator },
+          )
+        end
+        assert_equal "error_invalid_start_trading_date", exception.message
+      end
+    end
+
+    context "and the business has stopped trading" do
+      setup do
+        @calculator.stopped_trading = true
         setup_states_for_question(
           :when_did_you_start_trading?,
-          responding_with: "2015-02-01",
+          responding_with: "0000-01-01",
           initial_state: { calculator: @calculator },
         )
       end
 
-      should "set the from date of the date select to constant defined in the calculator" do
-        expected = Calculators::PartYearProfitTaxCreditsCalculator::START_OR_STOP_TRADING_EARLIEST_DATE
-        assert_equal expected, @question.range.begin
-      end
-
-      should "set the to date of the date select to the constant defined in the calculator" do
-        expected = Calculators::PartYearProfitTaxCreditsCalculator::START_OR_STOP_TRADING_LATEST_DATE
-        assert_equal expected, @question.range.end
-      end
-
-      should "store parsed response on calculator as started_trading_on" do
-        assert_equal Date.parse("2015-02-01"), @calculator.started_trading_on
-      end
-
-      context "responding with an invalid start trading date" do
-        setup do
-          @calculator.stubs(:valid_start_trading_date?).returns(false)
-        end
-
-        should "raise an exception" do
-          exception = assert_raise(SmartAnswer::InvalidResponse) do
-            setup_states_for_question(
-              :when_did_you_start_trading?,
-              responding_with: "0000-01-01",
-              initial_state: { calculator: @calculator },
-            )
-          end
-          assert_equal "error_invalid_start_trading_date", exception.message
-        end
-      end
-
-      context "and the business has stopped trading" do
-        setup do
-          @calculator.stopped_trading = true
-          setup_states_for_question(
-            :when_did_you_start_trading?,
-            responding_with: "0000-01-01",
-            initial_state: { calculator: @calculator },
-          )
-        end
-
-        should "go to when_did_you_stop_trading? question" do
-          assert_equal :when_did_you_stop_trading?, @new_state.current_node_name
-          assert_node_exists :when_did_you_stop_trading?
-        end
-      end
-
-      context "and the business is still trading" do
-        setup do
-          @calculator.stopped_trading = false
-          setup_states_for_question(
-            :when_did_you_start_trading?,
-            responding_with: "0000-01-01",
-            initial_state: { calculator: @calculator },
-          )
-        end
-
-        should "go to when_did_you_stop_trading? question" do
-          assert_equal :what_is_your_taxable_profit?, @new_state.current_node_name
-          assert_node_exists :what_is_your_taxable_profit?
-        end
+      should "go to when_did_you_stop_trading? question" do
+        assert_equal :when_did_you_stop_trading?, @new_state.current_node_name
+        assert_node_exists :when_did_you_stop_trading?
       end
     end
 
-    context "when answering when_did_you_stop_trading? question" do
+    context "and the business is still trading" do
       setup do
-        tax_year = YearRange.tax_year.starting_in(2015)
-        @calculator.stubs(tax_year: tax_year)
+        @calculator.stopped_trading = false
         setup_states_for_question(
-          :when_did_you_stop_trading?,
-          responding_with: "2015-06-01",
+          :when_did_you_start_trading?,
+          responding_with: "0000-01-01",
           initial_state: { calculator: @calculator },
         )
       end
 
-      should "set the from date of the date select to the constant defined in the calculator" do
-        expected = Calculators::PartYearProfitTaxCreditsCalculator::START_OR_STOP_TRADING_EARLIEST_DATE
-        assert_equal expected, @question.range.begin
+      should "go to when_did_you_stop_trading? question" do
+        assert_equal :what_is_your_taxable_profit?, @new_state.current_node_name
+        assert_node_exists :what_is_your_taxable_profit?
+      end
+    end
+  end
+
+  context "when answering when_did_you_stop_trading? question" do
+    setup do
+      tax_year = SmartAnswer::YearRange.tax_year.starting_in(2015)
+      @calculator.stubs(tax_year: tax_year)
+      setup_states_for_question(
+        :when_did_you_stop_trading?,
+        responding_with: "2015-06-01",
+        initial_state: { calculator: @calculator },
+      )
+    end
+
+    should "set the from date of the date select to the constant defined in the calculator" do
+      expected = SmartAnswer::Calculators::PartYearProfitTaxCreditsCalculator::START_OR_STOP_TRADING_EARLIEST_DATE
+      assert_equal expected, @question.range.begin
+    end
+
+    should "set the to date of the date select to the constant defined in the calculator" do
+      expected = SmartAnswer::Calculators::PartYearProfitTaxCreditsCalculator::START_OR_STOP_TRADING_LATEST_DATE
+      assert_equal expected, @question.range.end
+    end
+
+    should "store parsed response on calculator as stopped_trading_on" do
+      assert_equal Date.parse("2015-06-01"), @calculator.stopped_trading_on
+    end
+
+    should "go to what_is_your_taxable_profit? question" do
+      assert_equal :what_is_your_taxable_profit?, @new_state.current_node_name
+      assert_node_exists :what_is_your_taxable_profit?
+    end
+
+    context "responding with an invalid stopped trading date" do
+      setup do
+        @calculator.stubs(:valid_stopped_trading_date?).returns(false)
       end
 
-      should "set the to date of the date select to the constant defined in the calculator" do
-        expected = Calculators::PartYearProfitTaxCreditsCalculator::START_OR_STOP_TRADING_LATEST_DATE
-        assert_equal expected, @question.range.end
+      should "raise an exception" do
+        exception = assert_raise(SmartAnswer::InvalidResponse) do
+          setup_states_for_question(
+            :when_did_you_stop_trading?,
+            responding_with: "0000-01-01",
+            initial_state: { calculator: @calculator },
+          )
+        end
+        assert_equal "error_not_in_tax_year", exception.message
       end
+    end
+  end
 
-      should "store parsed response on calculator as stopped_trading_on" do
-        assert_equal Date.parse("2015-06-01"), @calculator.stopped_trading_on
+  context "when answering do_your_accounts_cover_a_12_month_period? question" do
+    context "responding with yes" do
+      setup do
+        accounting_year = SmartAnswer::YearRange.new(begins_on: Date.parse("2015-01-01"))
+        @calculator.stubs(:accounting_year).returns(accounting_year)
+        setup_states_for_question(
+          :do_your_accounts_cover_a_12_month_period?,
+          responding_with: "yes",
+          initial_state: { calculator: @calculator },
+        )
       end
 
       should "go to what_is_your_taxable_profit? question" do
         assert_equal :what_is_your_taxable_profit?, @new_state.current_node_name
         assert_node_exists :what_is_your_taxable_profit?
       end
-
-      context "responding with an invalid stopped trading date" do
-        setup do
-          @calculator.stubs(:valid_stopped_trading_date?).returns(false)
-        end
-
-        should "raise an exception" do
-          exception = assert_raise(SmartAnswer::InvalidResponse) do
-            setup_states_for_question(
-              :when_did_you_stop_trading?,
-              responding_with: "0000-01-01",
-              initial_state: { calculator: @calculator },
-            )
-          end
-          assert_equal "error_not_in_tax_year", exception.message
-        end
-      end
     end
 
-    context "when answering do_your_accounts_cover_a_12_month_period? question" do
-      context "responding with yes" do
-        setup do
-          accounting_year = YearRange.new(begins_on: Date.parse("2015-01-01"))
-          @calculator.stubs(:accounting_year).returns(accounting_year)
-          setup_states_for_question(
-            :do_your_accounts_cover_a_12_month_period?,
-            responding_with: "yes",
-            initial_state: { calculator: @calculator },
-          )
-        end
-
-        should "go to what_is_your_taxable_profit? question" do
-          assert_equal :what_is_your_taxable_profit?, @new_state.current_node_name
-          assert_node_exists :what_is_your_taxable_profit?
-        end
-      end
-
-      context "responding with no" do
-        setup do
-          accounting_year = YearRange.new(begins_on: Date.parse("2015-01-01"))
-          @calculator.stubs(:accounting_year).returns(accounting_year)
-          setup_states_for_question(
-            :do_your_accounts_cover_a_12_month_period?,
-            responding_with: "no",
-            initial_state: { calculator: @calculator },
-          )
-        end
-
-        should "go to when_did_you_start_trading question" do
-          assert_equal :when_did_you_start_trading?, @new_state.current_node_name
-          assert_node_exists :when_did_you_start_trading?
-        end
-      end
-    end
-
-    context "when answering what_is_your_taxable_profit? question" do
+    context "responding with no" do
       setup do
-        basis_period = YearRange.new(begins_on: Date.parse("2015-04-06"))
-        @calculator.stubs(basis_period: basis_period)
+        accounting_year = SmartAnswer::YearRange.new(begins_on: Date.parse("2015-01-01"))
+        @calculator.stubs(:accounting_year).returns(accounting_year)
         setup_states_for_question(
-          :what_is_your_taxable_profit?,
-          responding_with: "15000",
+          :do_your_accounts_cover_a_12_month_period?,
+          responding_with: "no",
           initial_state: { calculator: @calculator },
         )
       end
 
-      should "store parsed response on calculator as taxable_profit" do
-        assert_equal SmartAnswer::Money.new(15_000), @calculator.taxable_profit
+      should "go to when_did_you_start_trading question" do
+        assert_equal :when_did_you_start_trading?, @new_state.current_node_name
+        assert_node_exists :when_did_you_start_trading?
       end
+    end
+  end
 
-      should "go to result outcome" do
-        assert_equal :result, @new_state.current_node_name
-        assert_node_exists :result
-      end
+  context "when answering what_is_your_taxable_profit? question" do
+    setup do
+      basis_period = SmartAnswer::YearRange.new(begins_on: Date.parse("2015-04-06"))
+      @calculator.stubs(basis_period: basis_period)
+      setup_states_for_question(
+        :what_is_your_taxable_profit?,
+        responding_with: "15000",
+        initial_state: { calculator: @calculator },
+      )
+    end
+
+    should "store parsed response on calculator as taxable_profit" do
+      assert_equal SmartAnswer::Money.new(15_000), @calculator.taxable_profit
+    end
+
+    should "go to result outcome" do
+      assert_equal :result, @new_state.current_node_name
+      assert_node_exists :result
     end
   end
 end

--- a/test/unit/smart_answer_flows/part_year_profit_tax_credits_flow_test.rb
+++ b/test/unit/smart_answer_flows/part_year_profit_tax_credits_flow_test.rb
@@ -1,8 +1,6 @@
 require_relative "../../test_helper"
 require_relative "flow_unit_test_helper"
 
-require "smart_answer_flows/part-year-profit-tax-credits"
-
 class PartYearProfitTaxCreditsFlowTest < ActiveSupport::TestCase
   include FlowUnitTestHelper
 

--- a/test/unit/smart_answer_flows/part_year_profit_tax_credits_view_test.rb
+++ b/test/unit/smart_answer_flows/part_year_profit_tax_credits_view_test.rb
@@ -2,249 +2,247 @@ require_relative "../../test_helper"
 
 require "smart_answer_flows/part-year-profit-tax-credits"
 
-module SmartAnswer
-  class PartYearProfitTaxCreditsViewTest < ActiveSupport::TestCase
+class PartYearProfitTaxCreditsViewTest < ActiveSupport::TestCase
+  setup do
+    @flow = PartYearProfitTaxCreditsFlow.build
+  end
+
+  context "when rendering when_did_your_tax_credits_award_end? question" do
     setup do
-      @flow = PartYearProfitTaxCreditsFlow.build
+      question = @flow.node(:when_did_your_tax_credits_award_end?)
+      @state = SmartAnswer::State.new(question)
+      @presenter = QuestionPresenter.new(question, nil, @state)
     end
 
-    context "when rendering when_did_your_tax_credits_award_end? question" do
+    should "have a default error message" do
+      @state.error = "error-message"
+      assert_equal "You need to enter a date to continue.", @presenter.error
+    end
+  end
+
+  context "when rendering what_date_do_your_accounts_go_up_to? question" do
+    setup do
+      question = @flow.node(:what_date_do_your_accounts_go_up_to?)
+      @state = SmartAnswer::State.new(question)
+      @presenter = QuestionPresenter.new(question, nil, @state)
+    end
+
+    should "have a default error message" do
+      @state.error = "error-message"
+      assert_equal "You need to enter a date to continue.", @presenter.error
+    end
+  end
+
+  context "when rendering have_you_stopped_trading? question" do
+    setup do
+      question = @flow.node(:have_you_stopped_trading?)
+      @state = SmartAnswer::State.new(question)
+      @presenter = RadioQuestionPresenter.new(question, nil, @state)
+    end
+
+    should "have options with labels" do
+      assert_equal({ "yes" => "Yes", "no" => "No" }, values_vs_labels(@presenter.options))
+    end
+
+    should "have a default error message" do
+      @state.error = "error-message"
+      assert_equal "You need to select yes or no to continue.", @presenter.error
+    end
+  end
+
+  context "when rendering do_your_accounts_cover_a_12_month_period? question" do
+    setup do
+      question = @flow.node(:do_your_accounts_cover_a_12_month_period?)
+      @state = SmartAnswer::State.new(question)
+      @state.accounting_year_ends_on = Date.parse("2016-04-05")
+      calculator_options = {
+        accounting_year: stub(ends_on: Date.parse("2016-04-05")),
+      }
+      @calculator = stub("calculator", calculator_options)
+      @state.calculator = @calculator
+      @presenter = RadioQuestionPresenter.new(question, nil, @state)
+    end
+
+    should "display title with interpolated basis_period_ends_on" do
+      expected = "Do your accounts cover the 12 month period up to  5 April 2016?"
+      assert_equal expected, @presenter.title
+    end
+
+    should "have options with labels" do
+      assert_equal({ "yes" => "Yes", "no" => "No" }, values_vs_labels(@presenter.options))
+    end
+
+    should "have a default error message" do
+      @state.error = "error-message"
+      assert_equal "You need to select yes or no to continue.", @presenter.error
+    end
+  end
+
+  context "when rendering what_is_your_taxable_profit? question" do
+    setup do
+      question = @flow.node(:what_is_your_taxable_profit?)
+      @state = SmartAnswer::State.new(question)
+      calculator_options = {
+        basis_period: stub(begins_on: Date.parse("2015-04-06"), ends_on: Date.parse("2016-04-05")),
+      }
+      @calculator = stub("calculator", calculator_options)
+      @state.calculator = @calculator
+      @presenter = QuestionPresenter.new(question, nil, @state)
+    end
+
+    should "display title with interpolated basis_period_begins_on and basis_period_ends_on" do
+      expected = "What is your actual or estimated taxable profit between  6 April 2015 and  5 April 2016?"
+      assert_equal expected, @presenter.title
+    end
+
+    should "have a default error message" do
+      @state.error = "error-message"
+      assert_equal "Enter your taxable profit.", @presenter.error
+    end
+  end
+
+  context "when rendering did_you_start_trading_before_the_relevant_accounting_year? question" do
+    setup do
+      question = @flow.node(:did_you_start_trading_before_the_relevant_accounting_year?)
+      @state = SmartAnswer::State.new(question)
+      calculator_options = {
+        accounting_year: stub(begins_on: Date.parse("2015-04-06")),
+      }
+      @calculator = stub("calculator", calculator_options)
+      @state.calculator = @calculator
+      @presenter = RadioQuestionPresenter.new(question, nil, @state)
+    end
+
+    should "have options with labels" do
+      assert_equal({ "yes" => "Yes", "no" => "No" }, values_vs_labels(@presenter.options))
+    end
+
+    should "have a default error message" do
+      @state.error = "error-message"
+      assert_equal "You need to select yes or no to continue.", @presenter.error
+    end
+
+    should "display title with interpolated accounting_year_begins_on" do
+      expected = "Did you start trading before  6 April 2015?"
+      assert_equal expected, @presenter.title
+    end
+  end
+
+  context "when rendering when_did_you_stop_trading? question" do
+    setup do
+      question = @flow.node(:when_did_you_stop_trading?)
+      @state = SmartAnswer::State.new(question)
+      calculator_options = {
+        tax_year: stub(begins_on: Date.parse("2015-04-06"), ends_on: Date.parse("2016-04-05")),
+      }
+      @calculator = stub("calculator", calculator_options)
+      @state.calculator = @calculator
+      @presenter = QuestionPresenter.new(question, nil, @state)
+    end
+
+    should "display hint with interpolated tax_year_begins_on and tax_year_ends_on" do
+      expected = "This date must be between  6 April 2015 and  5 April 2016"
+      assert_match expected, @presenter.hint
+    end
+
+    should "have a default error message" do
+      @state.error = "error-message"
+      assert_equal "You need to enter a date to continue.", @presenter.error
+    end
+
+    should "display a useful error message when an invalid date is entered" do
+      @state.error = "error_not_in_tax_year"
+      expected = "The date must be between  6 April 2015 and  5 April 2016."
+      assert_equal expected, @presenter.error
+    end
+  end
+
+  context "when rendering when_did_you_start_trading? question" do
+    setup do
+      question = @flow.node(:when_did_you_start_trading?)
+      @state = SmartAnswer::State.new(question)
+      calculator_options = {
+        award_period: stub(ends_on: Date.parse("2015-08-01")),
+      }
+      @calculator = stub("calculator", calculator_options)
+      @state.calculator = @calculator
+      @presenter = QuestionPresenter.new(question, nil, @state)
+    end
+
+    should "display hint with interpolated award_period_ends_on" do
+      expected = "This date must be before  1 August 2015."
+      assert_equal expected, @presenter.hint
+    end
+
+    should "have a default error message" do
+      @state.error = "error-message"
+      assert_equal "You need to enter a date to continue.", @presenter.error
+    end
+  end
+
+  context "when rendering the result outcome" do
+    setup do
+      @outcome = @flow.node(:result)
+      calculator_options = {
+        tax_credits_award_ends_on: Date.parse("2016-02-20"),
+        basis_period: SmartAnswer::YearRange.new(begins_on: Date.parse("2015-04-06")),
+        taxable_profit: SmartAnswer::Money.new(15_000),
+        award_period_taxable_profit: SmartAnswer::Money.new(13_154),
+        stopped_trading_on: nil,
+      }
+      @calculator = stub("calculator", calculator_options)
+      @calculator.responds_like_instance_of(SmartAnswer::Calculators::PartYearProfitTaxCreditsCalculator)
+      @state = SmartAnswer::State.new(@outcome)
+      @state.calculator = @calculator
+    end
+
+    context "common output" do
       setup do
-        question = @flow.node(:when_did_your_tax_credits_award_end?)
-        @state = SmartAnswer::State.new(question)
-        @presenter = QuestionPresenter.new(question, nil, @state)
+        presenter = OutcomePresenter.new(@outcome, nil, @state)
+        @body = presenter.body
       end
 
-      should "have a default error message" do
-        @state.error = "error-message"
-        assert_equal "You need to enter a date to continue.", @presenter.error
+      should "display award_period_taxable_profit" do
+        assert_match "Your part-year taxable profit is £13,154", @body
+      end
+
+      should "display tax_credits_award_ends_on" do
+        assert_match "Your tax credits award ended on: 20 February 2016", @body
+      end
+
+      should "display taxable_profit" do
+        assert_match "Your estimated taxable profit between  6 April 2015 and  5 April 2016 was: £15,000", @body
       end
     end
 
-    context "when rendering what_date_do_your_accounts_go_up_to? question" do
+    context "and the stopped_trading_on date is not set" do
       setup do
-        question = @flow.node(:what_date_do_your_accounts_go_up_to?)
-        @state = SmartAnswer::State.new(question)
-        @presenter = QuestionPresenter.new(question, nil, @state)
+        @calculator.stubs(stopped_trading_on: nil)
+        presenter = OutcomePresenter.new(@outcome, nil, @state)
+        @body = presenter.body
       end
 
-      should "have a default error message" do
-        @state.error = "error-message"
-        assert_equal "You need to enter a date to continue.", @presenter.error
+      should "display basis_period ends_on" do
+        assert_match "Your business accounts end on:  5 April 2016", @body
       end
     end
 
-    context "when rendering have_you_stopped_trading? question" do
+    context "and the stopped_trading_on date is set" do
       setup do
-        question = @flow.node(:have_you_stopped_trading?)
-        @state = SmartAnswer::State.new(question)
-        @presenter = RadioQuestionPresenter.new(question, nil, @state)
+        @calculator.stubs(stopped_trading_on: Date.parse("2016-04-05"))
+        presenter = OutcomePresenter.new(@outcome, nil, @state)
+        @body = presenter.body
       end
 
-      should "have options with labels" do
-        assert_equal({ "yes" => "Yes", "no" => "No" }, values_vs_labels(@presenter.options))
-      end
-
-      should "have a default error message" do
-        @state.error = "error-message"
-        assert_equal "You need to select yes or no to continue.", @presenter.error
+      should "display the date the business stopped trading" do
+        assert_match "Your business stopped trading on:  5 April 2016", @body
       end
     end
+  end
 
-    context "when rendering do_your_accounts_cover_a_12_month_period? question" do
-      setup do
-        question = @flow.node(:do_your_accounts_cover_a_12_month_period?)
-        @state = SmartAnswer::State.new(question)
-        @state.accounting_year_ends_on = Date.parse("2016-04-05")
-        calculator_options = {
-          accounting_year: stub(ends_on: Date.parse("2016-04-05")),
-        }
-        @calculator = stub("calculator", calculator_options)
-        @state.calculator = @calculator
-        @presenter = RadioQuestionPresenter.new(question, nil, @state)
-      end
+private
 
-      should "display title with interpolated basis_period_ends_on" do
-        expected = "Do your accounts cover the 12 month period up to  5 April 2016?"
-        assert_equal expected, @presenter.title
-      end
-
-      should "have options with labels" do
-        assert_equal({ "yes" => "Yes", "no" => "No" }, values_vs_labels(@presenter.options))
-      end
-
-      should "have a default error message" do
-        @state.error = "error-message"
-        assert_equal "You need to select yes or no to continue.", @presenter.error
-      end
-    end
-
-    context "when rendering what_is_your_taxable_profit? question" do
-      setup do
-        question = @flow.node(:what_is_your_taxable_profit?)
-        @state = SmartAnswer::State.new(question)
-        calculator_options = {
-          basis_period: stub(begins_on: Date.parse("2015-04-06"), ends_on: Date.parse("2016-04-05")),
-        }
-        @calculator = stub("calculator", calculator_options)
-        @state.calculator = @calculator
-        @presenter = QuestionPresenter.new(question, nil, @state)
-      end
-
-      should "display title with interpolated basis_period_begins_on and basis_period_ends_on" do
-        expected = "What is your actual or estimated taxable profit between  6 April 2015 and  5 April 2016?"
-        assert_equal expected, @presenter.title
-      end
-
-      should "have a default error message" do
-        @state.error = "error-message"
-        assert_equal "Enter your taxable profit.", @presenter.error
-      end
-    end
-
-    context "when rendering did_you_start_trading_before_the_relevant_accounting_year? question" do
-      setup do
-        question = @flow.node(:did_you_start_trading_before_the_relevant_accounting_year?)
-        @state = SmartAnswer::State.new(question)
-        calculator_options = {
-          accounting_year: stub(begins_on: Date.parse("2015-04-06")),
-        }
-        @calculator = stub("calculator", calculator_options)
-        @state.calculator = @calculator
-        @presenter = RadioQuestionPresenter.new(question, nil, @state)
-      end
-
-      should "have options with labels" do
-        assert_equal({ "yes" => "Yes", "no" => "No" }, values_vs_labels(@presenter.options))
-      end
-
-      should "have a default error message" do
-        @state.error = "error-message"
-        assert_equal "You need to select yes or no to continue.", @presenter.error
-      end
-
-      should "display title with interpolated accounting_year_begins_on" do
-        expected = "Did you start trading before  6 April 2015?"
-        assert_equal expected, @presenter.title
-      end
-    end
-
-    context "when rendering when_did_you_stop_trading? question" do
-      setup do
-        question = @flow.node(:when_did_you_stop_trading?)
-        @state = SmartAnswer::State.new(question)
-        calculator_options = {
-          tax_year: stub(begins_on: Date.parse("2015-04-06"), ends_on: Date.parse("2016-04-05")),
-        }
-        @calculator = stub("calculator", calculator_options)
-        @state.calculator = @calculator
-        @presenter = QuestionPresenter.new(question, nil, @state)
-      end
-
-      should "display hint with interpolated tax_year_begins_on and tax_year_ends_on" do
-        expected = "This date must be between  6 April 2015 and  5 April 2016"
-        assert_match expected, @presenter.hint
-      end
-
-      should "have a default error message" do
-        @state.error = "error-message"
-        assert_equal "You need to enter a date to continue.", @presenter.error
-      end
-
-      should "display a useful error message when an invalid date is entered" do
-        @state.error = "error_not_in_tax_year"
-        expected = "The date must be between  6 April 2015 and  5 April 2016."
-        assert_equal expected, @presenter.error
-      end
-    end
-
-    context "when rendering when_did_you_start_trading? question" do
-      setup do
-        question = @flow.node(:when_did_you_start_trading?)
-        @state = SmartAnswer::State.new(question)
-        calculator_options = {
-          award_period: stub(ends_on: Date.parse("2015-08-01")),
-        }
-        @calculator = stub("calculator", calculator_options)
-        @state.calculator = @calculator
-        @presenter = QuestionPresenter.new(question, nil, @state)
-      end
-
-      should "display hint with interpolated award_period_ends_on" do
-        expected = "This date must be before  1 August 2015."
-        assert_equal expected, @presenter.hint
-      end
-
-      should "have a default error message" do
-        @state.error = "error-message"
-        assert_equal "You need to enter a date to continue.", @presenter.error
-      end
-    end
-
-    context "when rendering the result outcome" do
-      setup do
-        @outcome = @flow.node(:result)
-        calculator_options = {
-          tax_credits_award_ends_on: Date.parse("2016-02-20"),
-          basis_period: YearRange.new(begins_on: Date.parse("2015-04-06")),
-          taxable_profit: SmartAnswer::Money.new(15_000),
-          award_period_taxable_profit: SmartAnswer::Money.new(13_154),
-          stopped_trading_on: nil,
-        }
-        @calculator = stub("calculator", calculator_options)
-        @calculator.responds_like_instance_of(Calculators::PartYearProfitTaxCreditsCalculator)
-        @state = SmartAnswer::State.new(@outcome)
-        @state.calculator = @calculator
-      end
-
-      context "common output" do
-        setup do
-          presenter = OutcomePresenter.new(@outcome, nil, @state)
-          @body = presenter.body
-        end
-
-        should "display award_period_taxable_profit" do
-          assert_match "Your part-year taxable profit is £13,154", @body
-        end
-
-        should "display tax_credits_award_ends_on" do
-          assert_match "Your tax credits award ended on: 20 February 2016", @body
-        end
-
-        should "display taxable_profit" do
-          assert_match "Your estimated taxable profit between  6 April 2015 and  5 April 2016 was: £15,000", @body
-        end
-      end
-
-      context "and the stopped_trading_on date is not set" do
-        setup do
-          @calculator.stubs(stopped_trading_on: nil)
-          presenter = OutcomePresenter.new(@outcome, nil, @state)
-          @body = presenter.body
-        end
-
-        should "display basis_period ends_on" do
-          assert_match "Your business accounts end on:  5 April 2016", @body
-        end
-      end
-
-      context "and the stopped_trading_on date is set" do
-        setup do
-          @calculator.stubs(stopped_trading_on: Date.parse("2016-04-05"))
-          presenter = OutcomePresenter.new(@outcome, nil, @state)
-          @body = presenter.body
-        end
-
-        should "display the date the business stopped trading" do
-          assert_match "Your business stopped trading on:  5 April 2016", @body
-        end
-      end
-    end
-
-  private
-
-    def values_vs_labels(options)
-      options.each_with_object({}) { |o, h| h[o[:value]] = o[:label]; }
-    end
+  def values_vs_labels(options)
+    options.each_with_object({}) { |o, h| h[o[:value]] = o[:label]; }
   end
 end

--- a/test/unit/smart_answer_flows/part_year_profit_tax_credits_view_test.rb
+++ b/test/unit/smart_answer_flows/part_year_profit_tax_credits_view_test.rb
@@ -1,7 +1,5 @@
 require_relative "../../test_helper"
 
-require "smart_answer_flows/part-year-profit-tax-credits"
-
 class PartYearProfitTaxCreditsViewTest < ActiveSupport::TestCase
   setup do
     @flow = PartYearProfitTaxCreditsFlow.build

--- a/test/unit/smart_answer_flows/state_pension_age_flow_test.rb
+++ b/test/unit/smart_answer_flows/state_pension_age_flow_test.rb
@@ -2,26 +2,24 @@ require_relative "../../test_helper"
 
 require "smart_answer_flows/state-pension-age"
 
-module SmartAnswer
-  class StatePensionAgeFlowTest < ActiveSupport::TestCase
-    setup do
-      @flow = StatePensionAgeFlow.build
-    end
+class StatePensionAgeFlowTest < ActiveSupport::TestCase
+  setup do
+    @flow = StatePensionAgeFlow.build
+  end
 
-    context "validation" do
-      context "for :dob_age?" do
-        setup do
-          @question = @flow.node(:dob_age?)
-          @state = SmartAnswer::State.new(@question)
-          @state.gender = "male"
-        end
+  context "validation" do
+    context "for :dob_age?" do
+      setup do
+        @question = @flow.node(:dob_age?)
+        @state = SmartAnswer::State.new(@question)
+        @state.gender = "male"
+      end
 
-        should "raise if the date of birth is later than today's date" do
-          invalid_date_of_birth = 1.week.from_now.to_date
-          @state.response = invalid_date_of_birth
-          assert_raise(SmartAnswer::InvalidResponse) do
-            @question.transition(@state, invalid_date_of_birth)
-          end
+      should "raise if the date of birth is later than today's date" do
+        invalid_date_of_birth = 1.week.from_now.to_date
+        @state.response = invalid_date_of_birth
+        assert_raise(SmartAnswer::InvalidResponse) do
+          @question.transition(@state, invalid_date_of_birth)
         end
       end
     end

--- a/test/unit/smart_answer_flows/state_pension_age_flow_test.rb
+++ b/test/unit/smart_answer_flows/state_pension_age_flow_test.rb
@@ -1,7 +1,5 @@
 require_relative "../../test_helper"
 
-require "smart_answer_flows/state-pension-age"
-
 class StatePensionAgeFlowTest < ActiveSupport::TestCase
   setup do
     @flow = StatePensionAgeFlow.build

--- a/test/unit/smart_answer_flows/test_node.rb
+++ b/test/unit/smart_answer_flows/test_node.rb
@@ -1,39 +1,37 @@
 require "mocha/api"
 
-module SmartAnswer
-  module FlowUnitTestHelper
-    class TestNode
-      include Mocha::API
-      attr_reader :state
+module FlowUnitTestHelper
+  class TestNode
+    include Mocha::API
+    attr_reader :state
 
-      def initialize(flow, name)
-        @flow = flow
-        @name = name
-        @question = @flow.node(name)
-        @state = SmartAnswer::State.new(@question)
-        @calculator_stubs = {}
-      end
+    def initialize(flow, name)
+      @flow = flow
+      @name = name
+      @question = @flow.node(name)
+      @state = SmartAnswer::State.new(@question)
+      @calculator_stubs = {}
+    end
 
-      def with(initial_state = {})
-        initial_state.each do |(state_variable, value)|
-          @state.send("#{state_variable}=", value)
-        end
-        self
+    def with(initial_state = {})
+      initial_state.each do |(state_variable, value)|
+        @state.send("#{state_variable}=", value)
       end
+      self
+    end
 
-      def with_stubbed_calculator(stubs = {})
-        @calculator_stubs.merge!(stubs)
-        with(calculator: stub_everything(@calculator_stubs))
-      end
+    def with_stubbed_calculator(stubs = {})
+      @calculator_stubs.merge!(stubs)
+      with(calculator: stub_everything(@calculator_stubs))
+    end
 
-      def answer_with(response)
-        @response = response
-        self
-      end
+    def answer_with(response)
+      @response = response
+      self
+    end
 
-      def next_node
-        @question.transition(state, @response)
-      end
+    def next_node
+      @question.transition(state, @response)
     end
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/fU4RQYvF/494-foundational-work-to-implement-smart-answer-flow-test-adr

Note, this isn't as scary a diff as it may appear. The vast majority of the changes making up the diff are changes in tab indentation and can be hidden by the "hide whitespace changes" option. [👉  Direct link](https://github.com/alphagov/smart-answers/pull/5489/files?diff=split&w=1).

This takes the first step of the journey towards moving flows from `lib/smart_answer_flows` to `app/flows` by removing the unconventional usage of the `SmartAnswer` namespace for classes that aren't defined in a `lib/smart_answer` directory.

Doing this has allowed me to take a look at the autoloading and I've configured these classes to be autoloaded by Zeitwerk. This has allowed for the removal of some quirky reload practices and manual require statements. More information in individual commits.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
