### PR TITLE
Azerbaijan outcomes update

### DIFF
--- a/app/flows/marriage_abroad_flow/outcomes/countries/azerbaijan/ceremony_country/partner_british/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/azerbaijan/ceremony_country/partner_british/_opposite_sex.erb
@@ -10,7 +10,7 @@ You need to provide an affirmation document to prove you’re legally allowed to
 
 You need to:
 
-s1. Download an [affirmation](/government/publications/azerbaijan-affirmation-of-marital-status).
+s1. [Download an affirmation](/government/publications/azerbaijan-affirmation-of-marital-status).
 s2. Print it out but don’t sign it.
 s3. [Make an appointment at the embassy in Baku](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=99&service=10) to sign it.
 
@@ -25,12 +25,12 @@ You’ll need to bring:
 
 - your affirmation form
 - your passport     
-- your partner’s passport or ID     
+- your partner’s passport
 - evidence if you’ve changed your name by deed poll
 
-If you or your partner have been divorced, widowed or previously in a civil partnership, you’ll also need:
+You'll also need to bring evidence if you or your partner have been divorced, widowed or previously in a civil partnership. Bring:
 
-- your [decree absolute or final order](/copy-decree-absolute-final-order) (this could be a PDF and covering in email from the court) – if you’re divorced
+- your [decree absolute or final order](/copy-decree-absolute-final-order) (this could be a PDF and covering in email from the court) - if you’re divorced or your civil partnership has been dissolved
 - your annulment certificate - if your marriage or civil partnership was annulled
 - your (or your partner’s) former spouse or civil partner’s [death certificate](/order-copy-birth-death-marriage-certificate) - if you’ve been widowed
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/azerbaijan/ceremony_country/partner_local/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/azerbaijan/ceremony_country/partner_local/_opposite_sex.erb
@@ -10,7 +10,7 @@ You need to provide an affirmation document to prove you’re legally allowed to
 
 You need to:
 
-s1. Download an [affirmation](/government/publications/azerbaijan-affirmation-of-marital-status).
+s1. [Download an affirmation](/government/publications/azerbaijan-affirmation-of-marital-status).
 s2. Print it out but don’t sign it.
 s3. [Make an appointment at the embassy in Baku](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=99&service=10) to sign it.
 
@@ -25,12 +25,12 @@ You’ll need to bring:
 
 - your affirmation form
 - your passport     
-- your partner’s passport or ID     
+- your partner’s passport
 - evidence if you’ve changed your name by deed poll
 
-If you or your partner have been divorced, widowed or previously in a civil partnership, you’ll also need:
+You'll also need to bring evidence if you or your partner have been divorced, widowed or previously in a civil partnership. Bring:
 
-- your [decree absolute or final order](/copy-decree-absolute-final-order) (this could be a PDF and covering in email from the court) – if you’re divorced
+- your [decree absolute or final order](/copy-decree-absolute-final-order) (this could be a PDF and covering in email from the court) - if you’re divorced or your civil partnership has been dissolved
 - your annulment certificate - if your marriage or civil partnership was annulled
 - your (or your partner’s) former spouse or civil partner’s [death certificate](/order-copy-birth-death-marriage-certificate) - if you’ve been widowed
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/azerbaijan/ceremony_country/partner_other/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/azerbaijan/ceremony_country/partner_other/_opposite_sex.erb
@@ -10,7 +10,7 @@ You need to provide an affirmation document to prove you’re legally allowed to
 
 You need to:
 
-s1. Download an [affirmation](/government/publications/azerbaijan-affirmation-of-marital-status).
+s1. [Download an affirmation](/government/publications/azerbaijan-affirmation-of-marital-status).
 s2. Print it out but don’t sign it.
 s3. [Make an appointment at the embassy in Baku](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=99&service=10) to sign it.
 
@@ -25,12 +25,12 @@ You’ll need to bring:
 
 - your affirmation form
 - your passport     
-- your partner’s passport or ID     
+- your partner’s passport
 - evidence if you’ve changed your name by deed poll
 
-If you or your partner have been divorced, widowed or previously in a civil partnership, you’ll also need:
+You'll also need to bring evidence if you or your partner have been divorced, widowed or previously in a civil partnership. Bring:
 
-- your [decree absolute or final order](/copy-decree-absolute-final-order) (this could be a PDF and covering in email from the court) – if you’re divorced
+- your [decree absolute or final order](/copy-decree-absolute-final-order) (this could be a PDF and covering in email from the court) - if you’re divorced or your civil partnership has been dissolved
 - your annulment certificate - if your marriage or civil partnership was annulled
 - your (or your partner’s) former spouse or civil partner’s [death certificate](/order-copy-birth-death-marriage-certificate) - if you’ve been widowed
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/azerbaijan/third_country/partner_british/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/azerbaijan/third_country/partner_british/_opposite_sex.erb
@@ -10,7 +10,7 @@ You need to provide an affirmation document to prove you’re legally allowed to
 
 You need to:
 
