### PR TITLE
Add rule to hide corporation tax result

### DIFF
--- a/app/flows/next_steps_for_your_business_flow.rb
+++ b/app/flows/next_steps_for_your_business_flow.rb
@@ -17,6 +17,7 @@ class NextStepsForYourBusinessFlow < SmartAnswer::Flow
       on_response do |response|
         self.calculator = SmartAnswer::Calculators::NextStepsForYourBusinessCalculator.new
         calculator.annual_turnover_over_85k = response
+        calculator.registered_for_corp_tax = (ct == "true")
       end
 
       next_node do

--- a/lib/smart_answer/calculators/next_steps_for_your_business_calculator.rb
+++ b/lib/smart_answer/calculators/next_steps_for_your_business_calculator.rb
@@ -11,7 +11,8 @@ module SmartAnswer::Calculators
                   :employer,
                   :activities,
                   :needs_financial_support,
-                  :business_premises
+                  :business_premises,
+                  :registered_for_corp_tax
 
     def grouped_results
       grouped_results = filtered_results.group_by { |result| result["group"] }
@@ -28,7 +29,7 @@ module SmartAnswer::Calculators
     end
 
     RULES = {
-      r1: ->(_) { true },
+      r1: ->(calculator) { calculator.registered_for_corp_tax != true },
       r2: ->(_) { true },
       r3: ->(_) { true },
       r4: ->(_) { true },


### PR DESCRIPTION
For the "Next steps for you business" this add a rule to hide the corporation tax results based on the value of the ct query parameter. This query parameter is set by Companies House in links sent via email and indicates whether they've already been registered.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
