### PR TITLE
Add new question and outcome to marriage abroad flow

### DIFF
--- a/app/flows/marriage_abroad_flow.rb
+++ b/app/flows/marriage_abroad_flow.rb
@@ -97,10 +97,30 @@ class MarriageAbroadFlow < SmartAnswer::Flow
         calculator.sex_of_your_partner = response
       end
 
-      next_node do
-        if calculator.has_outcome_per_path?
+      next_node do |response|
+        if calculator.offers_consular_opposite_sex_civil_partnership? && response == "opposite_sex"
+          if calculator.ceremony_country == "vietnam" && calculator.partner_nationality == "partner_local"
+            outcome :outcome_marriage_abroad_in_country
+          else
+            question :marriage_or_civil_partnership?
+          end
+        elsif calculator.has_outcome_per_path?
           outcome :outcome_marriage_abroad_in_country
         end
+      end
+    end
+
+    # Q6
+    radio :marriage_or_civil_partnership? do
+      option :marriage
+      option :civil_partnership
+
+      on_response do |response|
+        calculator.type_of_ceremony = response
+      end
+
+      next_node do
+        outcome :outcome_marriage_abroad_in_country
       end
     end
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/japan/_opposite_sex_civil_partnership.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/japan/_opposite_sex_civil_partnership.erb
@@ -1,0 +1,64 @@
+You can register an opposite sex civil partnership at the British embassy in Tokyo under UK law (except for Scotland).
+
+You'll be asked to choose what part of the UK you want to register your civil partnership under. You can choose England, Wales or Northern Ireland. You cannot register it under Scotland.
+
+If you and your partner do not live in Japan, you need to have been in Japan for at least 21 days before you can register your civil partnership. You need to stay in Japan for the 21 days.
+
+^Check the [travel advice for Japan](/foreign-travel-advice/japan) before making any plans.
+
+##Prove you’re free to register a civil partnership
+
+You and your partner need to give notice and sign a declaration that you’re legally allowed to register a civil partnership.
+
+You need to have been in Japan for at least 7 full days before you can give notice. For example, if you arrived on Monday you cannot give notice until the following Tuesday.
+
+###Give notice of your civil partnership
+
+[Make an appointment at the embassy in Tokyo](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=152&service=6) to give notice of your civil partnership and set a date for your ceremony.
+
+It costs £50 to give notice. You can pay in the [local currency](/government/publications/japan-consular-fees) by card or in cash.
+
+You need to bring:
+
+- your and your partner’s passports
+- proof that you’ve been in Japan for at least 7 full days, for example a utility bill, bank statement, passport stamp or boarding pass
+
+If you or your partner have been married or in a civil partnership before, you’ll also need:
+
+- your [original decree absolute or final order](/copy-decree-absolute-final-order)  (this could be a printed PDF and covering email from the court) - if you’re divorced
+- your annulment certificate - if your marriage or civil partnership was annulled
+- your civil partnership dissolution - if your civil partnership was dissolved
+- your partner’s [death certificate](/order-copy-birth-death-marriage-certificate) and marriage certificate - if you’ve been widowed
+
+If your divorce, civil partnership dissolution or annulment took place outside the UK, you’ll need evidence that you or your ex partner lived in or were a national of that country at the time.
+
+The embassy will display your notice publicly for 14 days. If nobody registers an objection, you can register a civil partnership up to 3 months after the end of your notice period.
+
+###Sign a declaration
+
+You and your partner also need to sign a declaration to say that you’re legally allowed to register a civil partnership. The embassy will give you the document to sign at your appointment.
+
+You both need to bring proof that you live in Japan or you’ve been there for at least the last 7 full days. This could be a utility bill, bank statement, passport stamp or boarding pass.
+
+##Register your civil partnership
+
+Your civil partnership ceremony will be at the embassy on the date you agreed.
+
+You’ll need to bring 2 witnesses. Your witnesses must:
+
+- bring photo ID
+- be 16 or over
+- know you or your partner
+- understand English well enough to follow the ceremony and read the documents they have to sign
+
+You, your partner and your 2 witnesses will sign the civil partnership register.
+
+It costs £150 to register a civil partnership. You can also pay £50 for a civil partnership certificate if you want one.
+
+You can pay when you give notice or when you sign the register. You can pay in the [local currency](/government/publications/japan-consular-fees) by card or in cash.
+
+##After you register your civil partnership
+
+Your civil partnership will be recognised under UK law. It will not be recognised in Japan or other countries where opposite sex civil partnership is not legal.
+
+If your partner is not a British citizen, they can [apply for British citizenship](/british-citizenship/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.

--- a/app/flows/marriage_abroad_flow/outcomes/countries/japan/_title.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/japan/_title.erb
@@ -1,4 +1,6 @@
-<% if calculator.partner_is_same_sex? %>
+<% if calculator.is_civil_partnership? %>
+  Opposite sex civil partnership in Japan
+<% elsif calculator.partner_is_same_sex? %>
   Same-sex marriage and civil partnership in Japan
 <% else %>
   Marriage in Japan

--- a/app/flows/marriage_abroad_flow/outcomes/countries/panama/_opposite_sex_civil_partnership.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/panama/_opposite_sex_civil_partnership.erb
@@ -1,0 +1,66 @@
+You can register an opposite sex civil partnership at the British embassy in Panama City under UK law (except for Scotland).
+
+You’ll be asked to choose what part of the UK you want to register your civil partnership under. You can choose England, Wales or Northern Ireland. You cannot register it under Scotland.
+
+If you and your partner do not live in Panama, you need to have been in Panama for at least 21 days before you can register your civil partnership. You need to stay in Panama for the 21 days.
+
+^Check the [travel advice for Panama](/foreign-travel-advice/panama) before making any plans.
+
+##Prove you’re free to register a civil partnership
+
+You and your partner need to give notice and sign a declaration that you’re legally allowed to register a civil partnership.
+
+You need to have been in Panama for at least 7 full days before you can give notice. For example, if you arrived on Monday you cannot give notice until the following Tuesday.
+
+###Give notice of your civil partnership
+
+Make an appointment at the embassy or consulate to give notice of your civil partnership and set a date for your ceremony.
+
+You can [make an appointment at the British embassy in Panama City](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=134&service=10).
+
+It costs £50 to give notice. You can pay in the [local currency](/government/publications/panama-consular-fees) by card or in cash.
+
+You need to bring:
+
+- your and your partner’s passports
+- proof that you’ve been in Panama for at least 7 full days, for example a utility bill, bank statement, passport stamp or boarding pass
+
+If you or your partner have been married or in a civil partnership before, you’ll also need:
+
+- your [original decree absolute or final order](/copy-decree-absolute-final-order)  (this could be a printed PDF and covering email from the court) - if you’re divorced
+- your annulment certificate - if your marriage or civil partnership was annulled
+- your civil partnership dissolution - if your civil partnership was dissolved
+- your partner’s [death certificate](/order-copy-birth-death-marriage-certificate) and marriage certificate - if you’ve been widowed
+
+If your divorce, civil partnership dissolution or annulment took place outside the UK, you’ll need evidence that you or your ex partner lived in or were a national of that country at the time.
+
+The embassy will display your notice publicly for 14 days. If nobody registers an objection, you can register a civil partnership up to 3 months after the end of your notice period.
+
+###Sign a declaration
+
+You and your partner also need to sign a declaration to say that you’re legally allowed to register a civil partnership. The embassy will give you the document to sign at your appointment.
+
+You both need to bring proof that you live in Panama or you’ve been there for at least the last 7 full days. This could be a utility bill, bank statement, passport stamp or boarding pass.
+
+##Register your civil partnership
+
+Your civil partnership ceremony will be at the embassy on the date you agreed.
+
+You’ll need to bring 2 witnesses. Your witnesses must:
+
+- bring photo ID
+- be 16 or over
+- know you or your partner
+- understand English well enough to follow the ceremony and read the documents they have to sign
+
+You, your partner and your 2 witnesses will sign the civil partnership register.
+
+It costs £150 to register a civil partnership. You can also pay £50 for a civil partnership certificate if you want one.
+
+You can pay when you give notice or when you sign the register. You can pay in the [local currency](/government/publications/panama-consular-fees) by card or in cash.
+
+##After you register your civil partnership
+
+Your civil partnership will be recognised under UK law. It will not be recognised in Panama or other countries where opposite sex civil partnership is not legal.
+
+If your partner is not a British citizen, they can apply for [British citizenship](/british-citizenship/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.

--- a/app/flows/marriage_abroad_flow/outcomes/countries/panama/_title.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/panama/_title.erb
@@ -1,4 +1,6 @@
-<% if calculator.partner_is_same_sex? %>
+<% if calculator.is_civil_partnership? %>
+  Opposite sex civil partnership in Panama
+<% elsif calculator.partner_is_same_sex? %>
   Civil partnership and same sex marriage in Panama
 <% else %>
   Marriage in Panama

--- a/app/flows/marriage_abroad_flow/outcomes/countries/vietnam/_opposite_sex_civil_partnership.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/vietnam/_opposite_sex_civil_partnership.erb
@@ -1,0 +1,66 @@
+You can register an opposite sex civil partnership at the British embassy in Hanoi under UK law (except for Scotland).
+
+You’ll be asked to choose what part of the UK you want to register your civil partnership under. You can choose England, Wales or Northern Ireland. You cannot register it under Scotland.
+
+If you and your partner do not live in Vietnam, you need to have been in Vietnam for at least 21 days before you can register your civil partnership. You need to stay in Vietnam for the 21 days.
+
+^Check the [travel advice for Vietnam](/foreign-travel-advice/vietnam) before making any plans.
+
+##Prove you’re free to register a civil partnership
+
+You and your partner need to give notice and sign a declaration that you’re legally allowed to register a civil partnership.
+
+You need to have been in Vietnam for at least 7 full days before you can give notice. For example, if you arrived on Monday you cannot give notice until the following Tuesday.
+
+###Give notice of your civil partnership
+
+Make an appointment at the embassy or consulate to give notice of your civil partnership and set a date for your ceremony.
+
+You can [make an appointment at the British embassy in Hanoi](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=115&service=13).
+
+It costs £50 to give notice. You can pay in the [local currency](/government/publications/vietnam-consular-fees) by card (Mastercard or Visa) or in cash.
+
+You need to bring:
+
+- your and your partner’s passports
+- proof that you’ve been in Vietnam for at least 7 full days, for example a utility bill, bank statement, passport stamp or boarding pass
+
+If you or your partner have been married or in a civil partnership before, you’ll also need:
+
+- your [original decree absolute or final order](/copy-decree-absolute-final-order)  (this could be a printed PDF and covering email from the court) - if you’re divorced
+- your annulment certificate - if your marriage or civil partnership was annulled
+- your civil partnership dissolution - if your civil partnership was dissolved
+- your partner’s [death certificate](/order-copy-birth-death-marriage-certificate) and marriage certificate - if you’ve been widowed
+
+If your divorce, civil partnership dissolution or annulment took place outside the UK, you’ll need evidence that you or your ex partner lived in or were a national of that country at the time.
+
+The embassy will display your notice publicly for 14 days. If nobody registers an objection, you can register a civil partnership up to 3 months after the end of your notice period.
+
+###Sign a declaration
+
+You and your partner also need to sign a declaration to say that you’re legally allowed to register a civil partnership. The embassy will give you the document to sign at your appointment.
+
+You both need to bring proof that you live in Vietnam or you’ve been there for at least the last 7 full days. This could be a utility bill, bank statement, passport stamp or boarding pass.
+
+##Register your civil partnership
+
+Your civil partnership ceremony will be at the embassy on the date you agreed.
+
+You’ll need to bring 2 witnesses. Your witnesses must:
+
+- bring photo ID
+- be 16 or over
+- know you or your partner
+- understand English well enough to follow the ceremony and read the documents they have to sign
+
+You, your partner and your 2 witnesses will sign the civil partnership register.
+
+It costs £150 to register a civil partnership. You can also pay £50 for a civil partnership certificate if you want one.
+
+You can pay when you give notice or when you register your civil partnership. You can pay in the [local currency](/government/publications/vietnam-consular-fees) by card (Mastercard or Visa) or in cash.
+
+##After you register your civil partnership
+
+Your civil partnership will be recognised under UK law. It will not be recognised in Vietnam or other countries where opposite sex civil partnership is not legal.
+
+If your partner is not a British citizen, they can [apply for British citizenship](/british-citizenship/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.

--- a/app/flows/marriage_abroad_flow/outcomes/countries/vietnam/_title.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/vietnam/_title.erb
@@ -1,5 +1,7 @@
 <% text_for :title do %>
-  <% if calculator.partner_is_same_sex? %>
+  <% if calculator.is_civil_partnership? %>
+    Opposite sex civil partnership in Vietnam
+  <% elsif calculator.partner_is_same_sex? %>
     Same-sex marriage in Vietnam
   <% else %>
     Marriage in Vietnam

--- a/app/flows/marriage_abroad_flow/questions/marriage_or_civil_partnership.erb
+++ b/app/flows/marriage_abroad_flow/questions/marriage_or_civil_partnership.erb
@@ -1,0 +1,8 @@
+<% text_for :title do %>
+  Do you want to get married, or register a civil partnership?
+<% end %>
+
+<% options(
+  "marriage": "Get married",
+  "civil_partnership": "Register a civil partnership"
+) %>

--- a/config/smart_answers/marriage_abroad_data.yml
+++ b/config/smart_answers/marriage_abroad_data.yml
@@ -130,7 +130,6 @@ countries_with_18_outcomes:
   - oman
   - pakistan
   - palau
-  - panama
   - papua-new-guinea
   - paraguay
   - peru
@@ -185,10 +184,12 @@ countries_with_18_outcomes:
   - uzbekistan
   - vanuatu
   - venezuela
-  - vietnam
   - western-sahara
   - yemen
   - zambia
+countries_with_19_outcomes:
+  - panama
+  - vietnam
 countries_with_2_outcomes:
   - australia
   - croatia
@@ -197,7 +198,6 @@ countries_with_2_outcomes:
   - france
   - india
   - ireland
-  - japan
   - luxembourg
   - philippines
   - south-africa
@@ -207,6 +207,8 @@ countries_with_2_outcomes:
   - turkey
   - usa
   - zimbabwe
+countries_with_3_outcomes:
+  - japan
 countries_with_2_outcomes_marriage_or_pacs:
   - monaco
   - new-caledonia

--- a/lib/smart_answer/calculators/marriage_abroad_calculator.rb
+++ b/lib/smart_answer/calculators/marriage_abroad_calculator.rb
@@ -1,7 +1,7 @@
 module SmartAnswer::Calculators
   class MarriageAbroadCalculator
-    attr_accessor :ceremony_country, :marriage_or_pacs
-    attr_writer :resident_of, :partner_nationality, :sex_of_your_partner
+    attr_accessor :ceremony_country, :marriage_or_pacs, :partner_nationality
+    attr_writer :resident_of, :sex_of_your_partner, :type_of_ceremony
 
     def initialize(data_query: nil, rates_query: nil, country_name_formatter: nil, registrations_data_query: nil, services_data: nil)
       @data_query = data_query || MarriageAbroadDataQuery.new
@@ -46,6 +46,10 @@ module SmartAnswer::Calculators
 
     def want_to_get_married?
       @marriage_or_pacs == "marriage"
+    end
+
+    def is_civil_partnership?
+      @type_of_ceremony == "civil_partnership"
     end
 
     def world_location
@@ -142,6 +146,10 @@ module SmartAnswer::Calculators
       @data_query.dutch_caribbean_islands?(ceremony_country)
     end
 
+    def offers_consular_opposite_sex_civil_partnership?
+      @data_query.offers_consular_opposite_sex_civil_partnership?(ceremony_country)
+    end
+
     def ceremony_country_offers_pacs?
       MarriageAbroadDataQuery::CEREMONY_COUNTRIES_OFFERING_PACS.include?(ceremony_country)
     end
@@ -175,6 +183,8 @@ module SmartAnswer::Calculators
     def path_to_outcome
       if outcome_ceremony_location_country?
         [ceremony_country, ceremony_location_path_name]
+      elsif offers_consular_opposite_sex_civil_partnership? && is_civil_partnership?
+        [ceremony_country, "#{marriage_type_path_name}_#{@type_of_ceremony}"]
       elsif one_question_country?
         [ceremony_country, ceremony_country]
       elsif two_questions_country?
@@ -201,7 +211,8 @@ module SmartAnswer::Calculators
     end
 
     def two_questions_country?
-      @data_query.countries_with_2_outcomes.include?(ceremony_country)
+      @data_query.countries_with_2_outcomes.include?(ceremony_country) ||
+        @data_query.countries_with_3_outcomes.include?(ceremony_country)
     end
 
     def two_questions_country_marriage_or_pacs?
@@ -213,7 +224,8 @@ module SmartAnswer::Calculators
     end
 
     def four_questions_country?
-      @data_query.countries_with_18_outcomes.include?(ceremony_country)
+      @data_query.countries_with_18_outcomes.include?(ceremony_country) ||
+        @data_query.countries_with_19_outcomes.include?(ceremony_country)
     end
 
   private

--- a/lib/smart_answer/calculators/marriage_abroad_data_query.rb
+++ b/lib/smart_answer/calculators/marriage_abroad_data_query.rb
@@ -76,6 +76,16 @@ module SmartAnswer::Calculators
       vietnam
     ].freeze
 
+    CONSULAR_OPPOSITE_SEX_CIVIL_PARTNERSHIP = %w[
+      japan
+      vietnam
+      panama
+    ].freeze
+
+    def offers_consular_opposite_sex_civil_partnership?(country_slug)
+      CONSULAR_OPPOSITE_SEX_CIVIL_PARTNERSHIP.include?(country_slug)
+    end
+
     def ss_marriage_countries?(country_slug)
       SS_MARRIAGE_COUNTRIES.include?(country_slug)
     end
@@ -110,8 +120,10 @@ module SmartAnswer::Calculators
 
     def outcome_per_path_countries
       (countries_with_18_outcomes +
+      countries_with_19_outcomes +
       countries_with_6_outcomes +
       countries_with_2_outcomes +
+      countries_with_3_outcomes +
       countries_with_2_outcomes_marriage_or_pacs +
       countries_with_ceremony_location_outcomes +
       countries_with_1_outcome).sort
@@ -125,6 +137,10 @@ module SmartAnswer::Calculators
       country_outcomes(:countries_with_2_outcomes)
     end
 
+    def countries_with_3_outcomes
+      country_outcomes(:countries_with_3_outcomes)
+    end
+
     def countries_with_2_outcomes_marriage_or_pacs
       country_outcomes(:countries_with_2_outcomes_marriage_or_pacs)
     end
@@ -135,6 +151,10 @@ module SmartAnswer::Calculators
 
     def countries_with_18_outcomes
       country_outcomes(:countries_with_18_outcomes)
+    end
+
+    def countries_with_19_outcomes
+      country_outcomes(:countries_with_19_outcomes)
     end
 
     def countries_with_ceremony_location_outcomes

--- a/test/flows/marriage_abroad_flow_test.rb
+++ b/test/flows/marriage_abroad_flow_test.rb
@@ -26,7 +26,9 @@ class MarriageAbroadFlowTest < ActiveSupport::TestCase
 
   def all_countries_list
     all_types = %w[countries_with_ceremony_location_outcomes
+                   countries_with_19_outcomes
                    countries_with_2_outcomes_marriage_or_pacs
+                   countries_with_3_outcomes
                    countries_with_1_outcome
                    countries_with_2_outcomes
                    countries_with_6_outcomes
@@ -177,6 +179,25 @@ class MarriageAbroadFlowTest < ActiveSupport::TestCase
     end
   end
 
+  context "question: marriage_or_civil_partnership?" do
+    setup do
+      testing_node :marriage_or_civil_partnership?
+      stub_worldwide_api(all_countries_list)
+      add_responses country_of_ceremony?: random_country(:countries_with_3_outcomes),
+                    partner_opposite_or_same_sex?: "opposite_sex"
+    end
+
+    should "render question" do
+      assert_rendered_question
+    end
+
+    context "next_node" do
+      should "have a next_node of outcome_marriage_abroad_in_country" do
+        assert_next_node :outcome_marriage_abroad_in_country, for_response: "marriage"
+      end
+    end
+  end
+
   context "outcome :outcome_marriage_abroad_in_country" do
     setup { testing_node :outcome_marriage_abroad_in_country }
 
@@ -245,6 +266,32 @@ class MarriageAbroadFlowTest < ActiveSupport::TestCase
 
         should "render an opposite sex outcome" do
           add_responses partner_opposite_or_same_sex?: "opposite_sex"
+          assert_rendered_outcome
+        end
+
+        should "render a same sex outcome" do
+          add_responses partner_opposite_or_same_sex?: "same_sex"
+          assert_rendered_outcome
+        end
+      end
+    end
+
+    countries_list(:countries_with_3_outcomes).each do |country|
+      context "2 outcome country offering consular civil partnership: #{country}" do
+        setup do
+          stub_worldwide_api([country])
+          add_responses country_of_ceremony?: country
+        end
+
+        should "render an opposite sex civil partnership outcome" do
+          add_responses partner_opposite_or_same_sex?: "opposite_sex",
+                        marriage_or_civil_partnership?: "civil_partnership"
+          assert_rendered_outcome
+        end
+
+        should "render an opposite sex civil marriage outcome" do
+          add_responses partner_opposite_or_same_sex?: "opposite_sex",
+                        marriage_or_civil_partnership?: "marriage"
           assert_rendered_outcome
         end
 
@@ -436,6 +483,250 @@ class MarriageAbroadFlowTest < ActiveSupport::TestCase
           add_responses legal_residency?: "uk",
                         what_is_your_partners_nationality?: "partner_other",
                         partner_opposite_or_same_sex?: "opposite_sex"
+          assert_rendered_outcome
+        end
+
+        should "render an outcome where residency is in the UK and the partner is not local and same sex" do
+          add_responses legal_residency?: "uk",
+                        what_is_your_partners_nationality?: "partner_other",
+                        partner_opposite_or_same_sex?: "same_sex"
+          assert_rendered_outcome
+        end
+      end
+    end
+
+    countries_list(:countries_with_19_outcomes).each do |country|
+      context "18 outcome country offering consular civil partnerships: #{country}" do
+        setup do
+          # stubbing a single country at a time makes this test > 60s faster
+          stub_worldwide_api([country])
+          add_responses country_of_ceremony?: country
+        end
+
+        should "render an outcome where residency is in the ceremony country " \
+               "and the partner is British and opposite sex getting married" do
+          add_responses legal_residency?: "ceremony_country",
+                        what_is_your_partners_nationality?: "partner_british",
+                        partner_opposite_or_same_sex?: "opposite_sex",
+                        marriage_or_civil_partnership?: "marriage"
+          assert_rendered_outcome
+        end
+
+        should "render an outcome where residency is in the ceremony country " \
+               "and the partner is British and opposite sex registering a civil partnership" do
+          add_responses legal_residency?: "ceremony_country",
+                        what_is_your_partners_nationality?: "partner_british",
+                        partner_opposite_or_same_sex?: "opposite_sex",
+                        marriage_or_civil_partnership?: "civil_partnership"
+          assert_rendered_outcome
+        end
+
+        should "render an outcome where residency is in the ceremony country " \
+               "and the partner is British and same sex" do
+          add_responses legal_residency?: "ceremony_country",
+                        what_is_your_partners_nationality?: "partner_british",
+                        partner_opposite_or_same_sex?: "same_sex"
+          assert_rendered_outcome
+        end
+
+        should "render an outcome where residency is in the ceremony country " \
+               "and the partner is local and opposite sex getting married" do
+          add_responses legal_residency?: "ceremony_country",
+                        what_is_your_partners_nationality?: "partner_local",
+                        partner_opposite_or_same_sex?: "opposite_sex",
+                        marriage_or_civil_partnership?: "marriage"
+          assert_rendered_outcome
+        end
+
+        should "render an outcome where residency is in the ceremony country " \
+               "and the partner is local and opposite sex registering a " \
+               " civil partnership" do
+          add_responses legal_residency?: "ceremony_country",
+                        what_is_your_partners_nationality?: "partner_local",
+                        partner_opposite_or_same_sex?: "opposite_sex",
+                        marriage_or_civil_partnership?: "civil_partnership"
+          assert_rendered_outcome
+        end
+
+        should "render an outcome where residency is in the ceremony country " \
+               "and the partner is local and same sex" do
+          add_responses legal_residency?: "ceremony_country",
+                        what_is_your_partners_nationality?: "partner_local",
+                        partner_opposite_or_same_sex?: "same_sex"
+          assert_rendered_outcome
+        end
+
+        should "render an outcome where residency is in the ceremony country " \
+               "and the partner is not local and opposite sex getting married" do
+          add_responses legal_residency?: "ceremony_country",
+                        what_is_your_partners_nationality?: "partner_other",
+                        partner_opposite_or_same_sex?: "opposite_sex",
+                        marriage_or_civil_partnership?: "marriage"
+          assert_rendered_outcome
+        end
+
+        should "render an outcome where residency is in the ceremony country " \
+               "and the partner is not local and opposite sex registering a civil partnership" do
+          add_responses legal_residency?: "ceremony_country",
+                        what_is_your_partners_nationality?: "partner_other",
+                        partner_opposite_or_same_sex?: "opposite_sex",
+                        marriage_or_civil_partnership?: "civil_partnership"
+          assert_rendered_outcome
+        end
+
+        should "render an outcome where residency is in the ceremony country " \
+               "and the partner is not local and same sex" do
+          add_responses legal_residency?: "ceremony_country",
+                        what_is_your_partners_nationality?: "partner_other",
+                        partner_opposite_or_same_sex?: "same_sex"
+          assert_rendered_outcome
+        end
+
+        should "render an outcome where residency is in a different country " \
+               "and the partner is British and opposite sex getting married" do
+          add_responses legal_residency?: "third_country",
+                        what_is_your_partners_nationality?: "partner_british",
+                        partner_opposite_or_same_sex?: "opposite_sex",
+                        marriage_or_civil_partnership?: "marriage"
+          assert_rendered_outcome
+        end
+
+        should "render an outcome where residency is in a different country " \
+               "and the partner is British and opposite sex registering a " \
+               "civil partnership" do
+          add_responses legal_residency?: "third_country",
+                        what_is_your_partners_nationality?: "partner_british",
+                        partner_opposite_or_same_sex?: "opposite_sex",
+                        marriage_or_civil_partnership?: "civil_partnership"
+          assert_rendered_outcome
+        end
+
+        should "render an outcome where residency is in a different country " \
+               "and the partner is British and same sex" do
+          add_responses legal_residency?: "third_country",
+                        what_is_your_partners_nationality?: "partner_british",
+                        partner_opposite_or_same_sex?: "same_sex"
+          assert_rendered_outcome
+        end
+
+        should "render an outcome where residency is in a different country " \
+               "and the partner is local and opposite sex getting married" do
+          add_responses legal_residency?: "third_country",
+                        what_is_your_partners_nationality?: "partner_local",
+                        partner_opposite_or_same_sex?: "opposite_sex",
+                        marriage_or_civil_partnership?: "marriage"
+          assert_rendered_outcome
+        end
+
+        should "render an outcome where residency is in a different country " \
+               "and the partner is local and opposite sex registering a civil partnership" do
+          add_responses legal_residency?: "third_country",
+                        what_is_your_partners_nationality?: "partner_local",
+                        partner_opposite_or_same_sex?: "opposite_sex",
+                        marriage_or_civil_partnership?: "civil_partnership"
+          assert_rendered_outcome
+        end
+
+        should "render an outcome where residency is in a different country " \
+               "and the partner is local and same sex" do
+          add_responses legal_residency?: "third_country",
+                        what_is_your_partners_nationality?: "partner_local",
+                        partner_opposite_or_same_sex?: "same_sex"
+          assert_rendered_outcome
+        end
+
+        should "render an outcome where residency is in a different country " \
+               "and the partner is not local and opposite sex getting married" do
+          add_responses legal_residency?: "third_country",
+                        what_is_your_partners_nationality?: "partner_other",
+                        partner_opposite_or_same_sex?: "opposite_sex",
+                        marriage_or_civil_partnership?: "marriage"
+          assert_rendered_outcome
+        end
+
+        should "render an outcome where residency is in a different country " \
+               "and the partner is not local and opposite sex registering a " \
+               "civil partnership" do
+          add_responses legal_residency?: "third_country",
+                        what_is_your_partners_nationality?: "partner_other",
+                        partner_opposite_or_same_sex?: "opposite_sex",
+                        marriage_or_civil_partnership?: "civil_partnership"
+          assert_rendered_outcome
+        end
+
+        should "render an outcome where residency is in a different country " \
+               "and the partner is not local and same sex" do
+          add_responses legal_residency?: "third_country",
+                        what_is_your_partners_nationality?: "partner_other",
+                        partner_opposite_or_same_sex?: "same_sex"
+          assert_rendered_outcome
+        end
+
+        should "render an outcome where residency is in the UK and the partner " \
+                "is British and opposite sex getting married" do
+          add_responses legal_residency?: "uk",
+                        what_is_your_partners_nationality?: "partner_british",
+                        partner_opposite_or_same_sex?: "opposite_sex",
+                        marriage_or_civil_partnership?: "marriage"
+          assert_rendered_outcome
+        end
+
+        should "render an outcome where residency is in the UK and the partner " \
+               "is British and opposite sex registering a civil partnership" do
+          add_responses legal_residency?: "uk",
+                        what_is_your_partners_nationality?: "partner_british",
+                        partner_opposite_or_same_sex?: "opposite_sex",
+                        marriage_or_civil_partnership?: "civil_partnership"
+          assert_rendered_outcome
+        end
+
+        should "render an outcome where residency is in the UK and the partner is British and same sex" do
+          add_responses legal_residency?: "uk",
+                        what_is_your_partners_nationality?: "partner_british",
+                        partner_opposite_or_same_sex?: "same_sex"
+          assert_rendered_outcome
+        end
+
+        should "render an outcome where residency is in the UK and the partner "\
+               "is local and opposite sex getting married" do
+          add_responses legal_residency?: "uk",
+                        what_is_your_partners_nationality?: "partner_local",
+                        partner_opposite_or_same_sex?: "opposite_sex",
+                        marriage_or_civil_partnership?: "marriage"
+          assert_rendered_outcome
+        end
+
+        should "render an outcome where residency is in the UK and the partner " \
+               " is local and opposite sex registering a civil partnership" do
+          add_responses legal_residency?: "uk",
+                        what_is_your_partners_nationality?: "partner_local",
+                        partner_opposite_or_same_sex?: "opposite_sex",
+                        marriage_or_civil_partnership?: "civil_partnership"
+          assert_rendered_outcome
+        end
+
+        should "render an outcome where residency is in the UK and the partner is local and same sex" do
+          add_responses legal_residency?: "uk",
+                        what_is_your_partners_nationality?: "partner_local",
+                        partner_opposite_or_same_sex?: "same_sex"
+          assert_rendered_outcome
+        end
+
+        should "render an outcome where residency is in the UK and the partner " \
+               " is not local and opposite sex getting married" do
+          add_responses legal_residency?: "uk",
+                        what_is_your_partners_nationality?: "partner_other",
+                        partner_opposite_or_same_sex?: "opposite_sex",
+                        marriage_or_civil_partnership?: "marriage"
+          assert_rendered_outcome
+        end
+
+        should "render an outcome where residency is in the UK and the partner " \
+               " is not local and opposite sex registering a civil partnership" do
+          add_responses legal_residency?: "uk",
+                        what_is_your_partners_nationality?: "partner_other",
+                        partner_opposite_or_same_sex?: "opposite_sex",
+                        marriage_or_civil_partnership?: "civil_partnership"
           assert_rendered_outcome
         end
 

--- a/test/unit/calculators/marriage_abroad_calculator_test.rb
+++ b/test/unit/calculators/marriage_abroad_calculator_test.rb
@@ -58,6 +58,29 @@ module SmartAnswer
           assert_equal %w[2_outcome_country same_sex], @calculator.path_to_outcome
         end
 
+        context "country offers opposite sex civil partnership" do
+          setup do
+            MarriageAbroadDataQuery.any_instance
+                .stubs(:offers_consular_opposite_sex_civil_partnership?).returns(%w[country])
+          end
+
+          should "get outcome for consular civil partnership countries for opposite sex civil partnership" do
+            @calculator.ceremony_country = "country"
+            @calculator.sex_of_your_partner = "opposite_sex"
+            @calculator.type_of_ceremony = "civil_partnership"
+
+            assert_equal %w[country opposite_sex_civil_partnership], @calculator.path_to_outcome
+          end
+
+          should "get outcome for consular civil partnership countries for opposite sex marriage" do
+            @calculator.ceremony_country = "2_outcome_country"
+            @calculator.sex_of_your_partner = "opposite_sex"
+            @calculator.type_of_ceremony = "marriage"
+
+            assert_equal %w[2_outcome_country opposite_sex], @calculator.path_to_outcome
+          end
+        end
+
         context "when ceremony country is a three questions country" do
           setup do
             MarriageAbroadDataQuery.any_instance
@@ -690,6 +713,22 @@ module SmartAnswer
         should "return false if a PACS is not available in the ceremony country" do
           @calculator.ceremony_country = "country-without-pacs"
           assert_not @calculator.ceremony_country_offers_pacs?
+        end
+      end
+
+      context "#offers_consular_opposite_sex_civil_partnership?" do
+        setup do
+          @calculator = MarriageAbroadCalculator.new
+        end
+
+        should "return true if a consular opposite sex civil partnership is available in the ceremony country" do
+          @calculator.ceremony_country = "japan"
+          assert @calculator.offers_consular_opposite_sex_civil_partnership?
+        end
+
+        should "return false if a consular opposite sex civil partnership is not available in the ceremony country" do
+          @calculator.ceremony_country = "country-without-pacs"
+          assert_not @calculator.offers_consular_opposite_sex_civil_partnership?
         end
       end
 

--- a/test/unit/calculators/marriage_abroad_data_query_test.rb
+++ b/test/unit/calculators/marriage_abroad_data_query_test.rb
@@ -27,7 +27,14 @@ module SmartAnswer
           end
 
           should "only contain pre-defined data keys" do
-            keys = %w[countries_with_18_outcomes countries_with_2_outcomes countries_with_2_outcomes_marriage_or_pacs countries_with_6_outcomes countries_with_ceremony_location_outcomes countries_with_1_outcome]
+            keys = %w[countries_with_18_outcomes
+                      countries_with_19_outcomes
+                      countries_with_2_outcomes
+                      countries_with_3_outcomes
+                      countries_with_2_outcomes_marriage_or_pacs
+                      countries_with_6_outcomes
+                      countries_with_ceremony_location_outcomes
+                      countries_with_1_outcome]
             data = @data_query.marriage_data
 
             assert_equal keys, data.keys
@@ -302,15 +309,24 @@ module SmartAnswer
           should "return an alphabetical list of countries under all outcome groups" do
             YAML.stubs(:load_file).returns(
               countries_with_18_outcomes: %w[anguilla],
+              countries_with_19_outcomes: %w[panama],
               countries_with_6_outcomes: %w[bermuda],
               countries_with_2_outcomes: %w[cayman-islands],
+              countries_with_3_outcomes: %w[japan],
               countries_with_2_outcomes_marriage_or_pacs: %w[monaco],
               countries_with_ceremony_location_outcomes: %w[finland],
               countries_with_1_outcome: %w[french-guiana],
             )
 
             assert_equal @data_query.outcome_per_path_countries,
-                         %w[anguilla bermuda cayman-islands finland french-guiana monaco]
+                         %w[anguilla
+                            bermuda
+                            cayman-islands
+                            finland
+                            french-guiana
+                            japan
+                            monaco
+                            panama]
           end
         end
       end


### PR DESCRIPTION
Japan Vietnam and Panama offer consular opposite sex civil partnerships.

To provide this information in smart-answers this PR:
- Adds new question whether couples want to get married or register a
civil partnership
- Adds new outcomes for opposite sex civil partnerships for these countries

The `opposite_sex_civil_partnerships` outcomes for Panama and Vietnam (previously countries_with_18_outcomes) have been placed in the path `outcomes/panama/_opposite_sex_civil_partnership`. This differs from the typical pattern for outcomes in the marriage-abroad smart-answer. 

We deviated from the typical pattern since it would add around 9 outcomes for countries that previously has 18 outcomes. Since all of these outcomes would be the same it would create a large amount of duplication and make it more difficult to keep these files consistent with each other.

Trello card: 
https://trello.com/c/b6vvMECA/2600-2-add-new-question-and-outcome-to-japan-panama-and-vietnam-marriage-abroad-about-opposite-sex-civil-partnership
