### PR TITLE
Set additional parameters on state

### DIFF
--- a/lib/smart_answer/state_resolver.rb
+++ b/lib/smart_answer/state_resolver.rb
@@ -5,11 +5,17 @@ module SmartAnswer
     end
 
     def state_from_response_store(response_store, requested_node = nil)
-      resolve_state(start_state, response_store, requested_node)
+      start_state = State.new(@flow.questions.first.name)
+      @flow.additional_parameters.each do |param|
+        start_state[param] = response_store.get(param)
+      end
+
+      resolve_state(start_state.freeze, response_store, requested_node)
     end
 
     def state_from_params(params)
       responses = params[:responses].to_s.split("/")
+      start_state = State.new(@flow.questions.first.name).freeze
 
       state = responses.inject(start_state) do |current_state, response|
         return current_state if current_state.error
@@ -38,10 +44,6 @@ module SmartAnswer
 
       next_state = transition_state_to_next_node(state, response)
       resolve_state(next_state, response_store, requested_node)
-    end
-
-    def start_state
-      State.new(@flow.questions.first.name).freeze
     end
 
     def apply_response_to_state(state, response)

--- a/test/unit/state_resolver_test.rb
+++ b/test/unit/state_resolver_test.rb
@@ -4,6 +4,8 @@ module SmartAnswer
   class StateResolverTest < ActiveSupport::TestCase
     setup do
       @flow = SmartAnswer::Flow.build do
+        additional_parameters %w[c d]
+
         radio :x do
           option :yes
           option :no
@@ -106,6 +108,14 @@ module SmartAnswer
         assert_equal :x, state.current_node_name
         assert_equal ({}), state.accepted_responses
         assert_nil state.current_response
+      end
+
+      should "set additional parameters on the state" do
+        response_store = ResponseStore.new(responses: { "x" => "yes", "c" => "true" })
+        state = @state_resolver.state_from_response_store(response_store)
+
+        assert_equal :y, state.current_node_name
+        assert_equal "true", state.c
       end
     end
 


### PR DESCRIPTION
This allow additional parameters and their values to be set on the state object accessible within the flow. This allows additional parameters to be used in calculator objects. This is needed the next steps for you business flow - we need to access the `ct` parameter to hide or show a result.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
