### PR TITLE
Fix time sensitive test

### DIFF
--- a/test/flows/calculate_agricultural_holiday_entitlement_flow_test.rb
+++ b/test/flows/calculate_agricultural_holiday_entitlement_flow_test.rb
@@ -86,6 +86,7 @@ class CalculateAgriculturalHolidayEntitlementFlowTest < ActiveSupport::TestCase
 
   context "question: how_many_total_days?" do
     setup do
+      travel_to("2021-12-01")
       testing_node :how_many_total_days?
       add_responses work_the_same_number_of_days_each_week?: "different-number-of-days",
                     what_date_does_holiday_start?: "2021-12-01"


### PR DESCRIPTION
This test started to fail when the date hit "01/10/2021" due to the
dynamic question `how_many_total_days?, which works out how many days
are available from 1st of October (start of leave year) to the current
date. As the response was 50 days, this test will fail for the next 50
days. Freezing time at "2021-12-01" made available enough days to comply
with the 50 day response.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
