### PR TITLE
Update generators for changed flow naming approach

### DIFF
--- a/lib/generators/smart_answer/USAGE
+++ b/lib/generators/smart_answer/USAGE
@@ -5,8 +5,8 @@ Example:
     rails generate smart_answer foo_bar
 
     This will create:
-        lib/smart_answer_flows/foo_bar.rb
-        lib/smart_answer_flows/foo_bar/start.erb
-        lib/smart_answer_flows/foo_bar/questions/question.erb
-        lib/smart_answer_flows/foo_bar/outcomes/results.erb
+        app/flows/foo_bar_flow.rb
+        app/flows/foo_bar_flow/start.erb
+        app/flows/foo_bar_flow/questions/question.erb
+        app/flows/foo_bar_flow/outcomes/results.erb
         lib/smart_answer/calculators/foo_bar_calculator.rb

--- a/lib/generators/smart_answer/smart_answer_generator.rb
+++ b/lib/generators/smart_answer/smart_answer_generator.rb
@@ -2,7 +2,7 @@ class SmartAnswerGenerator < Rails::Generators::NamedBase
   source_root File.expand_path("templates", __dir__)
 
   def copy_flow
-    filename = "lib/smart_answer_flows/#{name.dasherize}.rb"
+    filename = "app/flows/#{name.underscore}_flow.rb"
     copy_file "flow.rb", filename
 
     gsub_file filename, "SmartAnswerName", name.camelize
@@ -17,19 +17,19 @@ class SmartAnswerGenerator < Rails::Generators::NamedBase
   end
 
   def copy_landing
-    filename = "lib/smart_answer_flows/#{name.dasherize}/start.erb"
+    filename = "app/flows/#{name.underscore}_flow/start.erb"
     copy_file "landing.erb", filename
 
     gsub_file filename, "TITLE", name.humanize
   end
 
   def copy_question
-    filename = "lib/smart_answer_flows/#{name.dasherize}/questions/question.erb"
+    filename = "app/flows/#{name.underscore}_flow/questions/question.erb"
     copy_file "question.erb", filename
   end
 
   def copy_results
-    filename = "lib/smart_answer_flows/#{name.dasherize}/outcomes/results.erb"
+    filename = "app/flows/#{name.underscore}_flow/outcomes/results.erb"
     copy_file "results.erb", filename
   end
 

--- a/test/lib/generators/smart_answer_generator_test.rb
+++ b/test/lib/generators/smart_answer_generator_test.rb
@@ -10,20 +10,20 @@ class SmartAnswerGeneratorTest < Rails::Generators::TestCase
     assert_nothing_raised do
       run_generator %w[example_smart_answer]
 
-      assert_file "lib/smart_answer_flows/example-smart-answer.rb" do |content|
+      assert_file "app/flows/example_smart_answer_flow.rb" do |content|
         assert_match(/ExampleSmartAnswerFlow/, content)
         assert_match(/name "example-smart-answer"/, content)
         assert_match(/content_id/, content)
         assert_match(/status :draft/, content)
       end
 
-      assert_file "lib/smart_answer_flows/example-smart-answer/start.erb" do |content|
+      assert_file "app/flows/example_smart_answer_flow/start.erb" do |content|
         assert_match(/Example smart answer/, content)
       end
 
-      assert_file "lib/smart_answer_flows/example-smart-answer/questions/question.erb"
+      assert_file "app/flows/example_smart_answer_flow/questions/question.erb"
 
-      assert_file "lib/smart_answer_flows/example-smart-answer/outcomes/results.erb"
+      assert_file "app/flows/example_smart_answer_flow/outcomes/results.erb"
 
       assert_file "lib/smart_answer/calculators/example_smart_answer_calculator.rb" do |content|
         assert_match(/ExampleSmartAnswer/, content)


### PR DESCRIPTION
Trello: https://trello.com/c/fU4RQYvF/494-foundational-work-to-implement-smart-answer-flow-test-adr

This is a draft as it follows the work of https://github.com/alphagov/smart-answers/pull/5512.

This updates the generator code for the change in file name format for Flow classes and related code.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
