### PR TITLE
Add redirect from path to query parameters based URLs

### DIFF
--- a/app/controllers/smart_answers_controller.rb
+++ b/app/controllers/smart_answers_controller.rb
@@ -3,6 +3,7 @@ class SmartAnswersController < ApplicationController
 
   before_action :find_smart_answer, except: %w[index]
   before_action :redirect_response_to_canonical_path, only: %w[show]
+  before_action :redirect_query_parameter_flows, only: %w[show]
   before_action :setup_content_item, except: %w[index]
 
   attr_accessor :content_item
@@ -47,6 +48,16 @@ class SmartAnswersController < ApplicationController
   end
 
 private
+
+  def redirect_query_parameter_flows
+    if @presenter.response_store == :query_parameters
+      redirect_to flow_path(
+        id: params[:id],
+        node_slug: @presenter.state.current_node_name,
+        params: @presenter.state.accepted_responses,
+      )
+    end
+  end
 
   def find_smart_answer
     @name = params[:id].to_sym

--- a/test/fixtures/flows/query_parameters_based_flow.rb
+++ b/test/fixtures/flows/query_parameters_based_flow.rb
@@ -7,13 +7,24 @@ class QueryParametersBasedFlow < SmartAnswer::Flow
     radio :question1 do
       option :response1
       option :response2
+      option :response3
 
-      next_node do
-        question :question2
+      next_node do |response|
+        if response == "response3"
+          question :question3
+        else
+          question :question2
+        end
       end
     end
 
     value_question :question2 do
+      next_node do
+        outcome :results
+      end
+    end
+
+    value_question :question3 do
       next_node do
         outcome :results
       end

--- a/test/fixtures/flows/query_parameters_based_flow/questions/question1.erb
+++ b/test/fixtures/flows/query_parameters_based_flow/questions/question1.erb
@@ -8,5 +8,6 @@
 
 <% options(
   response1: "Response 1",
-  response2: "Response 2"
+  response2: "Response 2",
+  response3: "Response 3"
 ) %>

--- a/test/fixtures/flows/query_parameters_based_flow/questions/question3.erb
+++ b/test/fixtures/flows/query_parameters_based_flow/questions/question3.erb
@@ -1,0 +1,7 @@
+<% text_for :title do %>
+  Question 3 title
+<% end %>
+
+<% text_for :hint do %>
+  Question 3 hint
+<% end %>

--- a/test/functional/smart_answers_controller_test.rb
+++ b/test/functional/smart_answers_controller_test.rb
@@ -156,6 +156,23 @@ class SmartAnswersControllerTest < ActionController::TestCase
       end
     end
 
+    context "flow response store is query parameters" do
+      should "redirect to the query parameter url" do
+        get :show, params: { id: "query-parameters-based", started: "y", responses: "response1" }
+        assert_redirected_to "/query-parameters-based/question2?question1=response1"
+      end
+
+      should "redirect to the query parameter url for first question" do
+        get :show, params: { id: "query-parameters-based", started: "y" }
+        assert_redirected_to "/query-parameters-based/question1"
+      end
+
+      should "redirect to the query parameter url with correct question branching" do
+        get :show, params: { id: "query-parameters-based", started: "y", responses: "response3" }
+        assert_redirected_to "/query-parameters-based/question3?question1=response3"
+      end
+    end
+
     context "debugging" do
       should "render debug information on the page when enabled" do
         @controller.stubs(:debug?).returns(true)


### PR DESCRIPTION
This adds support for legacy path based URLs for flows that have been converted to use query parameters. When navigating to a query parameter based flow with a path based URL, the user will automatically be redirected to equivalent query parameter based URL to continue.

This helps the migration of existing path based flows by preventing user interruption by supporting existing user sessions whilst the updated flow is deployed.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
