### PR TITLE
Remove hide_previous_answers_on_results_page

### DIFF
--- a/app/presenters/flow_presenter.rb
+++ b/app/presenters/flow_presenter.rb
@@ -9,7 +9,6 @@ class FlowPresenter
            :response_store,
            :questions,
            :use_hide_this_page?,
-           :hide_previous_answers_on_results_page?,
            to: :flow
 
   delegate :title, :meta_description, to: :start_node

--- a/app/views/smart_answers/result.html.erb
+++ b/app/views/smart_answers/result.html.erb
@@ -38,7 +38,7 @@
       </div>
     <% end %>
 
-    <%= render 'smart_answers/shared/previous_answers', hide_previous_answers: @presenter.hide_previous_answers_on_results_page? %>
+    <%= render 'smart_answers/shared/previous_answers' %>
   </div>
 
   <% if defined?(@presenter.finished?) and @presenter.finished? %>

--- a/app/views/smart_answers/shared/_previous_answers.html.erb
+++ b/app/views/smart_answers/shared/_previous_answers.html.erb
@@ -1,6 +1,6 @@
 <% if @presenter.accepted_responses.any? %>
   <%= render "govuk_publishing_components/components/heading", {
-    text: local_assigns[:hide_previous_answers] ? "Change your answers" : "Your answers",
+    text: "Your answers",
     heading_level: 2,
     font_size: "m",
     margin_bottom: 4
@@ -16,35 +16,33 @@
         "track-label": @presenter.current_node.title
       } %>
   <% end %>
-  <% unless local_assigns[:hide_previous_answers] %>
-    <% items = @presenter.answered_questions.map do |question|
-      accepted_response = @presenter.accepted_responses[question.node_name]
+  <% items = @presenter.answered_questions.map do |question|
+    accepted_response = @presenter.accepted_responses[question.node_name]
 
-      if question.multiple_responses?
-        value = render "govuk_publishing_components/components/list", {
-          items: question.response_labels(accepted_response)
-        }
-      else
-        value = question.response_label(accepted_response)
-      end
+    if question.multiple_responses?
+      value = render "govuk_publishing_components/components/list", {
+        items: question.response_labels(accepted_response)
+      }
+    else
+      value = question.response_label(accepted_response)
+    end
 
-      {
-        field: question.title,
-        value: value,
-        edit: {
-          href: @presenter.change_answer_link(question, response_store.forwarding_responses),
-          data_attributes: {
-            "module": "gem-track-click",
-            "track-category": "Smart Answer Change Link",
-            "track-action":  "Link clicked",
-            "track-label": "#{question.title} / #{question.response_label(accepted_response)}"
-          }
+    {
+      field: question.title,
+      value: value,
+      edit: {
+        href: @presenter.change_answer_link(question, response_store.forwarding_responses),
+        data_attributes: {
+          "module": "gem-track-click",
+          "track-category": "Smart Answer Change Link",
+          "track-action":  "Link clicked",
+          "track-label": "#{question.title} / #{question.response_label(accepted_response)}"
         }
       }
-    end %>
-    <%= render "govuk_publishing_components/components/summary_list", {
-      wide_title: true,
-      items: items
-    } %>
-  <% end %>
+    }
+  end %>
+  <%= render "govuk_publishing_components/components/summary_list", {
+    wide_title: true,
+    items: items
+  } %>
 <% end %>

--- a/lib/smart_answer/flow.rb
+++ b/lib/smart_answer/flow.rb
@@ -61,14 +61,6 @@ module SmartAnswer
       ActiveModel::Type::Boolean.new.cast(@use_hide_this_page)
     end
 
-    def hide_previous_answers_on_results_page(hide_previous_answers_on_results_page)
-      @hide_previous_answers_on_results_page = hide_previous_answers_on_results_page
-    end
-
-    def hide_previous_answers_on_results_page?
-      ActiveModel::Type::Boolean.new.cast(@hide_previous_answers_on_results_page)
-    end
-
     def status(potential_status = nil)
       if potential_status
         raise Flow::InvalidStatus unless %i[published draft].include? potential_status

--- a/test/unit/flow_test.rb
+++ b/test/unit/flow_test.rb
@@ -46,36 +46,6 @@ class FlowTest < ActiveSupport::TestCase
     assert_not smart_answer.use_hide_this_page?
   end
 
-  test "can set flag to hide previous answers on results page" do
-    smart_answer = SmartAnswer::Flow.build do
-      hide_previous_answers_on_results_page true
-    end
-
-    assert smart_answer.hide_previous_answers_on_results_page?
-  end
-
-  test "can set flag to hide previous answers on results pagewith string" do
-    smart_answer = SmartAnswer::Flow.build do
-      hide_previous_answers_on_results_page "yes"
-    end
-
-    assert smart_answer.hide_previous_answers_on_results_page?
-  end
-
-  test "can set flag not to hide previous answers on results page" do
-    smart_answer = SmartAnswer::Flow.build do
-      hide_previous_answers_on_results_page "false"
-    end
-
-    assert_not smart_answer.hide_previous_answers_on_results_page?
-  end
-
-  test "defaults to show previous answers on results page" do
-    smart_answer = SmartAnswer::Flow.build
-
-    assert_not smart_answer.hide_previous_answers_on_results_page?
-  end
-
   test "setting additional parameters" do
     s = SmartAnswer::Flow.build do
       additional_parameters %i[param1 param2]


### PR DESCRIPTION
Trello: https://trello.com/c/heJ1LOvw
Depends on: PR #5585 

# What's changed and why?

Only the find-coronavirus-support smart-answer used this functionality.Now that that smart-answer has been retired we no longer need to keep this check.

The setting hasn't been removed from find_coronavirus_support_flow as that code is being removed in a separate PR and it would cause merge conflicts to remove it here as well.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
