### PR TITLE
Remove no-op `from` and `to` date definitions

### DIFF
--- a/app/flows/all_smart_answer_questions_flow.rb
+++ b/app/flows/all_smart_answer_questions_flow.rb
@@ -43,8 +43,6 @@ class AllSmartAnswerQuestionsFlow < SmartAnswer::Flow
       from { Time.zone.today }
       to { 4.years.since(Time.zone.today) }
 
-      validate_in_range
-
       next_node do
         question :which_date_this_year?
       end

--- a/app/flows/all_smart_answer_questions_flow.rb
+++ b/app/flows/all_smart_answer_questions_flow.rb
@@ -51,9 +51,6 @@ class AllSmartAnswerQuestionsFlow < SmartAnswer::Flow
     end
 
     date_question :which_date_this_year? do
-      from { 1.year.ago.beginning_of_year.to_date }
-      to { ::Time.zone.today.end_of_year }
-
       default_year { 0 }
 
       next_node do

--- a/app/flows/calculate_agricultural_holiday_entitlement_flow.rb
+++ b/app/flows/calculate_agricultural_holiday_entitlement_flow.rb
@@ -43,9 +43,6 @@ class CalculateAgriculturalHolidayEntitlementFlow < SmartAnswer::Flow
     end
 
     date_question :what_date_does_holiday_start? do
-      from { Date.civil(Time.zone.today.year, 1, 1) }
-      to { Date.civil(Time.zone.today.year + 1, 12, 31) }
-
       on_response do |response|
         calculator.holiday_starts_on = response
       end

--- a/app/flows/calculate_married_couples_allowance_flow.rb
+++ b/app/flows/calculate_married_couples_allowance_flow.rb
@@ -36,9 +36,6 @@ class CalculateMarriedCouplesAllowanceFlow < SmartAnswer::Flow
     end
 
     date_question :whats_the_husbands_date_of_birth? do
-      from { Time.zone.today.end_of_year }
-      to { Date.parse("1 Jan 1896") }
-
       on_response do |response|
         calculator.birth_date = response
       end
@@ -49,9 +46,6 @@ class CalculateMarriedCouplesAllowanceFlow < SmartAnswer::Flow
     end
 
     date_question :whats_the_highest_earners_date_of_birth? do
-      to { Date.parse("1 Jan 1896") }
-      from { Time.zone.today.end_of_year }
-
       on_response do |response|
         calculator.birth_date = response
       end

--- a/app/flows/calculate_statutory_sick_pay_flow.rb
+++ b/app/flows/calculate_statutory_sick_pay_flow.rb
@@ -117,8 +117,6 @@ class CalculateStatutorySickPayFlow < SmartAnswer::Flow
         calculator.sick_start_date = response
       end
 
-      validate_in_range
-
       next_node do
         question :last_sick_day?
       end
@@ -132,8 +130,6 @@ class CalculateStatutorySickPayFlow < SmartAnswer::Flow
       on_response do |response|
         calculator.sick_end_date = response
       end
-
-      validate_in_range
 
       validate do
         calculator.valid_last_sick_day?
@@ -180,8 +176,6 @@ class CalculateStatutorySickPayFlow < SmartAnswer::Flow
         calculator.linked_sickness_start_date = response
       end
 
-      validate_in_range
-
       validate :error_linked_sickness_must_be_before do
         calculator.valid_linked_sickness_start_date?
       end
@@ -199,8 +193,6 @@ class CalculateStatutorySickPayFlow < SmartAnswer::Flow
       on_response do |response|
         calculator.linked_sickness_end_date = response
       end
-
-      validate_in_range
 
       validate :error_must_be_within_eight_weeks do
         calculator.within_eight_weeks_of_current_sickness_period?
@@ -265,7 +257,6 @@ class CalculateStatutorySickPayFlow < SmartAnswer::Flow
     date_question :last_payday_before_sickness? do
       from { Date.new(2010, 1, 1) }
       to { SmartAnswer::Calculators::StatutorySickPayCalculator.year_of_sickness }
