### PR TITLE
Remove extra `travel_to` block

### DIFF
--- a/test/flows/calculate_agricultural_holiday_entitlement_flow_test.rb
+++ b/test/flows/calculate_agricultural_holiday_entitlement_flow_test.rb
@@ -104,9 +104,7 @@ class CalculateAgriculturalHolidayEntitlementFlowTest < ActiveSupport::TestCase
 
     context "next_node" do
       should "have a next node of worked_for_same_employer? for any valid response" do
-        travel_to("2022-02-01") do
-          assert_next_node :worked_for_same_employer?, for_response: "50"
-        end
+        assert_next_node :worked_for_same_employer?, for_response: "50"
       end
     end
   end


### PR DESCRIPTION
This test was fixed independently by two people:

https://github.com/alphagov/smart-answers/pull/5630/commits/c3b85c472aab6438486fc6caf7b1213c263f19ab
https://github.com/alphagov/smart-answers/commit/071d11cf3d89023d8700823c8d122db752565458

And whilst individually they fixed the issue, together they cause the build to fail with:

```
RuntimeError:
Calling `travel_to` with a block, when we have previously already made a call to `travel_to`, can lead to confusing time stubbing.
```

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
