### PR TITLE
Resolve InvalidNode exception for visualise

### DIFF
--- a/app/presenters/graph_presenter.rb
+++ b/app/presenters/graph_presenter.rb
@@ -53,7 +53,7 @@ private
     when SmartAnswer::Question::Checkbox
       text << word_wrap(node_title(node))
       text << "\n\n"
-      text << node.options.map { |o| "[ ] #{o}" }.join("\n")
+      text << node.option_keys.map { |o| "[ ] #{o}" }.join("\n")
     when SmartAnswer::Question::Base
       text << word_wrap(node_title(node))
     when SmartAnswer::Outcome

--- a/test/fixtures/flows/graph_flow.rb
+++ b/test/fixtures/flows/graph_flow.rb
@@ -12,12 +12,12 @@ class GraphFlow < SmartAnswer::Flow
       end
     end
 
-    radio :q2? do
+    checkbox_question :q2? do
       option :a
       option :b
 
       next_node do |response|
-        if response == "a"
+        if response.split(",").include?("a")
           outcome :done_a
         else
           question :q_with_interpolation?

--- a/test/unit/graph_presenter_test.rb
+++ b/test/unit/graph_presenter_test.rb
@@ -15,7 +15,7 @@ module SmartAnswer
     test "presents labels of graph flow" do
       expected_labels = {
         q1?: "Radio\n-\nWhat is the answer to q1?\n\n( ) yes\n( ) no",
-        q2?: "Radio\n-\nWhat is the answer to q2?\n\n( ) a\n( ) b",
+        q2?: "Checkbox\n-\nWhat is the answer to q2?\n\n[ ] a\n[ ] b",
         q_with_interpolation?: "Radio\n-\nQuestion with <%= inter.pol.ation %>?\n\n( ) x\n( ) y",
         done_a: "Outcome\n-\ndone_a",
         done_b: "Outcome\n-\ndone_b",


### PR DESCRIPTION
https://github.com/alphagov/smart-answers/pull/5544 changed the purpose
of the options method on a checkbox question. This had the side effect
of breaking some (presumably untested) code in visualise which tried to
use that method.

I've resolved the problem by changing the options method to option_keys
and adapted the test so that this code has coverage.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
