### PR TITLE
Update apprenticeships section on business support outcome

### DIFF
--- a/app/flows/business_coronavirus_support_finder_flow/outcomes/results.erb
+++ b/app/flows/business_coronavirus_support_finder_flow/outcomes/results.erb
@@ -132,7 +132,7 @@
 
     Apprenticeships spend 80% of their time in the workplace and at least 20% on off-the-job training in a setting that suits your business needs. This can be a college, a training provider, an institute, or even your place of business.
 
-    You can apply for a new payment of £3,000 for each apprentice you take on as a new employee between 1 April 2021 and 30 September 2021. You can choose how you spend this incentive. You must have an apprenticeship service account and apply by 30 November 2021 for an incentive payment.
+    You can apply for a new payment of £3,000 for each apprentice you take on as a new employee between 1 April 2021 and 31 January 2022. You can choose how you spend this incentive. You must have an apprenticeship service account if you want to apply for an incentive payment.
 
     [Learn more about hiring an apprentice](https://www.apprenticeships.gov.uk/)
     $CTA


### PR DESCRIPTION
Updated apprenticeships section in coronavirus business support outcome as the scheme has been extended to 31 January 2022.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
