### PR TITLE
Update headings to use context inside option for outcome page

### DIFF
--- a/app/flows/all_smart_answer_questions_flow/outcomes/outcome.erb
+++ b/app/flows/all_smart_answer_questions_flow/outcomes/outcome.erb
@@ -1,5 +1,3 @@
-<% use_title_as_h1 true %>
-
 <% text_for :title do %>
   Congratulations
 <% end %>

--- a/app/flows/am_i_getting_minimum_wage_flow/outcomes/current_payment_above.erb
+++ b/app/flows/am_i_getting_minimum_wage_flow/outcomes/current_payment_above.erb
@@ -1,9 +1,9 @@
 <% govspeak_for :body do %>
   $C
   <% if calculator.eligible_for_living_wage? %>
-    Based on your answers, you appear to be getting the National Living Wage.
+    You appear to be getting the National Living Wage.
   <% else %>
-    Based on your answers, you appear to be getting the National Minimum Wage.
+    You appear to be getting the National Minimum Wage.
   <% end %>
   $C
 

--- a/app/flows/am_i_getting_minimum_wage_flow/outcomes/current_payment_below.erb
+++ b/app/flows/am_i_getting_minimum_wage_flow/outcomes/current_payment_below.erb
@@ -1,9 +1,9 @@
 <% govspeak_for :body do %>
   $C
   <% if calculator.eligible_for_living_wage? %>
-    Based on your answers, you appear to be not getting the National Living Wage.
+    You appear to be not getting the National Living Wage.
   <% else %>
-    Based on your answers, you appear to be not getting the National Minimum Wage.
+    You appear to be not getting the National Minimum Wage.
   <% end %>
   $C
 

--- a/app/flows/am_i_getting_minimum_wage_flow/outcomes/past_payment_above.erb
+++ b/app/flows/am_i_getting_minimum_wage_flow/outcomes/past_payment_above.erb
@@ -1,6 +1,6 @@
 <% govspeak_for :body do %>
   $C
-    Based on your answers, you appear to have been getting the National Minimum Wage.
+    You appear to have been getting the National Minimum Wage.
   $C
 
   <% if calculator.potential_underpayment? %>

--- a/app/flows/am_i_getting_minimum_wage_flow/outcomes/past_payment_below.erb
+++ b/app/flows/am_i_getting_minimum_wage_flow/outcomes/past_payment_below.erb
@@ -1,6 +1,6 @@
 <% govspeak_for :body do %>
   $C
-   Based on your answers, you appear to have not been getting the National Minimum Wage.
+    You appear to have not been getting the National Minimum Wage.
   $C
 
   This is because you were not being paid the [minimum rate](/national-minimum-wage-rates) you are entitled to.

--- a/app/flows/business_coronavirus_support_finder_flow/outcomes/results.erb
+++ b/app/flows/business_coronavirus_support_finder_flow/outcomes/results.erb
@@ -1,5 +1,3 @@
-<% use_title_as_h1 true %>
-
 <% text_for :title do %>
   Financial support your business might be entitled to
 <% end %>

--- a/app/flows/calculate_married_couples_allowance_flow/outcomes/_done_body.erb
+++ b/app/flows/calculate_married_couples_allowance_flow/outcomes/_done_body.erb
@@ -9,4 +9,4 @@ $C
 $C
 
 
-%This result is an estimate based on your answers.%
+%This result is an estimate.%

--- a/app/flows/calculate_your_redundancy_pay_flow/outcomes/done.erb
+++ b/app/flows/calculate_your_redundancy_pay_flow/outcomes/done.erb
@@ -1,5 +1,5 @@
 <% text_for :title do %>
-  Based on your answers, your statutory redundancy payment is <%= format_money(statutory_redundancy_pay) %> (<%= format_money(statutory_redundancy_pay_ni) %> in Northern Ireland).
+  Your statutory redundancy payment is <%= format_money(statutory_redundancy_pay) %> (<%= format_money(statutory_redundancy_pay_ni) %> in Northern Ireland).
 
 <% end %>
 

