### PR TITLE
Remove timecop gem 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,5 @@ group :test do
   gem "shoulda"
   gem "simplecov", require: false
   gem "simplecov-rcov", require: false
-  gem "timecop"
   gem "webmock", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -377,7 +377,6 @@ GEM
     thor (1.1.0)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    timecop (0.9.1)
     tzinfo (1.2.9)
       thread_safe (~> 0.1)
     uglifier (4.2.0)
@@ -454,7 +453,6 @@ DEPENDENCIES
   slimmer
   sprockets-rails
   tilt
-  timecop
   uglifier
   uk_postcode
   webmock

--- a/test/integration/engine/country_and_date_questions_test.rb
+++ b/test/integration/engine/country_and_date_questions_test.rb
@@ -35,7 +35,7 @@ class CountryAndDateQuestionsTest < EngineIntegrationTest
         vietnam
       ]
       stub_worldwide_api_has_locations(@location_slugs)
-      Timecop.travel("2013-01-01")
+      travel_to("2013-01-01")
       stub_content_store_has_item("/moved-to-country")
     end
 

--- a/test/integration/flows/am_i_getting_minimum_wage_test.rb
+++ b/test/integration/flows/am_i_getting_minimum_wage_test.rb
@@ -5,7 +5,7 @@ class AmIGettingMinimumWageTest < ActiveSupport::TestCase
   include FlowIntegrationTestHelper
 
   setup do
-    Timecop.freeze(Date.parse("2015-01-01"))
+    travel_to(Date.parse("2015-01-01"))
     setup_for_testing_flow AmIGettingMinimumWageFlow
   end
 
@@ -802,7 +802,7 @@ class AmIGettingMinimumWageTest < ActiveSupport::TestCase
 
   context "2020 scenarios" do
     setup do
-      Timecop.freeze(Date.parse("2020-04-01"))
+      travel_to(Date.parse("2020-04-01"))
       setup_for_testing_flow AmIGettingMinimumWageFlow
     end
 
@@ -1197,7 +1197,7 @@ class AmIGettingMinimumWageTest < ActiveSupport::TestCase
 
   context "2021 scenarios" do
     setup do
-      Timecop.freeze(Date.parse("2021-04-01"))
+      travel_to(Date.parse("2021-04-01"))
       setup_for_testing_flow AmIGettingMinimumWageFlow
     end
 

--- a/test/integration/flows/am_i_getting_minimum_wage_test.rb
+++ b/test/integration/flows/am_i_getting_minimum_wage_test.rb
@@ -5,7 +5,7 @@ class AmIGettingMinimumWageTest < ActiveSupport::TestCase
   include FlowIntegrationTestHelper
 
   setup do
-    travel_to(Date.parse("2015-01-01"))
+    travel_to("2015-01-01")
     setup_for_testing_flow AmIGettingMinimumWageFlow
   end
 
@@ -802,7 +802,7 @@ class AmIGettingMinimumWageTest < ActiveSupport::TestCase
 
   context "2020 scenarios" do
     setup do
-      travel_to(Date.parse("2020-04-01"))
+      travel_to("2020-04-01")
       setup_for_testing_flow AmIGettingMinimumWageFlow
     end
 
@@ -1197,7 +1197,7 @@ class AmIGettingMinimumWageTest < ActiveSupport::TestCase
 
   context "2021 scenarios" do
     setup do
-      travel_to(Date.parse("2021-04-01"))
+      travel_to("2021-04-01")
       setup_for_testing_flow AmIGettingMinimumWageFlow
     end
 

--- a/test/integration/flows/calculate_employee_redundancy_pay_test.rb
+++ b/test/integration/flows/calculate_employee_redundancy_pay_test.rb
@@ -5,7 +5,7 @@ class CalculateEmployeeRedundancyPayTest < ActiveSupport::TestCase
   include FlowIntegrationTestHelper
 
   setup do
-    Timecop.freeze("2019-08-31")
+    travel_to("2019-08-31")
     setup_for_testing_flow CalculateEmployeeRedundancyPayFlow
   end
 
@@ -16,7 +16,7 @@ class CalculateEmployeeRedundancyPayTest < ActiveSupport::TestCase
   context "answer with a valid date (within 4 years of now)" do
     setup do
       # Freeze to 2017 so that 2013 is still an allowed date
-      Timecop.freeze("2017-08-31")
+      travel_to("2017-08-31")
       add_response "2013-01-31"
     end
 
@@ -238,7 +238,7 @@ class CalculateEmployeeRedundancyPayTest < ActiveSupport::TestCase
 
   context "2012/2013 (rate ends on 1st Feb)" do
     should "use the correct rates" do
-      Timecop.freeze("2017-08-31")
+      travel_to("2017-08-31")
       add_response "2013-01-31"
       add_response "42"
       add_response "4.5"
@@ -251,7 +251,7 @@ class CalculateEmployeeRedundancyPayTest < ActiveSupport::TestCase
 
   context "2013/2014 (rate starts on 1st Feb)" do
     should "use the correct rates" do
-      Timecop.freeze("2017-08-31")
+      travel_to("2017-08-31")
       add_response "2013-02-01"
       add_response "42"
       add_response "4.5"

--- a/test/integration/flows/calculate_statutory_sick_pay_test.rb
+++ b/test/integration/flows/calculate_statutory_sick_pay_test.rb
@@ -524,7 +524,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
     end
 
     should "not allow dates next year" do
