### PR TITLE
Update self assessment penalties calculator

### DIFF
--- a/app/flows/estimate_self_assessment_penalties_flow.rb
+++ b/app/flows/estimate_self_assessment_penalties_flow.rb
@@ -11,6 +11,7 @@ class EstimateSelfAssessmentPenaltiesFlow < SmartAnswer::Flow
       option :"2017-18"
       option :"2018-19"
       option :"2019-20"
+      option :"2020-21"
 
       on_response do |response|
         self.calculator = SmartAnswer::Calculators::SelfAssessmentPenalties.new

--- a/app/flows/estimate_self_assessment_penalties_flow/questions/which_year.erb
+++ b/app/flows/estimate_self_assessment_penalties_flow/questions/which_year.erb
@@ -9,4 +9,5 @@
   "2017-18": "6 April 2017 to 5 April 2018",
   "2018-19": "6 April 2018 to 5 April 2019",
   "2019-20": "6 April 2019 to 5 April 2020",
+  "2020-21": "6 April 2020 to 5 April 2021",
 ) %>

--- a/lib/smart_answer/calculators/self_assessment_penalties.rb
+++ b/lib/smart_answer/calculators/self_assessment_penalties.rb
@@ -17,6 +17,7 @@ module SmartAnswer::Calculators
         "2018-19": ONLINE_FILING_DEADLINE_YEAR.starting_in(2020).begins_on,
         "2019-20": ONLINE_FILING_DEADLINE_YEAR.starting_in(2021).begins_on,
         "2019-20-covid-easement": ONLINE_FILING_DEADLINE_YEAR_FEB.starting_in(2021).begins_on,
+        "2020-21": ONLINE_FILING_DEADLINE_YEAR.starting_in(2022).begins_on,
       },
       paper_filing_deadline: {
         "2014-15": OFFLINE_FILING_DEADLINE_YEAR.starting_in(2015).begins_on,
@@ -25,6 +26,7 @@ module SmartAnswer::Calculators
         "2017-18": OFFLINE_FILING_DEADLINE_YEAR.starting_in(2018).begins_on,
         "2018-19": OFFLINE_FILING_DEADLINE_YEAR.starting_in(2019).begins_on,
         "2019-20": OFFLINE_FILING_DEADLINE_YEAR.starting_in(2020).begins_on,
+        "2020-21": OFFLINE_FILING_DEADLINE_YEAR.starting_in(2021).begins_on,
       },
       payment_deadline: {
         "2014-15": PAYMENT_DEADLINE_YEAR.starting_in(2016).begins_on,
@@ -33,6 +35,7 @@ module SmartAnswer::Calculators
         "2017-18": PAYMENT_DEADLINE_YEAR.starting_in(2019).begins_on,
         "2018-19": PAYMENT_DEADLINE_YEAR.starting_in(2020).begins_on,
         "2019-20": PAYMENT_DEADLINE_YEAR.starting_in(2021).begins_on,
+        "2020-21": PAYMENT_DEADLINE_YEAR.starting_in(2022).begins_on,
       },
     }.freeze
 
@@ -50,6 +53,8 @@ module SmartAnswer::Calculators
         SmartAnswer::YearRange.tax_year.starting_in(2018)
       when "2019-20"
         SmartAnswer::YearRange.tax_year.starting_in(2019)
+      when "2020-21"
+        SmartAnswer::YearRange.tax_year.starting_in(2020)
       end
     end
 
@@ -71,6 +76,8 @@ module SmartAnswer::Calculators
         PENALTY_YEAR.starting_in(2021).begins_on
       when "2019-20"
         PENALTY_YEAR.starting_in(2022).begins_on
+      when "2020-21"
+        PENALTY_YEAR.starting_in(2023).begins_on
       end
     end
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

The tax year 6 April 2013 to 5 April 2014 has been removed and the new tax year of 6 April 2020 to 5 April 2021 has been added.

Before:
![Screenshot 2021-10-21 at 12 46 18](https://user-images.githubusercontent.com/19667619/138303570-2ad6301a-95e4-40d0-ba06-6b7fd55576ad.png)

After:
![Screenshot 2021-10-21 at 12 46 25](https://user-images.githubusercontent.com/19667619/138303588-8bf8e98f-8b70-40f6-95f4-a046e3997689.png)

Trello card: https://trello.com/c/Owv8sjnN/2750-estimate-your-penalty-for-late-self-assessment-tax-returns-and-payments-annual-increment-of-year


