### PR TITLE
Allow additional parameters to pass through flow

### DIFF
--- a/app/controllers/flow_controller.rb
+++ b/app/controllers/flow_controller.rb
@@ -12,7 +12,7 @@ class FlowController < ApplicationController
   end
 
   def start
-    response_store.clear
+    response_store.clear_user_responses
     redirect_to flow_path(id: params[:id],
                           node_slug: flow.questions.first.slug,
                           params: response_store.forwarding_responses)

--- a/app/controllers/flow_controller.rb
+++ b/app/controllers/flow_controller.rb
@@ -26,7 +26,7 @@ class FlowController < ApplicationController
     else
       redirect_to flow_path(id: params[:id],
                             node_slug: @presenter.node_slug,
-                            params: state.forwarding_responses)
+                            params: response_store.forwarding_responses)
     end
   end
 
@@ -36,7 +36,7 @@ class FlowController < ApplicationController
     presenter = FlowPresenter.new(flow, state)
     redirect_to flow_path(id: params[:id],
                           node_slug: presenter.node_slug,
-                          params: state.forwarding_responses)
+                          params: response_store.forwarding_responses)
   end
 
   def destroy

--- a/app/controllers/flow_controller.rb
+++ b/app/controllers/flow_controller.rb
@@ -13,7 +13,9 @@ class FlowController < ApplicationController
 
   def start
     response_store.clear
-    redirect_to flow_path(id: params[:id], node_slug: flow.questions.first.slug)
+    redirect_to flow_path(id: params[:id],
+                          node_slug: flow.questions.first.slug,
+                          params: response_store.forwarding_responses)
   end
 
   def show

--- a/app/helpers/flow_helper.rb
+++ b/app/helpers/flow_helper.rb
@@ -6,7 +6,7 @@ module FlowHelper
   def response_store
     @response_store ||= begin
       keys = {
-        user_response_keys: flow.nodes.map(&:name),
+        user_response_keys: flow.questions.map { |node| node.name.to_s },
         additional_keys: flow.additional_parameters,
       }
 

--- a/app/helpers/flow_helper.rb
+++ b/app/helpers/flow_helper.rb
@@ -4,13 +4,18 @@ module FlowHelper
   end
 
   def response_store
-    @response_store ||= if flow.response_store == :session
-                          SessionResponseStore.new(flow_name: params[:id], session: session)
-                        else
-                          allowable_keys = flow.nodes.map(&:name)
-                          query_parameters = request.query_parameters.slice(*allowable_keys)
-                          ResponseStore.new(responses: query_parameters)
-                        end
+    @response_store ||= begin
+      keys = {
+        user_response_keys: flow.nodes.map(&:name),
+        additional_keys: flow.additional_parameters,
+      }
+
+      if flow.response_store == :session
+        SessionResponseStore.new(flow_name: params[:id], session: session, **keys)
+      else
+        QueryParametersResponseStore.new(query_parameters: request.query_parameters, **keys)
+      end
+    end
   end
 
   def content_item

--- a/app/presenters/flow_presenter.rb
+++ b/app/presenters/flow_presenter.rb
@@ -14,7 +14,7 @@ class FlowPresenter
 
   delegate :title, :meta_description, to: :start_node
   delegate :node_slug, to: :current_node
-  delegate :accepted_responses, :forwarding_responses, :current_response, to: :state
+  delegate :accepted_responses, :current_response, to: :state
 
   def initialize(flow, state)
     @flow = flow
@@ -42,7 +42,7 @@ class FlowPresenter
     @start_node ||= @flow.start_node.presenter(flow_presenter: self)
   end
 
-  def change_answer_link(question)
+  def change_answer_link(question, forwarding_responses)
     if response_store
       flow_path(@flow.name, node_slug: question.node_slug, params: forwarding_responses)
     else

--- a/app/presenters/flow_presenter.rb
+++ b/app/presenters/flow_presenter.rb
@@ -56,9 +56,9 @@ class FlowPresenter
     end
   end
 