-      Timecop.freeze("2017-01-01") do
+      travel_to("2017-01-01") do
         add_response (Time.zone.today.end_of_year + 1.day).to_s
         assert_current_node_is_error
       end
@@ -547,7 +547,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
     end
 
     should "not allow dates next year" do
-      Timecop.freeze("2017-01-01") do
+      travel_to("2017-01-01") do
         add_response (Time.zone.today.end_of_year + 1.day).to_s
         assert_current_node_is_error
       end

--- a/test/integration/flows/calculate_your_redundancy_pay_test.rb
+++ b/test/integration/flows/calculate_your_redundancy_pay_test.rb
@@ -5,7 +5,7 @@ class CalculateYourRedundancyPayTest < ActiveSupport::TestCase
   include FlowIntegrationTestHelper
 
   setup do
-    Timecop.freeze("2019-08-31")
+    travel_to("2019-08-31")
     setup_for_testing_flow CalculateYourRedundancyPayFlow
   end
 
@@ -16,7 +16,7 @@ class CalculateYourRedundancyPayTest < ActiveSupport::TestCase
   context "answer with a valid date (within 4 years of now)" do
     setup do
       # Freeze to 2017 so that 2013 is still an allowed date
-      Timecop.freeze("2017-08-31")
+      travel_to("2017-08-31")
       add_response "2013-01-31"
     end
 
@@ -238,7 +238,7 @@ class CalculateYourRedundancyPayTest < ActiveSupport::TestCase
 
   context "2012/2013 (rate ends on 1st Feb)" do
     should "use the correct rates" do
-      Timecop.freeze("2017-08-31")
+      travel_to("2017-08-31")
       add_response "2013-01-31"
       add_response "42"
       add_response "4.5"
@@ -251,7 +251,7 @@ class CalculateYourRedundancyPayTest < ActiveSupport::TestCase
 
   context "2013/2014 (rate starts on 1st Feb)" do
     should "use the correct rates" do
-      Timecop.freeze("2017-08-31")
+      travel_to("2017-08-31")
       add_response "2013-02-01"
       add_response "42"
       add_response "4.5"

--- a/test/integration/flows/maternity_calculator_test.rb
+++ b/test/integration/flows/maternity_calculator_test.rb
@@ -79,11 +79,7 @@ class MaternityCalculatorTest < ActiveSupport::TestCase
 
     context "given the date is April 9th (after changes)" do
       setup do
-        Timecop.travel("2013-04-09")
-      end
-
-      teardown do
-        Timecop.return
+        travel_to("2013-04-09")
       end
 
       ## QM1
@@ -658,7 +654,7 @@ class MaternityCalculatorTest < ActiveSupport::TestCase
   # https://govuk.zendesk.com/agent/tickets/2700341
   context "Example 1" do
     setup do
-      Timecop.freeze("2018-09-06")
+      travel_to("2018-09-06")
 
       add_response :maternity
       add_response Date.parse("2018-10-01")
@@ -671,10 +667,6 @@ class MaternityCalculatorTest < ActiveSupport::TestCase
       add_response "2"
       add_response "usual_paydates"
       add_response "last_day_of_the_month"
-    end
-
-    teardown do
-      Timecop.return
     end
 
     should "match the results provided by HMRC" do
@@ -697,7 +689,7 @@ class MaternityCalculatorTest < ActiveSupport::TestCase
 
   context "Example 2" do
     setup do
-      Timecop.freeze("2018-09-06")
+      travel_to("2018-09-06")
 
       add_response :maternity
       add_response Date.parse("2018-10-14")
@@ -711,10 +703,6 @@ class MaternityCalculatorTest < ActiveSupport::TestCase
       add_response "usual_paydates"
       add_response "last_working_day_of_the_month"
       add_response "1,2,3,5"
-    end
-
-    teardown do
-      Timecop.return
     end
 
     should "match the results provided by HMRC" do
@@ -737,7 +725,7 @@ class MaternityCalculatorTest < ActiveSupport::TestCase
 
   context "Example 3" do
     setup do
-      Timecop.freeze("2018-09-06")
+      travel_to("2018-09-06")
 
       add_response :maternity
       add_response Date.parse("2018-08-18")
@@ -750,10 +738,6 @@ class MaternityCalculatorTest < ActiveSupport::TestCase
       add_response "2"
       add_response "usual_paydates"
       add_response Date.parse("2018-06-22")
-    end
-
-    teardown do
-      Timecop.return
     end
 
     should "match the results provided by HMRC" do

--- a/test/integration/flows/paternity_calculator_test.rb
+++ b/test/integration/flows/paternity_calculator_test.rb
@@ -18,11 +18,7 @@ class PaternityCalculatorTest < ActiveSupport::TestCase
     setup { add_response :paternity }
     context "given the date is April 9th (post 4th April changes)" do
       setup do
-        Timecop.travel("2013-04-09")
-      end
-
-      teardown do
-        Timecop.return
+        travel_to("2013-04-09")
       end
 
       ## QP0

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -31,7 +31,6 @@ class ActiveSupport::TestCase
   parallelize workers: :number_of_processors
 
   teardown do
-    Timecop.return
     WorldLocation.reset_cache
   end
 end

--- a/test/unit/calculators/agricultural_holiday_entitlement_calculator_test.rb
+++ b/test/unit/calculators/agricultural_holiday_entitlement_calculator_test.rb
@@ -16,21 +16,21 @@ module SmartAnswer::Calculators
       end
       context "start_of_holiday_year" do
         should "divide the year on 1st Oct and return the relevant calculation start date" do
