### PR TITLE
Remove confusing acronyms

### DIFF
--- a/app/flows/check_uk_visa_flow.rb
+++ b/app/flows/check_uk_visa_flow.rb
@@ -160,8 +160,8 @@ class CheckUkVisaFlow < SmartAnswer::Flow
               calculator.passport_country_in_electronic_visa_waiver_list? ||
               calculator.travel_document?
             outcome :outcome_transit_leaving_airport
-          elsif calculator.passport_country_in_datv_list?
-            outcome :outcome_transit_leaving_airport_datv
+          elsif calculator.passport_country_in_direct_airside_transit_visa_list?
+            outcome :outcome_transit_leaving_airport_direct_airside_transit_visa
           end
         elsif calculator.passport_country_is_taiwan?
           outcome :outcome_transit_taiwan
@@ -169,7 +169,7 @@ class CheckUkVisaFlow < SmartAnswer::Flow
           outcome :outcome_no_visa_needed
         elsif calculator.applicant_is_stateless_or_a_refugee?
           outcome :outcome_transit_refugee_not_leaving_airport
-        elsif calculator.passport_country_in_datv_list?
+        elsif calculator.passport_country_in_direct_airside_transit_visa_list?
           outcome :outcome_transit_not_leaving_airport
         elsif calculator.passport_country_in_visa_national_list? || calculator.travel_document?
           outcome :outcome_no_visa_needed
@@ -196,7 +196,7 @@ class CheckUkVisaFlow < SmartAnswer::Flow
               outcome :outcome_study_waiver
             elsif calculator.passport_country_is_taiwan?
               outcome :outcome_study_waiver_taiwan
-            elsif calculator.passport_country_in_datv_list? ||
+            elsif calculator.passport_country_in_direct_airside_transit_visa_list? ||
                 calculator.passport_country_in_visa_national_list? ||
                 calculator.travel_document?
               outcome :outcome_study_m # outcome 3 study m visa needed short courses
@@ -271,7 +271,7 @@ class CheckUkVisaFlow < SmartAnswer::Flow
     outcome :outcome_joining_family_nvn
     outcome :outcome_marriage_nvn_british_overseas_territories
     outcome :outcome_marriage_taiwan
-    outcome :outcome_marriage_visa_nat_datv
+    outcome :outcome_marriage_visa_nat_direct_airside_transit_visa
     outcome :outcome_marriage_electronic_visa_waiver
     outcome :outcome_medical_n
     outcome :outcome_medical_y
@@ -290,7 +290,7 @@ class CheckUkVisaFlow < SmartAnswer::Flow
     outcome :outcome_study_no_visa_needed
     outcome :outcome_study_y
     outcome :outcome_transit_leaving_airport
-    outcome :outcome_transit_leaving_airport_datv
+    outcome :outcome_transit_leaving_airport_direct_airside_transit_visa
     outcome :outcome_transit_not_leaving_airport
     outcome :outcome_transit_refugee_not_leaving_airport
     outcome :outcome_transit_taiwan
@@ -371,13 +371,13 @@ class CheckUkVisaFlow < SmartAnswer::Flow
           next outcome(:outcome_marriage_electronic_visa_waiver)
         elsif calculator.passport_country_is_taiwan?
           next outcome(:outcome_marriage_taiwan)
-        elsif calculator.passport_country_in_datv_list? || calculator.passport_country_in_visa_national_list?
-          next outcome(:outcome_marriage_visa_nat_datv)
+        elsif calculator.passport_country_in_direct_airside_transit_visa_list? || calculator.passport_country_in_visa_national_list?
+          next outcome(:outcome_marriage_visa_nat_direct_airside_transit_visa)
         end
       end
 
       if calculator.transit_visit?
-        if calculator.passport_country_in_datv_list? ||
+        if calculator.passport_country_in_direct_airside_transit_visa_list? ||
             calculator.passport_country_in_visa_national_list? ||
             calculator.passport_country_is_taiwan? ||
             calculator.passport_country_is_venezuela? ||

--- a/app/flows/check_uk_visa_flow.rb
+++ b/app/flows/check_uk_visa_flow.rb
@@ -110,7 +110,7 @@ class CheckUkVisaFlow < SmartAnswer::Flow
         elsif calculator.travelling_to_ireland?
           if (calculator.passport_country_in_non_visa_national_list? ||
               calculator.passport_country_in_eea? ||
-              calculator.passport_country_in_ukot_list?) &&
+              calculator.passport_country_in_british_overseas_territories_list?) &&
               !calculator.travel_document?
             next outcome(:outcome_no_visa_needed)
           else
