### PR TITLE
Immigration rule changes add nursing to electives

### DIFF
--- a/app/flows/check_uk_visa_flow/outcomes/outcome_study_no_visa_needed.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_study_no_visa_needed.erb
@@ -14,14 +14,14 @@
   You can also do:
 
   * a short piece of research that’s relevant to your course overseas
-  * an ‘elective’ - an optional additional placement, if you’re studying medicine, veterinary medicine and science, or dentistry
+  * an ‘elective’ - an optional additional placement, if you’re studying medicine, nursing, dentistry or veterinary medicine and science  
   * a recreational course of up to 30 days, for example a dance course
 
   You cannot:
 
   * study at a [state funded school or academy](/types-of-school)
   * do a course that lasts longer than 6 months (except if you’re doing a distance learning course)
-  * do paid or unpaid work (this includes work experience or work placements, unless it is an eligible medical, veterinary or dentistry placement)
+  * do paid or unpaid work (this includes work experience or work placements, unless it is an eligible medical, nursing, dentistry or veterinary medicine and science placement)
   * live in the UK for long periods of time through frequent or successive visits
   * get [public funds](/government/publications/public-funds--2) (benefits)
 


### PR DESCRIPTION
ZENDESK: https://govuk.zendesk.com/agent/tickets/4700552 
TRELLO: https://trello.com/c/masbiQJA/3040-6-oct-check-if-you-need-a-uk-visa-immigration-rules-nursing-requirements-for-visitors

SUMMARY
Immigration rule change updates. From 6 October nursing students can visit the UK to do electives.
We need to update 1 outcome in the Check if you need a UK visa smart answer (outcome_study_no_visa_needed.erb).

PUBLISHING DATE: 9.30am on 6 October.

--------

ROUTE to outcome in smart answer: 
Country: Nationality that doesn’t need a visa e.g. France > Purpose of visit: study > Length of visit: less than 6 months. 

OUTCOME example:
https://www.gov.uk/check-uk-visa/y/france/study/six_months_or_less

-----

##What you can and cannot do

[1]

CHANGED

* an ‘elective’ - an optional additional placement, if you’re studying medicine, veterinary medicine and science, nursing or dentistry

TO

* an ‘elective’ - an optional additional placement, if you’re studying medicine, nursing, dentistry or veterinary medicine and science

REASON 
Adding nursing to electives information - rule change.

-------

[2]

CHANGED

* do paid or unpaid work (this includes work experience or work placements, unless it is an eligible medical, veterinary medicine and science, nursing or dentistry placement)

TO

* do paid or unpaid work (this includes work experience or work placements, unless it is an eligible medical, nursing, dentistry or veterinary medicine and science placement)

REASON 
Adding nursing - rule change AND aligning language with earlier bullet point, so it's now 'veterinary medicine and science'.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