--- a/app/flows/calculate_your_redundancy_pay_flow/outcomes/done_no_statutory.erb
+++ b/app/flows/calculate_your_redundancy_pay_flow/outcomes/done_no_statutory.erb
@@ -1,5 +1,5 @@
 <% text_for :title do %>
-  Based on your answers, you’re not entitled to statutory redundancy pay.
+  You’re not entitled to statutory redundancy pay.
 <% end %>
 
 <% govspeak_for :body do %>

--- a/app/flows/find_coronavirus_support_flow/outcomes/results.erb
+++ b/app/flows/find_coronavirus_support_flow/outcomes/results.erb
@@ -17,7 +17,7 @@
     <%= render("mental_health", calculator: calculator) if calculator.show_group?(:mental_health) %>
 
   <% else %>
-    Based on your answers, there’s no specific information for you in this service at the moment. It will be updated regularly.
+    There’s no specific information for you in this service at the moment. It will be updated regularly.
 
     [Financial help and information on staying safe at work](/coronavirus/worker-support)
 

--- a/app/flows/find_coronavirus_support_flow/outcomes/results.erb
+++ b/app/flows/find_coronavirus_support_flow/outcomes/results.erb
@@ -1,5 +1,3 @@
-<% use_title_as_h1 true %>
-
 <% text_for :title do %>
     Information based on your answers
 <% end %>

--- a/app/flows/minimum_wage_calculator_employers_flow/outcomes/current_payment_above.erb
+++ b/app/flows/minimum_wage_calculator_employers_flow/outcomes/current_payment_above.erb
@@ -1,9 +1,9 @@
 <% govspeak_for :body do %>
   $C
   <% if calculator.eligible_for_living_wage? %>
-    Based on your answers, you appear to be paying the National Living Wage.
+    You appear to be paying the National Living Wage.
   <% else %>
-    Based on your answers, you appear to be paying the National Minimum Wage.
+    You appear to be paying the National Minimum Wage.
   <% end %>
   $C
 

--- a/app/flows/minimum_wage_calculator_employers_flow/outcomes/current_payment_below.erb
+++ b/app/flows/minimum_wage_calculator_employers_flow/outcomes/current_payment_below.erb
@@ -1,9 +1,9 @@
 <% govspeak_for :body do %>
   $C
   <% if calculator.eligible_for_living_wage? %>
-    Based on your answers, you appear to be not paying the National Living Wage.
+    You appear to be not paying the National Living Wage.
   <% else %>
-    Based on your answers, you appear to be not paying the National Minimum Wage.
+    You appear to be not paying the National Minimum Wage.
   <% end %>
   $C
 

--- a/app/flows/minimum_wage_calculator_employers_flow/outcomes/past_payment_above.erb
+++ b/app/flows/minimum_wage_calculator_employers_flow/outcomes/past_payment_above.erb
@@ -1,6 +1,6 @@
 <% govspeak_for :body do %>
   $C
-  Based on your answers, you appear to have been paying National Minimum Wage.
+  You appear to have been paying National Minimum Wage.
 
   <% if calculator.potential_underpayment? %>
     As you have taken money from the worker’s pay for things they needed for their job or not paid the worker for any additional time they worked outside of their shift, this might mean you have underpaid them.

--- a/app/flows/minimum_wage_calculator_employers_flow/outcomes/past_payment_below.erb
+++ b/app/flows/minimum_wage_calculator_employers_flow/outcomes/past_payment_below.erb
@@ -1,6 +1,6 @@
 <% govspeak_for :body do %>
   $C
-  Based on your answers, you appear not to have been paying the National Minimum Wage.
+  You appear not to have been paying the National Minimum Wage.
   $C
 
   This is because you were not paying the [minimum rate](/national-minimum-wage-rates) the worker was entitled to.

