### PR TITLE
Remove extra spacing below 'Start now' button

### DIFF
--- a/app/views/smart_answers/landing.html.erb
+++ b/app/views/smart_answers/landing.html.erb
@@ -42,7 +42,6 @@
           href: @presenter.start_page_link(response_store.forwarding_responses),
           rel: "nofollow",
           start: true,
-          margin_bottom: true,
         } %>
       </section>
 


### PR DESCRIPTION
On the start page there is excessive spacing below the 'Start now' button. This is noticeable when the start page also has a 'Before you start' (post_body) section after the 'Start now' button. Spacing is reduced by removing extra margin on the bottom of the button.

Before:
<img width="806" alt="Find out how to claim money" src="https://user-images.githubusercontent.com/11051676/131979320-8f9763c6-1b46-4610-8096-336ed14e3f38.png">

After:
<img width="806" alt="Find out how to claim money" src="https://user-images.githubusercontent.com/11051676/131979337-7a535277-bf45-4f1f-bd00-ee5024cd9eb7.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