-      validate_in_range
 
       on_response do |response|
         calculator.relevant_period_to = response
@@ -284,7 +275,6 @@ class CalculateStatutorySickPayFlow < SmartAnswer::Flow
     date_question :last_payday_before_offset? do
       from { Date.new(2010, 1, 1) }
       to { SmartAnswer::Calculators::StatutorySickPayCalculator.year_of_sickness }
-      validate_in_range
 
       on_response do |response|
         calculator.relevant_period_from = response + 1.day

--- a/app/flows/calculate_your_holiday_entitlement_flow.rb
+++ b/app/flows/calculate_your_holiday_entitlement_flow.rb
@@ -75,9 +75,6 @@ class CalculateYourHolidayEntitlementFlow < SmartAnswer::Flow
 
     # Q4 - Q12 - Q20 - Q29 - Q36
     date_question :what_is_your_starting_date? do
-      from { Date.civil(1.year.ago.year, 1, 1) }
-      to { Date.civil(1.year.since(Time.zone.today).year, 12, 31) }
-
       on_response do |response|
         calculator.start_date = response
       end
@@ -93,9 +90,6 @@ class CalculateYourHolidayEntitlementFlow < SmartAnswer::Flow
 
     # Q5 - Q13 - Q21 - Q29 - Q30 - Q37
     date_question :what_is_your_leaving_date? do
-      from { Date.civil(1.year.ago.year, 1, 1) }
-      to { Date.civil(1.year.since(Time.zone.today).year, 12, 31) }
-
       on_response do |response|
         calculator.leaving_date = response
       end
@@ -128,9 +122,6 @@ class CalculateYourHolidayEntitlementFlow < SmartAnswer::Flow
 
     # Q6 - Q14 - Q22 - Q31 - Q38
     date_question :when_does_your_leave_year_start? do
-      from { Date.civil(1.year.ago.year, 1, 1) }
-      to { Date.civil(1.year.since(Time.zone.today).year, 12, 31) }
-
       on_response do |response|
         calculator.leave_year_start_date = response
       end

--- a/app/flows/estimate_self_assessment_penalties_flow.rb
+++ b/app/flows/estimate_self_assessment_penalties_flow.rb
@@ -37,9 +37,6 @@ class EstimateSelfAssessmentPenaltiesFlow < SmartAnswer::Flow
     end
 
     date_question :when_submitted? do
-      from { 3.years.ago(Time.zone.today) }
-      to { 2.years.since(Time.zone.today) }
-
       on_response do |response|
         calculator.filing_date = response
       end
@@ -52,9 +49,6 @@ class EstimateSelfAssessmentPenaltiesFlow < SmartAnswer::Flow
     end
 
     date_question :when_paid? do
-      from { 3.years.ago(Time.zone.today) }
-      to { 2.years.since(Time.zone.today) }
-
       on_response do |response|
         calculator.payment_date = response
       end

--- a/app/flows/maternity_paternity_calculator_flow/adoption_calculator_flow.rb
+++ b/app/flows/maternity_paternity_calculator_flow/adoption_calculator_flow.rb
@@ -154,9 +154,6 @@ class MaternityPaternityCalculatorFlow < SmartAnswer::Flow
       end
 
       date_question :last_normal_payday_adoption? do
-        from { 2.years.ago(Time.zone.today) }
-        to { 2.years.since(Time.zone.today) }
-
         on_response do |response|
           self.last_payday = response
           calculator.last_payday = last_payday
@@ -174,9 +171,6 @@ class MaternityPaternityCalculatorFlow < SmartAnswer::Flow
       end
 
       date_question :payday_eight_weeks_adoption? do
-        from { 2.years.ago(Time.zone.today) }
-        to { 2.years.since(Time.zone.today) }
-
         on_response do |response|
           self.last_payday_eight_weeks = response + 1.day
           calculator.pre_offset_payday = last_payday_eight_weeks

