### PR TITLE
Remove ability to define multiple on_response blocks

### DIFF
--- a/test/unit/question_base_test.rb
+++ b/test/unit/question_base_test.rb
@@ -5,6 +5,15 @@ class QuestionBaseTest < ActiveSupport::TestCase
     @question = SmartAnswer::Question::Base.new(nil, :example_question)
   end
 
+  context "#on_response" do
+    should "not allow multiple definitions of on_response" do
+      assert_raises(RuntimeError, "Multiple on_response blocks not allowed") do
+        @question.on_response { |_| nil }
+        @question.on_response { |_| nil }
+      end
+    end
+  end
+
   context "#transition" do
     should "pass input to next_node block" do
       input_was = nil


### PR DESCRIPTION
This removes the ability to define more than one on_response block for a question node. No flow currently has this requirement, removing the code to simplify the codebase. If multiple definitions of on_response are defined an error is thrown at app start app.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
