### PR TITLE
Replace phase banner with user research banner

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -33,4 +33,5 @@ $govuk-new-link-styles: true;
 @import "components/email-link";
 @import "components/result-item";
 @import "components/result-sections";
+@import "components/user-research-banner";
 @import "smart_answers";

--- a/app/assets/stylesheets/components/_user-research-banner.scss
+++ b/app/assets/stylesheets/components/_user-research-banner.scss
@@ -1,0 +1,29 @@
+.app-c-user-research-banner {
+  @include govuk-font($size: 16);
+  background-color: govuk-colour("light-grey");
+  padding: govuk-spacing(3);
+  margin: govuk-spacing(4) auto;
+  border-left: $govuk-border-width-wide solid govuk-colour("green");
+  @include govuk-media-query($from: tablet) {
+    margin: govuk-spacing(4) auto govuk-spacing(6);
+  }
+}
+
+.app-c-user-research-banner__title {
+  @include govuk-font($size: 16, $weight: bold);
+  display: block;
+  color: $govuk-text-colour;
+  margin-bottom: govuk-spacing(2);
+
+  @include govuk-media-query($from: tablet) {
+    margin-bottom: 0;
+    display: inline-block;
+
+    &:after {
+      @include govuk-font($size: 16);
+      color: $govuk-secondary-text-colour;
+      content: "|";
+      margin: 0 govuk-spacing(2);
+    }
+  }
+}

--- a/app/views/components/_user-research-banner.html.erb
+++ b/app/views/components/_user-research-banner.html.erb
@@ -1,0 +1,4 @@
+<%= tag.div class: "app-c-user-research-banner" do %>
+  <%= tag.span title, class: "app-c-user-research-banner__title" %>
+  <%= message %>
+<% end %>

--- a/app/views/components/docs/user-research-banner.yml
+++ b/app/views/components/docs/user-research-banner.yml
@@ -1,0 +1,9 @@
+name: User research banner
+description: Allows users to sign up for user research sessions
+shared_accessibility_criteria:
+  - link
+examples:
+  default:
+    data:
+      title: Help improve GOV.UK
+      message: <a href="#" class="govuk-link" target="_blank" rel="noopener noreferrer">Sign up to take part in user research (opens in a new tab)</a>

--- a/app/views/smart_answers/shared/_phase_banner.html.erb
+++ b/app/views/smart_answers/shared/_phase_banner.html.erb
@@ -1,6 +1,5 @@
 <% if @presenter.present? && @presenter.flow.name === 'next-steps-for-your-business' %>
-  <% feedback_message = capture do %>
-    Help improve GOV.UK –
+  <% banner_message = capture do %>
     <%= link_to "Sign up to take part in user research (opens in a new tab)",
       "https://signup.take-part-in-research.service.gov.uk/home?utm_campaign=Next_steps_ltd_co&utm_source=govukother&utm_medium=gov.uk&t=GDS&id=303",
       class: "govuk-link",
@@ -15,7 +14,8 @@
     %>
   <% end %>
 
-  <%= render "govuk_publishing_components/components/phase_banner", {
-    message: feedback_message
+  <%= render "components/user-research-banner", {
+    title: "Help improve GOV.UK",
+    message: banner_message,
   } %>
 <% end %>


### PR DESCRIPTION
In the first iteration, we used the existing phase banner, which was not designed to be used for signing up for user research and didn't seem to perform particularly well. We're updating it now with a new design, hoping to see a difference in sign-ups.

Preview the component [in isolation](https://smart-answer-add-user-r-kvny9f.herokuapp.com/component-guide/user-research-banner) or within the [next steps for your business flow](https://smart-answer-add-user-r-kvny9f.herokuapp.com/next-steps-for-your-business).

[Trello card](https://trello.com/c/ioFNNpMq)

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

![localhost_3010_next-steps-for-your-business_ (2)](https://user-images.githubusercontent.com/788096/134045693-7f114f8a-0c1b-4927-9912-0a9320dee85b.png)

</td><td valign="top">


![localhost_3010_next-steps-for-your-business_ (1)](https://user-images.githubusercontent.com/788096/134045709-1a2e1a45-4247-487c-bc8f-92fdbc2d4f49.png)

</td></tr>
<tr><td valign="top">

![localhost_3010_next-steps-for-your-business_ (3)](https://user-images.githubusercontent.com/788096/134045732-df27f270-72aa-42d8-abc4-525b35d87953.png)

</td><td valign="top">


![localhost_3010_next-steps-for-your-business_ (4)](https://user-images.githubusercontent.com/788096/134045744-9044fb12-fe17-4792-804f-c82dcae69ba4.png)

</td></tr>
</table>


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
