### PR TITLE
Update documentation for recent architectural changes

### DIFF
--- a/docs/design/erb-templates/landing-page-template.md
+++ b/docs/design/erb-templates/landing-page-template.md
@@ -1,6 +1,6 @@
 # Landing page template
 
-Landing page templates live in `lib/smart_answer_flows/<flow-name>/start.erb`.
+Landing page templates live in `app/flows/<flow-name>/start.erb`.
 
 ## Content types
 

--- a/docs/design/erb-templates/outcome-templates.md
+++ b/docs/design/erb-templates/outcome-templates.md
@@ -1,6 +1,6 @@
 # Outcome templates
 
-Outcome templates live in `lib/smart_answer_flows/<flow-name>/outcomes/<outcome-name>.erb`.
+Outcome templates live in `app/flows/<flow-name>/outcomes/<outcome-name>.erb`.
 
 ## Content types
 

--- a/docs/design/erb-templates/question-templates.md
+++ b/docs/design/erb-templates/question-templates.md
@@ -1,6 +1,6 @@
 # Question templates
 
-Question templates live in `lib/smart_answer_flows/<flow-name>/questions/<question-name>.erb`.
+Question templates live in `app/flows/<flow-name>/questions/<question-name>.erb`.
 
 ## Content types
 

--- a/docs/design/file-structure.md
+++ b/docs/design/file-structure.md
@@ -14,10 +14,8 @@ app
     |   |__ questions
     |   |   |__ <question-name>.erb (Optional: Data used to build questions e.g. question and option text)
     |__ shared
-    |    |__ <shared-directory-name>
-    |        |__ _<partial-name>.erb (Optional: Useful when you need to share content between Smart Answers)
-    |__ shared_logic
-        |__ <shared-logic-name>.rb (Optional: Useful when you need to share flow and question logic between Smart Answers)
+        |__ <shared-directory-name>
+            |__ _<partial-name>.erb (Optional: Useful when you need to share content between Smart Answers)
 lib
 |__ smart_answer
     |__ calculators

--- a/docs/design/file-structure.md
+++ b/docs/design/file-structure.md
@@ -3,11 +3,8 @@
 This is an overview of the components that make up a single Smart Answer.
 
 ```
-lib
-|__ smart_answer
-|   |__ calculators
-|       |__ <calculator-name>.rb (Optional: Object encapsulating business logic for the flow)
-|__ smart_answer_flows
+app
+|__ flows
     |__ <flow-name>.rb (Required: Flow and question logic)
     |__ <flow-name>
     |   |__ start.erb (Optional: Content for the landing page)
@@ -21,4 +18,8 @@ lib
     |        |__ _<partial-name>.erb (Optional: Useful when you need to share content between Smart Answers)
     |__ shared_logic
         |__ <shared-logic-name>.rb (Optional: Useful when you need to share flow and question logic between Smart Answers)
+lib
+|__ smart_answer
+    |__ calculators
+        |__ <calculator-name>.rb (Optional: Object encapsulating business logic for the flow)
 ```

--- a/docs/design/flow-definition.md
+++ b/docs/design/flow-definition.md
@@ -4,24 +4,20 @@ At the heart of each Smart Answer is a subclass of `SmartAnswer::Flow`. Subclass
 
 ## Naming
 
-The flow filename should be based on the path where the Smart Answer is to be found on gov.uk. For example, for a Smart Answer at https://www.gov.uk/example-smart-answer, the flow file should be named `lib/smart_answer_flows/example-smart-answer.rb`. Similarly the template directory should be named `lib/smart_answer_flows/example-smart-answer/`.
+The flow filename should be based on the path where the Smart Answer is to be found on gov.uk. For example, for a Smart Answer at https://www.gov.uk/example-smart-answer, the flow file should be named `app/flows/example_smart_answer_flow.rb`. Similarly the template directory should be named `app/flows/example_smart_answer_flow/`.
 
