### PR TITLE
Add ability to specify additional parameters in flow definitions

### DIFF
--- a/lib/smart_answer/flow.rb
+++ b/lib/smart_answer/flow.rb
@@ -44,6 +44,11 @@ module SmartAnswer
       @response_store
     end
 
+    def additional_parameters(additional_parameters = nil)
+      @additional_parameters = additional_parameters unless additional_parameters.nil?
+      @additional_parameters
+    end
+
     def use_hide_this_page(use_hide_this_page)
       raise "This flow is not session based" unless response_store == :session
 

--- a/lib/smart_answer_flows/next-steps-for-your-business.rb
+++ b/lib/smart_answer_flows/next-steps-for-your-business.rb
@@ -4,6 +4,7 @@ class NextStepsForYourBusinessFlow < SmartAnswer::Flow
     content_id "4d7751b5-d860-4812-aa36-5b8c57253ff2"
     status :published
     response_store :query_parameters
+    additional_parameters %i[ct crn]
 
     # ======================================================================
     # Will your business take more than £85,000 in a 12 month period?

--- a/test/unit/flow_test.rb
+++ b/test/unit/flow_test.rb
@@ -76,6 +76,14 @@ class FlowTest < ActiveSupport::TestCase
     assert_not smart_answer.hide_previous_answers_on_results_page?
   end
 
+  test "setting additional parameters" do
+    s = SmartAnswer::Flow.build do
+      additional_parameters %i[param1 param2]
+    end
+
+    assert_equal %i[param1 param2], s.additional_parameters
+  end
+
   test "Can set the content_id" do
     s = SmartAnswer::Flow.build do
       content_id "587920ff-b854-4adb-9334-451b45652467"


### PR DESCRIPTION
This allows additional parameters to be specified in flow definitions. Additional parameters are parameters other than the question node names that can be passed down the flow. All other parameters are stripped from the response store.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
