### PR TITLE
Update business support smart answer outcomes

### DIFF
--- a/app/flows/business_coronavirus_support_finder_flow/outcomes/results.erb
+++ b/app/flows/business_coronavirus_support_finder_flow/outcomes/results.erb
@@ -11,24 +11,15 @@
     $CTA
     ### Coronavirus Job Retention Scheme (furlough scheme)
 
-    If you've had to ask your employees to stop working or work less because of coronavirus (put them on 'furlough') you can get support to pay their wages for the hours they're furloughed. The scheme has been extended until the end of September 2021.
+    The Coronavirus Job Retention Scheme has now closed.
 
-    The government will pay:
+    You must submit any claims for eligible employees on furlough in September 2021 by 11:59pm on 14 October 2021.
+    
+    The government will pay 60% of employees' usual wages for hours they're furloughed, up to a maximum of £1,875 a month for September 2021.
 
-    - 80% of employees’ usual wages for hours they're furloughed, up to a maximum of £2,500 per month, until the end of June
-    - 70% of employees' usual wages for hours they're furloughed, up to a maximum of £2187.50 per month, until the end of July
-    - 60% of employees' usual wages for hours they're furloughed, up to a maximum of £1875 per month, until the end of August and September
+    Employees must receive 80% of their usual wages, up to a maximum of £2,500 per month, until the end of September 2021.
 
-    The employees must receive 80% of their usual wages up to a maximum of £2500 per month until the end of September 2021.
-    From July 2021 to September 2021, you will have to make up the difference between the government payment and what the employee should receive.
-
-
-    You must submit your claims by 11.59pm 14 calendar days after the month you’re claiming for. If this time falls on the weekend or a bank holiday then claims should be submitted on the next working day.
-    For example you must submit your claim by:
-
-    - 16 August 2021, for eligible employees on furlough in July 2021
-    - 14 September 2021, for eligible employees on furlough in August 2021
-
+    You will have to make up the difference between the government payment and what the employee should receive.
 
     [Check if your employees are eligible for the Coronavirus Job Retention Scheme](/guidance/claim-for-wage-costs-through-the-coronavirus-job-retention-scheme)
     $CTA
@@ -38,44 +29,23 @@
     $CTA
     ### Statutory Sick Pay rebate
 
-    You can claim back Statutory Sick Pay (SSP) you’ve paid for employees who are off sick, self isolating or shielding because of coronavirus. This scheme will cover up to 2 weeks of SSP for every eligible employee.
+    You can claim back Statutory Sick Pay (SSP) you’ve paid for employees who are off sick, self isolating or shielding because of coronavirus on or before 30 September 2021. You can claim up to 2 weeks of SSP for every eligible employee.
 
-    You’re eligible if both of the following apply to your business:
+    You’re eligible to claim if your business is both:
 
-    - it’s based in the UK
-    - it has had fewer than 250 employees since 28 February 2020
+    - based in the UK
+    - has had fewer than 250 employees since 28 February 2020
+
+    You must submit or amend claims on or before 31 December 2021.
 
     [Claim back Statutory Sick Pay paid to employees because of coronavirus](/guidance/claim-back-statutory-sick-pay-paid-to-employees-due-to-coronavirus-covid-19)
     $CTA
   <% end %>
 
-  <% if calculator.show?(:self_employed_income_scheme) %>
-    $CTA
-    ### Self-Employment Income Support Scheme (SEISS)
-
-    The fifth SEISS grant is now open for claims. This covers any business profit you think has been impacted by coronavirus (COVID-19) between May and September 2021. [Find out how to claim a grant through SEISS](/guidance/claim-a-grant-through-the-coronavirus-covid-19-self-employment-income-support-scheme). 
-
-    The grant is taxable and will be paid out in a single instalment. 
-
-    The amount of the fifth grant will be determined by how much your turnover fell in the year April 2020 to April 2021.
-
-    If your turnover fell by: 
-    
-    - 30% or more, the grant is worth 80% of three months' average trading profits, capped at £7,500
-    - 30% or less, the grant is worth 30% of three months' average trading profits, capped at £2,850
-
-    To be eligible for the fifth grant you must be self-employed or a member of a partnership. You must also have traded in the tax years: 
-
-    - 2019 to 2020 (and submitted your tax return on or before 2 March 2021)
-    - 2020 to 2021
-
-    $CTA
-  <% end %>
-
   $CTA
