### PR TITLE
Remove unnecessary preload_flows option

### DIFF
--- a/lib/smart_answer/flow_registry.rb
+++ b/lib/smart_answer/flow_registry.rb
@@ -3,6 +3,8 @@ module SmartAnswer
     class NotFound < StandardError; end
     FLOW_DIR = Rails.root.join("lib/smart_answer_flows")
 
+    attr_reader :flows, :load_path
+
     def self.instance
       @instance ||= new
     end
@@ -12,60 +14,22 @@ module SmartAnswer
     end
 
     def initialize(options = {})
-      @load_path = Pathname.new(options[:smart_answer_load_path] || FLOW_DIR)
-      preload_flows! if !Rails.env.development? || options[:preload_flows]
-    end
-    attr_reader :load_path
-
-    def find(name)
-      raise NotFound, "'#{name}' not found" unless available?(name)
-
-      find_by_name(name) || raise(NotFound)
-    end
-
-    def flows
-      available_flows.map { |s| find_by_name(s) }.compact
-    end
-
-    def available_flows
-      Dir[@load_path.join("*.rb")].map do |path|
-        File.basename(path, ".rb")
+      @load_path = Pathname.new(options.fetch(:smart_answer_load_path, FLOW_DIR))
+      @flows = Dir[@load_path.join("*.rb")].map do |path|
+        build_flow(File.basename(path, ".rb"))
       end
     end
 
-    def preloaded?
-      @preloaded.present?
+    def find(name)
+      @flows.find { |flow| flow.name == name } || raise(NotFound, "'#{name}' not found")
     end
 
   private
-
-    def find_by_name(name)
-      @preloaded ? preloaded(name) : build_flow(name)
-    end
-
-    def available?(name)
-      if @preloaded
-        @preloaded.key?(name)
-      else
-        available_flows.include?(name)
-      end
-    end
 
     def build_flow(name)
       class_prefix = name.tr("-", "_").camelize
       namespaced_class = "#{class_prefix}Flow".constantize
       namespaced_class.build
-    end
-
-    def preload_flows!
-      @preloaded = {}
-      available_flows.each do |flow_name|
-        @preloaded[flow_name] = build_flow(flow_name)
-      end
-    end
-
-    def preloaded(name)
-      @preloaded && @preloaded[name]
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -76,7 +76,6 @@ RSpec.configure do |config|
     Dir[fixture_load_path.join("*.rb")].map { |path| require path }
 
     SmartAnswer::FlowRegistry.reset_instance(
-      preload_flows: false,
       smart_answer_load_path: fixture_load_path,
     )
   end

--- a/test/support/fixture_methods.rb
+++ b/test/support/fixture_methods.rb
@@ -7,22 +7,24 @@ module FixtureMethods
     File.read(fixture_file(filename))
   end
 
+  def fixture_flows_path
+    Rails.root.join("test/fixtures/smart_answer_flows")
+  end
+
+  def require_fixture_flows
+    Dir[fixture_flows_path.join("*.rb")].map { |path| require path }
+  end
+
   def setup_fixture_flows
     stub_request(:get, %r{#{Plek.new.find("content-store")}/content/(.*)})
       .to_return(status: 404, body: {}.to_json)
 
-    fixture_flows_path = Rails.root.join("test/fixtures/smart_answer_flows")
-    # require each of the flows since they're outside the autload path
-    Dir[fixture_flows_path.join("*.rb")].map { |path| require path }
+    require_fixture_flows
 
-    @preload_flows = SmartAnswer::FlowRegistry.instance.preloaded?
-    SmartAnswer::FlowRegistry.reset_instance(
-      preload_flows: false,
-      smart_answer_load_path: fixture_flows_path,
-    )
+    SmartAnswer::FlowRegistry.reset_instance(smart_answer_load_path: fixture_flows_path)
   end
 
   def teardown_fixture_flows
-    SmartAnswer::FlowRegistry.reset_instance(preload_flows: @preload_flows)
+    SmartAnswer::FlowRegistry.reset_instance
   end
 end

--- a/test/unit/flow_registry_test.rb
+++ b/test/unit/flow_registry_test.rb
@@ -2,6 +2,8 @@ require_relative "../test_helper"
 
 module SmartAnswer
   class FlowRegistryTest < ActiveSupport::TestCase
+    setup { require_fixture_flows }
+
     def registry(options = {})
       FlowRegistry.new(options.merge(smart_answer_load_path: File.expand_path("../fixtures/smart_answer_flows", __dir__)))
     end
@@ -28,42 +30,6 @@ module SmartAnswer
       flows = registry.flows
       assert_kind_of Enumerable, flows
       assert_kind_of Flow, flows.first
-    end
-
-    context "without preloaded flows" do
-      setup do
-        @r = registry
-      end
-
-      should "build a new flow instance each time" do
-        first_call = registry.find("flow-sample")
-        second_call = registry.find("flow-sample")
-
-        assert_equal first_call.name, second_call.name
-        assert_not_equal first_call.object_id, second_call.object_id
-      end
-    end
-
-    context "with preloaded flows" do
-      setup do
-        @r = registry(preload_flows: true)
-      end
-
-      should "not hit the filesystem when finding a flow" do
-        Dir.expects(:[]).never
-        File.expects(:read).never
-
-        assert @r.find("flow-sample").is_a?(Flow)
-      end
-
-      should "not hit the filesystem when finding a non-existent flow" do
-        Dir.expects(:[]).never
-        File.expects(:read).never
-
-        assert_raises FlowRegistry::NotFound do
-          @r.find("non_existent")
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/fU4RQYvF/494-foundational-work-to-implement-smart-answer-flow-test-adr

Avoiding preloading of flows in development has a near negligible impact
on performance compared to more significant things (notably view
rendering). However it's presence means that we need a quirky system
where Flow classes have an unconventional file name pattern where that
needs special autoload code and the extra logic in this flow registry
class.

This has been removed as a precursor to a step where the class names of
Flows are changed from their unusual kebab-case style (e.g.
benefits-cap-calculator.rb) to the conventional Ruby snake_case style
(e.g. benefits_cap_calculator_flow.rb).

Some benchmarks from rendering /benefits-cap-calculator

main branch, initial request: Completed 200 OK in 2040ms (Views: 1934.1ms | Allocations: 1066068)
main branch, subsequent request: Completed 200 OK in 725ms (Views: 675.3ms | Allocations: 169443)

this branch, initial request: Completed 200 OK in 2100ms (Views: 1889.1ms | Allocations: 1136213)
this branch, subsequent request: Completed 200 OK in 466ms (Views: 410.7ms | Allocations: 168485)

The impact of this change is that there are more object allocations on
an initial request, however given the view rendering takes ~2s and
the time to load flows takes ~0.1s it's unlikely to be noticeable
for any developers.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