@@ -119,7 +119,7 @@ class CheckUkVisaFlow < SmartAnswer::Flow
         elsif calculator.travelling_to_elsewhere?
           if (calculator.passport_country_in_non_visa_national_list? ||
               calculator.passport_country_in_eea? ||
-              calculator.passport_country_in_ukot_list?) &&
+              calculator.passport_country_in_british_overseas_territories_list?) &&
               !calculator.travel_document?
             next outcome(:outcome_no_visa_needed)
           else
@@ -200,13 +200,13 @@ class CheckUkVisaFlow < SmartAnswer::Flow
                 calculator.passport_country_in_visa_national_list? ||
                 calculator.travel_document?
               outcome :outcome_study_m # outcome 3 study m visa needed short courses
-            elsif calculator.passport_country_in_ukot_list? || calculator.passport_country_in_non_visa_national_list? || calculator.passport_country_in_eea?
+            elsif calculator.passport_country_in_british_overseas_territories_list? || calculator.passport_country_in_non_visa_national_list? || calculator.passport_country_in_eea?
               outcome :outcome_study_no_visa_needed # outcome 1 no visa needed
             end
           elsif calculator.work_visit?
             if calculator.passport_country_in_electronic_visa_waiver_list?
               outcome :outcome_work_waiver
-            elsif (calculator.passport_country_in_ukot_list? ||
+            elsif (calculator.passport_country_in_british_overseas_territories_list? ||
                 calculator.passport_country_is_taiwan? ||
                 calculator.passport_country_in_non_visa_national_list? ||
                 calculator.passport_country_in_eea?) &&
@@ -269,7 +269,7 @@ class CheckUkVisaFlow < SmartAnswer::Flow
     outcome :outcome_diplomatic_business
     outcome :outcome_joining_family_m
     outcome :outcome_joining_family_nvn
-    outcome :outcome_marriage_nvn_ukot
+    outcome :outcome_marriage_nvn_british_overseas_territories
     outcome :outcome_marriage_taiwan
     outcome :outcome_marriage_visa_nat_datv
     outcome :outcome_marriage_electronic_visa_waiver
@@ -325,7 +325,7 @@ class CheckUkVisaFlow < SmartAnswer::Flow
           next outcome(:outcome_school_waiver)
         elsif calculator.passport_country_is_taiwan?
           next outcome(:outcome_study_waiver_taiwan)
-        elsif calculator.passport_country_in_non_visa_national_list? || calculator.passport_country_in_ukot_list? || calculator.passport_country_in_eea?
+        elsif calculator.passport_country_in_non_visa_national_list? || calculator.passport_country_in_british_overseas_territories_list? || calculator.passport_country_in_eea?
           next outcome(:outcome_school_n)
         else
           next outcome(:outcome_school_y)
@@ -339,7 +339,7 @@ class CheckUkVisaFlow < SmartAnswer::Flow
           next outcome(:outcome_visit_waiver_taiwan)
         elsif (calculator.passport_country_in_non_visa_national_list? ||
             calculator.passport_country_in_eea? ||
-            calculator.passport_country_in_ukot_list?) &&
+            calculator.passport_country_in_british_overseas_territories_list?) &&
             !calculator.travel_document?
           next outcome(:outcome_medical_n)
         else
@@ -354,7 +354,7 @@ class CheckUkVisaFlow < SmartAnswer::Flow
           next outcome(:outcome_visit_waiver_taiwan)
         elsif (calculator.passport_country_in_non_visa_national_list? ||
             calculator.passport_country_in_eea? ||
-            calculator.passport_country_in_ukot_list?) &&
+            calculator.passport_country_in_british_overseas_territories_list?) &&
             !calculator.travel_document?
           next outcome(:outcome_tourism_n)
         else
@@ -364,9 +364,9 @@ class CheckUkVisaFlow < SmartAnswer::Flow
 
       if calculator.marriage_visit?
         if calculator.passport_country_in_eea?
-          next outcome(:outcome_marriage_nvn_ukot)
-        elsif calculator.passport_country_in_non_visa_national_list? || calculator.passport_country_in_ukot_list?
-          next outcome(:outcome_marriage_nvn_ukot)
+          next outcome(:outcome_marriage_nvn_british_overseas_territories)
+        elsif calculator.passport_country_in_non_visa_national_list? || calculator.passport_country_in_british_overseas_territories_list?
+          next outcome(:outcome_marriage_nvn_british_overseas_territories)
         elsif calculator.passport_country_in_electronic_visa_waiver_list?
           next outcome(:outcome_marriage_electronic_visa_waiver)
         elsif calculator.passport_country_is_taiwan?
