### PR TITLE
Add ability to dynamically define question options

### DIFF
--- a/app/presenters/graph_presenter.rb
+++ b/app/presenters/graph_presenter.rb
@@ -49,7 +49,7 @@ private
     when SmartAnswer::Question::Radio
       text << word_wrap(node_title(node))
       text << "\n\n"
-      text << node.permitted_options.map { |o| "( ) #{o}" }.join("\n")
+      text << node.option_keys.map { |o| "( ) #{o}" }.join("\n")
     when SmartAnswer::Question::Checkbox
       text << word_wrap(node_title(node))
       text << "\n\n"

--- a/app/presenters/question_with_options_presenter.rb
+++ b/app/presenters/question_with_options_presenter.rb
@@ -4,7 +4,7 @@ class QuestionWithOptionsPresenter < QuestionPresenter
   end
 
   def option_attributes(key)
-    option = @renderer.option(key.to_sym)
+    option = @renderer.option(key)
 
     if option.is_a?(String)
       { label: option, value: key }

--- a/app/presenters/question_with_options_presenter.rb
+++ b/app/presenters/question_with_options_presenter.rb
@@ -1,9 +1,5 @@
 class QuestionWithOptionsPresenter < QuestionPresenter
   def options
-    unless @node.options_block.nil?
-      @node.option_keys = @state.instance_exec(&@node.options_block)
-    end
-
     @node.option_keys.map { |option_key| option_attributes(option_key) }
   end
 

--- a/app/presenters/question_with_options_presenter.rb
+++ b/app/presenters/question_with_options_presenter.rb
@@ -1,6 +1,10 @@
 class QuestionWithOptionsPresenter < QuestionPresenter
   def options
-    @node.options.map { |option_key| option_attributes(option_key) }
+    unless @node.options_block.nil?
+      @node.option_keys = @state.instance_exec(&@node.options_block)
+    end
+
+    @node.option_keys.map { |option_key| option_attributes(option_key) }
   end
 
   def option_attributes(key)

--- a/lib/smart_answer/erb_renderer.rb
+++ b/lib/smart_answer/erb_renderer.rb
@@ -21,7 +21,7 @@ module SmartAnswer
 
     def option(key)
       rendered_view
-      @view.options.fetch(key)
+      @view.options.with_indifferent_access.fetch(key)
     end
 
     def content_for(name)

--- a/lib/smart_answer/flow.rb
+++ b/lib/smart_answer/flow.rb
@@ -20,6 +20,7 @@ module SmartAnswer
     def initialize
       @nodes = []
       @additional_parameters = []
+      @setup = nil
       status(:draft)
     end
 
@@ -76,6 +77,12 @@ module SmartAnswer
       end
 
       @status
+    end
+
+    def setup(&block)
+      return @setup unless block_given?
+
+      @setup = block
     end
 
     def radio(name, &block)

--- a/lib/smart_answer/node.rb
+++ b/lib/smart_answer/node.rb
@@ -76,6 +76,8 @@ module SmartAnswer
       end
     end
 
+    def setup(_state); end
+
     def transition(current_state, _input)
       new_state = current_state.dup
       next_node = next_node_for(new_state, nil)

--- a/lib/smart_answer/question/checkbox.rb
+++ b/lib/smart_answer/question/checkbox.rb
@@ -4,22 +4,39 @@ module SmartAnswer
       PRESENTER_CLASS = CheckboxQuestionPresenter
       NONE_OPTION = "none".freeze
 
-      attr_reader :options
+      attr_accessor :option_keys, :options_block
 
       def initialize(flow, name, &block)
-        @options = []
+        @option_keys = []
+        @options_block = nil
         super
       end
 
-      def option(option_slug)
-        raise InvalidNode, "Can't use reserved option name '#{NONE_OPTION}'" if option_slug.to_s == NONE_OPTION
-        raise InvalidNode, "Invalid option specified" unless option_slug.to_s =~ /\A[a-z0-9_-]+\z/
+      def none_option
+        @option_keys << NONE_OPTION
+      end
 
