### PR TITLE
Fix event tracking when page is translated

### DIFF
--- a/app/assets/javascripts/modules/track-results.js
+++ b/app/assets/javascripts/modules/track-results.js
@@ -33,7 +33,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   }
 
   TrackResults.prototype.trackClickEvent = function (event) {
-    var $link = event.target
+    var $link = event.currentTarget
     var options = { transport: 'beacon' }
     var href = $link.getAttribute('href')
     var linkText = $link.innerText.trim()


### PR DESCRIPTION
When Google Chrome's built-in Google Translate extension translates pages, it modifies not just the text but also the
HTML structure of a document.

Before translation:

```
<a href="/standard-visitor-visa">Standard Visitor visa</a>
```

After translation (using Google Translate extension built into Google Chrome):

```
<a href="/standard-visitor-visa"><font style="vertical-align: inherit;"><font style="vertical-align: inherit;">demande de visa de visiteur standard</font></font></a>
```

The Event Listener is attached to the `font` element, rather than the `a` element, which is a problem as the `font` doesn't have the href (what we supply as the event action in the Google Analytics call).

The `closest` function isn't supported in Internet Explorer but there is already a [polyfill in Publishing Components](https://github.com/alphagov/govuk_publishing_components/blob/e3b952e0365c8174da7ed7e8e964951bd3cbc074/app/assets/javascripts/govuk_publishing_components/vendor/polyfills/closest.js#L15-L23).

From some manual testing this seems to resolve the problem.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