@@ -383,7 +383,7 @@ class CheckUkVisaFlow < SmartAnswer::Flow
             calculator.passport_country_is_venezuela? ||
             calculator.passport_country_in_non_visa_national_list? ||
             calculator.passport_country_in_eea? ||
-            calculator.passport_country_in_ukot_list? ||
+            calculator.passport_country_in_british_overseas_territories_list? ||
             calculator.travel_document?
           next question(:travelling_to_cta?)
         else
@@ -392,7 +392,7 @@ class CheckUkVisaFlow < SmartAnswer::Flow
       end
 
       if calculator.family_visit?
-        if calculator.passport_country_in_ukot_list?
+        if calculator.passport_country_in_british_overseas_territories_list?
           next outcome(:outcome_joining_family_m)
         elsif calculator.passport_country_in_non_visa_national_list? || calculator.passport_country_in_eea?
           next outcome(:outcome_joining_family_nvn)

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_no_visa_needed.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_no_visa_needed.erb
@@ -8,7 +8,7 @@
 
     If you come to the UK before this time, you can apply to the [EU Settlement Scheme](/settled-status-eu-citizens-families) by 30 June 2021 to continue to work, live or study in the UK.
   <% elsif (calculator.travelling_to_elsewhere? || calculator.travelling_to_ireland?) &&
-       (calculator.passport_country_in_non_visa_national_list? || calculator.passport_country_in_eea? || calculator.passport_country_in_ukot_list?) %>
+       (calculator.passport_country_in_non_visa_national_list? || calculator.passport_country_in_eea? || calculator.passport_country_in_british_overseas_territories_list?) %>
 
     However, you should bring evidence of your onward journey to show to officers at the UK border.
 

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_transit_to_the_republic_of_ireland.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_transit_to_the_republic_of_ireland.erb
@@ -25,7 +25,7 @@
     You’ll usually need to apply for a UK [standard visitor visa](/standard-visitor-visa).
   <% end %>
 
-  <% if calculator.passport_country_in_datv_list? ||
+  <% if calculator.passport_country_in_direct_airside_transit_visa_list? ||
       calculator.passport_country_is_taiwan? ||
       calculator.passport_country_in_electronic_visa_waiver_list? ||
       calculator.passport_country_in_visa_national_list? %>
@@ -41,7 +41,7 @@
      - have the right documents for your destination (for example a visa for that country)
     <% if calculator.passport_country_in_visa_national_list? ||
          calculator.passport_country_is_taiwan? ||
-         calculator.passport_country_in_datv_list? ||
+         calculator.passport_country_in_direct_airside_transit_visa_list? ||
          passport_country_in_electronic_visa_waiver_list? %>
 
       You must also have an Irish biometric visa (marked ‘BC’ or ‘BC BIVS’ in the ‘Remarks’ section) and an onward flight ticket to the Republic of Ireland.

--- a/app/flows/check_uk_visa_flow/questions/channel_islands_or_isle_of_man.erb
+++ b/app/flows/check_uk_visa_flow/questions/channel_islands_or_isle_of_man.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% govspeak_for :body do %>
-  <% if calculator.passport_country_in_ukot_list? ||
+  <% if calculator.passport_country_in_british_overseas_territories_list? ||
      calculator.passport_country_in_non_visa_national_list? %>
     You might need a UK visa if you don’t have a visa (or a wet ink stamp) for the Channel Islands or the Isle of Man.
   <% elsif calculator.passport_country_in_electronic_visa_waiver_list? %>

--- a/app/flows/check_uk_visa_flow/questions/channel_islands_or_isle_of_man.erb
+++ b/app/flows/check_uk_visa_flow/questions/channel_islands_or_isle_of_man.erb
@@ -8,7 +8,7 @@
     You might need a UK visa if you don’t have a visa (or a wet ink stamp) for the Channel Islands or the Isle of Man.
   <% elsif calculator.passport_country_in_electronic_visa_waiver_list? %>
     You’ll need a UK visa or an  [Electronic Visa Waiver](/get-electronic-visa-waiver) if you don’t have a visa (or wet ink stamp) for the Channel Islands or the Isle of Man.
-  <% elsif calculator.passport_country_in_datv_list? ||
+  <% elsif calculator.passport_country_in_direct_airside_transit_visa_list? ||
      calculator.passport_country_in_visa_national_list? %>
     You’ll need a UK visa if you don’t have a visa (or a wet ink stamp) for the Channel Islands or the Isle of Man.
   <% else %>

