### PR TITLE
Use .govuk-link on index page

### DIFF
--- a/app/helpers/index_helper.rb
+++ b/app/helpers/index_helper.rb
@@ -1,6 +1,6 @@
 module IndexHelper
   def title_and_url(flow_name, title)
-    sanitize(title) + tag.br + link_to("/#{flow_name}", flow_landing_path(flow_name))
+    sanitize(title) + tag.br + link_to("/#{flow_name}", flow_landing_path(flow_name), class: "govuk-link")
   end
 
   def live_link(flow_name, status)
@@ -12,8 +12,8 @@ module IndexHelper
   end
 
   def code_links(flow_class)
-    link_to("Definition", "https://www.github.com/alphagov/smart-answers/blob/main/app/flows/#{flow_class.name.underscore}.rb") +
+    link_to("Definition", "https://www.github.com/alphagov/smart-answers/blob/main/app/flows/#{flow_class.name.underscore}.rb", class: "govuk-link") +
       tag.br +
-      link_to("Content files", "https://www.github.com/alphagov/smart-answers/blob/main/app/flows/#{flow_class.name.underscore}")
+      link_to("Content files", "https://www.github.com/alphagov/smart-answers/blob/main/app/flows/#{flow_class.name.underscore}", class: "govuk-link")
   end
 end

--- a/app/views/smart_answers/index.html.erb
+++ b/app/views/smart_answers/index.html.erb
@@ -18,11 +18,11 @@
           presenter = flow.start_node.presenter
           [
             { text: title_and_url(flow.name, presenter.title) },
-            { text: link_to(flow.status.capitalize, live_link(flow.name, flow.status)) },
+            { text: link_to(flow.status.capitalize, live_link(flow.name, flow.status), class: "govuk-link") },
             { text: flow.questions.count },
             { text: flow.outcomes.count },
             { text: code_links(flow.class) },
-            { text: link_to('Visualise', visualise_path(flow.name)) },
+            { text: link_to('Visualise', visualise_path(flow.name), class: "govuk-link") },
           ]
         end
       } %>


### PR DESCRIPTION
This applies the link styling to the mostly hidden index page. Just a
small thing to keep the GOV.UK brand flowing :-)

Before:

<img width="1022" alt="Screenshot 2021-08-02 at 18 48 53" src="https://user-images.githubusercontent.com/282717/127903152-92f4b7d9-09ea-4274-b693-1f6c378f3f0a.png">

After:

<img width="1066" alt="Screenshot 2021-08-02 at 18 49 27" src="https://user-images.githubusercontent.com/282717/127903147-05e25861-d26b-4bb3-88fb-068ad5a1dcca.png">

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