-        @options << option_slug.to_s
+      def option(key)
+        key = key.to_s
+
+        raise InvalidNode, "Can't use reserved option name '#{NONE_OPTION}'" if key == NONE_OPTION
+        raise InvalidNode, "Invalid option specified" unless key =~ /\A[a-z0-9_-]+\z/
+
+        @option_keys << key
+      end
+
+      def options(&block)
+        raise InvalidNode, "Options needs to be a given a block" unless block_given?
+
+        @options_block = block
+      end
+
+      def none_option?
+        @option_keys.include?(NONE_OPTION)
       end
 
       def valid_option?(option)
-        @options.include?(option) || option == NONE_OPTION
+        @option_keys.include?(option)
       end
 
       def parse_input(raw_input)
@@ -36,14 +53,6 @@ module SmartAnswer
           raise SmartAnswer::InvalidResponse, "Illegal option #{option} for #{name}", caller unless valid_option?(option)
         end
         raw_input.sort.join(",")
-      end
-
-      def none_option?
-        @options.include?(NONE_OPTION)
-      end
-
-      def none_option
-        @options << NONE_OPTION
       end
     end
   end

--- a/lib/smart_answer/question/checkbox.rb
+++ b/lib/smart_answer/question/checkbox.rb
@@ -39,6 +39,12 @@ module SmartAnswer
         @option_keys.include?(option)
       end
 
+      def setup(state)
+        unless @options_block.nil?
+          @option_keys = state.instance_exec(&@options_block)
+        end
+      end
+
       def parse_input(raw_input)
         if raw_input.blank?
           # Raise on for blank input when showing a 'none' option as input is required.

--- a/lib/smart_answer/question/radio.rb
+++ b/lib/smart_answer/question/radio.rb
@@ -3,23 +3,26 @@ module SmartAnswer
     class Radio < Base
       PRESENTER_CLASS = RadioQuestionPresenter
 
-      attr_reader :permitted_options
+      attr_accessor :option_keys, :options_block
 
       def initialize(flow, name, &block)
-        @permitted_options = []
+        @option_keys = []
+        @options_block = nil
         super
       end
 
-      def option(option_key)
-        @permitted_options << option_key.to_s
+      def option(key)
+        @option_keys << key.to_s
       end
 
-      def options
-        @permitted_options
+      def options(&block)
+        raise InvalidNode, "Options needs to be a given a block" unless block_given?
+
+        @options_block = block
       end
 
       def valid_option?(option)
-        options.include?(option.to_s)
+        @option_keys.include?(option.to_s)
       end
 
       def parse_input(raw_input)

--- a/lib/smart_answer/question/radio.rb
+++ b/lib/smart_answer/question/radio.rb
@@ -25,6 +25,12 @@ module SmartAnswer
         @option_keys.include?(option.to_s)
       end
 
+      def setup(state)
+        unless @options_block.nil?
+          @option_keys = state.instance_exec(&@options_block)
+        end
+      end
+
       def parse_input(raw_input)
         raise SmartAnswer::InvalidResponse, "Illegal option #{raw_input} for #{name}", caller unless valid_option?(raw_input)
 

--- a/lib/smart_answer/state_resolver.rb
+++ b/lib/smart_answer/state_resolver.rb
@@ -38,10 +38,12 @@ module SmartAnswer
 
     def resolve_state(state, response_store, requested_node)
       node_name = state.current_node_name.to_s
-      response = response_store.get(node_name)
-      reached_an_outcome = @flow.node(node_name.to_sym).outcome?
+      node = @flow.node(node_name.to_sym)
+      node.setup(state)
 
-      return state if response.nil? || reached_an_outcome || state.error
+      response = response_store.get(node_name)
+
+      return state if response.nil? || node.outcome? || state.error
       return apply_response_to_state(state, response) if requested_node == node_name
 
       next_state = transition_state_to_next_node(state, response)

--- a/lib/smart_answer/state_resolver.rb
+++ b/lib/smart_answer/state_resolver.rb
@@ -6,6 +6,8 @@ module SmartAnswer
 
     def state_from_response_store(response_store, requested_node = nil)
       start_state = State.new(@flow.questions.first.name)
+      start_state.instance_eval(&@flow.setup) if @flow.setup
+
       @flow.additional_parameters.each do |param|
         start_state[param] = response_store.get(param)
       end

--- a/test/unit/checkbox_question_presenter_test.rb
+++ b/test/unit/checkbox_question_presenter_test.rb
@@ -10,9 +10,9 @@ module SmartAnswer
 
       @renderer = stub("renderer")
 