-s1. Download an [affirmation](/government/publications/azerbaijan-affirmation-of-marital-status).
+s1. [Download an affirmation](/government/publications/azerbaijan-affirmation-of-marital-status).
 s2. Print it out but don’t sign it.
 s3. [Make an appointment at the embassy in Baku](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=99&service=10) to sign it.
 
@@ -25,12 +25,12 @@ You’ll need to bring:
 
 - your affirmation form
 - your passport     
-- your partner’s passport or ID     
+- your partner’s passport
 - evidence if you’ve changed your name by deed poll
 
-If you or your partner have been divorced, widowed or previously in a civil partnership, you’ll also need:
+You'll also need to bring evidence if you or your partner have been divorced, widowed or previously in a civil partnership. Bring:
 
-- your [decree absolute or final order](/copy-decree-absolute-final-order) (this could be a PDF and covering in email from the court) – if you’re divorced
+- your [decree absolute or final order](/copy-decree-absolute-final-order) (this could be a PDF and covering in email from the court) - if you’re divorced or your civil partnership has been dissolved
 - your annulment certificate - if your marriage or civil partnership was annulled
 - your (or your partner’s) former spouse or civil partner’s [death certificate](/order-copy-birth-death-marriage-certificate) - if you’ve been widowed
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/azerbaijan/third_country/partner_local/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/azerbaijan/third_country/partner_local/_opposite_sex.erb
@@ -10,7 +10,7 @@ You need to provide an affirmation document to prove you’re legally allowed to
 
 You need to:
 
-s1. Download an [affirmation](/government/publications/azerbaijan-affirmation-of-marital-status).
+s1. [Download an affirmation](/government/publications/azerbaijan-affirmation-of-marital-status).
 s2. Print it out but don’t sign it.
 s3. [Make an appointment at the embassy in Baku](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=99&service=10) to sign it.
 
@@ -25,12 +25,12 @@ You’ll need to bring:
 
 - your affirmation form
 - your passport     
-- your partner’s passport or ID     
+- your partner’s passport
 - evidence if you’ve changed your name by deed poll
 
-If you or your partner have been divorced, widowed or previously in a civil partnership, you’ll also need:
+You'll also need to bring evidence if you or your partner have been divorced, widowed or previously in a civil partnership. Bring:
 
-- your [decree absolute or final order](/copy-decree-absolute-final-order) (this could be a PDF and covering in email from the court) – if you’re divorced
+- your [decree absolute or final order](/copy-decree-absolute-final-order) (this could be a PDF and covering in email from the court) - if you’re divorced or your civil partnership has been dissolved
 - your annulment certificate - if your marriage or civil partnership was annulled
 - your (or your partner’s) former spouse or civil partner’s [death certificate](/order-copy-birth-death-marriage-certificate) - if you’ve been widowed
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/azerbaijan/third_country/partner_other/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/azerbaijan/third_country/partner_other/_opposite_sex.erb
@@ -10,7 +10,7 @@ You need to provide an affirmation document to prove you’re legally allowed to
 
 You need to:
 
-s1. Download an [affirmation](/government/publications/azerbaijan-affirmation-of-marital-status).
+s1. [Download an affirmation](/government/publications/azerbaijan-affirmation-of-marital-status).
 s2. Print it out but don’t sign it.
 s3. [Make an appointment at the embassy in Baku](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=99&service=10) to sign it.
 
@@ -25,12 +25,12 @@ You’ll need to bring:
 
 - your affirmation form
 - your passport     
-- your partner’s passport or ID     
+- your partner’s passport
 - evidence if you’ve changed your name by deed poll
 
-If you or your partner have been divorced, widowed or previously in a civil partnership, you’ll also need:
+You'll also need to bring evidence if you or your partner have been divorced, widowed or previously in a civil partnership. Bring:
 
-- your [decree absolute or final order](/copy-decree-absolute-final-order) (this could be a PDF and covering in email from the court) – if you’re divorced
+- your [decree absolute or final order](/copy-decree-absolute-final-order) (this could be a PDF and covering in email from the court) - if you’re divorced or your civil partnership has been dissolved
 - your annulment certificate - if your marriage or civil partnership was annulled
 - your (or your partner’s) former spouse or civil partner’s [death certificate](/order-copy-birth-death-marriage-certificate) - if you’ve been widowed
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/azerbaijan/uk/partner_british/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/azerbaijan/uk/partner_british/_opposite_sex.erb
@@ -11,7 +11,7 @@ It’s valid for 6 months.
 
 You need to:
 