-The flow class should be a camel-case version of the flow filename with the suffix, `Flow` e.g. in the case above it would be `ExampleSmartAnswerFlow`. The class should inherit from `SmartAnswer::Flow` and be in the `SmartAnswer` namespace.
+The flow class should be a camel-case version of the flow filename e.g. in the case above it would be `ExampleSmartAnswerFlow`. The class should inherit from `SmartAnswer::Flow`.
 
 For example:
 
 ```ruby
-# lib/smart_answer_flows/example-smart-answer/example-smart-answer.rb
-module SmartAnswer
-  class ExampleSmartAnswerFlow < Flow
-    def define
-      # flow definition specified here
-    end
+# app/flows/example_smart_answer_flow.rb
+class ExampleSmartAnswerFlow < SmartAnswer::Flow
+  def define
+    # flow definition specified here
   end
 end
 ```
-
-> Note that much of the above does not follow standard Ruby or Rails conventions which isn't ideal. However, the plan is to move towards using such conventions as soon as possible.
 
 ## Definition
 
@@ -45,15 +41,13 @@ It's important to understand this distinction between "flow definition time" and
 There are a number of methods on `SmartAnswer::Flow` which allow "metadata" for the flow to be specified:
 
 ```ruby
-module SmartAnswer
-  class ExampleSmartAnswerFlow < Flow
-    def define
-      name 'example-smart-answer' # this is the path where the Smart Answer will be registered on gov.uk (via the publishing-api)
-      content_id "bfda3b4f-166b-48e7-9aaf-21bfbd606207" # a UUID used by v2 of the Publishing API (?)
-      status :published # this indicates whether or not the flow is available to be published to live gov.uk , those with `:draft` status will be available on draft gov.uk
+class ExampleSmartAnswerFlow < SmartAnswer::Flow
+  def define
+    name 'example-smart-answer' # this is the path where the Smart Answer will be registered on gov.uk (via the publishing-api)
+    content_id "bfda3b4f-166b-48e7-9aaf-21bfbd606207" # a UUID used by v2 of the Publishing API (?)
+    status :published # this indicates whether or not the flow is available to be published to live gov.uk , those with `:draft` status will be available on draft gov.uk
 
-      # question & outcome definitions specified here
-    end
+    # question & outcome definitions specified here
   end
 end
 ```
