### PR TITLE
Remove HM Armed Forces email address

### DIFF
--- a/app/flows/register_a_birth_flow/start.erb
+++ b/app/flows/register_a_birth_flow/start.erb
@@ -20,6 +20,4 @@
 
   You can still [apply for a UK passport for your child](/apply-renew-passport) even if you do not register the birth in the UK.
 
-^If you’re a member of HM Armed Forces or you work with them, you may be able to register a birth abroad. Email <dbs-jcccgroupmailbox@mod.gov.uk> to check if you’re eligible.^
-
 <% end %>


### PR DESCRIPTION
https://govuk.zendesk.com/agent/tickets/4530452
https://trello.com/c/P5tXAZ3m/3589-amendment-to-register-a-birth-page-content-change-request

REMOVE
^If you’re a member of HM Armed Forces or you work with them, you may be able to register a birth abroad. Email <dbs-jcccgroupmailbox@mod.gov.uk> to check if you’re eligible.^

REASON
FCDO and MOD have both agreed to remove the public reference to this service and just publicise it internally. MOD were being subjected to high numbers of emails from ineligible users and they are not able to cope with them.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
