### PR TITLE
Single page - multiple country - search and select functionality

### DIFF
--- a/app/controllers/flow_controller.rb
+++ b/app/controllers/flow_controller.rb
@@ -38,7 +38,7 @@ class FlowController < ApplicationController
     presenter = FlowPresenter.new(flow, state)
     redirect_to flow_path(id: params[:id],
                           node_slug: presenter.node_slug,
-                          params: response_store.forwarding_responses)
+                          params: response_store.forwarding_responses.as_json)
   end
 
   def destroy

--- a/app/flows/country_search_and_filter_flow.rb
+++ b/app/flows/country_search_and_filter_flow.rb
@@ -4,12 +4,16 @@ class CountrySearchAndFilterFlow < SmartAnswer::Flow
     content_id "cb3d7d6a-0140-4706-8583-bafecdf06f53"
     status :draft
 
-    checkbox_question :countries do
-      self.select_filter = true
+    # checkbox_question :countries do
+    #   self.select_filter = true
+    #
+    #   SmartAnswer::Calculators::CountrySearchAndFilterCalculator.countries.each_key do |slug|
+    #     option slug.to_sym
+    #   end
 
-      SmartAnswer::Calculators::CountrySearchAndFilterCalculator.countries.each_key do |slug|
-        option slug.to_sym
-      end
+    multiple_country_select :countries do
+      self.select_count = 6
+      options
 
       on_response do |response|
         self.calculator = SmartAnswer::Calculators::CountrySearchAndFilterCalculator.new

--- a/app/flows/country_search_and_filter_flow.rb
+++ b/app/flows/country_search_and_filter_flow.rb
@@ -1,11 +1,13 @@
 class CountrySearchAndFilterFlow < SmartAnswer::Flow
   def define
-      name "country-search-and-filter"
-      content_id "cb3d7d6a-0140-4706-8583-bafecdf06f53"
-      status :draft
+    name "country-search-and-filter"
+    content_id "cb3d7d6a-0140-4706-8583-bafecdf06f53"
+    status :draft
 
     checkbox_question :countries do
-      SmartAnswer::Calculators::CountrySearchAndFilterCalculator.countries.keys.each do |slug|
+      self.select_filter = true
+
+      SmartAnswer::Calculators::CountrySearchAndFilterCalculator.countries.each_key do |slug|
         option slug.to_sym
       end
 

--- a/app/flows/country_search_and_filter_flow.rb
+++ b/app/flows/country_search_and_filter_flow.rb
@@ -1,0 +1,24 @@
+class CountrySearchAndFilterFlow < SmartAnswer::Flow
+  def define
+      name "country-search-and-filter"
+      content_id "cb3d7d6a-0140-4706-8583-bafecdf06f53"
+      status :draft
+
+    checkbox_question :countries do
+      SmartAnswer::Calculators::CountrySearchAndFilterCalculator.countries.keys.each do |slug|
+        option slug.to_sym
+      end
+
+      on_response do |response|
+        self.calculator = SmartAnswer::Calculators::CountrySearchAndFilterCalculator.new
+        calculator.countries = response
+      end
+
+      next_node do
+        outcome :results
+      end
+    end
+
+    outcome :results
+  end
+end

--- a/app/flows/country_search_and_filter_flow.rb
+++ b/app/flows/country_search_and_filter_flow.rb
@@ -3,6 +3,7 @@ class CountrySearchAndFilterFlow < SmartAnswer::Flow
     name "country-search-and-filter"
     content_id "cb3d7d6a-0140-4706-8583-bafecdf06f53"
     status :draft
+    response_store :query_parameters
 
     # checkbox_question :countries do
     #   self.select_filter = true

--- a/app/flows/country_search_and_filter_flow/outcomes/results.erb
+++ b/app/flows/country_search_and_filter_flow/outcomes/results.erb
@@ -3,5 +3,5 @@
 <% end %>
 
 <% govspeak_for :body do %>
-  Countries: [<%= calculator.countries %>]
+  Countries: <%= calculator.countries %>
 <% end %>

--- a/app/flows/country_search_and_filter_flow/outcomes/results.erb
+++ b/app/flows/country_search_and_filter_flow/outcomes/results.erb
@@ -1,0 +1,7 @@
+<% text_for :title do %>
+  Thank you
+<% end %>
+
+<% govspeak_for :body do %>
+  Countries: [<%= calculator.countries %>]
+<% end %>

--- a/app/flows/country_search_and_filter_flow/questions/countries.erb
+++ b/app/flows/country_search_and_filter_flow/questions/countries.erb
@@ -1,0 +1,5 @@
+<% text_for :title do %>
+  Countries
+<% end %>
+
+<% options(SmartAnswer::Calculators::CountrySearchAndFilterCalculator.countries) %>

--- a/app/flows/country_search_and_filter_flow/start.erb
+++ b/app/flows/country_search_and_filter_flow/start.erb
@@ -1,0 +1,3 @@
+<% text_for :title do %>
+  Country search and filter
+<% end %>

--- a/app/presenters/checkbox_question_presenter.rb
+++ b/app/presenters/checkbox_question_presenter.rb
@@ -13,6 +13,10 @@ class CheckboxQuestionPresenter < QuestionWithOptionsPresenter
     true
   end
 
