### PR TITLE
Update translators.yml

### DIFF
--- a/config/smart_answers/translators.yml
+++ b/config/smart_answers/translators.yml
@@ -43,7 +43,7 @@ lebanon: /government/publications/lebanon-list-of-lawyers
 libya: /government/publications/libya-list-of-translators
 lithuania: /government/publications/lithuania-list-of-lawyers
 luxembourg: /government/publications/british-embassy-luxembourg-translators
-mexico: /government/publications/mexico-list-of-lawyers
+mexico: /government/publications/mexico-list-of-translators-and-interpreters
 moldova: /government/publications/moldova-list-of-lawyers
 montenegro: /government/publications/montenegro-list-of-lawyers
 morocco: /government/publications/morocco-list-of-lawyers


### PR DESCRIPTION
Updated the link for Mexico translators from /government/publications/mexico-list-of-lawyers to government/publications/mexico-list-of-translators-and-interpreters
Because the content is about translators not lawyers. 

Trello: https://trello.com/c/5tGilggk/3575-%F0%9F%92%A5-change-to-link-on-outcome-link-for-mexico 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
