### PR TITLE
Fixed broken links in marriage abroad outcomes

### DIFF
--- a/app/flows/marriage_abroad_flow/outcomes/_contact_method.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/_contact_method.erb
@@ -68,8 +68,6 @@
     [Make an appointment at the embassy in Lima.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=125&service=13)
   <% when 'russia' %>
     [Make an appointment at the embassy in Moscow.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=132&service=10)
-
-    [Make an appointment at the embassy in St Petersburg.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-st-petersburg/notice-of-marriage-or-civil-partnership/slot_picker)
   <% when 'serbia' %>
     [Make an appointment at the embassy in Belgrade.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=102&service=10)
   <% when 'slovenia' %>

--- a/app/flows/marriage_abroad_flow/outcomes/countries/romania/uk/partner_british/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/romania/uk/partner_british/_opposite_sex.erb
@@ -14,7 +14,7 @@ You can normally get a CNI by giving a notice of marriage at your local register
 
 You need to exchange your UK-issued CNI for one that’s valid in Romania at the nearest embassy or consulate to where you’re getting married.
 
-[Make an appointment to exchange your CNI at the British Embassy Bucharest](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bucharest/exchange-a-certificate-of-no-impediment/slot_picker).
+[Make an appointment to exchange your CNI at the British Embassy Bucharest](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=20&service=4).
 
 You should also check with the local authorities in Romania to find out if you need to provide legalised and translated copies of any other documents.
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/romania/uk/partner_local/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/romania/uk/partner_local/_opposite_sex.erb
@@ -14,7 +14,7 @@ You can normally get a CNI by giving a notice of marriage at your local register
 
 You need to exchange your UK-issued CNI for one that’s valid in Romania at the nearest embassy or consulate to where you’re getting married.
 
-[Make an appointment to exchange your CNI at the British Embassy Bucharest](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bucharest/exchange-a-certificate-of-no-impediment/slot_picker).
+[Make an appointment to exchange your CNI at the British Embassy Bucharest](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=20&service=4).
 
 You should also check with the local authorities in Romania to find out if you need to provide legalised and translated copies of any other documents.
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/romania/uk/partner_other/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/romania/uk/partner_other/_opposite_sex.erb
@@ -14,7 +14,7 @@ You can normally get a CNI by giving a notice of marriage at your local register
 
 You need to exchange your UK-issued CNI for one that’s valid in Romania at the nearest embassy or consulate to where you’re getting married.
 
-[Make an appointment to exchange your CNI at the British Embassy Bucharest](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bucharest/exchange-a-certificate-of-no-impediment/slot_picker).
+[Make an appointment to exchange your CNI at the British Embassy Bucharest](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=20&service=4).
 
 You should also check with the local authorities in Romania to find out if you need to provide legalised and translated copies of any other documents.
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/singapore/ceremony_country/partner_british/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/singapore/ceremony_country/partner_british/_opposite_sex.erb
@@ -5,6 +5,6 @@ Contact the relevant local authorities in Singapore to find out about local marr
 
 The UK doesn’t issue certificates of no impediment (CNI) for marriages in Commonwealth countries. You’ll need to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
 