-  def start_page_link
+  def start_page_link(forwarding_responses)
     if response_store
-      start_flow_path(name)
+      start_flow_path(name, params: forwarding_responses)
     else
       smart_answer_path(name)
     end

--- a/app/views/smart_answers/landing.html.erb
+++ b/app/views/smart_answers/landing.html.erb
@@ -39,7 +39,7 @@
 
         <%= render "govuk_publishing_components/components/button", {
           text: start_node.start_button_text,
-          href: @presenter.start_page_link,
+          href: @presenter.start_page_link(response_store.forwarding_responses),
           rel: "nofollow",
           start: true,
           margin_bottom: true,

--- a/app/views/smart_answers/question.html.erb
+++ b/app/views/smart_answers/question.html.erb
@@ -22,7 +22,7 @@
 
         <%= content_tag(:div, question.post_body, class: "govuk-!-margin-bottom-4") if question.post_body.present? %>
 
-        <% controller_name == 'flow' && @presenter.forwarding_responses.each do |name, value| %>
+        <% controller_name == 'flow' && response_store.forwarding_responses.each do |name, value| %>
           <% if value.kind_of?(Array) %>
             <% value.each do |item| %>
               <input type="hidden" name="<%= name %>[]" value="<%= item %>" />

--- a/app/views/smart_answers/shared/_previous_answers.html.erb
+++ b/app/views/smart_answers/shared/_previous_answers.html.erb
@@ -32,7 +32,7 @@
         field: question.title,
         value: value,
         edit: {
-          href: @presenter.change_answer_link(question),
+          href: @presenter.change_answer_link(question, response_store.forwarding_responses),
           data_attributes: {
             "module": "gem-track-click",
             "track-category": "Smart Answer Change Link",

--- a/lib/query_parameters_response_store.rb
+++ b/lib/query_parameters_response_store.rb
@@ -1,0 +1,9 @@
+class QueryParametersResponseStore < ResponseStore
+  def initialize(query_parameters:, user_response_keys:, additional_keys:)
+    allowable_keys = user_response_keys + additional_keys
+
+    super(responses: query_parameters.slice(*allowable_keys),
+          user_response_keys: user_response_keys,
+          additional_keys: additional_keys)
+  end
+end

--- a/lib/response_store.rb
+++ b/lib/response_store.rb
@@ -21,6 +21,10 @@ class ResponseStore
     @store = {}
   end
 
+  def clear_user_responses
+    @user_response_keys.each { |key| all.delete(key) }
+  end
+
   def forwarding_responses
     all
   end

--- a/lib/response_store.rb
+++ b/lib/response_store.rb
@@ -18,4 +18,8 @@ class ResponseStore
   def clear
     @store = {}
   end
+
+  def forwarding_responses
+    all
+  end
 end

--- a/lib/response_store.rb
+++ b/lib/response_store.rb
@@ -1,5 +1,7 @@
 class ResponseStore
-  def initialize(responses:)
+  def initialize(responses: {}, user_response_keys: [], additional_keys: [])
+    @user_response_keys = user_response_keys
+    @additional_keys = additional_keys
     @store = responses
   end
 

--- a/lib/session_response_store.rb
+++ b/lib/session_response_store.rb
@@ -12,4 +12,8 @@ class SessionResponseStore < ResponseStore
   def clear
     @store.delete(@flow_name)
   end
+
+  def forwarding_responses
+    {}
+  end
 end

--- a/lib/session_response_store.rb
+++ b/lib/session_response_store.rb
@@ -1,7 +1,9 @@
 class SessionResponseStore < ResponseStore
-  def initialize(flow_name:, session:)
+  def initialize(flow_name:, session:, user_response_keys: [], additional_keys: [])
     @flow_name = flow_name
-    super(responses: session)
+    super(responses: session,
+          user_response_keys: user_response_keys,
+          additional_keys: additional_keys)
   end
 
   def all

--- a/lib/smart_answer/flow.rb
+++ b/lib/smart_answer/flow.rb
@@ -19,6 +19,7 @@ module SmartAnswer
 
     def initialize
       @nodes = []
+      @additional_parameters = []
       status(:draft)
     end
 

--- a/lib/smart_answer/state.rb
+++ b/lib/smart_answer/state.rb
@@ -2,10 +2,9 @@ require "ostruct"
 
 module SmartAnswer
   class State < OpenStruct
-    def initialize(start_node_name, forwarding_responses: {})
+    def initialize(start_node_name)
       super(current_node_name: start_node_name,
             accepted_responses: {},
-            forwarding_responses: forwarding_responses,
             current_response: nil,
             error: nil)
     end
@@ -39,7 +38,6 @@ module SmartAnswer
     def initialize_copy(orig)
       super
       self.accepted_responses = orig.accepted_responses.dup
-      self.forwarding_responses = orig.forwarding_responses.dup
     end
   end
 end

--- a/lib/smart_answer/state_resolver.rb
+++ b/lib/smart_answer/state_resolver.rb
@@ -5,8 +5,7 @@ module SmartAnswer
     end
 
     def state_from_response_store(response_store, requested_node = nil)
-      forwarding_responses = @flow.response_store == :session ? {} : response_store.all
-      resolve_state(start_state(forwarding_responses),
+      resolve_state(start_state(response_store.forwarding_responses),
                     response_store,
                     requested_node)
     end

--- a/lib/smart_answer/state_resolver.rb
+++ b/lib/smart_answer/state_resolver.rb
@@ -5,9 +5,7 @@ module SmartAnswer
     end
 
     def state_from_response_store(response_store, requested_node = nil)
-      resolve_state(start_state(response_store.forwarding_responses),
-                    response_store,
-                    requested_node)
+      resolve_state(start_state, response_store, requested_node)
     end
 
     def state_from_params(params)
@@ -42,9 +40,8 @@ module SmartAnswer
       resolve_state(next_state, response_store, requested_node)
     end
 
-    def start_state(forwarding_responses = {})
-      State.new(@flow.questions.first.name,
-                forwarding_responses: forwarding_responses).freeze
+    def start_state
+      State.new(@flow.questions.first.name).freeze
     end
 
     def apply_response_to_state(state, response)

--- a/test/helpers/flow_helper_test.rb
+++ b/test/helpers/flow_helper_test.rb
@@ -26,7 +26,10 @@ class FlowHelperTest < ActionView::TestCase
         stubs(:flow).returns(flow_object)
 
         SessionResponseStore.expects(:new).with(
-          flow_name: params[:id], session: session,
+          flow_name: params[:id],
+          session: session,
+          user_response_keys: [],
+          additional_keys: [],
         ).returns(store)
 
         assert_same store, response_store
@@ -49,7 +52,9 @@ class FlowHelperTest < ActionView::TestCase
         stubs(:flow).returns(flow_object)
 
         ResponseStore.expects(:new).with(
-          responses: { "question1": "response1" },
+          query_parameters: { "question1": "response1", "key": "value" },
+          user_response_keys: %w[question1],
+          additional_keys: [],
         ).returns(store)
 
         assert_same store, response_store

--- a/test/unit/flow_presenter_test.rb
+++ b/test/unit/flow_presenter_test.rb
@@ -129,12 +129,11 @@ class FlowPresenterTest < ActiveSupport::TestCase
 
   test "#start_page_link returns the start page link for a response store flow" do
     @flow.response_store(:query_parameters)
-    state = SmartAnswer::State.new(:first_question_key)
-    flow_presenter = FlowPresenter.new(@flow, state)
-    assert_equal "/flow-name/start", flow_presenter.start_page_link
+    flow_presenter = FlowPresenter.new(@flow, nil)
+    assert_equal "/flow-name/start?key=value", flow_presenter.start_page_link({ "key" => "value" })
   end
 
   test "#start_page_link returns the start page link for a non response store flow" do
-    assert_equal "/flow-name/y", @flow_presenter.start_page_link
+    assert_equal "/flow-name/y", @flow_presenter.start_page_link({ "key" => "value" })
   end
 end

--- a/test/unit/flow_presenter_test.rb
+++ b/test/unit/flow_presenter_test.rb
@@ -107,12 +107,13 @@ class FlowPresenterTest < ActiveSupport::TestCase
 
   test "#change_answer_link returns a previous question link for a response store flow" do
     @flow.response_store(:query_parameters)
-    state = SmartAnswer::State.new(:second_question_key, forwarding_responses: { first_question_key: "answer" })
+    forwarding_responses = { first_question_key: "answer" }
+    state = SmartAnswer::State.new(:second_question_key, forwarding_responses: forwarding_responses)
     flow_presenter = FlowPresenter.new(@flow, state)
     question = OpenStruct.new(node_slug: "foo")
     assert_equal(
       "/#{@flow.name}/foo?first_question_key=answer",
-      flow_presenter.change_answer_link(question),
+      flow_presenter.change_answer_link(question, forwarding_responses),
     )
   end
 
@@ -122,7 +123,7 @@ class FlowPresenterTest < ActiveSupport::TestCase
     questions = flow_presenter.answered_questions
     assert_equal(
       "/#{@flow.name}/y/question-1-answer?previous_response=question-2-answer",
-      flow_presenter.change_answer_link(questions.last),
+      flow_presenter.change_answer_link(questions.last, {}),
     )
   end
 

--- a/test/unit/flow_presenter_test.rb
+++ b/test/unit/flow_presenter_test.rb
@@ -107,13 +107,12 @@ class FlowPresenterTest < ActiveSupport::TestCase
 
   test "#change_answer_link returns a previous question link for a response store flow" do
     @flow.response_store(:query_parameters)
-    forwarding_responses = { first_question_key: "answer" }
-    state = SmartAnswer::State.new(:second_question_key, forwarding_responses: forwarding_responses)
+    state = SmartAnswer::State.new(:second_question_key)
     flow_presenter = FlowPresenter.new(@flow, state)
     question = OpenStruct.new(node_slug: "foo")
     assert_equal(
       "/#{@flow.name}/foo?first_question_key=answer",
-      flow_presenter.change_answer_link(question, forwarding_responses),
+      flow_presenter.change_answer_link(question, { first_question_key: "answer" }),
     )
   end
 

--- a/test/unit/query_parameters_response_store_test.rb
+++ b/test/unit/query_parameters_response_store_test.rb
@@ -1,0 +1,16 @@
+require_relative "../test_helper"
+
+class QueryParametersResponseStoreTest < ActiveSupport::TestCase
+  context "#new" do
+    should "not store parameters unless specified key" do
+      responses = { k: "v", k2: "v2", k3: "v3" }
+      response_store = QueryParametersResponseStore.new(
+        query_parameters: responses,
+        user_response_keys: [:k],
+        additional_keys: [:k2],
+      )
+
+      assert_equal({ k: "v", k2: "v2" }, response_store.all)
+    end
+  end
+end

--- a/test/unit/response_store_test.rb
+++ b/test/unit/response_store_test.rb
@@ -55,4 +55,15 @@ class ResponseStoreTest < ActiveSupport::TestCase
       assert_equal(responses, response_store.forwarding_responses)
     end
   end
+
+  context "#clear_user_responses" do
+    should "clear only responses that match user response keys" do
+      responses = { k1: "v1", k2: "v2", k3: "v3" }
+      response_store = ResponseStore.new(responses: responses,
+                                         user_response_keys: %i[k2 k3])
+
+      response_store.clear_user_responses
+      assert_equal({ k1: "v1" }, response_store.all)
+    end
+  end
 end

--- a/test/unit/response_store_test.rb
+++ b/test/unit/response_store_test.rb
@@ -46,4 +46,13 @@ class ResponseStoreTest < ActiveSupport::TestCase
       assert_equal({}, response_store.all)
     end
   end
+
+  context "#forwarding_responses" do
+    should "return all responses" do
+      responses = { "key" => "value" }
+      response_store = ResponseStore.new(responses: responses)
+
+      assert_equal(responses, response_store.forwarding_responses)
+    end
+  end
 end

--- a/test/unit/session_response_store_test.rb
+++ b/test/unit/session_response_store_test.rb
@@ -54,4 +54,13 @@ class SessionResponseStoreTest < ActiveSupport::TestCase
       assert_equal({ "flow-2" => { "key" => "value" } }, session)
     end
   end
+
+  context "#forwarding_responses" do
+    should "return empty hash" do
+      session = { "flow" => { "key" => "value" } }
+      response_store = SessionResponseStore.new(flow_name: "flow", session: session)
+
+      assert_equal({}, response_store.forwarding_responses)
+    end
+  end
 end

--- a/test/unit/state_resolver_test.rb
+++ b/test/unit/state_resolver_test.rb
@@ -108,7 +108,7 @@ module SmartAnswer
         assert_nil state.current_response
       end
 
-      should "maintain all responses for forwarding by query string on a non-session response_store" do
+      should "maintain forwarding responses from the response_store" do
         @flow.response_store(:query_parameters)
         responses = { "x" => "yes", "y" => "no", "z" => "yes" }
         response_store = ResponseStore.new(responses: responses)
@@ -116,16 +116,6 @@ module SmartAnswer
         state = @state_resolver.state_from_response_store(response_store, "y")
 
         assert_equal responses, state.forwarding_responses
-      end
-
-      should "not maintain forwarding responses on a session response_store as they're stored in the session" do
-        @flow.response_store(:session)
-        responses = { "x" => "yes", "y" => "no", "z" => "yes" }
-        response_store = ResponseStore.new(responses: responses)
-
-        state = @state_resolver.state_from_response_store(response_store)
-
-        assert_empty state.forwarding_responses
       end
     end
 

--- a/test/unit/state_resolver_test.rb
+++ b/test/unit/state_resolver_test.rb
@@ -107,16 +107,6 @@ module SmartAnswer
         assert_equal ({}), state.accepted_responses
         assert_nil state.current_response
       end
-
-      should "maintain forwarding responses from the response_store" do
-        @flow.response_store(:query_parameters)
-        responses = { "x" => "yes", "y" => "no", "z" => "yes" }
-        response_store = ResponseStore.new(responses: responses)
-
-        state = @state_resolver.state_from_response_store(response_store, "y")
-
-        assert_equal responses, state.forwarding_responses
-      end
     end
 
     context "#state_from_params" do

--- a/test/unit/state_test.rb
+++ b/test/unit/state_test.rb
@@ -19,7 +19,6 @@ module SmartAnswer
       state = State.new(:start_node)
       assert_equal :start_node, state.current_node_name
       assert_equal ({}), state.accepted_responses
-      assert_equal ({}), state.forwarding_responses
       assert_nil state.current_response
       assert_nil state.error
     end


### PR DESCRIPTION
This adds the ability to pass permitted query parameters from the start page to rest of the flow nodes.

This functionality is needed by the "Next steps for you business" flow, which needs to use the "ct" and "crn" query parameters as filtering parameters on the results page.

To enable this functionality, this PR makes the following changes:
- Adds a new QueryParametersResponseStore subclass store encapsulate behaviour for query_parameter flows
- The QueryParametersResponseStore will store all parameters that are question node name or specified by additional parameters attribute in the flow definition
- Refactor forwarding parameters to be a method in the response store, rather than state.
- Changes the behaviour of the start page to only delete user submitted responses when starting a flow. So the additional parameters pass to the flow and not cleared.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
