### PR TITLE
Provide an explanation when unpublishing a Smart Answer

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -45,6 +45,14 @@ namespace :publishing_api do
     GdsApi.publishing_api.unpublish(args.content_id, type: "gone", discard_drafts: true)
   end
 
+  desc "Unpublish a content item with a type of gone and an explanation"
+  task :unpublish_gone_with_explanation, %i[content_id explanation] => :environment do |_, args|
+    raise "Missing content_id parameter" unless args.content_id
+    raise "Missing explanation parameter" unless args.explanation
+
+    GdsApi.publishing_api.unpublish(args.content_id, type: "gone", explanation: args.explanation, discard_drafts: true)
+  end
+
   desc "Unpublish a content item with a type of vanish"
   task :unpublish_vanish, [:content_id] => :environment do |_, args|
     raise "Missing content_id parameter" unless args.content_id

--- a/test/unit/tasks/publishing_api_rake_test.rb
+++ b/test/unit/tasks/publishing_api_rake_test.rb
@@ -128,6 +128,39 @@ class PublishingApiRakeTest < ActiveSupport::TestCase
     end
   end
 
+  context "publishing_api:unpublish_gone_with_explanation rake task" do
+    setup do
+      Rake::Task["publishing_api:unpublish_gone_with_explanation"].reenable
+    end
+
+    should "raise exception when content_id isn't supplied" do
+      exception = assert_raises RuntimeError do
+        Rake::Task["publishing_api:unpublish_gone_with_explanation"].invoke(nil, "explanation")
+      end
+
+      assert_equal "Missing content_id parameter", exception.message
+    end
+
+    should "raise exception when explanation isn't supplied" do
+      exception = assert_raises RuntimeError do
+        Rake::Task["publishing_api:unpublish_gone_with_explanation"].invoke("content-id", nil)
+      end
+
+      assert_equal "Missing explanation parameter", exception.message
+    end
+
+    should "send an unpublishing of type gone to the Publishing API" do
+      explanation = "The latest support and advice has been added to www.gov.uk/somewhere."
+      unpublish_request = stub_publishing_api_unpublish(
+        "content-id",
+        body: { type: "gone", explanation: explanation, discard_drafts: true },
+      )
+
+      Rake::Task["publishing_api:unpublish_gone_with_explanation"].invoke("content-id", explanation)
+      assert_requested unpublish_request
+    end
+  end
+
   context "publishing_api:unpublish_vanish rake task" do
     setup do
       Rake::Task["publishing_api:unpublish_vanish"].reenable


### PR DESCRIPTION
Adds a rake task to provide an explanation for unpublishing with a type of 'gone'.

This allows us to provide further information to the user about where to find information once the smart answer has been removed.

We render the explanation for a 'gone' type in [Government Frontend](https://github.com/alphagov/government-frontend/blob/70981a31ae4561502afa9ada78e13999aa8d2bb8/app/views/content_items/gone.html.erb#L12).

[Docs with further info](https://docs.publishing.service.gov.uk/manual/redirect-routes.html#manually-apply-a-redirect-from-any-publishing-app).

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