-However, you can swear an affidavit (written statement of facts) that you’re free to marry in front of a local [notary public or commissioner of oaths](http://www.conp.sg/co-np-directory-listing).
+However, you can swear an affidavit (written statement of facts) that you’re free to marry in front of a local [notary public or commissioner of oaths](https://legalisation.sal.sg/Directory).
 
 *[CNI]:certificate of no impediment

--- a/app/flows/marriage_abroad_flow/outcomes/countries/singapore/ceremony_country/partner_local/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/singapore/ceremony_country/partner_local/_opposite_sex.erb
@@ -5,7 +5,7 @@ Contact the relevant local authorities in Singapore to find out about local marr
 
 The UK doesn’t issue certificates of no impediment (CNI) for marriages in Commonwealth countries. You’ll need to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
 
-However, you can swear an affidavit (written statement of facts) that you’re free to marry in front of a local [notary public or commissioner of oaths](http://www.conp.sg/co-np-directory-listing).
+However, you can swear an affidavit (written statement of facts) that you’re free to marry in front of a local [notary public or commissioner of oaths](https://legalisation.sal.sg/Directory).
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/singapore/ceremony_country/partner_other/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/singapore/ceremony_country/partner_other/_opposite_sex.erb
@@ -5,7 +5,7 @@ Contact the relevant local authorities in Singapore to find out about local marr
 
 The UK doesn’t issue certificates of no impediment (CNI) for marriages in Commonwealth countries. You’ll need to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
 
-However, you can swear an affidavit (written statement of facts) that you’re free to marry in front of a local [notary public or commissioner of oaths](http://www.conp.sg/co-np-directory-listing).
+However, you can swear an affidavit (written statement of facts) that you’re free to marry in front of a local [notary public or commissioner of oaths](https://legalisation.sal.sg/Directory).
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/singapore/third_country/partner_british/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/singapore/third_country/partner_british/_opposite_sex.erb
@@ -5,6 +5,6 @@ Contact the relevant local authorities in Singapore to find out about local marr
 
 The UK doesn’t issue certificates of no impediment (CNI) for marriages in Commonwealth countries. You’ll need to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
 
-However, you can swear an affidavit (written statement of facts) that you’re free to marry in front of a local [notary public or commissioner of oaths](http://www.conp.sg/co-np-directory-listing).
+However, you can swear an affidavit (written statement of facts) that you’re free to marry in front of a local [notary public or commissioner of oaths](https://legalisation.sal.sg/Directory).
 
 *[CNI]:certificate of no impediment

--- a/app/flows/marriage_abroad_flow/outcomes/countries/singapore/third_country/partner_local/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/singapore/third_country/partner_local/_opposite_sex.erb
@@ -5,7 +5,7 @@ Contact the relevant local authorities in Singapore to find out about local marr
 
 The UK doesn’t issue certificates of no impediment (CNI) for marriages in Commonwealth countries. You’ll need to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
 
-However, you can swear an affidavit (written statement of facts) that you’re free to marry in front of a local [notary public or commissioner of oaths](http://www.conp.sg/co-np-directory-listing).
+However, you can swear an affidavit (written statement of facts) that you’re free to marry in front of a local [notary public or commissioner of oaths](https://legalisation.sal.sg/Directory).
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/singapore/third_country/partner_other/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/singapore/third_country/partner_other/_opposite_sex.erb
@@ -5,7 +5,7 @@ Contact the relevant local authorities in Singapore to find out about local marr
 
 The UK doesn’t issue certificates of no impediment (CNI) for marriages in Commonwealth countries. You’ll need to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
 
-However, you can swear an affidavit (written statement of facts) that you’re free to marry in front of a local [notary public or commissioner of oaths](http://www.conp.sg/co-np-directory-listing).
+However, you can swear an affidavit (written statement of facts) that you’re free to marry in front of a local [notary public or commissioner of oaths](https://legalisation.sal.sg/Directory).
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/singapore/uk/partner_british/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/singapore/uk/partner_british/_opposite_sex.erb
@@ -5,6 +5,6 @@ Contact the [High Commission of Singapore](/government/publications/foreign-emba
 
 The UK doesn’t issue certificates of no impediment (CNI) for marriages in Commonwealth countries. You’ll need to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
 
-However, you can swear an affidavit (written statement of facts) that you’re free to marry in front of a local [notary public or commissioner of oaths](http://www.conp.sg/co-np-directory-listing).
+However, you can swear an affidavit (written statement of facts) that you’re free to marry in front of a local [notary public or commissioner of oaths](https://legalisation.sal.sg/Directory).
 
 *[CNI]:certificate of no impediment

--- a/app/flows/marriage_abroad_flow/outcomes/countries/singapore/uk/partner_local/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/singapore/uk/partner_local/_opposite_sex.erb
@@ -5,7 +5,7 @@ Contact the [High Commission of Singapore](/government/publications/foreign-emba
 
 The UK doesn’t issue certificates of no impediment (CNI) for marriages in Commonwealth countries. You’ll need to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
 
-However, you can swear an affidavit (written statement of facts) that you’re free to marry in front of a local [notary public or commissioner of oaths](http://www.conp.sg/co-np-directory-listing).
+However, you can swear an affidavit (written statement of facts) that you’re free to marry in front of a local [notary public or commissioner of oaths](https://legalisation.sal.sg/Directory).
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/singapore/uk/partner_other/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/singapore/uk/partner_other/_opposite_sex.erb
@@ -5,7 +5,7 @@ Contact the [High Commission of Singapore](/government/publications/foreign-emba
 
 The UK doesn’t issue certificates of no impediment (CNI) for marriages in Commonwealth countries. You’ll need to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
 
-However, you can swear an affidavit (written statement of facts) that you’re free to marry in front of a local [notary public or commissioner of oaths](http://www.conp.sg/co-np-directory-listing).
+However, you can swear an affidavit (written statement of facts) that you’re free to marry in front of a local [notary public or commissioner of oaths](https://legalisation.sal.sg/Directory).
 
 ##Naturalisation of your partner if they move to the UK
 


### PR DESCRIPTION
I've fixed a few broken links in marriage abroad outcomes:

1. Removed a link to the St Petersburg embassy as it's now closed.
2. Fixed a link to the Bucharest embassy in 3 outcomes.
3. Fixed a link to the Singapore Academy of law in 9 outcomes. 