### PR TITLE
Remove redundant code from CheckUkVisaFlow

### DIFF
--- a/app/flows/check_uk_visa_flow.rb
+++ b/app/flows/check_uk_visa_flow.rb
@@ -377,18 +377,7 @@ class CheckUkVisaFlow < SmartAnswer::Flow
       end
 
       if calculator.transit_visit?
-        if calculator.passport_country_in_direct_airside_transit_visa_list? ||
-            calculator.passport_country_in_visa_national_list? ||
-            calculator.passport_country_is_taiwan? ||
-            calculator.passport_country_is_venezuela? ||
-            calculator.passport_country_in_non_visa_national_list? ||
-            calculator.passport_country_in_eea? ||
-            calculator.passport_country_in_british_overseas_territories_list? ||
-            calculator.travel_document?
-          next question(:travelling_to_cta?)
-        else
-          next outcome(:outcome_no_visa_needed)
-        end
+        next question(:travelling_to_cta?)
       end
 
       if calculator.family_visit?

--- a/app/flows/check_uk_visa_flow.rb
+++ b/app/flows/check_uk_visa_flow.rb
@@ -230,8 +230,6 @@ class CheckUkVisaFlow < SmartAnswer::Flow
       next_node do |response|
         if response == "yes"
           outcome :outcome_tourism_visa_partner
-        elsif calculator.family_visit?
-          question :partner_family_british_citizen?
         else
           outcome :outcome_standard_visitor_visa
         end

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_no_visa_needed.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_no_visa_needed.erb
@@ -3,12 +3,8 @@
 <% end %>
 
 <% govspeak_for :body do %>
-  <% if calculator.passport_country_in_eea? && calculator.travelling_before_2021? %>
-    You do not need a visa if you enter the UK by 11pm on 31 December 2020.
-
-    If you come to the UK before this time, you can apply to the [EU Settlement Scheme](/settled-status-eu-citizens-families) by 30 June 2021 to continue to work, live or study in the UK.
-  <% elsif (calculator.travelling_to_elsewhere? || calculator.travelling_to_ireland?) &&
-       (calculator.passport_country_in_non_visa_national_list? || calculator.passport_country_in_eea? || calculator.passport_country_in_british_overseas_territories_list?) %>
+  <% if (calculator.travelling_to_elsewhere? || calculator.travelling_to_ireland?) &&
+      (calculator.passport_country_in_non_visa_national_list? || calculator.passport_country_in_eea? || calculator.passport_country_in_british_overseas_territories_list?) %>
 
     However, you should bring evidence of your onward journey to show to officers at the UK border.
 

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_transit_taiwan_through_border_control.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_transit_taiwan_through_border_control.erb
@@ -19,9 +19,9 @@
 
   One of the following must also apply:
 
-  - you’re travelling to (or on part of a reasonable journey to) Australia, Canada, New Zealand or the USA and have a valid visa for that country <%= render partial: 'b1_b2_visa_exception', locals: {calculator: calculator} %>
-  - you’re travelling from (or on part of a reasonable journey from) Australia, Canada, New Zealand or the USA and have a valid visa for that country <%= render partial: 'b1_b2_visa_exception', locals: {calculator: calculator} %>
-  - you’re travelling from (or on part of a reasonable journey from) Australia, Canada, New Zealand or the USA and it’s less than 6 months since you last entered that country with a valid entry visa <%= render partial: 'b1_b2_visa_exception', locals: {calculator: calculator} %>
+  - you’re travelling to (or on part of a reasonable journey to) Australia, Canada, New Zealand or the USA and have a valid visa for that country
+  - you’re travelling from (or on part of a reasonable journey from) Australia, Canada, New Zealand or the USA and have a valid visa for that country
+  - you’re travelling from (or on part of a reasonable journey from) Australia, Canada, New Zealand or the USA and it’s less than 6 months since you last entered that country with a valid entry visa
   - you have a permanent residence permit issued by Australia or New Zealand
   - you have a common format residence permit issued by an European Economic Area (EEA) country or Switzerland
   - you have a permanent residence permit issued by Canada on or after 28 June 2002

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_transit_to_the_republic_of_ireland.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_transit_to_the_republic_of_ireland.erb
@@ -25,92 +25,20 @@
     You’ll usually need to apply for a UK [standard visitor visa](/standard-visitor-visa).
   <% end %>
 
-  <% if calculator.passport_country_in_direct_airside_transit_visa_list? ||
-      calculator.passport_country_is_taiwan? ||
-      calculator.passport_country_in_electronic_visa_waiver_list? ||
-      calculator.passport_country_in_visa_national_list? %>
 
-    ##Transiting without a visa
+  ##Transiting without a visa
 