-s1. Download an [affirmation](/government/publications/azerbaijan-affirmation-of-marital-status).
+s1. [Download an affirmation](/government/publications/azerbaijan-affirmation-of-marital-status).
 s2. Print it out but don’t sign it.
 s3. [Make an appointment at the embassy in Baku](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=99&service=10) to sign it.
 
@@ -26,12 +26,12 @@ You’ll need to bring:
 
 - your affirmation form
 - your passport     
-- your partner’s passport or ID     
+- your partner’s passport
 - evidence if you’ve changed your name by deed poll
 
-If you or your partner have been divorced, widowed or previously in a civil partnership, you’ll also need:
+You'll also need to bring evidence if you or your partner have been divorced, widowed or previously in a civil partnership. Bring:
 
-- your [decree absolute or final order](/copy-decree-absolute-final-order) (this could be a PDF and covering in email from the court) – if you’re divorced
+- your [decree absolute or final order](/copy-decree-absolute-final-order) (this could be a PDF and covering in email from the court) - if you’re divorced or your civil partnership has been dissolved
 - your annulment certificate - if your marriage or civil partnership was annulled
 - your (or your partner’s) former spouse or civil partner’s [death certificate](/order-copy-birth-death-marriage-certificate) - if you’ve been widowed
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/azerbaijan/uk/partner_local/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/azerbaijan/uk/partner_local/_opposite_sex.erb
@@ -11,7 +11,7 @@ It’s valid for 6 months.
 
 You need to:
 
-s1. Download an [affirmation](/government/publications/azerbaijan-affirmation-of-marital-status).
+s1. [Download an affirmation](/government/publications/azerbaijan-affirmation-of-marital-status).
 s2. Print it out but don’t sign it.
 s3. [Make an appointment at the embassy in Baku](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=99&service=10) to sign it.
 
@@ -26,12 +26,12 @@ You’ll need to bring:
 
 - your affirmation form
 - your passport     
-- your partner’s passport or ID     
+- your partner’s passport
 - evidence if you’ve changed your name by deed poll
 
-If you or your partner have been divorced, widowed or previously in a civil partnership, you’ll also need:
+You'll also need to bring evidence if you or your partner have been divorced, widowed or previously in a civil partnership. Bring:
 
-- your [decree absolute or final order](/copy-decree-absolute-final-order) (this could be a PDF and covering in email from the court) – if you’re divorced
+- your [decree absolute or final order](/copy-decree-absolute-final-order) (this could be a PDF and covering in email from the court) - if you’re divorced or your civil partnership has been dissolved
 - your annulment certificate - if your marriage or civil partnership was annulled
 - your (or your partner’s) former spouse or civil partner’s [death certificate](/order-copy-birth-death-marriage-certificate) - if you’ve been widowed
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/azerbaijan/uk/partner_other/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/azerbaijan/uk/partner_other/_opposite_sex.erb
@@ -10,7 +10,7 @@ You need to provide an affirmation document to prove you’re legally allowed to
 
 You need to:
 
-s1. Download an [affirmation](/government/publications/azerbaijan-affirmation-of-marital-status).
+s1. [Download an affirmation](/government/publications/azerbaijan-affirmation-of-marital-status).
 s2. Print it out but don’t sign it.
 s3. [Make an appointment at the embassy in Baku](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=99&service=10) to sign it.
 
@@ -25,12 +25,12 @@ You’ll need to bring:
 
 - your affirmation form
 - your passport     
-- your partner’s passport or ID     
+- your partner’s passport
 - evidence if you’ve changed your name by deed poll
 
-If you or your partner have been divorced, widowed or previously in a civil partnership, you’ll also need:
+You'll also need to bring evidence if you or your partner have been divorced, widowed or previously in a civil partnership. Bring:
 
-- your [decree absolute or final order](/copy-decree-absolute-final-order) (this could be a PDF and covering in email from the court) – if you’re divorced
+- your [decree absolute or final order](/copy-decree-absolute-final-order) (this could be a PDF and covering in email from the court) - if you’re divorced or your civil partnership has been dissolved
 - your annulment certificate - if your marriage or civil partnership was annulled
 - your (or your partner’s) former spouse or civil partner’s [death certificate](/order-copy-birth-death-marriage-certificate) - if you’ve been widowed
 


### PR DESCRIPTION
1) Removing ‘your partner’s ID’ as an option - a passport is the only form of ID they’ll accept

2) Making the sentence before the second bullet point list clearer, as they had feedback that users were missing this next section

3) Adding a mention of civil partnership dissolution to that bullet point about final orders

https://govuk.zendesk.com/agent/tickets/4585484
https://trello.com/c/hdpS6Vrv/3561-azerbaijan-getting-married-abroad-update-to-document-requirements

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