-          Timecop.travel(Date.civil(Time.zone.today.year, 6, 1))
+          travel_to(Date.civil(Time.zone.today.year, 6, 1))
           assert_equal Date.civil(Time.zone.today.year - 1, 10, 1), @calc.start_of_holiday_year
-          Timecop.travel(Date.civil(Time.zone.today.year, 10, 2))
+          travel_to(Date.civil(Time.zone.today.year, 10, 2))
           assert_equal Date.civil(Time.zone.today.year, 10, 1), @calc.start_of_holiday_year
         end
       end
       context "weeks_worked" do
         should "give the number of weeks between the calculation period and holiday start dates" do
-          Timecop.travel(Date.civil(Time.zone.today.year, 10, 2))
+          travel_to(Date.civil(Time.zone.today.year, 10, 2))
           assert_equal 4, @calc.weeks_worked(Date.civil(Time.zone.today.year, 11, 1))
         end
       end
       context "available_days" do
         should "give the number of days since the calculation period started" do
-          Timecop.travel(Date.civil(Time.zone.today.year, 12, 25))
+          travel_to(Date.civil(Time.zone.today.year, 12, 25))
           assert_equal 85, @calc.available_days
         end
       end

--- a/test/unit/calculators/married_couple_allowance_calculator_test.rb
+++ b/test/unit/calculators/married_couple_allowance_calculator_test.rb
@@ -114,7 +114,7 @@ module SmartAnswer::Calculators
     end
 
     test "rate values for year 2013" do
-      travel_to(Date.parse("2013-06-01")) do
+      travel_to("2013-06-01") do
         calculator = MarriedCouplesAllowanceCalculator.new
 
         assert_equal 9440, calculator.personal_allowance
@@ -125,7 +125,7 @@ module SmartAnswer::Calculators
     end
 
     test "rate values for year 2014" do
-      travel_to(Date.parse("2014-06-01")) do
+      travel_to("2014-06-01") do
         calculator = MarriedCouplesAllowanceCalculator.new
 
         assert_equal 10_000, calculator.personal_allowance
@@ -136,7 +136,7 @@ module SmartAnswer::Calculators
     end
 
     test "rate values for year 2015" do
-      travel_to(Date.parse("2015-06-01")) do
+      travel_to("2015-06-01") do
         calculator = MarriedCouplesAllowanceCalculator.new
 
         assert_equal 10_600, calculator.personal_allowance
@@ -147,7 +147,7 @@ module SmartAnswer::Calculators
     end
 
     test "rate values for year 2016" do
-      travel_to(Date.parse("2016-06-01")) do
+      travel_to("2016-06-01") do
         calculator = MarriedCouplesAllowanceCalculator.new
 
         assert_equal 11_000, calculator.personal_allowance
@@ -158,7 +158,7 @@ module SmartAnswer::Calculators
     end
 
     test "rate values for year 2017" do
-      travel_to(Date.parse("2017-06-01")) do
+      travel_to("2017-06-01") do
         calculator = MarriedCouplesAllowanceCalculator.new
 
         assert_equal 11_000, calculator.personal_allowance
@@ -169,7 +169,7 @@ module SmartAnswer::Calculators
     end
 
     test "rate values for 2018/19" do
-      travel_to(Date.parse("2018-06-01")) do
+      travel_to("2018-06-01") do
         calculator = MarriedCouplesAllowanceCalculator.new
 
         assert_equal 11_850, calculator.personal_allowance
@@ -180,7 +180,7 @@ module SmartAnswer::Calculators
     end
 
     test "rate values for 2019/20" do
-      travel_to(Date.parse("2019-06-01")) do
+      travel_to("2019-06-01") do
         calculator = MarriedCouplesAllowanceCalculator.new
 
         assert_equal 12_500, calculator.personal_allowance
@@ -191,7 +191,7 @@ module SmartAnswer::Calculators
     end
 
     test "rate values for 2020/21" do
-      travel_to(Date.parse("2020-06-01")) do
+      travel_to("2020-06-01") do
         calculator = MarriedCouplesAllowanceCalculator.new
 
         assert_equal 12_500, calculator.personal_allowance

--- a/test/unit/calculators/married_couple_allowance_calculator_test.rb
+++ b/test/unit/calculators/married_couple_allowance_calculator_test.rb
@@ -114,7 +114,7 @@ module SmartAnswer::Calculators
     end
 
     test "rate values for year 2013" do
-      Timecop.freeze(Date.parse("2013-06-01")) do
+      travel_to(Date.parse("2013-06-01")) do
         calculator = MarriedCouplesAllowanceCalculator.new
 
         assert_equal 9440, calculator.personal_allowance
@@ -125,7 +125,7 @@ module SmartAnswer::Calculators
     end
 
     test "rate values for year 2014" do
-      Timecop.freeze(Date.parse("2014-06-01")) do
+      travel_to(Date.parse("2014-06-01")) do
         calculator = MarriedCouplesAllowanceCalculator.new
 
         assert_equal 10_000, calculator.personal_allowance
@@ -136,7 +136,7 @@ module SmartAnswer::Calculators
     end
 
     test "rate values for year 2015" do
-      Timecop.freeze(Date.parse("2015-06-01")) do
+      travel_to(Date.parse("2015-06-01")) do
         calculator = MarriedCouplesAllowanceCalculator.new
 
         assert_equal 10_600, calculator.personal_allowance