--- a/app/flows/maternity_paternity_calculator_flow/maternity_calculator_flow.rb
+++ b/app/flows/maternity_paternity_calculator_flow/maternity_calculator_flow.rb
@@ -5,9 +5,6 @@ class MaternityPaternityCalculatorFlow < SmartAnswer::Flow
 
       ## QM1
       date_question :baby_due_date_maternity? do
-        from { 1.year.ago(Time.zone.today) }
-        to { 2.years.since(Time.zone.today) }
-
         on_response do |response|
           self.calculator = SmartAnswer::Calculators::MaternityPayCalculator.new(response)
         end
@@ -19,9 +16,6 @@ class MaternityPaternityCalculatorFlow < SmartAnswer::Flow
 
       ## QM2
       date_question :date_leave_starts? do
-        from { 2.years.ago(Time.zone.today) }
-        to { 2.years.since(Time.zone.today) }
-
         on_response do |response|
           self.leave_start_date = response
           calculator.leave_start_date = leave_start_date
@@ -81,9 +75,6 @@ class MaternityPaternityCalculatorFlow < SmartAnswer::Flow
 
       ## QM5
       date_question :last_normal_payday? do
-        from { 2.years.ago(Time.zone.today) }
-        to { 2.years.since(Time.zone.today) }
-
         on_response do |response|
           self.last_payday = response
           calculator.last_payday = last_payday
@@ -100,9 +91,6 @@ class MaternityPaternityCalculatorFlow < SmartAnswer::Flow
 
       ## QM6
       date_question :payday_eight_weeks? do
-        from { 2.years.ago(Time.zone.today) }
-        to { 2.years.since(Time.zone.today) }
-
         on_response do |response|
           self.last_payday_eight_weeks = 1.day.after(response)
           calculator.pre_offset_payday = last_payday_eight_weeks

--- a/app/flows/maternity_paternity_calculator_flow/paternity_calculator_flow.rb
+++ b/app/flows/maternity_paternity_calculator_flow/paternity_calculator_flow.rb
@@ -206,9 +206,6 @@ class MaternityPaternityCalculatorFlow < SmartAnswer::Flow
 
       ## QP8
       date_question :employee_start_paternity? do
-        from { 2.years.ago(Time.zone.today) }
-        to { 2.years.since(Time.zone.today) }
-
         on_response do |response|
           self.employee_leave_start = response
           self.leave_start_date = employee_leave_start
@@ -251,9 +248,6 @@ class MaternityPaternityCalculatorFlow < SmartAnswer::Flow
 
       ## QP10
       date_question :last_normal_payday_paternity? do
-        from { 2.years.ago(Time.zone.today) }
-        to { 2.years.since(Time.zone.today) }
-
         on_response do |response|
           calculator.last_payday = response
         end
@@ -269,9 +263,6 @@ class MaternityPaternityCalculatorFlow < SmartAnswer::Flow
 
       ## QP11
       date_question :payday_eight_weeks_paternity? do
-        from { 2.years.ago(Time.zone.today) }
-        to { 2.years.since(Time.zone.today) }
-
         on_response do |response|
           calculator.pre_offset_payday = response + 1.day
           self.relevant_period = calculator.formatted_relevant_period
@@ -349,9 +340,6 @@ class MaternityPaternityCalculatorFlow < SmartAnswer::Flow
 
       ## QP15 - Also shared with adoption calculator here onwards
       date_question :next_pay_day_paternity? do
-        from { 2.years.ago(Time.zone.today) }
-        to { 2.years.since(Time.zone.today) }
-
         on_response do |response|
           self.next_pay_day = response
           calculator.pay_date = next_pay_day

--- a/app/flows/part_year_profit_tax_credits_flow.rb
+++ b/app/flows/part_year_profit_tax_credits_flow.rb
@@ -6,9 +6,6 @@ class PartYearProfitTaxCreditsFlow < SmartAnswer::Flow
     content_id "de6723a5-7256-4bfd-aad3-82b04b06b73e"
 
     date_question :when_did_your_tax_credits_award_end? do