--- a/app/flows/simplified_expenses_checker_flow/outcomes/you_can_use_result.erb
+++ b/app/flows/simplified_expenses_checker_flow/outcomes/you_can_use_result.erb
@@ -20,7 +20,7 @@
     ##For your other business expenses
 
   <% end %>
-  Based on your answers you would probably be better off <% if calculator.simple_total > calculator.current_scheme_costs %>using simplified expenses<% else %>working out your expenses based on the actual costs<% end %>.
+  You would probably be better off <% if calculator.simple_total > calculator.current_scheme_costs %>using simplified expenses<% else %>working out your expenses based on the actual costs<% end %>.
 
   These 2 sets of results show what you can claim using each method.
 

--- a/app/presenters/outcome_presenter.rb
+++ b/app/presenters/outcome_presenter.rb
@@ -22,14 +22,6 @@ class OutcomePresenter < NodePresenter
     @renderer.content_for(:description)
   end
 
-  def heading_title
-    title_as_heading? ? title : @flow_presenter.title
-  end
-
-  def title_as_heading?
-    @renderer.use_title_as_h1
-  end
-
   def body
     @renderer.content_for(:body)
   end

--- a/app/views/smart_answers/result.html.erb
+++ b/app/views/smart_answers/result.html.erb
@@ -12,7 +12,9 @@
   <div id="result-info" class="govuk-grid-column-two-thirds outcome">
     <%= render 'smart_answers/shared/debug' %>
     <%= render "govuk_publishing_components/components/title", {
-      title: outcome.heading_title
+      title: "Information based on your answers",
+      context: outcome.heading_title + ":",
+      context_inside: true,
     } %>
 
     <div class="govuk-!-margin-bottom-6" data-module="track-results" data-flow-name="<%= @name %>">

--- a/app/views/smart_answers/result.html.erb
+++ b/app/views/smart_answers/result.html.erb
@@ -13,7 +13,7 @@
     <%= render 'smart_answers/shared/debug' %>
     <%= render "govuk_publishing_components/components/title", {
       title: "Information based on your answers",
-      context: outcome.heading_title + ":",
+      context: @presenter.title + ":",
       context_inside: true,
     } %>
 
@@ -22,7 +22,7 @@
         <%= render "govuk_publishing_components/components/heading", {
           text: outcome.title,
           margin_bottom: 6
-        } unless outcome.title_as_heading? %>
+        } %>
       <% end %>
 
       <%= outcome.body %>

