### PR TITLE
Only show UK Ancestry Visa for certain nationalities

### DIFF
--- a/app/flows/check_uk_visa_flow/outcomes/_uk_ancestry_visa.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/_uk_ancestry_visa.erb
@@ -1,6 +1,6 @@
-##If you’re a citizen of a Commonwealth country
+##If one of your grandparents was born in the UK
 
-You may be able to live and work in the UK with a [UK Ancestry visa](https://www.gov.uk/ancestry-visa) if one of your grandparents was born in the UK.
+You may be able to live and work in the UK with a [UK Ancestry visa](https://www.gov.uk/ancestry-visa).
 
 With this visa, you can:
 
@@ -11,10 +11,8 @@ With this visa, you can:
 
 The eligibility criteria include:
 
-+ being from a [Commonwealth country](https://thecommonwealth.org/member-countries)
-+ proving that one of your grandparents was born in the UK, the Channel Islands or the Isle of Man
 + being aged 17 or over
-
++ proving that one of your grandparents was born in the UK, the Channel Islands or the Isle of Man
 
 ###How long you can stay
 

--- a/app/flows/check_uk_visa_flow/outcomes/_uk_ancestry_visa.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/_uk_ancestry_visa.erb
@@ -1,25 +1,29 @@
-##If one of your grandparents was born in the UK
+<% if calculator.passport_country_in_uk_ancestry_visa_list? %>
 
-You may be able to live and work in the UK with a [UK Ancestry visa](https://www.gov.uk/ancestry-visa).
+  ##If one of your grandparents was born in the UK
 
-With this visa, you can:
+  You may be able to live and work in the UK with a [UK Ancestry visa](https://www.gov.uk/ancestry-visa).
 
-<% if local_assigns[:show_business] %>
-  + start a business
+  With this visa, you can:
+
+  <% if local_assigns[:show_business] %>
+    + start a business
+  <% end %>
+  + work in the UK without a job offer, including voluntary work
+  + be an employee, self-employed or a director of a company
+
+  ###Eligibility
+
+  The eligibility criteria include:
+
+  + being aged 17 or over
+  + proving that one of your grandparents was born in the UK, the Channel Islands or the Isle of Man
+
+  ###How long you can stay
+
+  This visa lasts for 5 years. After this time, you may be able to apply to either:
+
+  + extend it for a further 5 years
+  + settle permanently in the UK
+
 <% end %>
-+ work in the UK without a job offer, including voluntary work
-+ be an employee, self-employed or a director of a company
-
-###Eligibility
-
-The eligibility criteria include:
-
-+ being aged 17 or over
-+ proving that one of your grandparents was born in the UK, the Channel Islands or the Isle of Man
-
-###How long you can stay
-
-This visa lasts for 5 years. After this time, you may be able to apply to either:
-
-+ extend it for a further 5 years
-+ settle permanently in the UK

--- a/app/flows/check_uk_visa_flow/outcomes/_uk_ancestry_visa.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/_uk_ancestry_visa.erb
@@ -4,6 +4,9 @@ You may be able to live and work in the UK with a [UK Ancestry visa](https://www
 
 With this visa, you can:
 
+<% if local_assigns[:show_business] %>
+  + start a business
+<% end %>
 + work in the UK without a job offer, including voluntary work
 + be an employee, self-employed or a director of a company
 

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_work_y_academic.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_work_y_academic.erb
@@ -79,5 +79,5 @@
 
   <%= render partial: 'country_in_youth_mobility_scheme', locals: { calculator: calculator } %>
 
-  <%= render partial: 'uk_ancestry_visa' %>
+  <%= render partial: 'uk_ancestry_visa', locals: { calculator: calculator } %>
 <% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_work_y_academic.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_work_y_academic.erb
@@ -79,5 +79,5 @@
 
   <%= render partial: 'country_in_youth_mobility_scheme', locals: { calculator: calculator } %>
 
-  <%= render partial: 'citizen_of_commonwealth_country' %>
+  <%= render partial: 'uk_ancestry_visa' %>
 <% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_work_y_arts.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_work_y_arts.erb
@@ -98,7 +98,7 @@
 
   <%= render partial: 'country_in_youth_mobility_scheme', locals: { calculator: calculator } %>
 
-  <%= render partial: 'uk_ancestry_visa' %>
+  <%= render partial: 'uk_ancestry_visa', locals: { calculator: calculator } %>
 
   ----
 

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_work_y_arts.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_work_y_arts.erb
@@ -98,7 +98,7 @@
 
   <%= render partial: 'country_in_youth_mobility_scheme', locals: { calculator: calculator } %>
 
-  <%= render partial: 'citizen_of_commonwealth_country' %>
+  <%= render partial: 'uk_ancestry_visa' %>
 
   ----
 

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_work_y_business.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_work_y_business.erb
@@ -90,7 +90,7 @@
 
   <%= render partial: 'country_in_youth_mobility_scheme', locals: { calculator: calculator } %>
 
-  <%= render partial: 'uk_ancestry_visa', locals: { show_business: true } %>
+  <%= render partial: 'uk_ancestry_visa', locals: {calculator: calculator, show_business: true } %>
 
 ----
 

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_work_y_business.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_work_y_business.erb
@@ -90,33 +90,9 @@
 
   <%= render partial: 'country_in_youth_mobility_scheme', locals: { calculator: calculator } %>
 
-  ##If you’re a citizen of a Commonwealth country
+  <%= render partial: 'uk_ancestry_visa', locals: { show_business: true } %>
 
-  You may be able to live and work in the UK with a [UK Ancestry visa](https://www.gov.uk/ancestry-visa) if one of your grandparents was born in the UK.
-
-  With this visa, you can:
-
-  + start a business
-  + work in the UK without a job offer, including voluntary work
-  + be an employee, self-employed or a director of a company
-
-  ###Eligibility
-
-  The eligibility criteria include:
-
-  + being from a [Commonwealth country](https://thecommonwealth.org/member-countries)
-  + proving that one of your grandparents was born in the UK, the Channel Islands or the Isle of Man
-  + being aged 17 or over
-
-
-  ###How long you can stay
-
-  This visa lasts for 5 years. After this time, you may be able to apply to either:
-
-  + extend it for a further 5 years
-  + settle permanently in the UK
-
-  ----
+----
 
   ##If you want to invest in UK businesses
 

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_work_y_digital.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_work_y_digital.erb
@@ -69,5 +69,5 @@
 
   <%= render partial: 'country_in_youth_mobility_scheme', locals: { calculator: calculator } %>
 
-  <%= render partial: 'citizen_of_commonwealth_country' %>
+  <%= render partial: 'uk_ancestry_visa' %>
 <% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_work_y_digital.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_work_y_digital.erb
@@ -69,5 +69,5 @@
 
   <%= render partial: 'country_in_youth_mobility_scheme', locals: { calculator: calculator } %>
 
-  <%= render partial: 'uk_ancestry_visa' %>
+  <%= render partial: 'uk_ancestry_visa', locals: { calculator: calculator } %>
 <% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_work_y_health.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_work_y_health.erb
@@ -41,7 +41,7 @@
 
   <%= render partial: 'country_in_youth_mobility_scheme', locals: { calculator: calculator } %>
 
-  <%= render partial: 'citizen_of_commonwealth_country' %>
+  <%= render partial: 'uk_ancestry_visa' %>
 
   ----
 

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_work_y_health.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_work_y_health.erb
@@ -41,7 +41,7 @@
 
   <%= render partial: 'country_in_youth_mobility_scheme', locals: { calculator: calculator } %>
 
-  <%= render partial: 'uk_ancestry_visa' %>
+  <%= render partial: 'uk_ancestry_visa', locals: { calculator: calculator } %>
 
   ----
 

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_work_y_other.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_work_y_other.erb
@@ -44,7 +44,7 @@
 
   <%= render partial: 'country_in_youth_mobility_scheme', locals: { calculator: calculator } %>
 
-  <%= render partial: 'citizen_of_commonwealth_country' %>
+  <%= render partial: 'uk_ancestry_visa' %>
 
   ----
 

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_work_y_other.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_work_y_other.erb
@@ -44,7 +44,7 @@
 
   <%= render partial: 'country_in_youth_mobility_scheme', locals: { calculator: calculator } %>
 
-  <%= render partial: 'uk_ancestry_visa' %>
+  <%= render partial: 'uk_ancestry_visa', locals: { calculator: calculator } %>
 
   ----
 

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_work_y_religious.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_work_y_religious.erb
@@ -46,5 +46,5 @@
 
   <%= render partial: 'country_in_youth_mobility_scheme', locals: { calculator: calculator } %>
 
-  <%= render partial: 'citizen_of_commonwealth_country' %>
+  <%= render partial: 'uk_ancestry_visa' %>
 <% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_work_y_religious.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_work_y_religious.erb
@@ -46,5 +46,5 @@
 
   <%= render partial: 'country_in_youth_mobility_scheme', locals: { calculator: calculator } %>
 
-  <%= render partial: 'uk_ancestry_visa' %>
+  <%= render partial: 'uk_ancestry_visa', locals: { calculator: calculator } %>
 <% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_work_y_sports.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_work_y_sports.erb
@@ -46,5 +46,5 @@
 
   ----
 
-  <%= render partial: 'uk_ancestry_visa' %>
+  <%= render partial: 'uk_ancestry_visa', locals: { calculator: calculator } %>
 <% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_work_y_sports.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_work_y_sports.erb
@@ -46,5 +46,5 @@
 
   ----
 
-  <%= render partial: 'citizen_of_commonwealth_country' %>
+  <%= render partial: 'uk_ancestry_visa' %>
 <% end %>

--- a/lib/smart_answer/calculators/uk_visa_calculator.rb
+++ b/lib/smart_answer/calculators/uk_visa_calculator.rb
@@ -33,6 +33,10 @@ module SmartAnswer::Calculators
       COUNTRY_GROUP_YOUTH_MOBILITY_SCHEME.include?(@passport_country)
     end
 
+    def passport_country_in_uk_ancestry_visa_list?
+      COUNTRY_GROUP_UK_ANCESTRY_VISA.include?(@passport_country)
+    end
+
     def passport_country_in_electronic_visa_waiver_list?
       COUNTRY_GROUP_ELECTRONIC_VISA_WAIVER.include?(@passport_country)
     end
@@ -182,6 +186,62 @@ module SmartAnswer::Calculators
       the-occupied-palestinian-territories
       wallis-and-futuna
       western-sahara
+    ].freeze
+
+    COUNTRY_GROUP_COMMONWEALTH = %w[
+      antigua-and-barbuda
+      australia
+      bahamas
+      bangladesh
+      barbados
+      belize
+      botswana
+      brunei
+      cameroon
+      canada
+      cyprus
+      dominica
+      eswatini
+      fiji
+      ghana
+      grenada
+      guyana
+      india
+      jamaica
+      kenya
+      kiribati
+      lesotho
+      malawi
+      malaysia
+      maldives
+      malta
+      mauritius
+      mozambique
+      namibia
+      nauru
+      new-zealand
+      nigeria
+      pakistan
+      papua-new-guinea
+      rwanda
+      samoa
+      seychelles
+      sierra-leone
+      singapore
+      solomon-islands
+      south-africa
+      sri-lanka
+      st-kitts-and-nevis
+      st-lucia
+      st-vincent-and-the-grenadines
+      tanzania
+      the-gambia
+      tonga
+      trinidad-and-tobago
+      tuvalu
+      uganda
+      vanuatu
+      zambia
     ].freeze
 
     COUNTRY_GROUP_BRITISH_OVERSEAS_TERRITORIES = %w[
@@ -457,6 +517,14 @@ module SmartAnswer::Calculators
       "san-marino",
       "south-korea",
       "taiwan",
+    ].flatten.freeze
+
+    COUNTRY_GROUP_UK_ANCESTRY_VISA = [
+      COUNTRY_GROUP_COMMONWEALTH,
+      COUNTRY_GROUP_BRITISH_OVERSEAS_TERRITORIES,
+      COUNTRY_GROUP_BRITISH_NATIONAL_OVERSEAS,
+      "british-overseas-citizen",
+      "zimbabwe",
     ].flatten.freeze
   end
 end

--- a/test/flows/check_uk_visa_flow_test.rb
+++ b/test/flows/check_uk_visa_flow_test.rb
@@ -720,6 +720,7 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
     test_stateless_or_refugee_outcome_guidance
     test_bno_outcome_guidance
     test_country_in_youth_mobility_outcome_guidance
+    test_country_in_uk_ancestry_visa
   end
 
   context "outcome: outcome_work_y_arts" do
@@ -746,6 +747,7 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
     test_stateless_or_refugee_outcome_guidance
     test_bno_outcome_guidance
     test_country_in_youth_mobility_outcome_guidance
+    test_country_in_uk_ancestry_visa_with_business_information
   end
 
   context "outcome: outcome_work_y_business" do
@@ -759,6 +761,7 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
     test_stateless_or_refugee_outcome_guidance
     test_bno_outcome_guidance
     test_country_in_youth_mobility_outcome_guidance
+    test_country_in_uk_ancestry_visa
   end
 
   context "outcome: outcome_work_y_digital" do
@@ -772,6 +775,7 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
     test_stateless_or_refugee_outcome_guidance
     test_bno_outcome_guidance
     test_country_in_youth_mobility_outcome_guidance
+    test_country_in_uk_ancestry_visa
   end
 
   context "outcome: outcome_work_y_health" do
@@ -785,6 +789,7 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
     test_stateless_or_refugee_outcome_guidance
     test_bno_outcome_guidance
     test_country_in_youth_mobility_outcome_guidance
+    test_country_in_uk_ancestry_visa
   end
 
   context "outcome: outcome_work_y_other" do
@@ -798,6 +803,7 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
     test_stateless_or_refugee_outcome_guidance
     test_bno_outcome_guidance
     test_country_in_youth_mobility_outcome_guidance
+    test_country_in_uk_ancestry_visa
   end
 
   context "outcome: outcome_work_y_religious" do
@@ -811,6 +817,7 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
     test_stateless_or_refugee_outcome_guidance
     test_bno_outcome_guidance
     test_country_in_youth_mobility_outcome_guidance
+    test_country_in_uk_ancestry_visa
   end
 
   context "outcome: outcome_work_y_other" do

--- a/test/support/flows/check_uk_visa_flow_test_helper.rb
+++ b/test/support/flows/check_uk_visa_flow_test_helper.rb
@@ -30,6 +30,21 @@ module CheckUkVisaFlowTestHelper
     end
   end
 
+  def test_country_in_uk_ancestry_visa
+    should "render visa country guidance when passport country is in the UK Ancestry Visa list" do
+      add_responses what_passport_do_you_have?: "canada"
+      assert_rendered_outcome text: "If one of your grandparents was born in the UK"
+    end
+  end
+
+  def test_country_in_uk_ancestry_visa_with_business_information
+    should "render visa country guidance with business information when passport country is in the UK Ancestry Visa list" do
+      add_responses what_passport_do_you_have?: "canada"
+      assert_rendered_outcome text: "If one of your grandparents was born in the UK"
+      assert_rendered_outcome text: "start a business"
+    end
+  end
+
   def test_shared_purpose_of_visit_next_nodes
     should "have a next node of staying_for_how_long? for a 'study' response" do
       assert_next_node :staying_for_how_long?, for_response: "study"

--- a/test/unit/calculators/uk_visa_calculator_test.rb
+++ b/test/unit/calculators/uk_visa_calculator_test.rb
@@ -213,6 +213,20 @@ module SmartAnswer
         end
       end
 
+      context "#passport_country_in_uk_ancestry_visa_list?" do
+        should "return true if passport_country is in list of UK Ancestry Visa countries" do
+          calculator = UkVisaCalculator.new
+          calculator.passport_country = "australia"
+          assert calculator.passport_country_in_youth_mobility_scheme_list?
+        end
+
+        should "return false if passport_country is not in list of UK Ancestry Visa countries" do
+          calculator = UkVisaCalculator.new
+          calculator.passport_country = "slovenia"
+          assert_not calculator.passport_country_in_youth_mobility_scheme_list?
+        end
+      end
+
       context "#passport_country_in_electronic_visa_waiver_list?" do
         should "return true if passport_country is in list of countries that can apply for an electronic visa waiver" do
           calculator = UkVisaCalculator.new


### PR DESCRIPTION
The UK Ancestry Visa is currently shown in the Check UK Visa smart answer outcomes regardless of whether the user is eligible for the visa.
    
This change only shows the information to those with a nationality that is eligible.

[Trello card](https://trello.com/c/UiVZoKHq)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️