### PR TITLE
Revert "Bump govuk_publishing_components from 24.20.0 to 24.21.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,7 +137,7 @@ GEM
       sentry-ruby (~> 4.5.0)
       statsd-ruby (~> 1.5.0)
       unicorn (>= 5.4, < 5.9)
-    govuk_publishing_components (24.21.0)
+    govuk_publishing_components (24.20.0)
       govuk_app_config
       kramdown
       plek


### PR DESCRIPTION
Reverts alphagov/smart-answers#5511. This release caused a breaking change. Revert the dependency until the issue can be resolved.