### PR TITLE
Fix use of removed namespace

### DIFF
--- a/test/flows/calculate_your_holiday_entitlement_flow_test.rb
+++ b/test/flows/calculate_your_holiday_entitlement_flow_test.rb
@@ -1,12 +1,10 @@
 require "test_helper"
 require "support/flow_test_helper"
 
-require "smart_answer_flows/calculate-your-holiday-entitlement"
-
 class CalculateYourHolidayEntitlementFlowTest < ActiveSupport::TestCase
   include FlowTestHelper
 
-  setup { testing_flow SmartAnswer::CalculateYourHolidayEntitlementFlow }
+  setup { testing_flow CalculateYourHolidayEntitlementFlow }
 
   should "render a start page" do
     assert_rendered_start_page


### PR DESCRIPTION
I accidentally broke the build by not rebasing
https://github.com/alphagov/smart-answers/pull/5486 prior to merging.

This removes the removed SmartAnswer namespace from this flow test and
the unnecessary require.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