-      from { SmartAnswer::Calculators::PartYearProfitTaxCreditsCalculator::TAX_CREDITS_AWARD_ENDS_EARLIEST_DATE }
-      to   { SmartAnswer::Calculators::PartYearProfitTaxCreditsCalculator::TAX_CREDITS_AWARD_ENDS_LATEST_DATE }
-
       on_response do |response|
         self.calculator = SmartAnswer::Calculators::PartYearProfitTaxCreditsCalculator.new
         calculator.tax_credits_award_ends_on = response
@@ -68,9 +65,6 @@ class PartYearProfitTaxCreditsFlow < SmartAnswer::Flow
     end
 
     date_question :when_did_you_stop_trading? do
-      from { SmartAnswer::Calculators::PartYearProfitTaxCreditsCalculator::START_OR_STOP_TRADING_EARLIEST_DATE }
-      to   { SmartAnswer::Calculators::PartYearProfitTaxCreditsCalculator::START_OR_STOP_TRADING_LATEST_DATE }
-
       on_response do |response|
         calculator.stopped_trading_on = response
       end
@@ -98,9 +92,6 @@ class PartYearProfitTaxCreditsFlow < SmartAnswer::Flow
     end
 
     date_question :when_did_you_start_trading? do
-      from { SmartAnswer::Calculators::PartYearProfitTaxCreditsCalculator::START_OR_STOP_TRADING_EARLIEST_DATE }
-      to   { SmartAnswer::Calculators::PartYearProfitTaxCreditsCalculator::START_OR_STOP_TRADING_LATEST_DATE }
-
       on_response do |response|
         calculator.started_trading_on = response
       end

--- a/app/flows/register_a_birth_flow.rb
+++ b/app/flows/register_a_birth_flow.rb
@@ -63,9 +63,6 @@ class RegisterABirthFlow < SmartAnswer::Flow
 
     # Q4
     date_question :childs_date_of_birth? do
-      from { Time.zone.today.end_of_year }
-      to { 50.years.ago(Time.zone.today) }
-
       on_response do |response|
         calculator.childs_date_of_birth = response
       end

--- a/app/flows/shared/redundancy_pay_flow.rb
+++ b/app/flows/shared/redundancy_pay_flow.rb
@@ -3,7 +3,6 @@ class RedundancyPayFlow < SmartAnswer::Flow
     date_question :date_of_redundancy? do
       from { SmartAnswer::Calculators::RedundancyCalculator.first_selectable_date }
       to { SmartAnswer::Calculators::RedundancyCalculator.last_selectable_date }
-      validate_in_range
 
       on_response do |response|
         self.rates = SmartAnswer::Calculators::RedundancyCalculator.redundancy_rates(response)

--- a/lib/smart_answer/calculators/part_year_profit_tax_credits_calculator.rb
+++ b/lib/smart_answer/calculators/part_year_profit_tax_credits_calculator.rb
@@ -3,12 +3,6 @@ module SmartAnswer
     class PartYearProfitTaxCreditsCalculator
       include ActiveModel::Model
 
-      TAX_CREDITS_AWARD_ENDS_EARLIEST_DATE = Date.parse("2015-01-01")
-      TAX_CREDITS_AWARD_ENDS_LATEST_DATE   = Date.parse("2022-12-31")
-
-      START_OR_STOP_TRADING_EARLIEST_DATE = TAX_CREDITS_AWARD_ENDS_EARLIEST_DATE - 2.years
-      START_OR_STOP_TRADING_LATEST_DATE   = TAX_CREDITS_AWARD_ENDS_LATEST_DATE + 1.year
-
       attr_accessor :tax_credits_award_ends_on,
                     :accounts_end_month_and_day,
                     :taxable_profit,

--- a/lib/smart_answer/question/date.rb
+++ b/lib/smart_answer/question/date.rb
@@ -50,7 +50,15 @@ module SmartAnswer
       end
 
       def range
-        @range ||= from && to ? from..to : false
+        if from && to
+          raise "to date must be after the from date" if from >= to
+
+          from..to
+        elsif !from && !to
+          false
+        else
+          raise "Both from and to must be defined to validate a date question"
+        end
       end
 
       def parse_input(input)

