### PR TITLE
Add prefix labels for value and money questions

### DIFF
--- a/app/presenters/money_question_presenter.rb
+++ b/app/presenters/money_question_presenter.rb
@@ -4,4 +4,8 @@ class MoneyQuestionPresenter < QuestionPresenter
   def response_label(value)
     format_money(SmartAnswer::Money.new(value))
   end
+
+  def prefix_label
+    super || "£"
+  end
 end

--- a/app/presenters/question_presenter.rb
+++ b/app/presenters/question_presenter.rb
@@ -50,6 +50,11 @@ class QuestionPresenter < NodePresenter
     content.presence
   end
 
+  def prefix_label
+    content = @renderer.content_for(:prefix_label)
+    content.presence
+  end
+
   def body
     @renderer.content_for(:body).presence
   end

--- a/app/views/smart_answers/inputs/_money_question.html.erb
+++ b/app/views/smart_answers/inputs/_money_question.html.erb
@@ -11,5 +11,6 @@
   hint: question.hint,
   suffix: question.suffix_label,
   value: question.current_response,
-  error_message: question.error
+  error_message: question.error,
+  prefix: question.prefix_label
 } %>

--- a/app/views/smart_answers/inputs/_value_question.html.erb
+++ b/app/views/smart_answers/inputs/_value_question.html.erb
@@ -11,5 +11,6 @@
   hint: question.hint,
   suffix: question.suffix_label,
   value: question.current_response,
-  error_message: question.error
+  error_message: question.error,
+  prefix: question.prefix_label
 } %>

--- a/test/unit/money_question_presenter_test.rb
+++ b/test/unit/money_question_presenter_test.rb
@@ -32,5 +32,11 @@ module SmartAnswer
 
       assert_equal "caption-text", @presenter.caption
     end
+
+    test "#prefix_label return '£' by default" do
+      @renderer.stubs(:content_for).with(:prefix_label).returns(" ")
+
+      assert_equal "£", @presenter.prefix_label
+    end
   end
 end

--- a/test/unit/question_presenter_test.rb
+++ b/test/unit/question_presenter_test.rb
@@ -54,6 +54,18 @@ module SmartAnswer
       assert_nil @presenter.suffix_label
     end
 
+    test "#prefix_label returns single line of content rendered for prefix_label block" do
+      @renderer.stubs(:content_for).with(:prefix_label).returns("prefix-label-text")
+
+      assert_equal "prefix-label-text", @presenter.prefix_label
+    end
+
+    test "#prefix_label return nil if text empty" do
+      @renderer.stubs(:content_for).with(:prefix_label).returns(" ")
+
+      assert_nil @presenter.prefix_label
+    end
+
     test "#body returns content rendered for body block" do
       @renderer.stubs(:content_for).with(:body).returns("body-html")
 


### PR DESCRIPTION
This adds the ability to specify a prefix label for value and money questions. This uses the GOV.UK Design system pattern and built input form component. Prefix labels can be used to help users better understand what input is required.

For money questions the default prefix label is a "£". 

<img width="299" alt="image" src="https://user-images.githubusercontent.com/11051676/131974728-13967c0d-41cb-4a9b-864b-567c412aa9ed.png">

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