-    You might be eligible for ‘transit without visa’ if:
+  You might be eligible for ‘transit without visa’ if:
 
-     - you arrive and depart by air
+  - you arrive and depart by air
+  - have a confirmed onward flight that leaves on the day you arrive or before midnight on the day after you arrive
+  - have the right documents for your destination (for example a visa for that country)
 
-     - have a confirmed onward flight that leaves on the day you arrive or before midnight on the day after you arrive
+  You must also have an Irish biometric visa (marked ‘BC’ or ‘BC BIVS’ in the ‘Remarks’ section) and an onward flight ticket to the Republic of Ireland.
 
-     - have the right documents for your destination (for example a visa for that country)
-    <% if calculator.passport_country_in_visa_national_list? ||
-         calculator.passport_country_is_taiwan? ||
-         calculator.passport_country_in_direct_airside_transit_visa_list? ||
-         passport_country_in_electronic_visa_waiver_list? %>
+  E-visas or e-residence permits are not acceptable for transiting through immigration control without a visa.
 
-      You must also have an Irish biometric visa (marked ‘BC’ or ‘BC BIVS’ in the ‘Remarks’ section) and an onward flight ticket to the Republic of Ireland.
+  All visas and residence permits must be valid.
 
-      E-visas or e-residence permits are not acceptable for transiting through immigration control without a visa.
-
-      All visas and residence permits must be valid.
-
-      You won’t be able to transit without a visa if a Border Force officer decides you don’t qualify under the immigration rules.
-
-    <% else %>
-
-      You must also:
-
-      - be travelling to (or on part of a reasonable journey to) Australia, Canada, New Zealand or the USA and have a valid visa for that country
-
-      - be travelling from (or on part of a reasonable journey from) Australia, Canada, New Zealand or the USA and have a valid visa for that country
-
-      - be travelling from (or on part of a reasonable journey from) Australia, Canada, New Zealand or the USA and it’s less than 6 months since you last entered that country with a valid entry visa
-
-      - have a residence permit issued by Australia or New Zealand
-
-      - have a common format residence permit issued by an European Economic Area (EEA) country or Switzerland
-
-      - have a residence permit issued by Canada issued after 28 June 2002
-
-      - have a uniform format category D visa for entry to a country in the EEA or Switzerland
-
-      - have an Irish biometric visa (marked ‘BC’ or ‘BC BIVS’ in the ‘Remarks’ section) and an onward flight ticket to the Republic of Ireland
-
-      - have a valid USA permanent residence card issued by the USA on or after 21 April 1998
-
-      - have a valid USA I-551 Temporary Immigrant visa issued by the USA (a wet-ink stamp version will not be accepted)
-
-      - have an expired USA I-551 Permanent Residence card issued by the USA on or after 21 April 1998, with a valid I-797 letter authorising extension
-
-      - have a valid standalone US Immigration Form 155A/155B issued by the USA (attached to a sealed brown envelope)
-
-      You won’t be able to transit without a visa if a Border Force officer decides you don’t qualify under the immigration rules. You can [apply for a transit visa](/transit-visa) before you travel if you’re unsure whether you qualify for transiting without a visa.
-
-      E-visas or e-residence permits are not acceptable for transiting through immigration control without a visa.
-
-      All visas and residence permits must be valid.
-
-      Australian paper confirmation slips are not accepted.
-
-      ^Transiting without a visa is decided by the immigration officer at the border. You won’t be allowed to transit if they decide you need a visa, so you might want to apply for a transit visa before you travel.^
-
-    <% end %>
-  <% else %>
-
-    You don’t need a visa if:
-
-    - you’re travelling to (or on part of a reasonable journey to) Australia, Canada, New Zealand or the USA and have a valid visa for that country
-    - you’re travelling from (or on part of a reasonable journey from) Australia, Canada, New Zealand or the USA and have a valid visa for that country
-    - you’re travelling from (or on part of a reasonable journey from) Australia, Canada, New Zealand or the USA and it’s less than 6 months since you last entered that country with a valid entry visa
-
-    You also won’t need a visa if you have any of the following:
-
-    - a residence permit issued by Australia or New Zealand
-    - a common format residence permit issued by an European Economic Area (EEA) country or Switzerland
-    - a residence permit issued by Canada issued after 28 June 2002
-    - a uniform format category D visa for entry to a country in the EEA or Switzerland
-    - an Irish biometric visa (marked ‘BC’ or ‘BC BIVS’ in the ‘Remarks’ section) and an onward flight ticket to the Republic of Ireland
-    - a valid USA permanent residence card issued by the USA on or after 21 April 1998
-    - a valid USA I-551 Temporary Immigrant visa issued by the USA (a wet-ink stamp version will not be accepted)
-    - an expired USA I-551 Permanent Residence card issued by the USA on or after 21 April 1998, with a valid I-797 letter authorising extension
-    - a valid standalone US Immigration Form 155A/155B issued by the USA (attached to a sealed brown envelope)
-    - a Taiwanese passport with a personal ID number on the bio data page
-  <% end %>
-
+  You won’t be able to transit without a visa if a Border Force officer decides you don’t qualify under the immigration rules.
 <% end %>

