### PR TITLE
Remove unnecessary govuk-width-container class

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -34,7 +34,7 @@
   <body class="govuk-template__body">
     <div id="wrapper">
       <%= yield :hide_this_page_banner %>
-      <div class="govuk-width-container smart_answer">
+      <div class="smart_answer">
         <%= render "smart_answers/shared/phase_banner" %>
         <%= yield :breadcrumbs %>
         <main id="content" role="main">


### PR DESCRIPTION
## What
Remove the `govuk-width-container` class from the layout.

## Why
This class is already being added to the #wrapper div above via slimmer, meaning that the margin around pages on mobile are larger than the rest of gov.uk.

Flagged by zendesk ticket: https://govuk.zendesk.com/agent/tickets/4663513

[Test page](https://www.gov.uk/towing-rules)

## Visual changes

| Before | After |
| --- | --- |
| ![Screenshot 2021-08-16 at 10 27 38](https://user-images.githubusercontent.com/64783893/129542554-c06da255-f0d0-4a7d-90bd-6a79392dab5d.png) | ![Screenshot 2021-08-16 at 10 27 28](https://user-images.githubusercontent.com/64783893/129542571-81df9a6e-9171-49f3-ac60-44b04a4e7d31.png) |