+  def select_filter?
+    @node.select_filter
+  end
+
   def checkboxes
     options.each_with_object([]) do |option, items|
       if option[:value] == "none"

--- a/app/presenters/multiple_country_select_question_presenter.rb
+++ b/app/presenters/multiple_country_select_question_presenter.rb
@@ -1,0 +1,15 @@
+class MultipleCountrySelectQuestionPresenter < QuestionPresenter
+  def select_count
+    @node.select_count
+  end
+
+  def select_options(counter)
+    @node.options.map do |option|
+      {
+        text: option.name,
+        value: option.slug,
+        selected: current_response.nil? ? false : option.slug == current_response[counter.to_s],
+      }
+    end
+  end
+end

--- a/app/views/smart_answers/inputs/_checkbox_question.html.erb
+++ b/app/views/smart_answers/inputs/_checkbox_question.html.erb
@@ -10,3 +10,9 @@
   hint_text: question.hint,
   items: question.checkboxes
 } %>
+
+<% if question.select_filter? %>
+  <script type="text/javascript">
+    console.log("You are seeing this because the 'select_filter' flag is set!")
+  </script>
+<% end %>

--- a/app/views/smart_answers/inputs/_multiple_country_select_question.html.erb
+++ b/app/views/smart_answers/inputs/_multiple_country_select_question.html.erb
@@ -1,0 +1,8 @@
+<% question.select_count.times do |i| %>
+  <%= render "govuk_publishing_components/components/select", {
+    id: "response_#{i}",
+    name: "response[#{i}]",
+    label: "",
+    options: question.select_options(i).prepend({text: "", value: "", selected: false})
+  } %>
+<% end %>

--- a/lib/smart_answer/calculators/country_search_and_filter_calculator.rb
+++ b/lib/smart_answer/calculators/country_search_and_filter_calculator.rb
@@ -1,0 +1,13 @@
+module SmartAnswer::Calculators
+  class CountrySearchAndFilterCalculator
+    attr_accessor :countries
+
+    def self.countries
+      countries = {}
+      WorldLocation.all.each do |country|
+        countries[country.slug] = country.title
+      end
+      countries
+    end
+  end
+end

--- a/lib/smart_answer/flow.rb
+++ b/lib/smart_answer/flow.rb
@@ -75,6 +75,10 @@ module SmartAnswer
       add_node Question::CountrySelect.new(self, name, options, &block)
     end
 
+    def multiple_country_select(name, options = {}, &block)
+      add_node Question::MultipleCountrySelect.new(self, name, options, &block)
+    end
+
     def date_question(name, &block)
       add_node Question::Date.new(self, name, &block)
     end

--- a/lib/smart_answer/question/checkbox.rb
+++ b/lib/smart_answer/question/checkbox.rb
@@ -4,7 +4,7 @@ module SmartAnswer
       PRESENTER_CLASS = CheckboxQuestionPresenter
       NONE_OPTION = "none".freeze
 
-      attr_accessor :option_keys, :options_block
+      attr_accessor :option_keys, :options_block, :select_filter
 
       def initialize(flow, name, &block)
         @option_keys = []

--- a/lib/smart_answer/question/multiple_country_select.rb
+++ b/lib/smart_answer/question/multiple_country_select.rb
@@ -1,0 +1,34 @@
+module SmartAnswer
+  module Question
+    class MultipleCountrySelect < Base
+      PRESENTER_CLASS = MultipleCountrySelectQuestionPresenter
+
+      attr_accessor :select_count
+
+      def initialize(flow, name, _options = {}, &block)
+        @select_count = 1
+        super(flow, name, &block)
+      end
+
+      def options
+        country_list
+      end
+
+      def country_list
+        @country_list ||= WorldLocation.all
+      end
+
+      def parse_input(raw_input)
+        return {} if raw_input.blank?
+        return raw_input if raw_input.is_a?(Hash)
+
+        parsed_input = {}
+        raw_input.split("&").each do |selection|
+          entry = selection.split("=")
+          parsed_input[entry.first.to_i] = entry.last
+        end
+        parsed_input
+      end
+    end
+  end
+end

--- a/lib/smart_answer/question/multiple_country_select.rb
+++ b/lib/smart_answer/question/multiple_country_select.rb
@@ -21,6 +21,7 @@ module SmartAnswer
       def parse_input(raw_input)
         return {} if raw_input.blank?
         return raw_input if raw_input.is_a?(Hash)
+        return raw_input.as_json if raw_input.is_a?(ActionController::Parameters)
 
         parsed_input = {}
         raw_input.split("&").each do |selection|


### PR DESCRIPTION
### What
Investigate the possibility of creating a single page - multiple country - search and select question in Smart Answers.

### Why do this?
The Devs have previously created a [Travel Abroad Smart Answer prototype](https://trello.com/c/QX4xqxtj/360-dev-mob-for-setting-up-a-travel-smart-answer-ahead-of-building-out-the-flow). This used a UX of "Select country" and "Any more countries?" loop to gather a number of countries from the user. This UX is not ideal and we have been asked to investigate a better approach.

The preferred option is to gather all of the countries that the user is travelling to - and through(?) - using a single page. 

[Trello](https://trello.com/c/wflaXLfD/395-single-page-multiple-country-search-and-select-functionality)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