--- a/test/unit/flow_test.rb
+++ b/test/unit/flow_test.rb
@@ -164,7 +164,8 @@ class FlowTest < ActiveSupport::TestCase
 
     assert_equal 1, s.nodes.size
     assert_equal 1, s.questions.size
-    assert_equal Date.parse("2011-01-01")..Date.parse("2014-01-01"), s.questions.first.range
+    assert_equal Date.parse("2011-01-01"), s.questions.first.from
+    assert_equal Date.parse("2014-01-01"), s.questions.first.to
   end
 
   test "Can build value question nodes" do

--- a/test/unit/flows/part_year_profit_tax_credits_flow_test.rb
+++ b/test/unit/flows/part_year_profit_tax_credits_flow_test.rb
@@ -26,16 +26,6 @@ class PartYearProfitTaxCreditsFlowTest < ActiveSupport::TestCase
       assert_same @calculator, @new_state.calculator
     end
 
-    should "set the from date of the date select to the constant defined in the calculator" do
-      expected = SmartAnswer::Calculators::PartYearProfitTaxCreditsCalculator::TAX_CREDITS_AWARD_ENDS_EARLIEST_DATE
-      assert_equal expected, @question.range.begin
-    end
-
-    should "set the to date of the date select to the constant defined in the calculator" do
-      expected = SmartAnswer::Calculators::PartYearProfitTaxCreditsCalculator::TAX_CREDITS_AWARD_ENDS_LATEST_DATE
-      assert_equal expected, @question.range.end
-    end
-
     should "store parsed response on calculator as tax_credits_award_ends_on" do
       assert_equal Date.parse("2016-02-20"), @calculator.tax_credits_award_ends_on
     end
@@ -164,16 +154,6 @@ class PartYearProfitTaxCreditsFlowTest < ActiveSupport::TestCase
       )
     end
 
-    should "set the from date of the date select to constant defined in the calculator" do
-      expected = SmartAnswer::Calculators::PartYearProfitTaxCreditsCalculator::START_OR_STOP_TRADING_EARLIEST_DATE
-      assert_equal expected, @question.range.begin
-    end
-
-    should "set the to date of the date select to the constant defined in the calculator" do
-      expected = SmartAnswer::Calculators::PartYearProfitTaxCreditsCalculator::START_OR_STOP_TRADING_LATEST_DATE
-      assert_equal expected, @question.range.end
-    end
-
     should "store parsed response on calculator as started_trading_on" do
       assert_equal Date.parse("2015-02-01"), @calculator.started_trading_on
     end
@@ -237,16 +217,6 @@ class PartYearProfitTaxCreditsFlowTest < ActiveSupport::TestCase
         responding_with: "2015-06-01",
         initial_state: { calculator: @calculator },
       )
-    end
-
-    should "set the from date of the date select to the constant defined in the calculator" do
-      expected = SmartAnswer::Calculators::PartYearProfitTaxCreditsCalculator::START_OR_STOP_TRADING_EARLIEST_DATE
-      assert_equal expected, @question.range.begin
-    end
-
-    should "set the to date of the date select to the constant defined in the calculator" do
-      expected = SmartAnswer::Calculators::PartYearProfitTaxCreditsCalculator::START_OR_STOP_TRADING_LATEST_DATE
-      assert_equal expected, @question.range.end
     end
 
     should "store parsed response on calculator as stopped_trading_on" do


### PR DESCRIPTION
This PR changes the behaviour of setting `from` and `to` dates on a date question to validate that the input matches that range. It then removes all the cases where `from` and `to` were used without validation. These have been removed because setting them had no effect on the behaviour of the application, prior to https://github.com/alphagov/smart-answers/pull/4598 these used to set the range of `<select>` elements but these are now boundless `<input type="text">` elements.

I think a further improvement could be to remove these `from` and `to` attributes from date questions and define this validation in a `validate` block. However I couldn't tell how big a can of worms that would open and felt this was a sufficient net improvement alone.

More info in the commits...

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