-      @renderer.stubs(:option).with(:option1).returns("Option 1")
-      @renderer.stubs(:option).with(:option2).returns({ label: "Option 2", hint_text: "Hint 2" })
-      @renderer.stubs(:option).with(:option3).returns({ label: "Option 3" })
+      @renderer.stubs(:option).with("option1").returns("Option 1")
+      @renderer.stubs(:option).with("option2").returns({ label: "Option 2", hint_text: "Hint 2" })
+      @renderer.stubs(:option).with("option3").returns({ label: "Option 3" })
 
       @presenter = CheckboxQuestionPresenter.new(@question, nil, nil, renderer: @renderer)
       @presenter.stubs(:current_response).returns(nil)
@@ -35,7 +35,7 @@ module SmartAnswer
 
     test "#checkboxes return array including an or divider for none options" do
       @question.none_option
-      @renderer.stubs(:option).with(:none).returns({ label: "None" })
+      @renderer.stubs(:option).with("none").returns({ label: "None" })
 
       expected_value = [
         { label: "Option 1", value: "option1", hint: nil, checked: false, exclusive: nil },

--- a/test/unit/checkbox_question_test.rb
+++ b/test/unit/checkbox_question_test.rb
@@ -12,7 +12,15 @@ module SmartAnswer
           option :reddy_brown
         end
 
-        assert_equal %w[red blue green blue-green reddy_brown], q.options
+        assert_equal %w[red blue green blue-green reddy_brown], q.option_keys
+      end
+
+      should "be able to specify options with block" do
+        q = Question::Checkbox.new(nil, :something) do
+          options { %w[x y z] }
+        end
+
+        assert_equal %w[x y z], q.options_block.call
       end
 
       should "not be able to use reserved 'none' option" do

--- a/test/unit/checkbox_question_test.rb
+++ b/test/unit/checkbox_question_test.rb
@@ -39,6 +39,29 @@ module SmartAnswer
       end
     end
 
+    context "setup" do
+      should "resolve the options keys from the option block" do
+        q = Question::Checkbox.new(nil, :example) do
+          options { %i[x y] }
+        end
+
+        q.setup(nil)
+
+        assert_equal %i[x y], q.option_keys
+      end
+
+      should "not clear options keys if option block is nil" do
+        q = Question::Checkbox.new(nil, :example) do
+          option :a
+          option :b
+        end
+
+        q.setup(nil)
+
+        assert_equal %w[a b], q.option_keys
+      end
+    end
+
     context "parsing response" do
       setup do
         @question = Question::Checkbox.new(nil, :something) do

--- a/test/unit/erb_renderer_test.rb
+++ b/test/unit/erb_renderer_test.rb
@@ -130,7 +130,7 @@ module SmartAnswer
         renderer = ErbRenderer.new(template_directory: erb_template_directory, template_name: "template-name")
 
         assert_equal "option-one-text", renderer.option(:option_one)
-        assert_equal({ label: "option-two-text", hint_text: "option-two-hint-text" }, renderer.option(:option_two))
+        assert_equal({ "label" => "option-two-text", "hint_text" => "option-two-hint-text" }, renderer.option(:option_two))
       end
     end
 

--- a/test/unit/flow_registry_test.rb
+++ b/test/unit/flow_registry_test.rb
@@ -12,7 +12,7 @@ module SmartAnswer
       flow = registry.find("radio-sample")
       assert_equal 2, flow.questions.size
       assert_equal :hotter_or_colder?, flow.questions.first.name
-      assert_equal %w[hotter colder], flow.questions.first.options
+      assert_equal %w[hotter colder], flow.questions.first.option_keys
       assert_equal %i[hot cold frozen], flow.outcomes.map(&:name)
     end
 

--- a/test/unit/flow_test.rb
+++ b/test/unit/flow_test.rb
@@ -92,6 +92,16 @@ class FlowTest < ActiveSupport::TestCase
     assert_equal "587920ff-b854-4adb-9334-451b45652467", s.content_id
   end
 
+  test "Can define the setup block" do
+    s = SmartAnswer::Flow.build do
+      setup do
+        return "setup"
+      end
+    end
+
+    assert_equal "setup", s.setup.call
+  end
+
   test "Can build outcome nodes" do
     s = SmartAnswer::Flow.build do
       outcome :you_dont_have_a_sweet_tooth

--- a/test/unit/node_test.rb
+++ b/test/unit/node_test.rb
@@ -98,6 +98,12 @@ module SmartAnswer
       end
     end
 
+    context "#setup" do
+      should "be a method" do
+        assert_equal nil, @node.setup(nil)
+      end
+    end
+
     context "#transition" do
       should "copy values from initial state to new state" do
         @node.next_node { outcome :done }

--- a/test/unit/question_with_options_presenter_test.rb
+++ b/test/unit/question_with_options_presenter_test.rb
@@ -3,28 +3,50 @@ require_relative "../test_helper"
 module SmartAnswer
   class QuestionWithOptionsPresenterTest < ActiveSupport::TestCase
     setup do
-      question = Question::Radio.new(nil, :question_name?)
-      question.option(:option_one)
-      question.option(:option_two)
+      @renderer = stub("renderer")
 
-      renderer = stub("renderer")
-
-      renderer.stubs(:option).with(:option_one).returns("option-one-text")
-      renderer.stubs(:option).with(:option_two).returns({ label: "option-two-text", hint_text: "option-two-hint" })
-      @presenter = QuestionWithOptionsPresenter.new(question, nil, nil, renderer: renderer)
+      @renderer.stubs(:option).with(:option_one).returns("option-one-text")
+      @renderer.stubs(:option).with(:option_two).returns({ label: "option-two-text", hint_text: "option-two-hint" })
+      @renderer.stubs(:option).with(:option_three).returns("option-three-text")
     end
 
-    test "#all_options returns options with labels and values" do
-      assert_equal(%w[option_one option_two], @presenter.options.map { |o| o[:value] })
-      assert_equal(%w[option-one-text option-two-text], @presenter.options.map { |o| o[:label] })
+    context "question defined with option keys" do
+      setup do
+        question = Question::Radio.new(nil, :question_name?) do
+          option(:option_one)
+          option(:option_two)
+        end
+
+        @presenter = QuestionWithOptionsPresenter.new(question, nil, nil, renderer: @renderer)
+      end
+
+      should "options returns options with labels and values" do
+        assert_equal(%w[option_one option_two], @presenter.options.map { |o| o[:value] })
+        assert_equal(%w[option-one-text option-two-text], @presenter.options.map { |o| o[:label] })
+      end
+
+      should "option_attributes returns a hash when option attribute is a string from the renderer" do
+        assert_equal({ label: "option-one-text", value: "option_one" }, @presenter.option_attributes("option_one"))
+      end
+
+      should "option_attributes returns a hash when option attribute is a hash from the renderer" do
+        assert_equal({ label: "option-two-text", value: "option_two", hint_text: "option-two-hint" }, @presenter.option_attributes("option_two"))
+      end
     end
 
-    test "#option_attributes returns a hash when option attribute is a string from the renderer" do
-      assert_equal({ label: "option-one-text", value: "option_one" }, @presenter.option_attributes("option_one"))
-    end
+    context "question defined with an option block" do
+      setup do
+        question = Question::Radio.new(nil, :question_name?) do
+          options { %w[option_two option_three] }
+        end
 
-    test "#option_attributes returns a hash when option attribute is a hash from the renderer" do
-      assert_equal({ label: "option-two-text", value: "option_two", hint_text: "option-two-hint" }, @presenter.option_attributes("option_two"))
+        @presenter = QuestionWithOptionsPresenter.new(question, nil, nil, renderer: @renderer)
+      end
+
+      should "options returns options with labels and values" do
+        assert_equal(%w[option_two option_three], @presenter.options.map { |o| o[:value] })
+        assert_equal(%w[option-two-text option-three-text], @presenter.options.map { |o| o[:label] })
+      end
     end
   end
 end

--- a/test/unit/question_with_options_presenter_test.rb
+++ b/test/unit/question_with_options_presenter_test.rb
@@ -7,7 +7,6 @@ module SmartAnswer
 
       @renderer.stubs(:option).with(:option_one).returns("option-one-text")
       @renderer.stubs(:option).with(:option_two).returns({ label: "option-two-text", hint_text: "option-two-hint" })
-      @renderer.stubs(:option).with(:option_three).returns("option-three-text")
     end
 
     context "question defined with option keys" do
@@ -31,21 +30,6 @@ module SmartAnswer
 
       should "option_attributes returns a hash when option attribute is a hash from the renderer" do
         assert_equal({ label: "option-two-text", value: "option_two", hint_text: "option-two-hint" }, @presenter.option_attributes("option_two"))
-      end
-    end
-
-    context "question defined with an option block" do
-      setup do
-        question = Question::Radio.new(nil, :question_name?) do
-          options { %w[option_two option_three] }
-        end
-
-        @presenter = QuestionWithOptionsPresenter.new(question, nil, nil, renderer: @renderer)
-      end
-
-      should "options returns options with labels and values" do
-        assert_equal(%w[option_two option_three], @presenter.options.map { |o| o[:value] })
-        assert_equal(%w[option-two-text option-three-text], @presenter.options.map { |o| o[:label] })
       end
     end
   end

--- a/test/unit/question_with_options_presenter_test.rb
+++ b/test/unit/question_with_options_presenter_test.rb
@@ -5,8 +5,8 @@ module SmartAnswer
     setup do
       @renderer = stub("renderer")
 
-      @renderer.stubs(:option).with(:option_one).returns("option-one-text")
-      @renderer.stubs(:option).with(:option_two).returns({ label: "option-two-text", hint_text: "option-two-hint" })
+      @renderer.stubs(:option).with("option_one").returns("option-one-text")
+      @renderer.stubs(:option).with("option_two").returns({ label: "option-two-text", hint_text: "option-two-hint" })
     end
 
     context "question defined with option keys" do

--- a/test/unit/radio_question_presenter_test.rb
+++ b/test/unit/radio_question_presenter_test.rb
@@ -10,9 +10,9 @@ module SmartAnswer
 
       @renderer = stub("renderer")
 
-      @renderer.stubs(:option).with(:option1).returns("Option 1")
-      @renderer.stubs(:option).with(:option2).returns("Option 2")
-      @renderer.stubs(:option).with(:option3).returns("Option 3")
+      @renderer.stubs(:option).with("option1").returns("Option 1")
+      @renderer.stubs(:option).with("option2").returns("Option 2")
+      @renderer.stubs(:option).with("option3").returns("Option 3")
 
       @presenter = RadioQuestionPresenter.new(@question, nil, nil, renderer: @renderer)
       @presenter.stubs(:current_response).returns(nil)

--- a/test/unit/radio_question_test.rb
+++ b/test/unit/radio_question_test.rb
@@ -53,5 +53,26 @@ module SmartAnswer
         q.transition(current_state, :invalid)
       end
     end
+
+    test "Setup resolves the options keys from the option block" do
+      q = Question::Radio.new(nil, :example) do
+        options { %i[x y] }
+      end
+
+      q.setup(nil)
+
+      assert_equal %i[x y], q.option_keys
+    end
+
+    test "Setup doesn't clear options keys if option block is nil" do
+      q = Question::Radio.new(nil, :example) do
+        option :a
+        option :b
+      end
+
+      q.setup(nil)
+
+      assert_equal %w[a b], q.option_keys
+    end
   end
 end

--- a/test/unit/radio_question_test.rb
+++ b/test/unit/radio_question_test.rb
@@ -2,22 +2,21 @@ require_relative "../test_helper"
 
 module SmartAnswer
   class RadioQuestionTest < ActiveSupport::TestCase
-    test "Can list options" do
+    test "Can add options as keys" do
       q = Question::Radio.new(nil, :example) do
         option :yes
         option :no
       end
 
-      assert_equal %w[yes no], q.options
+      assert_equal %w[yes no], q.option_keys
     end
 
-    test "Can list options without transitions" do
+    test "Can add options as a block" do
       q = Question::Radio.new(nil, :example) do
-        option :yes
-        option :no
+        options { %i[x y] }
       end
 
-      assert_equal %w[yes no], q.options
+      assert_equal %i[x y], q.options_block.call
     end
 
     test "Can determine next state on provision of an input" do

--- a/test/unit/state_resolver_test.rb
+++ b/test/unit/state_resolver_test.rb
@@ -6,6 +6,10 @@ module SmartAnswer
       @flow = SmartAnswer::Flow.build do
         additional_parameters %w[c d]
 
+        setup do
+          self.e = :f
+        end
+
         radio :x do
           option :yes
           option :no
@@ -116,6 +120,13 @@ module SmartAnswer
 
         assert_equal :y, state.current_node_name
         assert_equal "true", state.c
+      end
+
+      should "run setup on the start state" do
+        response_store = ResponseStore.new(responses: {})
+        state = @state_resolver.state_from_response_store(response_store)
+
+        assert_equal :f, state.e
       end
     end
 

--- a/test/unit/state_resolver_test.rb
+++ b/test/unit/state_resolver_test.rb
@@ -122,11 +122,23 @@ module SmartAnswer
         assert_equal "true", state.c
       end
 
-      should "run setup on the start state" do
+      should "run the flow setup block on the start state" do
         response_store = ResponseStore.new(responses: {})
         state = @state_resolver.state_from_response_store(response_store)
 
         assert_equal :f, state.e
+      end
+
+      should "run setup method for each visited node in order" do
+        response_store = ResponseStore.new(responses: { "x" => "yes", "y" => "no" })
+        setup_order = sequence("setup_order")
+
+        @flow.node(:x).expects(:setup).once.in_sequence(setup_order)
+        @flow.node(:y).expects(:setup).once.in_sequence(setup_order)
+        @flow.node(:b).expects(:setup).once.in_sequence(setup_order)
+        @flow.node(:a).expects(:setup).never
+
+        @state_resolver.state_from_response_store(response_store)
       end
     end
 


### PR DESCRIPTION
This PR introduces the ability dynamic define options for radio and checkbox question at request time. This is useful for flows that have differing options depending on answers to previous questions.

Dynamic options are specified as a block within the flow definition. The block needs to return an array of string or symbols that are option keys.
```ruby
radio :node_name do
  options { return <array of option keys> }
end
```
For example:
```ruby
class ExampleFlow < SmartAnswer::Flow
  def define
    name "example"
    ...
    radio :question1 do
      option :yes
      option :no

     on_response { |response| self.x = response }

      next_node { question :question2 }
    end

    radio :question2 do
      options do
        x == "yes" ? ["a", "b"] : ["a", "b", "c"]
      end

      next_node { question :question3 }
    end
    ...
  end
end
```

The option block runs when before the node is rendered, but after the state has resolved for previous nodes. This allows you to modify options based on previous responses.

The existing method and syntax  to specify static options (`option <key_name>`) is still support and unaffected. If both static and dynamic options are defined, the dynamic options will take precedence and replace the static options.

Without dynamic options, flow's currently must define duplicate version of the same question and have addition logic within the next node block to handle which options to show the user. The duplicate question means that redundant content must specified as each question will need its own erb content template, which will be largely that same. An example of flow that suffers from this is the [additional-commodity-code flow](https://github.com/alphagov/smart-answers/blob/main/app/flows/additional_commodity_code_flow.rb). This flow currently has 11 question nodes, however there's only 4 different questions asked to the user. An example of how this flow could be refactor is [seen here.](https://github.com/alphagov/smart-answers/pull/5545/files#diff-3a0bcabf152b44fe0c875947e0c911e9b5c767349058872da04a53d54ee05d76L2)

In addition to dynamic options, the PR introduces a setup block that can be specified in the flow definition before node blocks. For example:

```ruby
class ExampleFlow < SmartAnswer::Flow
  def define
    name "example"
    ...
    setup do                                <-
      self.calculator = SomeCalculator.new  <- NEW SETUP BLOCK SYNTAX
    end                                     <-

    radio :question1 do
    end
    ...
  end
end
```

This is needed because previously the `on_response` block in the first question was relied upon to initial state. For example [set up calculator classes](https://github.com/alphagov/smart-answers/blob/6303598b1af8dae71592e85746e8a681ad11deab/app/flows/additional_commodity_code_flow.rb#L17). It meant the initial state wasn't configure until after the first question was rendered and a response was given. This prevents the dynamic options block from using initialisation logic, as it executes before page render. This aside, setting up state was also a misuse of the purpose of the `on_response` blocks.


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