@@ -147,7 +147,7 @@ module SmartAnswer::Calculators
     end
 
     test "rate values for year 2016" do
-      Timecop.freeze(Date.parse("2016-06-01")) do
+      travel_to(Date.parse("2016-06-01")) do
         calculator = MarriedCouplesAllowanceCalculator.new
 
         assert_equal 11_000, calculator.personal_allowance
@@ -158,7 +158,7 @@ module SmartAnswer::Calculators
     end
 
     test "rate values for year 2017" do
-      Timecop.freeze(Date.parse("2017-06-01")) do
+      travel_to(Date.parse("2017-06-01")) do
         calculator = MarriedCouplesAllowanceCalculator.new
 
         assert_equal 11_000, calculator.personal_allowance
@@ -169,7 +169,7 @@ module SmartAnswer::Calculators
     end
 
     test "rate values for 2018/19" do
-      Timecop.freeze(Date.parse("2018-06-01")) do
+      travel_to(Date.parse("2018-06-01")) do
         calculator = MarriedCouplesAllowanceCalculator.new
 
         assert_equal 11_850, calculator.personal_allowance
@@ -180,7 +180,7 @@ module SmartAnswer::Calculators
     end
 
     test "rate values for 2019/20" do
-      Timecop.freeze(Date.parse("2019-06-01")) do
+      travel_to(Date.parse("2019-06-01")) do
         calculator = MarriedCouplesAllowanceCalculator.new
 
         assert_equal 12_500, calculator.personal_allowance
@@ -191,7 +191,7 @@ module SmartAnswer::Calculators
     end
 
     test "rate values for 2020/21" do
-      Timecop.freeze(Date.parse("2020-06-01")) do
+      travel_to(Date.parse("2020-06-01")) do
         calculator = MarriedCouplesAllowanceCalculator.new
 
         assert_equal 12_500, calculator.personal_allowance

--- a/test/unit/calculators/maternity_pay_calculator_test.rb
+++ b/test/unit/calculators/maternity_pay_calculator_test.rb
@@ -11,7 +11,7 @@ module SmartAnswer::Calculators
           @due_date = 4.months.since(Time.zone.today)
           @start_of_week_in_four_months = @due_date - @due_date.wday
           @calculator = MaternityPayCalculator.new(@due_date)
-          Timecop.travel("25 March 2013")
+          travel_to("25 March 2013")
         end
 
         should "calculate expected birth week" do
@@ -548,7 +548,7 @@ module SmartAnswer::Calculators
 
       context "pay date starting month is December" do
         should "produce a list of the paydates adjust one month forward" do
-          Timecop.travel("26 Jul 2013")
+          travel_to("26 Jul 2013")
 
           calculator = MaternityPayCalculator.new(Date.parse("14 January 2014"))
           calculator.leave_start_date = Date.parse("12 December 2013")

--- a/test/unit/calculators/minimum_wage_calculator_test.rb
+++ b/test/unit/calculators/minimum_wage_calculator_test.rb
@@ -300,7 +300,7 @@ module SmartAnswer::Calculators
     # Test URL: /am-i-getting-minimum-wage/y/past_payment/2010-10-01/apprentice_under_19/7/35/78.0/0/no
     context "Historical adjustment for apprentices (hours:35, pay:78)" do
       setup do