--- a/lib/smart_answer/calculators/uk_visa_calculator.rb
+++ b/lib/smart_answer/calculators/uk_visa_calculator.rb
@@ -26,8 +26,8 @@ module SmartAnswer::Calculators
       COUNTRY_GROUP_BRITISH_OVERSEAS_TERRITORIES.include?(@passport_country)
     end
 
-    def passport_country_in_datv_list?
-      COUNTRY_GROUP_DATV.include?(@passport_country)
+    def passport_country_in_direct_airside_transit_visa_list?
+      COUNTRY_GROUP_DIRECT_AIRSIDE_TRANSIT_VISA.include?(@passport_country)
     end
 
     def passport_country_in_youth_mobility_scheme_list?
@@ -329,7 +329,7 @@ module SmartAnswer::Calculators
       zambia
     ].freeze
 
-    COUNTRY_GROUP_DATV = %w[
+    COUNTRY_GROUP_DIRECT_AIRSIDE_TRANSIT_VISA = %w[
       afghanistan
       albania
       algeria

--- a/lib/smart_answer/calculators/uk_visa_calculator.rb
+++ b/lib/smart_answer/calculators/uk_visa_calculator.rb
@@ -22,8 +22,8 @@ module SmartAnswer::Calculators
       COUNTRY_GROUP_VISA_NATIONAL.include?(@passport_country)
     end
 
-    def passport_country_in_ukot_list?
-      COUNTRY_GROUP_UKOT.include?(@passport_country)
+    def passport_country_in_british_overseas_territories_list?
+      COUNTRY_GROUP_BRITISH_OVERSEAS_TERRITORIES.include?(@passport_country)
     end
 
     def passport_country_in_datv_list?
@@ -189,7 +189,7 @@ module SmartAnswer::Calculators
       western-sahara
     ].freeze
 
-    COUNTRY_GROUP_UKOT = %w[
+    COUNTRY_GROUP_BRITISH_OVERSEAS_TERRITORIES = %w[
       anguilla
       bermuda
       british-dependent-territories-citizen

--- a/test/integration/flows/check_uk_visa_test.rb
+++ b/test/integration/flows/check_uk_visa_test.rb
@@ -104,7 +104,7 @@ class CheckUkVisaTest < ActiveSupport::TestCase
       should "suggest to apply in country of originallity or residence for outcome_marriage" do
         add_response "marriage"
 
-        assert_current_node :outcome_marriage_visa_nat_datv
+        assert_current_node :outcome_marriage_visa_nat_direct_airside_transit_visa
       end
     end
 
@@ -662,7 +662,7 @@ class CheckUkVisaTest < ActiveSupport::TestCase
     end
   end
 
-  context "choose a DATV country" do
+  context "choose a DIRECT_AIRSIDE_TRANSIT_VISA country" do
     setup do
       add_response "democratic-republic-of-the-congo"
     end
@@ -714,7 +714,7 @@ class CheckUkVisaTest < ActiveSupport::TestCase
         add_response "marriage"
       end
       should "take you to  marriage outcome" do
-        assert_current_node :outcome_marriage_visa_nat_datv
+        assert_current_node :outcome_marriage_visa_nat_direct_airside_transit_visa
       end
     end
     context "get private medical treatment" do
@@ -738,7 +738,7 @@ class CheckUkVisaTest < ActiveSupport::TestCase
           add_response "yes"
         end
         should "take you to transit_leaving_airport outcome" do
-          assert_current_node :outcome_transit_leaving_airport_datv
+          assert_current_node :outcome_transit_leaving_airport_direct_airside_transit_visa
         end
       end
       context "not planning to leave airport" do
@@ -763,8 +763,8 @@ class CheckUkVisaTest < ActiveSupport::TestCase
           setup do
             add_response "yes"
           end
-          should "lead to outcome_transit_leaving_airport_datv" do
-            assert_current_node :outcome_transit_leaving_airport_datv
+          should "lead to outcome_transit_leaving_airport_direct_airside_transit_visa" do
+            assert_current_node :outcome_transit_leaving_airport_direct_airside_transit_visa
           end
         end
         context "not leaving airport" do
@@ -1418,7 +1418,7 @@ class CheckUkVisaTest < ActiveSupport::TestCase
 
     should "mention B1 and B2 visas when leaving the airport" do
       add_response "yes"
-      assert_current_node :outcome_transit_leaving_airport_datv
+      assert_current_node :outcome_transit_leaving_airport_direct_airside_transit_visa
     end
 
     should "mention B1 and B2 visas when not leaving the airport" do
@@ -1504,7 +1504,7 @@ class CheckUkVisaTest < ActiveSupport::TestCase
         context "answer yes" do
           should "go to outcome transit leaving airport" do # /estonia/alien/transit/somewhere_else/yes
             add_response "yes"
-            assert_current_node :outcome_transit_leaving_airport_datv
+            assert_current_node :outcome_transit_leaving_airport_direct_airside_transit_visa
           end
         end
 
@@ -1585,7 +1585,7 @@ class CheckUkVisaTest < ActiveSupport::TestCase
         context "answer yes" do
           should "go to outcome transit leaving airport" do # /latvia/alien/transit/somewhere_else/yes
             add_response "yes"
-            assert_current_node :outcome_transit_leaving_airport_datv
+            assert_current_node :outcome_transit_leaving_airport_direct_airside_transit_visa
           end
         end
 

--- a/test/integration/flows/check_uk_visa_test.rb
+++ b/test/integration/flows/check_uk_visa_test.rb
@@ -250,8 +250,8 @@ class CheckUkVisaTest < ActiveSupport::TestCase
         add_response "marriage"
       end
 
-      should "take you to outcome outcome_marriage_nvn_ukot" do
-        assert_current_node :outcome_marriage_nvn_ukot
+      should "take you to outcome outcome_marriage_nvn_british_overseas_territories" do
+        assert_current_node :outcome_marriage_nvn_british_overseas_territories
       end
     end
 
@@ -336,7 +336,7 @@ class CheckUkVisaTest < ActiveSupport::TestCase
     end
   end
 
-  context "choose a UKOT country" do
+  context "choose a BRITISH_OVERSEAS_TERRITORIES country" do
     setup do
       add_response "anguilla"
     end
@@ -382,7 +382,7 @@ class CheckUkVisaTest < ActiveSupport::TestCase
         add_response "marriage"
       end
       should "take you to the marriage outcome" do
-        assert_current_node :outcome_marriage_nvn_ukot
+        assert_current_node :outcome_marriage_nvn_british_overseas_territories
       end
     end
     context "get private medical treatment" do
@@ -457,7 +457,7 @@ class CheckUkVisaTest < ActiveSupport::TestCase
         add_response "marriage"
       end
       should "take you to marriage outcome" do
-        assert_current_node :outcome_marriage_nvn_ukot
+        assert_current_node :outcome_marriage_nvn_british_overseas_territories
       end
     end
     context "get private medical treatment" do

--- a/test/unit/calculators/uk_visa_calculator_test.rb
+++ b/test/unit/calculators/uk_visa_calculator_test.rb
@@ -73,17 +73,17 @@ module SmartAnswer
         end
       end
 
-      context "#passport_country_in_datv_list?" do
+      context "#passport_country_in_direct_airside_transit_visa_list?" do
         should "return true if passport_country is in list of countries requiring a direct airside transit visa" do
           calculator = UkVisaCalculator.new
           calculator.passport_country = "afghanistan"
-          assert calculator.passport_country_in_datv_list?
+          assert calculator.passport_country_in_direct_airside_transit_visa_list?
         end
 
         should "return false if passport_country is not in list of countries requiring a direct airside transit visa" do
           calculator = UkVisaCalculator.new
           calculator.passport_country = "made-up-country"
-          assert_not calculator.passport_country_in_datv_list?
+          assert_not calculator.passport_country_in_direct_airside_transit_visa_list?
         end
       end
 

--- a/test/unit/calculators/uk_visa_calculator_test.rb
+++ b/test/unit/calculators/uk_visa_calculator_test.rb
@@ -59,17 +59,17 @@ module SmartAnswer
         end
       end
 
-      context "#passport_country_in_ukot_list?" do
+      context "#passport_country_in_british_overseas_territories_list?" do
         should "return true if passport_country is in list of uk overseas territories" do
           calculator = UkVisaCalculator.new
           calculator.passport_country = "anguilla"
-          assert calculator.passport_country_in_ukot_list?
+          assert calculator.passport_country_in_british_overseas_territories_list?
         end
 
         should "return false if passport_country is not in list of uk overseas territories" do
           calculator = UkVisaCalculator.new
           calculator.passport_country = "made-up-country"
-          assert_not calculator.passport_country_in_ukot_list?
+          assert_not calculator.passport_country_in_british_overseas_territories_list?
         end
       end
 


### PR DESCRIPTION
Replaces two acronyms used in the calculator with their full name (UKOT = British Overseas Territories and DATV = Direct Airside Transit Visa). These were confusing as their purpose was not immediately clear and took me a long time to realise what the lists were for.

[Trello card](https://trello.com/c/UiVZoKHq)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️