### PR TITLE
Fix test deprecation

### DIFF
--- a/test/unit/node_test.rb
+++ b/test/unit/node_test.rb
@@ -100,7 +100,7 @@ module SmartAnswer
 
     context "#setup" do
       should "be a method" do
-        assert_equal nil, @node.setup(nil)
+        assert_nil @node.setup(nil)
       end
     end
 


### PR DESCRIPTION
This resolves a warning of:

```
DEPRECATED: Use assert_nil if expecting nil from test/unit/node_test.rb:103. This will fail in Minitest 6.
```

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