-        Timecop.travel(Date.parse("30 Sep 2013"))
+        travel_to(Date.parse("30 Sep 2013"))
       end
       should "equal 10.07 historical adjustment" do
         @calculator = MinimumWageCalculator.new(
@@ -640,7 +640,7 @@ module SmartAnswer::Calculators
 
     context "historical below minimum wage" do
       setup do
-        Timecop.travel(Date.parse("2012-10-09"))
+        travel_to(Date.parse("2012-10-09"))
       end
       should "return false to minimum_wage_or_above?" do
         @calculator = MinimumWageCalculator.new(

--- a/test/unit/calculators/minimum_wage_calculator_test.rb
+++ b/test/unit/calculators/minimum_wage_calculator_test.rb
@@ -300,7 +300,7 @@ module SmartAnswer::Calculators
     # Test URL: /am-i-getting-minimum-wage/y/past_payment/2010-10-01/apprentice_under_19/7/35/78.0/0/no
     context "Historical adjustment for apprentices (hours:35, pay:78)" do
       setup do
-        travel_to(Date.parse("30 Sep 2013"))
+        travel_to("30 Sep 2013")
       end
       should "equal 10.07 historical adjustment" do
         @calculator = MinimumWageCalculator.new(
@@ -640,7 +640,7 @@ module SmartAnswer::Calculators
 
     context "historical below minimum wage" do
       setup do
-        travel_to(Date.parse("2012-10-09"))
+        travel_to("2012-10-09")
       end
       should "return false to minimum_wage_or_above?" do
         @calculator = MinimumWageCalculator.new(

--- a/test/unit/calculators/personal_allowance_calculator_test.rb
+++ b/test/unit/calculators/personal_allowance_calculator_test.rb
@@ -17,7 +17,7 @@ module SmartAnswer::Calculators
 
     context "before 2013 to 2014 tax year" do
       setup do
-        travel_to(Date.parse("2012-11-11"))
+        travel_to("2012-11-11")
       end
 
       should "return the basic allowance for someone aged 64 at end of tax year" do
@@ -47,7 +47,7 @@ module SmartAnswer::Calculators
 
     context "in or after 2013 to 2014 tax year" do
       setup do
-        travel_to(Date.parse("2014-04-06"))
+        travel_to("2014-04-06")
       end
 
       should "return the basic allowance for someone born on 6th April 1948" do

--- a/test/unit/calculators/personal_allowance_calculator_test.rb
+++ b/test/unit/calculators/personal_allowance_calculator_test.rb
@@ -15,13 +15,9 @@ module SmartAnswer::Calculators
       )
     end
 
-    teardown do
-      Timecop.return
-    end
-
     context "before 2013 to 2014 tax year" do
       setup do
-        Timecop.freeze(Date.parse("2012-11-11"))
+        travel_to(Date.parse("2012-11-11"))
       end
 
       should "return the basic allowance for someone aged 64 at end of tax year" do
@@ -51,7 +47,7 @@ module SmartAnswer::Calculators
 
     context "in or after 2013 to 2014 tax year" do
       setup do
-        Timecop.freeze(Date.parse("2014-04-06"))
+        travel_to(Date.parse("2014-04-06"))
       end
 
       should "return the basic allowance for someone born on 6th April 1948" do

--- a/test/unit/calculators/redundancy_calculator_test.rb
+++ b/test/unit/calculators/redundancy_calculator_test.rb
@@ -146,24 +146,24 @@ module SmartAnswer::Calculators
       context "Earliest selectable date" do
         context "Months January to August" do
           should "return the start of the year, four years ago if date is January 1st" do
-            Timecop.freeze("2016-01-01")
+            travel_to("2016-01-01")
             assert_equal Date.parse("2012-01-01"), RedundancyCalculator.first_selectable_date
           end
 
           should "return the start of the year, four years ago if date is August 31st" do
-            Timecop.freeze("2016-08-31")
+            travel_to("2016-08-31")
             assert_equal Date.parse("2012-01-01"), RedundancyCalculator.first_selectable_date
           end
         end
 
         context "Months September to December" do
           should "return the start of the year, three years ago if date is September 1st" do
-            Timecop.freeze("2016-09-01")
+            travel_to("2016-09-01")
             assert_equal Date.parse("2013-01-01"), RedundancyCalculator.first_selectable_date
           end
 
           should "return the start of the year, three years ago if date is December 31st" do
-            Timecop.freeze("2016-12-31")
+            travel_to("2016-12-31")
             assert_equal Date.parse("2013-01-01"), RedundancyCalculator.first_selectable_date
           end
         end
@@ -172,24 +172,24 @@ module SmartAnswer::Calculators
       context "Last selectable date" do
         context "Months January to August" do
           should "return the end of the current year if the date is January 1st" do
-            Timecop.freeze("2016-01-01")
+            travel_to("2016-01-01")
             assert_equal Date.parse("2016-12-31"), RedundancyCalculator.last_selectable_date
           end
 
           should "return the end of the current year if the date is August 31st" do
-            Timecop.freeze("2016-08-31")
+            travel_to("2016-08-31")
             assert_equal Date.parse("2016-12-31"), RedundancyCalculator.last_selectable_date
           end
         end
 
         context "Months September to December" do
           should "return end of the next year if the date is September 1st" do
-            Timecop.freeze("2016-09-01")
+            travel_to("2016-09-01")
             assert_equal Date.parse("2017-12-31"), RedundancyCalculator.last_selectable_date
           end
 
           should "return end of the next year if the date is December 31st" do
-            Timecop.freeze("2016-12-31")
+            travel_to("2016-12-31")
             assert_equal Date.parse("2017-12-31"), RedundancyCalculator.last_selectable_date
           end
         end

--- a/test/unit/calculators/registrations_data_query_test.rb
+++ b/test/unit/calculators/registrations_data_query_test.rb
@@ -95,7 +95,7 @@ module SmartAnswer::Calculators
       context "fetching document return fees" do
         context "when before 2015-08-01" do
           setup do
-            Timecop.travel("2015-07-31")
+            travel_to("2015-07-31")
           end
 
           should "display 4.50, 12.50 and 22" do
@@ -107,7 +107,7 @@ module SmartAnswer::Calculators
 
         context "on and after 2015-08-01" do
           setup do
-            Timecop.travel("2015-08-01")
+            travel_to("2015-08-01")
           end
 
           should "display 4.50, 12.50 and 22" do

--- a/test/unit/calculators/state_pension_age_calculator_test.rb
+++ b/test/unit/calculators/state_pension_age_calculator_test.rb
@@ -186,21 +186,21 @@ module SmartAnswer::Calculators
       end
 
       should "return true for someone yet to reach their state pension date" do
-        Timecop.freeze do
+        freeze_time do
           @calculator.stubs(:state_pension_date).returns(Time.zone.today + 1.day)
           assert @calculator.before_state_pension_date?
         end
       end
 
       should "return false for someone who has reached their state pension date" do
-        Timecop.freeze do
+        freeze_time do
           @calculator.stubs(:state_pension_date).returns(Time.zone.today)
           assert_not @calculator.before_state_pension_date?
         end
       end
 
       should "return false for someone who has just passed their state pension date" do
-        Timecop.freeze do
+        freeze_time do
           @calculator.stubs(:state_pension_date).returns(Time.zone.today - 1.day)
           assert_not @calculator.before_state_pension_date?
         end
@@ -213,21 +213,21 @@ module SmartAnswer::Calculators
       end
 
       should "return true for someone just over 30 days away from their pension_credit_date" do
-        Timecop.freeze do
+        freeze_time do
           @calculator.stubs(:state_pension_date).returns(Time.zone.today + 31.days)
           assert @calculator.before_state_pension_date?(days: 2)
         end
       end
 
       should "return false for someone exactly 30 days away" do
-        Timecop.freeze do
+        freeze_time do
           @calculator.stubs(:state_pension_date).returns(Time.zone.today + 30.days)
           assert_not @calculator.before_state_pension_date?(days: 30)
         end
       end
 
       should "return false for someone less than 30 days to their pension credit date" do
-        Timecop.freeze do
+        freeze_time do
           @calculator.stubs(:state_pension_date).returns(Time.zone.today + 29.days)
           assert_not @calculator.before_state_pension_date?(days: 30)
         end
@@ -240,21 +240,21 @@ module SmartAnswer::Calculators
       end
 
       should "return true for someone yet to reach their pension credit date" do
-        Timecop.freeze do
+        freeze_time do
           @calculator.stubs(:pension_credit_date).returns(Time.zone.today + 1.day)
           assert @calculator.before_pension_credit_date?
         end
       end
 
       should "return false for someone has just reached their pension credit date" do
-        Timecop.freeze do
+        freeze_time do
           @calculator.stubs(:pension_credit_date).returns(Time.zone.today)
           assert_not @calculator.before_pension_credit_date?
         end
       end
 
       should "return false for someone who has just passed their pension credit date" do
-        Timecop.freeze do
+        freeze_time do
           @calculator.stubs(:pension_credit_date).returns(Time.zone.today - 1.day)
           assert_not @calculator.before_pension_credit_date?
         end
@@ -284,7 +284,7 @@ module SmartAnswer::Calculators
 
     context "#over_16_years_old?" do
       should "be true for someone just older than 16" do
-        Timecop.freeze do
+        freeze_time do
           date_of_birth = (16.years + 1.minute).ago
 
           calculator = StatePensionAgeCalculator.new(dob: date_of_birth)
@@ -293,7 +293,7 @@ module SmartAnswer::Calculators
       end
 
       should "return false for someone exactly 16 years old" do
-        Timecop.freeze do
+        freeze_time do
           date_of_birth = 16.years.ago
 
           calculator = StatePensionAgeCalculator.new(dob: date_of_birth)
@@ -302,7 +302,7 @@ module SmartAnswer::Calculators
       end
 
       should "return false for someone just under 16 years old" do
-        Timecop.freeze do
+        freeze_time do
           date_of_birth = (16.years - 1.minute).ago
 
           calculator = StatePensionAgeCalculator.new(dob: date_of_birth)
@@ -320,13 +320,13 @@ module SmartAnswer::Calculators
           @calculator = StatePensionAgeCalculator.new(@answers.merge(gender: "female"))
         end
         should "return true for a woman approaching state pension age (at 61 years, 10 months, 20 days) in 2 months time" do
-          Timecop.freeze(Date.parse("2013-07-06")) do
+          travel_to(Date.parse("2013-07-06")) do
             assert @calculator.can_apply?
           end
         end
 
         should "return false for a woman approaching state pension age (at 61 years, 10 months, 20 days) in more than 2 months time" do
-          Timecop.freeze(Date.parse("2013-07-05")) do
+          travel_to(Date.parse("2013-07-05")) do
             assert_not @calculator.can_apply?
           end
         end
@@ -337,13 +337,13 @@ module SmartAnswer::Calculators
           @calculator = StatePensionAgeCalculator.new(@answers.merge(gender: "male"))
         end
         should "return true for a man approaching pension age (at 65 years) in 2 months time" do
-          Timecop.freeze(Date.parse("2016-10-17")) do
+          travel_to(Date.parse("2016-10-17")) do
             assert @calculator.can_apply?
           end
         end
 
         should "return false for a man approaching pension age (at 65 years) in more than 2 months time" do
-          Timecop.freeze(Date.parse("2016-10-16")) do
+          travel_to(Date.parse("2016-10-16")) do
             assert_not @calculator.can_apply?
           end
         end

--- a/test/unit/calculators/state_pension_age_calculator_test.rb
+++ b/test/unit/calculators/state_pension_age_calculator_test.rb
@@ -320,13 +320,13 @@ module SmartAnswer::Calculators
           @calculator = StatePensionAgeCalculator.new(@answers.merge(gender: "female"))
         end
         should "return true for a woman approaching state pension age (at 61 years, 10 months, 20 days) in 2 months time" do
-          travel_to(Date.parse("2013-07-06")) do
+          travel_to("2013-07-06") do
             assert @calculator.can_apply?
           end
         end
 
         should "return false for a woman approaching state pension age (at 61 years, 10 months, 20 days) in more than 2 months time" do
-          travel_to(Date.parse("2013-07-05")) do
+          travel_to("2013-07-05") do
             assert_not @calculator.can_apply?
           end
         end
@@ -337,13 +337,13 @@ module SmartAnswer::Calculators
           @calculator = StatePensionAgeCalculator.new(@answers.merge(gender: "male"))
         end
         should "return true for a man approaching pension age (at 65 years) in 2 months time" do
-          travel_to(Date.parse("2016-10-17")) do
+          travel_to("2016-10-17") do
             assert @calculator.can_apply?
           end
         end
 
         should "return false for a man approaching pension age (at 65 years) in more than 2 months time" do
-          travel_to(Date.parse("2016-10-16")) do
+          travel_to("2016-10-16") do
             assert_not @calculator.can_apply?
           end
         end

--- a/test/unit/calculators/state_pension_topup_calculator_test.rb
+++ b/test/unit/calculators/state_pension_topup_calculator_test.rb
@@ -34,17 +34,17 @@ module SmartAnswer::Calculators
     context "top-up start date" do
       context "Should show current year" do
         should "be 2015" do
-          Timecop.freeze("2015-10-31")
+          travel_to("2015-10-31")
           assert_equal 2015, @calculator.topup_start_year
         end
 
         should "be 2016" do
-          Timecop.freeze("2016-10-31")
+          travel_to("2016-10-31")
           assert_equal 2016, @calculator.topup_start_year
         end
 
         should "be 2015 if year is before scheme start date" do
-          Timecop.freeze("2014-10-31")
+          travel_to("2014-10-31")
           assert_equal 2015, @calculator.topup_start_year
         end
       end
@@ -53,7 +53,7 @@ module SmartAnswer::Calculators
     context "lump_sum_and_age" do
       context "when male" do
         setup do
-          Timecop.freeze("2016-12-01")
+          travel_to("2016-12-01")
           @calculator.gender = "male"
         end
 
@@ -102,7 +102,7 @@ module SmartAnswer::Calculators
 
       context "when female" do
         setup do
-          Timecop.freeze("2016-12-01")
+          travel_to("2016-12-01")
           @calculator.gender = "female"
         end
 
@@ -143,12 +143,8 @@ module SmartAnswer::Calculators
 
       context "end of scheme" do
         setup do
-          Timecop.freeze("2017-02-01")
+          travel_to("2017-02-01")
           @calculator.gender = "male"
-        end
-
-        teardown do
-          Timecop.return
         end
 
         should "show two rates for final year of scheme when birthday before end of scheme" do

--- a/test/unit/calculators/statutory_sick_pay_calculator_test.rb
+++ b/test/unit/calculators/statutory_sick_pay_calculator_test.rb
@@ -1007,12 +1007,12 @@ module SmartAnswer
 
       context "possible year of sickness" do
         should "returns 31 Dec 2017 when month is between January and May" do
-          Timecop.freeze("1 May 2017")
+          travel_to("1 May 2017")
           assert_equal StatutorySickPayCalculator.year_of_sickness, Date.parse("31 Dec 2017")
         end
 
         should "returns 31 Dec 2018 when month is between June and December" do
-          Timecop.freeze("1 June 2017")
+          travel_to("1 June 2017")
           assert_equal StatutorySickPayCalculator.year_of_sickness, Date.parse("31 Dec 2018")
         end
       end

--- a/test/unit/calculators/workplace_pension_calculator_test.rb
+++ b/test/unit/calculators/workplace_pension_calculator_test.rb
@@ -25,28 +25,28 @@ module SmartAnswer::Calculators
 
     context "lower earnings limit annual rate" do
       should "return the lel rate based on the date" do
-        travel_to(Date.parse("2013-04-07")) do
+        travel_to("2013-04-07") do
           assert_equal 5564, WorkplacePensionCalculator.new.lel_annual_rate
         end
       end
     end
     context "lower earnings limit annual rate" do
       should "return the lel rate based on the date" do
-        travel_to(Date.parse("2013-04-08")) do
+        travel_to("2013-04-08") do
           assert_equal 5668, WorkplacePensionCalculator.new.lel_annual_rate
         end
       end
     end
     context "threshold limit annual rate" do
       should "return the threshold rate based on the date" do
-        travel_to(Date.parse("2013-04-07")) do
+        travel_to("2013-04-07") do
           assert_equal 8105, WorkplacePensionCalculator.new.threshold_annual_rate
         end
       end
     end
     context "threshold limit annual rate" do
       should "return the lel rate based on the date" do
-        travel_to(Date.parse("2013-04-08")) do
+        travel_to("2013-04-08") do
           assert_equal 9440, WorkplacePensionCalculator.new.threshold_annual_rate
         end
       end

--- a/test/unit/calculators/workplace_pension_calculator_test.rb
+++ b/test/unit/calculators/workplace_pension_calculator_test.rb
@@ -25,28 +25,28 @@ module SmartAnswer::Calculators
 
     context "lower earnings limit annual rate" do
       should "return the lel rate based on the date" do
-        Timecop.travel(Date.parse("2013-04-07")) do
+        travel_to(Date.parse("2013-04-07")) do
           assert_equal 5564, WorkplacePensionCalculator.new.lel_annual_rate
         end
       end
     end
     context "lower earnings limit annual rate" do
       should "return the lel rate based on the date" do
-        Timecop.travel(Date.parse("2013-04-08")) do
+        travel_to(Date.parse("2013-04-08")) do
           assert_equal 5668, WorkplacePensionCalculator.new.lel_annual_rate
         end
       end
     end
     context "threshold limit annual rate" do
       should "return the threshold rate based on the date" do
-        Timecop.travel(Date.parse("2013-04-07")) do
+        travel_to(Date.parse("2013-04-07")) do
           assert_equal 8105, WorkplacePensionCalculator.new.threshold_annual_rate
         end
       end
     end
     context "threshold limit annual rate" do
       should "return the lel rate based on the date" do
-        Timecop.travel(Date.parse("2013-04-08")) do
+        travel_to(Date.parse("2013-04-08")) do
           assert_equal 9440, WorkplacePensionCalculator.new.threshold_annual_rate
         end
       end

--- a/test/unit/date_helper_test.rb
+++ b/test/unit/date_helper_test.rb
@@ -13,7 +13,7 @@ module SmartAnswer
 
     context "current day" do
       should "return today, if rates query date is not set" do
-        Timecop.freeze("2016-09-27") do
+        travel_to("2016-09-27") do
           assert_equal Date.parse("2016-09-27"), SmartAnswer::DateHelper.current_day
         end
       end

--- a/test/unit/date_of_birth_test.rb
+++ b/test/unit/date_of_birth_test.rb
@@ -4,11 +4,7 @@ module SmartAnswer
   class DateOfBirthTest < ActiveSupport::TestCase
     setup do
       @today = Date.parse("2015-05-15")
-      Timecop.freeze(@today)
-    end
-
-    teardown do
-      Timecop.return
+      travel_to(@today)
     end
 
     context "when birthday has not yet occurred in this year" do

--- a/test/unit/flows/child_benefit_tax_calculator_view_test.rb
+++ b/test/unit/flows/child_benefit_tax_calculator_view_test.rb
@@ -288,7 +288,7 @@ class ChildBenefitTaxCalculatorViewTest < ActiveSupport::TestCase
 
     context "when tax year is incomplete" do
       setup do
-        Timecop.freeze("2019-07-02")
+        travel_to("2019-07-02")
         @calculator.stubs(calculate_adjusted_net_income: SmartAnswer::Money.new(60_000))
         @presenter = OutcomePresenter.new(@outcome, nil, @state)
         @body = @presenter.body

--- a/test/unit/world_location_test.rb
+++ b/test/unit/world_location_test.rb
@@ -55,13 +55,13 @@ class WorldLocationTest < ActiveSupport::TestCase
       should "cache the loaded locations for a day" do
         first = WorldLocation.all
 
-        Timecop.travel(23.hours.from_now) do
+        travel_to(23.hours.from_now) do
           second = WorldLocation.all
           assert_requested :get, @endpoint, times: 1
           assert_equal first, second
         end
 
-        Timecop.travel(25.hours.from_now) do
+        travel_to(25.hours.from_now) do
           third = WorldLocation.all
           assert_requested :get, @endpoint, times: 2
           assert_equal first, third
@@ -73,14 +73,14 @@ class WorldLocationTest < ActiveSupport::TestCase
 
         stub_request(:get, "#{WORLDWIDE_API_ENDPOINT}/api/world-locations").to_timeout
 
-        Timecop.travel(25.hours.from_now) do
+        travel_to(25.hours.from_now) do
           assert_nothing_raised do
             second = WorldLocation.all
             assert_equal first, second
           end
         end
 
-        Timecop.travel(1.week.from_now + 1.hour) do
+        travel_to(1.week.from_now + 1.hour) do
           assert_raises GdsApi::TimedOutException do
             WorldLocation.all
           end
@@ -154,13 +154,13 @@ class WorldLocationTest < ActiveSupport::TestCase
       should "cache the loaded location for a day" do
         first = WorldLocation.find("rohan")
 
-        Timecop.travel(23.hours.from_now) do
+        travel_to(23.hours.from_now) do
           second = WorldLocation.find("rohan")
           assert_requested @rohan_request, times: 1
           assert_equal first, second
         end
 
-        Timecop.travel(25.hours.from_now) do
+        travel_to(25.hours.from_now) do
           third = WorldLocation.find("rohan")
           assert_requested @rohan_request, times: 2
           assert_equal first, third
@@ -171,14 +171,14 @@ class WorldLocationTest < ActiveSupport::TestCase
         first = WorldLocation.find("rohan")
         @rohan_request.to_timeout
 
-        Timecop.travel(25.hours.from_now) do
+        travel_to(25.hours.from_now) do
           assert_nothing_raised do
             second = WorldLocation.find("rohan")
             assert_equal first, second
           end
         end
 
-        Timecop.travel(1.week.from_now + 1.hour) do
+        travel_to(1.week.from_now + 1.hour) do
           assert_raises GdsApi::TimedOutException do
             WorldLocation.find("rohan")
           end

--- a/test/unit/year_range_with_fixed_start_date_test.rb
+++ b/test/unit/year_range_with_fixed_start_date_test.rb
@@ -51,12 +51,8 @@ module SmartAnswer
 
       context "when tax year is built for today" do
         setup do
-          Timecop.freeze(Date.parse("2000-01-01"))
+          travel_to(Date.parse("2000-01-01"))
           @tax_year1999 = @tax_year.current
-        end
-
-        teardown do
-          Timecop.return
         end
 
         should "begin on 6th April" do

--- a/test/unit/year_range_with_fixed_start_date_test.rb
+++ b/test/unit/year_range_with_fixed_start_date_test.rb
@@ -51,7 +51,7 @@ module SmartAnswer
 
       context "when tax year is built for today" do
         setup do
-          travel_to(Date.parse("2000-01-01"))
+          travel_to("2000-01-01")
           @tax_year1999 = @tax_year.current
         end
 


### PR DESCRIPTION
This isn't needed any more as ActiveSupport provides time helpers.

We also don't need an equivalent of `Timecop.return` as
ActiveSupport::Testing::TestHelpers hooks into the teardown method and
resets the time (it also transpires that most of the Timecop.return
weren't needed).

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