-  ### Support for businesses paying tax: Time To Pay Service
+  ### Support for businesses paying tax: Time To Pay Arrangement
 
-  If you cannot pay your tax bill on time because of coronavirus, you may be able to delay it without a penalty using HMRC’s Time to Pay service.
+  If you cannot pay your tax bill on time because of coronavirus, you may be able to set up a Time to Pay Arrangement with HMRC. This lets you spread the cost of your tax bill by paying everything you owe in affordable instalments. 
 
   You might be eligible if your UK business:
 
@@ -106,9 +76,7 @@
     $CTA
     ### VAT reduction for hospitality, accommodation and attractions
 
-    You may be eligible for a 5% reduced rate of VAT until 30 September 2021 if your business is in the hospitality, hotel or holiday accommodation sector.
-
-    From 1 October 2021 to 31 March 2022, the reduced rate of 12.5% will apply.
+    You may be eligible for a 12.5% reduced rate of VAT until 31 March 2022 if your business is in the hospitality, hotel or holiday accommodation sector.
 
     [Find out if your business is eligible for VAT reduction](/guidance/vat-reduced-rate-for-hospitality-holiday-accommodation-and-attractions).
     $CTA
@@ -121,7 +89,7 @@
 
   You can get up to £10 million, but the actual amount offered will be at the discretion of participating lenders. The government guarantees 80% of the finance to the lender, but you will still be responsible for your debt.
 
-  The scheme is open until 31 December 2021.
+  The scheme is open until 31 December 2021, subject to review.
 
   You can apply for a loan if your business:
 
@@ -164,7 +132,7 @@
 
     Apprenticeships spend 80% of their time in the workplace and at least 20% on off-the-job training in a setting that suits your business needs. This can be a college, a training provider, an institute, or even your place of business.
 
-    You can apply for a new payment of £3,000 for each apprentice you take on as a new employee between 1 April 2021 and 30 September 2021. You can choose how you spend this incentive. You must have an apprenticeship service account if you want to apply for an incentive payment.
+    You can apply for a new payment of £3,000 for each apprentice you take on as a new employee between 1 April 2021 and 30 September 2021. You can choose how you spend this incentive. You must have an apprenticeship service account and apply by 30 November 2021 for an incentive payment.
 
     [Learn more about hiring an apprentice](https://www.apprenticeships.gov.uk/)
     $CTA

--- a/test/flows/business_coronavirus_support_finder_flow_test.rb
+++ b/test/flows/business_coronavirus_support_finder_flow_test.rb
@@ -168,10 +168,6 @@ class BusinessCoronavirusSupportFinderFlowTest < ActiveSupport::TestCase
       assert_rendered_outcome text: "Statutory Sick Pay rebate"
     end
 
-    should "render self_employed_income_scheme if self_employed is yes" do
-      assert_rendered_outcome text: "Self-Employment Income Support Scheme (SEISS)"
-    end
-
     should "render kickstart_scheme if business_based is not set to northern_ireland" do
       assert_rendered_outcome text: "Support to create job placements: Kickstart Scheme"
     end

--- a/test/flows/calculate_agricultural_holiday_entitlement_flow_test.rb
+++ b/test/flows/calculate_agricultural_holiday_entitlement_flow_test.rb
@@ -103,7 +103,9 @@ class CalculateAgriculturalHolidayEntitlementFlowTest < ActiveSupport::TestCase
 
     context "next_node" do
       should "have a next node of worked_for_same_employer? for any valid response" do
-        assert_next_node :worked_for_same_employer?, for_response: "50"
+        travel_to("2022-02-01") do
+          assert_next_node :worked_for_same_employer?, for_response: "50"
+        end
       end
     end
   end


### PR DESCRIPTION
This PR updates or removes sections in the outcome for the ['Find coronavirus financial support for your business' smart answer](https://www.gov.uk/business-coronavirus-support-finder).

The following sections have been updated in the outcome:

- Coronavirus Job Retention Scheme (furlough scheme)
- Statutory Sick Pay rebate
- Support for businesses paying tax: Time To Pay Arrangement (was 'Support for businesses paying tax: Time To Pay Service')
- VAT reduction for hospitality, accommodation and attractions
- Recovery Loan Scheme
- Apprenticeships

The 'Self-Employment Income Support Scheme (SEISS)' section was removed as the fifth grant as now closed for claims.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