--- a/docs/design/erb-templates/outcome-templates.md
+++ b/docs/design/erb-templates/outcome-templates.md
@@ -32,16 +32,6 @@ Used to generate the main content. Expected to be govspeak or HTML. Example:
 <% end %>
 ```
 
-### `:use_title_as_h1`
-
-When `true`, specifies that you want to use the given `title` as the outcome page
-`<h1>` heading instead of the default `<h2>` heading.  The flow title is no longer
-shown.
-
-```erb
-<% use_title_as_h1 true %>
-```
-
 ### `next_steps`
 
 Used to generate the "next steps" content (at the top of the right-hand sidebar). Expected to be govspeak or HTML. Example:

--- a/lib/smart_answer/erb_renderer.rb
+++ b/lib/smart_answer/erb_renderer.rb
@@ -17,7 +17,6 @@ module SmartAnswer
     end
 
     delegate :hide_caption, to: :rendered_view
-    delegate :use_title_as_h1, to: :rendered_view
 
     def option(key)
       rendered_view

--- a/lib/smart_answer/erb_renderer/question_options_helper.rb
+++ b/lib/smart_answer/erb_renderer/question_options_helper.rb
@@ -7,9 +7,5 @@ module SmartAnswer
     def hide_caption(hide_caption = false) # rubocop:disable Style/OptionalBooleanParameter
       @hide_caption = hide_caption || @hide_caption
     end
-
-    def use_title_as_h1(use_title_as_h1 = false) # rubocop:disable Style/OptionalBooleanParameter
-      @use_title_as_h1 = use_title_as_h1 || @use_title_as_h1
-    end
   end
 end

--- a/test/flows/am_i_getting_minimum_wage_flow_test.rb
+++ b/test/flows/am_i_getting_minimum_wage_flow_test.rb
@@ -38,11 +38,11 @@ class AmIGettingMinimumWageFlowTest < ActiveSupport::TestCase
 
     should "render living wage copy if a user is eligible for the national living wage" do
       add_responses how_old_are_you?: @living_wage_age
-      assert_rendered_outcome text: "you appear to be getting the National Living Wage"
+      assert_rendered_outcome text: "You appear to be getting the National Living Wage"
     end
 
     should "render minimum wage copy if a user is not eligible for the national living wage" do
-      assert_rendered_outcome text: "you appear to be getting the National Minimum Wage"
+      assert_rendered_outcome text: "You appear to be getting the National Minimum Wage"
     end
 
     should "render underpayment information for someone underpaid" do
@@ -81,11 +81,11 @@ class AmIGettingMinimumWageFlowTest < ActiveSupport::TestCase
 
     should "render living wage copy if a user is eligible for the national living wage" do
       add_responses how_old_are_you?: @living_wage_age
-      assert_rendered_outcome text: "you appear to be not getting the National Living Wage"
+      assert_rendered_outcome text: "You appear to be not getting the National Living Wage"
     end
 
     should "render minimum wage copy if a user is not eligible for the national living wage" do
-      assert_rendered_outcome text: "you appear to be not getting the National Minimum Wage"
+      assert_rendered_outcome text: "You appear to be not getting the National Minimum Wage"
     end
 
     should "render underpayment information for someone underpaid" do

--- a/test/flows/find_coronavirus_support_flow_test.rb
+++ b/test/flows/find_coronavirus_support_flow_test.rb
@@ -594,7 +594,7 @@ class FindCoronavirusSupportFlowFlowTest < ActiveSupport::TestCase
       end
 
       should "render no information guidance if need_help_with? is none" do
-        assert_rendered_outcome text: "Based on your answers, there’s no specific information for you in this service at the moment."
+        assert_rendered_outcome text: "There’s no specific information for you in this service at the moment."
       end
 
       should "render extra guidance for England" do

--- a/test/flows/minimum_wage_calculators_employers_flow_test.rb
+++ b/test/flows/minimum_wage_calculators_employers_flow_test.rb
@@ -38,11 +38,11 @@ class MinimumWageCalculatorEmployersFlowTest < ActiveSupport::TestCase
 
     should "render living wage copy if an employee is eligible for the national living wage" do
       add_responses how_old_are_you?: @living_wage_age
-      assert_rendered_outcome text: "you appear to be paying the National Living Wage"
+      assert_rendered_outcome text: "You appear to be paying the National Living Wage"
     end
 
     should "render minimum wage copy if an employee is not eligible for the national living wage" do
-      assert_rendered_outcome text: "you appear to be paying the National Minimum Wage"
+      assert_rendered_outcome text: "You appear to be paying the National Minimum Wage"
     end
 
     should "render underpayment information for someone potentially underpaid" do
@@ -71,11 +71,11 @@ class MinimumWageCalculatorEmployersFlowTest < ActiveSupport::TestCase
 
     should "render living wage copy if an employee is eligible for the national living wage" do
       add_responses how_old_are_you?: @living_wage_age
-      assert_rendered_outcome text: "you appear to be not paying the National Living Wage"
+      assert_rendered_outcome text: "You appear to be not paying the National Living Wage"
     end
 
     should "render minimum wage copy if an employee is not eligible for the national living wage" do
-      assert_rendered_outcome text: "you appear to be not paying the National Minimum Wage"
+      assert_rendered_outcome text: "You appear to be not paying the National Minimum Wage"
     end
 
     should "render underpayment information for someone underpaid" do

--- a/test/unit/erb_renderer_test.rb
+++ b/test/unit/erb_renderer_test.rb
@@ -63,36 +63,6 @@ module SmartAnswer
       end
     end
 
-    test "#use_title_as_h1 returns true if it is set to true" do
-      erb_template = "<% use_title_as_h1 true %>"
-
-      with_erb_template_file("template-name", erb_template) do |erb_template_directory|
-        renderer = ErbRenderer.new(template_directory: erb_template_directory, template_name: "template-name")
-
-        assert renderer.use_title_as_h1
-      end
-    end
-
-    test "#use_title_as_h1 returns false if it is set to false" do
-      erb_template = "<% use_title_as_h1 false %>"
-
-      with_erb_template_file("template-name", erb_template) do |erb_template_directory|
-        renderer = ErbRenderer.new(template_directory: erb_template_directory, template_name: "template-name")
-
-        assert_not renderer.use_title_as_h1
-      end
-    end
-
-    test "#use_title_as_h1 returns false if it is not set" do
-      erb_template = ""
-
-      with_erb_template_file("template-name", erb_template) do |erb_template_directory|
-        renderer = ErbRenderer.new(template_directory: erb_template_directory, template_name: "template-name")
-
-        assert_not renderer.use_title_as_h1
-      end
-    end
-
     test "#hide_caption returns true if set as true in the view" do
       erb_template = "<% hide_caption true %>"
 

--- a/test/unit/outcome_presenter_test.rb
+++ b/test/unit/outcome_presenter_test.rb
@@ -51,28 +51,6 @@ module SmartAnswer
       assert_equal "title-text", @presenter.title
     end
 
-    test "#heading_title when title_as_heading is false returns the flow title" do
-      flow = stub("flow_presenter")
-      outcome = OutcomePresenter.new(stub("outcome"), flow, nil, renderer: stub("renderer"))
-
-      flow.stubs(:title).returns("flow-title")
-      outcome.stubs(:title).returns("outcome-title")
-      outcome.stubs(:title_as_heading?).returns(false)
-
-      assert_equal outcome.heading_title, flow.title
-    end
-
-    test "#heading_title when title_as_heading is true returns the outcome title" do
-      flow = stub("flow_presenter")
-      outcome = OutcomePresenter.new(stub("outcome"), flow, nil, renderer: stub("renderer"))
-
-      flow.stubs(:title).returns("flow-title")
-      outcome.stubs(:title).returns("outcome-title")
-      outcome.stubs(:title_as_heading?).returns(true)
-
-      assert_equal outcome.heading_title, outcome.title
-    end
-
     test "#body returns content rendered for body block" do
       @renderer.stubs(:content_for).with(:body).returns("body-html")
 


### PR DESCRIPTION
## What?

- Smart answers have the same title for both Landing page and Outcome page - which is a duplicate page title and fails the accessibility guidelines.
- The outcome pages currently use the title component (where the caption / context is not nested in the H1) https://components.publishing.service.gov.uk/component-guide/title/with_context.
- We need to update the Outcome page so that the page title and H1 has the agreed heading which is `[Service name]: What you need to know based on the answers you gave`.
- This will use the design system pattern where the caption (service name) is part of the heading (what you need to know based on the answers you gave). for example https://design-system.service.gov.uk/styles/typography/captions-inside/index.html. This has been recently added as an option to the title component - https://components.publishing.service.gov.uk/component-guide/title/with_context_inside

## Why?

Fail of WCAG SC 2.4.6

## Visuals Before & After

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/87758239/128171502-ffd2b20f-f6c2-4826-aed6-d297a59b5f4e.png" width="300"> | <img src="https://user-images.githubusercontent.com/87758239/128236530-635e3b41-4915-474e-99c0-2e144dd56211.png" width="300"> |

## Anything else

Example of where the original issue exists:
https://www.gov.uk/calculate-your-redundancy-pay/y/2020-01-01/20/1.0