### PR TITLE
Remove BaseStateTransitionError and LoggedError classes

### DIFF
--- a/lib/smart_answer/base_state_transition_error.rb
+++ b/lib/smart_answer/base_state_transition_error.rb
@@ -1,3 +1,0 @@
-module SmartAnswer
-  class BaseStateTransitionError < StandardError; end
-end

--- a/lib/smart_answer/invalid_response.rb
+++ b/lib/smart_answer/invalid_response.rb
@@ -1,3 +1,3 @@
 module SmartAnswer
-  class InvalidResponse < BaseStateTransitionError; end
+  class InvalidResponse < StandardError; end
 end

--- a/lib/smart_answer/logged_error.rb
+++ b/lib/smart_answer/logged_error.rb
@@ -1,8 +1,0 @@
-module SmartAnswer
-  class LoggedError < BaseStateTransitionError
-    def initialize(message = nil, log_message = nil)
-      super(message)
-      @log_message = log_message
-    end
-  end
-end

--- a/lib/smart_answer/state_resolver.rb
+++ b/lib/smart_answer/state_resolver.rb
@@ -69,8 +69,6 @@ module SmartAnswer
     end
 
     def error_state(state, response, error)
-      GovukError.notify(error) if error.is_a?(LoggedError)
-
       state.dup.tap do |new_state|
         new_state.error = error.message
         new_state.current_response = response

--- a/lib/smart_answer/state_resolver.rb
+++ b/lib/smart_answer/state_resolver.rb
@@ -64,7 +64,7 @@ module SmartAnswer
 
     def transition_state_to_next_node(state, response)
       @flow.node(state.current_node_name).transition(state, response)
-    rescue BaseStateTransitionError => e
+    rescue InvalidResponse => e
       error_state(state, response, e)
     end
 


### PR DESCRIPTION
This removes the unused LoggedError and BaseStateTransitionError classes.

### BaseStateTransitionError
BaseStateTransitionError is the parent class for the InvalidResponse class, however BaseStateTransitionError is an empty class. Therefore InvalidResponse can inherit directly from StandardError. 

e.g.
before: StandardError -> BaseStateTransitionError (empty class) -> InvalidResponse
after: StandardError -> InvalidResponse

### LoggedError

LoggedError is never instantiated in the codebase and the class is never used. We have a check for LoggedError objects, however this will never be true.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