--- a/lib/smart_answer/calculators/uk_visa_calculator.rb
+++ b/lib/smart_answer/calculators/uk_visa_calculator.rb
@@ -2,8 +2,7 @@ module SmartAnswer::Calculators
   class UkVisaCalculator
     include ActiveModel::Model
 
-    attr_writer :when_coming_to_uk_answer,
-                :passport_country,
+    attr_writer :passport_country,
                 :purpose_of_visit_answer,
                 :travelling_to_cta_answer,
                 :passing_through_uk_border_control_answer,
@@ -100,10 +99,6 @@ module SmartAnswer::Calculators
 
     def travel_document?
       @travel_document_type == "travel_document"
-    end
-
-    def travelling_before_2021?
-      @when_coming_to_uk_answer == "before_2021"
     end
 
     def tourism_visit?

--- a/test/flows/check_uk_visa_flow_test.rb
+++ b/test/flows/check_uk_visa_flow_test.rb
@@ -452,8 +452,6 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
       should "have a next node of outcome_standard_visitor_visa for a 'no' response and a non family visit" do
         assert_next_node :outcome_standard_visitor_visa, for_response: "no"
       end
-
-      # impossible to reach partner_family_british_citizen?
     end
   end
 

--- a/test/flows/check_uk_visa_flow_test.rb
+++ b/test/flows/check_uk_visa_flow_test.rb
@@ -558,7 +558,6 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
   end
 
   context "outcome: outcome_no_visa_needed" do
-    # travelling before 2021 conditional is unreachable
     setup do
       testing_node :outcome_no_visa_needed
       add_responses what_passport_do_you_have?: @eea_country,

--- a/test/flows/check_uk_visa_flow_test.rb
+++ b/test/flows/check_uk_visa_flow_test.rb
@@ -683,10 +683,6 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
     end
   end
 
-  context "outcome: outcome_transit_taiwan_through_border_control" do
-    # conditionals are unreachable
-  end
-
   context "outcome: outcome_work_n" do
     setup do
       testing_node :outcome_work_n

--- a/test/flows/check_uk_visa_flow_test.rb
+++ b/test/flows/check_uk_visa_flow_test.rb
@@ -646,8 +646,6 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
       add_responses what_passport_do_you_have?: @visa_national_country
       assert_rendered_outcome text: "You’ll need a visa to pass through the UK (unless you’re exempt)"
     end
-
-    # unreachable conditionals left
   end
 
   context "outcome: outcome_transit_leaving_airport" do

--- a/test/flows/check_uk_visa_flow_test.rb
+++ b/test/flows/check_uk_visa_flow_test.rb
@@ -145,8 +145,6 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
     context "next_node" do
       test_shared_purpose_of_visit_next_nodes
 
-      # outcome_no_visa_needed is unreachable
-
       should "have a next node of travelling_to_cta? for a 'transit' response" do
         assert_next_node :travelling_to_cta?, for_response: "transit"
       end

--- a/test/unit/calculators/uk_visa_calculator_test.rb
+++ b/test/unit/calculators/uk_visa_calculator_test.rb
@@ -17,20 +17,6 @@ module SmartAnswer
         end
       end
 
-      context "#travelling_before_2021?" do
-        should "return true if travelling before 2021" do
-          calculator = UkVisaCalculator.new
-          calculator.when_coming_to_uk_answer = "before_2021"
-          assert calculator.travelling_before_2021?
-        end
-
-        should "return false if travelling after 2021" do
-          calculator = UkVisaCalculator.new
-          calculator.when_coming_to_uk_answer = "from_2021"
-          assert_not calculator.travelling_before_2021?
-        end
-      end
-
       context "#passport_country_in_visa_national_list?" do
         should "return true if passport_country is in list of visa national countries" do
           calculator = UkVisaCalculator.new


### PR DESCRIPTION
Trello: https://trello.com/c/bMMeYqKl/542-smart-answer-flow-tests-check-uk-visa

This removes code that cannot be executed due to prior logic in this flow. I've opened this as a separate PR that is based on https://github.com/alphagov/smart-answers/pull/5568 so as to avoid over complicating that PR.

More info is in the commits.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