@@ -93,22 +87,20 @@ Question nodes are defined by calls to one of the various [question-type methods
 For example:
 
 ```ruby
-module SmartAnswer
-  class ExampleSmartAnswerFlow < Flow
-    def define
-      # self = instance of SmartAnswer::Flow
+class ExampleSmartAnswerFlow < SmartAnswer::Flow
+  def define
+    # self = instance of SmartAnswer::Flow
 
-      # metadata specified here
+    # metadata specified here
 
-      radio :question_key do
-        option :option_key_1
-        option :option_key_2
+    radio :question_key do
+      option :option_key_1
+      option :option_key_2
 
-        # optional blocks specified here
+      # optional blocks specified here
 
-        next_node do
-          # routing logic specified here
-        end
+      next_node do
+        # routing logic specified here
       end
     end
   end

--- a/docs/design/flow-definition.md
+++ b/docs/design/flow-definition.md
@@ -70,7 +70,7 @@ Some flows (e.g. [register-a-birth][local-variable-in-flow-definition]) define l
 
 Every flow has an implicit start node which represents the "landing page" i.e. the page which displays the "Start" button. There is no representation of this start node in the flow definition. Clicking the "Start" button on the "landing page" takes you to the page for the first question node (see below).
 
-Also see the documentation for [landing page templates](/docs/smart-answers/erb-templates/landing-page-template.md).
+Also see the documentation for [landing page templates](erb-templates/landing-page-template.md).
 
 ### Question nodes
 
@@ -251,7 +251,7 @@ Each of these block types and the point at which they are executed is explained 
   1. A `SmartAnswer::InvalidResponse` exception is raised with the `message_key` set as the exception message.
   2. This exception is handled within the app and prevents the transition to the next node.
   3. The `message_key` from the exception message is set on the built-in state variable, `error`.
-  4. When the question template is re-rendered, the `error` state variable is used to lookup the appropriate validation error message in the [question template](/docs/smart-answers/erb-templates/question-templates.md#error_messagemessage).
+  4. When the question template is re-rendered, the `error` state variable is used to lookup the appropriate validation error message in the [question template](erb-templates/question-templates.md#error_messagemessage).
 
 > The use of these blocks is encouraged. However, they should call `valid_xxx?` methods on the `calculator` state variable and not rely on the `response` argument passed into the block.
 
@@ -283,7 +283,7 @@ See the [documentation on storing data](storing-data.md).
 
 #### Templates
 
-See the [documentation for question templates](/docs/smart-answers/erb-templates/question-templates.md).
+See the [documentation for question templates](erb-templates/question-templates.md).
 
 ### Outcome nodes
 
@@ -295,7 +295,7 @@ If any attempt is made to process a response when the current node is an outcome
 
 #### Templates
 
-See the [documentation for outcome templates](/docs/smart-answers/erb-templates/outcome-templates.md).
+See the [documentation for outcome templates](erb-templates/outcome-templates.md).
 
 [instance-eval]: http://ruby-doc.org/core-2.6.1/BasicObject.html#method-i-instance_eval
 [instance-exec]: http://ruby-doc.org/core-2.6.1/BasicObject.html#method-i-instance_exec

--- a/docs/design/flow-definition.md
+++ b/docs/design/flow-definition.md
@@ -180,7 +180,7 @@ new_state.equal?(state) # => false (i.e. they are *different* instances)
 new_state.example_state_variable # => 123
 ```
 
-It's important to note that `Object#dup` does not do a "deep" copy. Thus any "state variables" set on the state which are references to other objects will continue to reference the _same_ instances of those other object - those objects will *not* themselves be duplicated. The *only* exceptions to this are two built-in state variables, `responses` & `path` ([see below](#built-in-state-variables)) which are themselves duplicated using `Object#dup` in `State#initialize_copy`.
+It's important to note that `Object#dup` does not do a "deep" copy. Thus any "state variables" set on the state which are references to other objects will continue to reference the _same_ instances of those other object - those objects will *not* themselves be duplicated. The exceptions to this are built-in state variables: `accepted_responses` and `forwarding_responses` ([see below](#built-in-state-variables)), these are duplicated using `Object#dup` in `State#initialize_copy`.
 
 ```ruby
 state = SmartAnswer::State.new(:first_node)
@@ -197,19 +197,19 @@ It's possible to [view the state](viewing-state.md) when you're running the app 
 
 ##### Built-in state variables
 
-* `current_node` - symbol key for the node being processed
-* `path` - array of symbol keys for nodes previously processed
-* `responses` - user responses parsed from request path; usually strings (?)
-* `response` - always `nil` (?)
+* `current_node_name` - symbol key for the node being processed
+* `accepted_responses` - hash of symbol keys for nodes previously processed with the answer input
+* `forwarding_responses` - hash of unprocessed user input of questions, used to store answers when returning to previous nodes
+* `current_response` - the user input provided for the current question if provided
 * `error` - key for validation error message to display; usually a string (?)
 
 ```ruby
 state = SmartAnswer::State.new(:first_node)
-# => #<SmartAnswer::State current_node=:first_node, path=[], responses=[], response=nil, error=nil>
+# => #<SmartAnswer::State current_node_name=:first_node, accepted_responses={}, forwarding_responses={}, current_response=nil, error=nil>
 first_state = state.transition_to(:second_node, 'first-response')
-# => #<SmartAnswer::State current_node=:second_node, path=[:first_node], responses=["first-response"], response=nil, error=nil>
+# => #<SmartAnswer::State current_node_name=:second_node, accepted_responses={:first_node=>"first-response"}, forwarding_responses={}, current_response=nil, error=nil> 
 second_state = first_state.transition_to(:third_node, 'second-response')
-# => #<SmartAnswer::State current_node=:third_node, path=[:first_node, :second_node], responses=["first-response", "second-response"], response=nil, error=nil>
+# => #<SmartAnswer::State current_node_name=:third_node, accepted_responses={:first_node=>"first-response", :second_node=>"second-response"}, forwarding_responses={}, current_response=nil, error=nil>
 ```
 
 > Note that some of the application code (e.g. illegal radio response) erroneously sets the error key to the validation error message *string*. Since this string is not the *key* to an error message, the default error message is displayed.

--- a/docs/tasks/creating-a-new-smart-answer.md
+++ b/docs/tasks/creating-a-new-smart-answer.md
@@ -91,7 +91,7 @@ Open the new landing page template your editor and copy/paste the following cont
 
 Refresh the Smart Answer in your browser to see this new content.
 
-Read more about [landing page templates](/docs/smart-answers/erb-templates/landing-page-template.md).
+Read more about [landing page templates](../design/erb-templates/landing-page-template.md).
 
 Click "Start now" to visit the first question. You should see an error message indicating that we're now missing an ERB template for our question.
 
@@ -122,7 +122,7 @@ Open the new question page template in your editor and copy/paste the following 
 
 Refresh the Smart Answer in your browser to see this new content.
 
-Read more about [question page templates](/docs/smart-answers/erb-templates/question-templates.md).
+Read more about [question page templates](../design/erb-templates/question-templates.md).
 
 Enter any value in the text field and click "Continue". You should see an error message indicating that we're now missing an ERB template for the outcome.
 
@@ -153,7 +153,7 @@ Open the new outcome page template in your editor and copy/paste the following c
 
 Refresh the Smart Answer in your browser to see this new content.
 
-Read more about [outcome page templates](/docs/smart-answers/erb-templates/outcome-templates.md).
+Read more about [outcome page templates](../design/erb-templates/outcome-templates.md).
 
 And that's all there is to an incredibly simple Smart Answer.
 

--- a/docs/tasks/creating-a-new-smart-answer.md
+++ b/docs/tasks/creating-a-new-smart-answer.md
@@ -37,7 +37,7 @@ This walks through the basics of manually creating a new Smart Answer.
 Start by creating a new file to hold the logic of our flow:
 
 ```bash
-$ touch lib/smart_answer_flows/example-smart-answer.rb
+$ touch app/flows/example_smart_answer_flow.rb
 ```
 
 Open the new file in your editor and copy/paste this skeleton flow:
@@ -69,8 +69,8 @@ If you were to run `rails server` and visit [http://localhost:3000/example-smart
 Create a new file for our landing page template.
 
 ```
-$ mkdir lib/smart_answer_flows/example-smart-answer
-$ touch lib/smart_answer_flows/example-smart-answer/start.erb
+$ mkdir app/flows/example_smart_answer_flow
+$ touch app/flows/example_smart_answer_flow/start.erb
 ```
 
 Although the landing page template needs to exist, it doesn't actually need to contain anything!
@@ -100,8 +100,8 @@ Click "Start now" to visit the first question. You should see an error message i
 Create a new file for our question page template.
 
 ```
-$ mkdir lib/smart_answer_flows/example-smart-answer/questions
-$ touch lib/smart_answer_flows/example-smart-answer/questions/question_1.erb
+$ mkdir app/flows/example_smart_answer_flow/questions
+$ touch app/flows/example_smart_answer_flow/questions/question_1.erb
 ```
 
 Although the question page template needs to exist, it doesn't actually need to contain anything!
@@ -131,8 +131,8 @@ Enter any value in the text field and click "Continue". You should see an error 
 Create a new file for our outcome page template.
 
 ```
-$ mkdir lib/smart_answer_flows/example-smart-answer/outcomes
-$ touch lib/smart_answer_flows/example-smart-answer/outcomes/outcome_1.erb
+$ mkdir app/flows/example_smart_answer_flow/outcomes
+$ touch app/flows/example_smart_answer/outcomes/outcome_1.erb
 ```
 
 Although the question page template needs to exist, it doesn't actually need to contain anything!

--- a/docs/tasks/flattening-outcomes.md
+++ b/docs/tasks/flattening-outcomes.md
@@ -6,11 +6,11 @@
 
 **2. Add or move the country into the right section of these files:**
   - `config/smart_answers/marriage_abroad_data.yml`
-  - `test/integration/smart_answer_flows/marriage_abroad_test.rb`
+  - `test/integration/flows/marriage_abroad_test.rb`
 
 **3. Update any special cases in these files:**
-  - `test/integration/smart_answer_flows/marriage_abroad_test.rb`
-  - `lib/smart_answer_flows/marriage-abroad.rb`
+  - `test/integration/flows/marriage_abroad_test.rb`
+  - `app/flows/marriage_abroad_flow.rb`
 
 **4. Remove any special-case outcome files for the country here:**
-  - `lib/smart_answer_flows/marriage-abroad/outcomes`
+  - `app/flows/marriage_abroad/outcomes`

--- a/docs/tasks/retiring-a-smart-answer.md
+++ b/docs/tasks/retiring-a-smart-answer.md
@@ -11,24 +11,24 @@ Remove all the files and directories associated with the individual Smart
 Answer and their associated tests, examples of common files:
 
 - Flow class files
-  - lib/smart_answer_flows/<\smart-answer-name>.rb
+  - app/flows/<\smart-answer>\_flow.rb
 - ERB templates directory
-  - lib/smart_answer_flows/<\smart-answer-name>
+  - app/flows/<\smart-answer>\_flow
 - YAML files
-  - config/smart_answers/rates/<\smart-answer-name>.yml
-  - config/smart_answers/<\smart-answer-name>.yml
+  - config/smart_answers/rates/<\smart-answer>.yml
+  - config/smart_answers/<\smart-answer>.yml
 - Calculators, data query and other ruby files
-  - lib/smart_answer/calculators/<\smart-answer-name>\_calculator.rb
-  - lib/smart_answer/calculators/<\smart-answer-name>\_data_query.rb
+  - lib/smart_answer/calculators/<\smart-answer>\_calculator.rb
+  - lib/smart_answer/calculators/<\smart-answer>\_data_query.rb
 
 ## Removing the content item
 
 Before removing a Smart Answer you will need the content_id for the Smart
 Answer. These can be found in the
-`lib/smart_answer_flows/<\smart-answer-name>.rb` file of the Smart Answer that
+`app/flows/<\smart-answer>_flow.rb` file of the Smart Answer that
 is being retired. For redirecting or replacing a Smart Answer you will also
 need to know the paths of these pages these are based off the `name` attribute
-of the `lib/smart_answer_flows/<\smart-answer-name>.rb` file. For example, for
+of the `app/flows/<\smart-answer>_flow.rb` file. For example, for
 the Marriage Abroad Smart Answer the path is `/marriage-abroad`.
 
 ### Redirecting users to a different URL
@@ -41,7 +41,7 @@ destination, `/random`, you'd run the following rake task:
 bundle exec rake "publishing_api:unpublish_redirect[<content_id>,<base_path>,/random,prefix]"
 ```
 
-Applying this to the [Marriage Abroad](../../lib/smart_answer_flows/marriage-abroad.rb)
+Applying this to the [Marriage Abroad](../../app/flows/marriage_abroad_flow.rb)
 Smart Answer you'd run the following command:
 
 ```


### PR DESCRIPTION
Trello: https://trello.com/c/fU4RQYvF/494-foundational-work-to-implement-smart-answer-flow-test-adr

This is a draft as it follows on from https://github.com/alphagov/smart-answers/pull/5512. It captures the changes introduced by that PR and any other bits of out-of-date documentation I found along the way.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
