### PR TITLE
Round trip travel smart-answer for COVID-19

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -35,3 +35,30 @@ $govuk-new-link-styles: true;
 @import "components/result-sections";
 @import "components/user-research-banner";
 @import "smart_answers";
+
+.travel-abroad__heading {
+  padding: govuk-spacing(4) 0;
+  margin-bottom: govuk-spacing(4);
+  border-top: solid 3px $govuk-link-colour;
+  border-bottom: solid 1px $govuk-border-colour;
+
+  @include govuk-media-query($from: tablet) {
+    margin-bottom: govuk-spacing(8);
+  }
+}
+
+.travel-abroad__section {
+  margin-bottom: govuk-spacing(2);
+
+  & + .travel-abroad__heading {
+    margin-top: govuk-spacing(8);
+  }
+}
+
+.travel-abroad__country {
+  margin-bottom: govuk-spacing(7);
+}
+
+.travel-abroad__reasons {
+  margin-bottom: govuk-spacing(6);
+}

--- a/app/flows/covid_travel_abroad_flow.rb
+++ b/app/flows/covid_travel_abroad_flow.rb
@@ -117,6 +117,8 @@ class CovidTravelAbroadFlow < SmartAnswer::Flow
       end
     end
 
-    outcome :results
+    outcome :results do
+      view_template "smart_answers/custom_result_full_width"
+    end
   end
 end

--- a/app/flows/covid_travel_abroad_flow.rb
+++ b/app/flows/covid_travel_abroad_flow.rb
@@ -29,7 +29,11 @@ class CovidTravelAbroadFlow < SmartAnswer::Flow
 
         next_node do
           if calculator.any_other_countries == "no"
-            question :vaccination_status
+            if calculator.countries.count > 1
+              question :transit_countries
+            else
+              question :vaccination_status
+            end
           else
             question "which_#{calculator.countries.count}_country".to_sym
           end
@@ -50,6 +54,18 @@ class CovidTravelAbroadFlow < SmartAnswer::Flow
         next_node do
           question "any_other_countries_#{calculator.countries.count}".to_sym
         end
+      end
+    end
+
+    checkbox_question :transit_countries do
+      options { calculator.countries.dup << "none" }
+
+      on_response do |response|
+        calculator.transit_countries = response unless response == "none"
+      end
+
+      next_node do
+          question :vaccination_status
       end
     end
 

--- a/app/flows/covid_travel_abroad_flow.rb
+++ b/app/flows/covid_travel_abroad_flow.rb
@@ -1,0 +1,10 @@
+class CovidTravelAbroadFlow < SmartAnswer::Flow
+  def define
+    name "covid-travel-abroad"
+    content_id "b46df1e7-e770-43ab-8b4c-ce402736420c"
+    status :draft
+    response_store :query_parameters
+
+    outcome :results
+  end
+end

--- a/app/flows/covid_travel_abroad_flow.rb
+++ b/app/flows/covid_travel_abroad_flow.rb
@@ -5,13 +5,28 @@ class CovidTravelAbroadFlow < SmartAnswer::Flow
     status :draft
     response_store :query_parameters
 
+    radio :vaccination_status do
+      option :vaccinated
+      option :in_trial
+      option :exempt
+      option :none
+
+      on_response do |response|
+        self.calculator = SmartAnswer::Calculators::CovidTravelAbroadCalculator.new
+        calculator.vaccination_status = response
+      end
+
+      next_node do
+        question :travelling_with_children
+      end
+    end
+
     checkbox_question :travelling_with_children do
       option :zero_to_four
       option :five_to_seventeen
       none_option
 
       on_response do |response|
-        self.calculator = SmartAnswer::Calculators::CovidTravelAbroadCalculator.new
         calculator.travelling_with_children = response
       end
 

--- a/app/flows/covid_travel_abroad_flow.rb
+++ b/app/flows/covid_travel_abroad_flow.rb
@@ -5,6 +5,17 @@ class CovidTravelAbroadFlow < SmartAnswer::Flow
     status :draft
     response_store :query_parameters
 
+    country_select "which_country".to_sym, exclude_countries: [] do
+      on_response do |response|
+        self.calculator = SmartAnswer::Calculators::CovidTravelAbroadCalculator.new
+        calculator.countries << response
+      end
+
+      next_node do
+        question :vaccination_status
+      end
+    end
+
     radio :vaccination_status do
       option :vaccinated
       option :in_trial
@@ -12,7 +23,6 @@ class CovidTravelAbroadFlow < SmartAnswer::Flow
       option :none
 
       on_response do |response|
-        self.calculator = SmartAnswer::Calculators::CovidTravelAbroadCalculator.new
         calculator.vaccination_status = response
       end
 

--- a/app/flows/covid_travel_abroad_flow.rb
+++ b/app/flows/covid_travel_abroad_flow.rb
@@ -5,6 +5,21 @@ class CovidTravelAbroadFlow < SmartAnswer::Flow
     status :draft
     response_store :query_parameters
 
+    checkbox_question :travelling_with_children do
+      option :zero_to_four
+      option :five_to_seventeen
+      none_option
+
+      on_response do |response|
+        self.calculator = SmartAnswer::Calculators::CovidTravelAbroadCalculator.new
+        calculator.travelling_with_children = response
+      end
+
+      next_node do
+        outcome :results
+      end
+    end
+
     outcome :results
   end
 end

--- a/app/flows/covid_travel_abroad_flow.rb
+++ b/app/flows/covid_travel_abroad_flow.rb
@@ -31,6 +31,8 @@ class CovidTravelAbroadFlow < SmartAnswer::Flow
           if calculator.any_other_countries == "no"
             if calculator.countries.count > 1
               question :transit_countries
+            elsif calculator.red_list_countries.any?
+              question :going_to_countries_within_10_days
             else
               question :vaccination_status
             end
@@ -65,7 +67,24 @@ class CovidTravelAbroadFlow < SmartAnswer::Flow
       end
 
       next_node do
+        if calculator.red_list_countries.any?
+          question :going_to_countries_within_10_days
+        else
           question :vaccination_status
+        end
+      end
+    end
+
+    radio :going_to_countries_within_10_days do
+      option :yes
+      option :no
+
+      on_response do |response|
+        calculator.going_to_countries_within_10_days = response
+      end
+
+      next_node do
+        question :vaccination_status
       end
     end
 

--- a/app/flows/covid_travel_abroad_flow/outcomes/_children_five_to_seventeen.erb
+++ b/app/flows/covid_travel_abroad_flow/outcomes/_children_five_to_seventeen.erb
@@ -1,0 +1,19 @@
+<div class="govuk-grid-row travel-abroad__section">
+  <div class="govuk-grid-column-one-third">&nbsp;</div>
+
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "Returning to England with young people aged 5 to 17",
+      heading_level: 3,
+      font_size: "m",
+      margin_bottom: 4,
+    } %>
+    <p class="govuk-body">Children aged 12 to 17 must take a PCR or rapid lateral flow COVID-19 test in the 48 hours before travel to England.</p>
+
+    <p class="govuk-body">On arrival in England, children aged 5 to 17 must:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>take a PCR COVID-19 test on or before day 2 after arrival (the day they arrive is day 0)</li>
+        <li>quarantine at home or the place they're staying while they wait for their test result</li>
+      </ul>
+  </div>
+</div>

--- a/app/flows/covid_travel_abroad_flow/outcomes/_children_zero_to_four.erb
+++ b/app/flows/covid_travel_abroad_flow/outcomes/_children_zero_to_four.erb
@@ -1,0 +1,13 @@
+<div class="govuk-grid-row travel-abroad__section">
+  <div class="govuk-grid-column-one-third">&nbsp;</div>
+
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "Returning to England with children aged 4 and under",
+      heading_level: 3,
+      font_size: "m",
+      margin_bottom: 4,
+    } %>
+    <p class="govuk-body">Children aged 0 to 4 do not have to take any COVID-19 travel tests and do not have to quarantine on arrival in England.</p>
+  </div>
+</div>

--- a/app/flows/covid_travel_abroad_flow/outcomes/_country.erb
+++ b/app/flows/covid_travel_abroad_flow/outcomes/_country.erb
@@ -1,0 +1,34 @@
+<%= render "govuk_publishing_components/components/heading", {
+  text: country.title,
+  heading_level: 3,
+  font_size: "m",
+  margin_bottom: 4,
+} %>
+
+<% if calculator.countries_with_content_headers_converted.include?(country.slug) %>
+  <p class="govuk-body">You should read the following sections of the <%= country.title %> entry requirements guidance on:</p>
+
+  <% if calculator.transit_countries.include?(country.slug) %>
+    <ul class="govuk-list govuk-list--bullet">
+      <li><a href="https://www.gov.uk/foreign-travel-advice/<%= country.slug %>/entry-requirements#if-youre-transiting-through-<%= country.slug %>" class="govuk-link">travelling through <%= country.title %></a></li>
+    </ul>
+  <% else %>
+    <ul class="govuk-list govuk-list--bullet">
+      <% if calculator.vaccination_status == "none" %>
+        <li><a href="https://www.gov.uk/foreign-travel-advice/<%= country.slug %>/entry-requirements/#if-youre-not-fully-vaccinated" class="govuk-link">people who aren't fully vaccinated</a></li>
+      <% else %>
+        <li><a href="https://www.gov.uk/foreign-travel-advice/<%= country.slug %>/entry-requirements/#if-youre-fully-vaccinated" class="govuk-link">fully vaccinated people</a></li>
+      <% end %>
+
+      <% unless calculator.travelling_with_children == ["none"] %>
+        <li><a href="https://www.gov.uk/foreign-travel-advice/<%= country.slug %>/entry-requirements/#children-and-young-people" class="govuk-link">travelling with children and young people</a></li>
+      <% end %>
+
+      <li><a href="https://www.gov.uk/foreign-travel-advice/<%= country.slug %>/entry-requirements/#exemptions" class="govuk-link">exemptions</a></li>
+    </ul>
+
+    <p class="govuk-body">There may be <a href="https://www.gov.uk/foreign-travel-advice/<%= country.slug %>/entry-requirements" class="govuk-link">other requirements for entering <%= country.title %></a> that you need to follow.</p>
+  <% end %>
+<% else %>
+  <p class="govuk-body">You should read the <a href="https://www.gov.uk/foreign-travel-advice/<%= country.slug %>/entry-requirements" class="govuk-link"><%= country.title %> entry requirements</a>.</p>
+<% end %>

--- a/app/flows/covid_travel_abroad_flow/outcomes/_exempt_compassionate.erb
+++ b/app/flows/covid_travel_abroad_flow/outcomes/_exempt_compassionate.erb
@@ -1,0 +1,15 @@
+<div class="govuk-grid-row travel-abroad__section">
+  <div class="govuk-grid-column-one-third">&nbsp;</div>
+
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "Exemptions for compassionate reasons",
+      heading_level: 3,
+      font_size: "m",
+      margin_bottom: 4,
+    } %>
+    <p class="govuk-body">If it is not possible to accommodate a visit to a severely ill or dying relative or member of your household from within a quarantine hotel, you may be able to quarantine somewhere else instead.</p>
+
+    <p class="govuk-body">See information on <a href="https://www.gov.uk/guidance/exemptions-from-managed-quarantine-for-compassionate-reasons" class="govuk-link">who can get a compassionate exemption, how to apply and what happens after a decision is made</a>.</p>
+  </div>
+</div>

--- a/app/flows/covid_travel_abroad_flow/outcomes/_exempt_job.erb
+++ b/app/flows/covid_travel_abroad_flow/outcomes/_exempt_job.erb
@@ -1,0 +1,13 @@
+<div class="govuk-grid-row travel-abroad__section">
+  <div class="govuk-grid-column-one-third">&nbsp;</div>
+
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "Exemptions because of your job",
+      heading_level: 3,
+      font_size: "m",
+      margin_bottom: 4,
+    } %>
+    <p class="govuk-body">Some of the rules for returning to England may not apply because of the job you do. <a href="https://www.gov.uk/government/publications/coronavirus-covid-19-travellers-exempt-from-uk-border-rules/coronavirus-covid-19-travellers-exempt-from-uk-border-rules" class="govuk-link">Find out which jobs qualify for exemptions</a>.</p>
+  </div>
+</div>

--- a/app/flows/covid_travel_abroad_flow/outcomes/_exempt_medical.erb
+++ b/app/flows/covid_travel_abroad_flow/outcomes/_exempt_medical.erb
@@ -1,0 +1,15 @@
+<div class="govuk-grid-row travel-abroad__section">
+  <div class="govuk-grid-column-one-third">&nbsp;</div>
+
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "Exemptions for medical reasons",
+      heading_level: 3,
+      font_size: "m",
+      margin_bottom: 4,
+    } %>
+    <p class="govuk-body">Your health may mean that you do not need to stay in a quarantine hotel and must quarantine somewhere else instead.</p>
+
+    <p class="govuk-body">See information on <a href="https://www.gov.uk/guidance/exemptions-from-managed-quarantine-for-medical-and-compassionate-reasons" class="govuk-link">who can get a medical exemption, how to apply and what happens after a decision is made</a>.</p>
+  </div>
+</div>

--- a/app/flows/covid_travel_abroad_flow/outcomes/_fully_vaxed.erb
+++ b/app/flows/covid_travel_abroad_flow/outcomes/_fully_vaxed.erb
@@ -1,0 +1,60 @@
+<% content = capture do %>
+  <%= render "govuk_publishing_components/components/heading", {
+    text: "Proof of vaccination",
+    heading_level: 3,
+    font_size: "m",
+    margin_bottom: 4,
+  } %>
+
+  <p class="govuk-body">You must be able to prove that you've been fully vaccinated. If you live in England, you can prove your vaccination status using the <a href="https://www.gov.uk/guidance/nhs-covid-pass" class="govuk-link">NHS COVID Pass</a>.</p>
+
+  <p class="govuk-body">If you were vaccinated in another country or territory, see <a href="https://www.gov.uk/guidance/countries-with-approved-covid-19-vaccination-programmes-and-proof-of-vaccination#countries-with-an-approved-proof-of-vaccination-and-examples-of-proof-required" class="govuk-link">examples of what you can use as proof of vaccination</a>.</p>
+
+  <%= render "govuk_publishing_components/components/heading", {
+    text: "Before you travel to England",
+    heading_level: 3,
+    font_size: "m",
+    margin_bottom: 4,
+  } %>
+
+  <p class="govuk-body">You must:</p>
+
+  <ul class="govuk-list govuk-list--bullet">
+    <li><a href="https://www.gov.uk/find-travel-test-provider" class="govuk-link">take a PCR or rapid lateral flow COVID-19 test</a> - to be taken in the 48 hours before you travel to England</li>
+    <li><a href="https://www.gov.uk/find-travel-test-provider" class="govuk-link">book and pay for a COVID-19 PCR test</a> - to be taken after arrival before the end of day 2</li>
+    <li><a href="https://www.gov.uk/provide-journey-contact-details-before-travel-uk" class="govuk-link">complete a passenger locator form</a> - to be completed in the 48 hours before you arrive in England</li>
+  </ul>
+
+  <p class="govuk-body">You must use a private test provider. You cannot use a free NHS test.</p>
+
+  <p class="govuk-body">You will need to enter your COVID-19 test booking reference number on your passenger locator form.</p>
+
+  <%= render "govuk_publishing_components/components/heading", {
+    text: "When you arrive in England",
+    heading_level: 3,
+    font_size: "m",
+    margin_bottom: 4,
+  } %>
+
+  <p class="govuk-body">You must take the COVID-19 PCR test you booked before travel on or before day 2 (the day you arrive is day 0).</p>
+
+  <p class="govuk-body">You must <a href="https://www.gov.uk/guidance/how-to-quarantine-when-you-arrive-in-england" class="govuk-link">quarantine at home or the place you're staying</a> while you wait for your test result.</p>
+
+  <p class="govuk-body">If the test result is negative, you can end your quarantine.</p>
+
+  <p class="govuk-body">If the test is positive or unclear, you must <a href="https://www.nhs.uk/conditions/coronavirus-covid-19/self-isolation-and-treatment/when-to-self-isolate-and-what-to-do" class="govuk-link">self-isolate</a> for 10 full days (the day of the test is day 0).</p>
+
+  <p class="govuk-body">If the test is unclear, you can choose to take another private test.</p>
+
+  <p class="govuk-body">If you haven't received your test result after 13 days, you can end your quarantine (the day you arrive is day 0).</p>
+<% end %>
+
+<%
+  data = {
+    title: "Returning to England if you're fully vaccinated",
+    reasons: ['You are fully vaccinated'],
+    content: content
+  }
+%>
+
+<%= render partial: "travel_result_layout", locals: { data: data, calculator: calculator } %>

--- a/app/flows/covid_travel_abroad_flow/outcomes/_medical_treatment.erb
+++ b/app/flows/covid_travel_abroad_flow/outcomes/_medical_treatment.erb
@@ -1,0 +1,15 @@
+<div class="govuk-grid-row travel-abroad__section">
+  <div class="govuk-grid-column-one-third">&nbsp;</div>
+
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "Returning to England to receive urgent medical treatment",
+      heading_level: 3,
+      font_size: "m",
+      margin_bottom: 4,
+    } %>
+    <p class="govuk-body">If you're returning to receive urgent, unplanned treatment in England, you do not need to take any travel tests.</p>
+
+    <p class="govuk-body">You can travel to and from your healthcare provider and the place you're staying in England and must <a href="https://www.gov.uk/guidance/how-to-quarantine-when-you-arrive-in-england" class="govuk-link">follow quarantine rules</a>.</p>
+  </div>
+</div>

--- a/app/flows/covid_travel_abroad_flow/outcomes/_not_fully_vaxed.erb
+++ b/app/flows/covid_travel_abroad_flow/outcomes/_not_fully_vaxed.erb
@@ -1,0 +1,88 @@
+<% content = capture do %>
+  <%= render "govuk_publishing_components/components/heading", {
+    text: "Before you travel to England",
+    heading_level: 3,
+    font_size: "m",
+    margin_bottom: 4,
+  } %>
+
+  <p class="govuk-body">You must:</p>
+
+  <ul class="govuk-list govuk-list--bullet">
+    <li><a href="https://www.gov.uk/guidance/coronavirus-covid-19-testing-for-people-travelling-to-england" class="govuk-link">take a pre-departure COVID-19 test</a> within the 3 days before you travel to England</li>
+    <li><a href="https://www.gov.uk/find-travel-test-provider" class="govuk-link">book and pay for day 2 and day 8 COVID-19 PCR tests</a> to take after you arrive in England</li>
+    <li><a href="https://www.gov.uk/provide-journey-contact-details-before-travel-uk" class="govuk-link">complete a passenger locator form</a> within the 48 hours before you arrive in England</li>
+  </ul>
+
+  <%= render "govuk_publishing_components/components/heading", {
+    text: "When you arrive in England",
+    heading_level: 3,
+    font_size: "m",
+    margin_bottom: 4,
+  } %>
+
+  <p class="govuk-body">You must:</p>
+
+  <ul class="govuk-list govuk-list--bullet">
+    <li><a href="https://www.gov.uk/guidance/how-to-quarantine-when-you-arrive-in-england" class="govuk-link">quarantine at home or in the place you're staying for 10 days</a></li>
+    <li>take the COVID-19 PCR tests that you booked before travel - take the first test on or before day 2 and the second test on or after day 8 (the day you arrive is day 0)</li>
+  </ul>
+
+  <p class="govuk-body">If you're in England for less than 10 days, you must quarantine for the length of your stay. You must book day 2 and day 8 PCR tests but only need to take them if you are still in England on those days.</p>
+
+  <%= render "govuk_publishing_components/components/heading", {
+    text: "If the test result is positive",
+    heading_level: 4,
+    font_size: "s",
+    margin_bottom: 4,
+  } %>
+
+  <p class="govuk-body">If your day 2 test is positive, you must <a href="https://www.nhs.uk/conditions/coronavirus-covid-19/self-isolation-and-treatment/when-to-self-isolate-and-what-to-do" class="govuk-link">self-isolate</a> for 10 days (the day you took the test is day 0). You do not need to take the day 8 test.</p>
+
+  <p class="govuk-body">If your day 8 test is positive, you must <a href="https://www.nhs.uk/conditions/coronavirus-covid-19/self-isolation-and-treatment/when-to-self-isolate-and-what-to-do" class="govuk-link">self-isolate</a> for 10 days (the day you took the day 8 test is day 0).</p>
+
+  <%= render "govuk_publishing_components/components/heading", {
+    text: "If the test result is negative",
+    heading_level: 4,
+    font_size: "s",
+    margin_bottom: 4,
+  } %>
+
+  <p class="govuk-body">If your day 2 test is negative, you must continue to quarantine then take your day 8 test on or after day 8.</p>
+
+  <p class="govuk-body">If your day 8 test is negative and you receive the result before day 10, you must continue to quarantine but can stop on day 10 (the day you arrived in England is day 0).</p>
+
+  <p class="govuk-body">If your day 8 test is negative and you receive the result after day 10, you can stop quarantine when you get the result (the day you arrived in England is day 0).</p>
+
+  <%= render "govuk_publishing_components/components/heading", {
+    text: "If the test result is unclear",
+    heading_level: 4,
+    font_size: "s",
+    margin_bottom: 4,
+  } %>
+
+  <p class="govuk-body">If the result of your day 2 test is unclear, you must self-isolate for 10 full days (the day you took the test is day 0).</p>
+
+  <p class="govuk-body">If your day 8 test is unclear, you must self-isolate for 10 full days (the day you took the day 8 test is day 0).</p>
+
+  <p class="govuk-body">You can choose to take another private test. If that test result is negative and you receive the result before day 10, you must continue to quarantine but can stop on day 10 (the day you arrived in England is day 0)you can stop quarantine on day 10. If that test result is negative and you receive the result after day 10, you can stop quarantine when you get the result (the day you arrived in England is day 0).</p>
+
+  <%= render "govuk_publishing_components/components/heading", {
+    text: "Ending quarantine early using Test to Release",
+    heading_level: 3,
+    font_size: "m",
+    margin_bottom: 4,
+  } %>
+
+  <p class="govuk-body">You may be able to end quarantine early if you pay for a private COVID-19 test through the <a href="https://www.gov.uk/guidance/coronavirus-covid-19-test-to-release-for-international-travel" class="govuk-link">Test to Release</a> scheme.</p>
+<% end %>
+
+<%
+  data = {
+    title: "Returning to England if you're not fully vaccinated",
+    reasons: ['You are not fully vaccinated'],
+    content: content
+  }
+%>
+
+<%= render partial: "travel_result_layout", locals: { data: data, calculator: calculator } %>

--- a/app/flows/covid_travel_abroad_flow/outcomes/_red_list_children_five_to_seventeen.erb
+++ b/app/flows/covid_travel_abroad_flow/outcomes/_red_list_children_five_to_seventeen.erb
@@ -1,0 +1,15 @@
+<div class="govuk-grid-row travel-abroad__section">
+  <div class="govuk-grid-column-one-third">&nbsp;</div>
+
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "Returning to England with young people aged 5 to 17",
+      heading_level: 3,
+      font_size: "m",
+      margin_bottom: 4,
+    } %>
+    <p class="govuk-body">Children aged 12 to 17 must take a COVID-19 test in the 3 days before travel to England.</p>
+
+    <p class="govuk-body">On arrival in England, children aged 5 to 17 must quarantine in a managed hotel for 10 full days and take 2 COVID-19 tests.</p>
+  </div>
+</div>

--- a/app/flows/covid_travel_abroad_flow/outcomes/_red_list_children_zero_to_four.erb
+++ b/app/flows/covid_travel_abroad_flow/outcomes/_red_list_children_zero_to_four.erb
@@ -1,0 +1,13 @@
+<div class="govuk-grid-row travel-abroad__section">
+  <div class="govuk-grid-column-one-third">&nbsp;</div>
+
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "Returning to England with children aged 4 and under",
+      heading_level: 3,
+      font_size: "m",
+      margin_bottom: 4,
+    } %>
+    <p class="govuk-body">Children aged 4 or under do not have to take any travel tests but must enter managed quarantine.</p>
+  </div>
+</div>

--- a/app/flows/covid_travel_abroad_flow/outcomes/_return_from_red_list.erb
+++ b/app/flows/covid_travel_abroad_flow/outcomes/_return_from_red_list.erb
@@ -1,0 +1,51 @@
+<% content = capture do %>
+  <p class="govuk-body">You've said you'll be in a red list country within 10 days of arriving in England. This means different rules apply for entering England.</p>
+
+  <p class="govuk-body">You will only be allowed to enter the UK if you either:</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>are a British or Irish National</li>
+    <li>have residence rights in the UK</li>
+  </ul>
+
+  <p class="govuk-body">If you live in England, you should not travel to countries or territories on the red list.</p>
+
+  <%= render "govuk_publishing_components/components/heading", {
+    text: "Before you travel to England",
+    heading_level: 3,
+    font_size: "m",
+    margin_bottom: 4,
+  } %>
+
+  <p class="govuk-body">You must:</p>
+
+  <ul class="govuk-list govuk-list--bullet">
+    <li>take a COVID-19 test – you must take the test in the 3 days before you travel to England</li>
+    <li><a href="https://www.gov.uk/guidance/booking-and-staying-in-a-quarantine-hotel-when-you-arrive-in-england" class="govuk-link">book a quarantine hotel package, including 2 COVID-19 tests</a></li>
+    <li><a href="https://www.gov.uk/provide-journey-contact-details-before-travel-uk" class="govuk-link">complete a passenger locator form</a></li>
+  </ul>
+
+  <p class="govuk-body">You must do this even if you are fully vaccinated.</p>
+
+  <p class="govuk-body"><a href="https://www.gov.uk/guidance/coronavirus-covid-19-testing-for-people-travelling-to-england" class="govuk-link">Read more about taking a COVID-19 test before you travel to England</a>.</p>
+
+  <%= render "govuk_publishing_components/components/heading", {
+    text: "When you arrive in England",
+    heading_level: 3,
+    font_size: "m",
+    margin_bottom: 4,
+  } %>
+
+  <p class="govuk-body">When you arrive in England you must <a href="https://www.gov.uk/guidance/booking-and-staying-in-a-quarantine-hotel-when-you-arrive-in-england" class="govuk-link">quarantine in a managed hotel, and take 2 COVID-19 tests</a>.</p>
+
+  <p class="govuk-body">You must do this even if you are fully vaccinated.</p>
+<% end %>
+
+<%
+  data = {
+    title: "Returning to England after visiting a red list country",
+    reasons: ['You will be in a red list country within 10 days of returning to England'],
+    content: content
+  }
+%>
+
+<%= render partial: "travel_result_layout", locals: { data: data, calculator: calculator } %>

--- a/app/flows/covid_travel_abroad_flow/outcomes/_travel_result_layout.erb
+++ b/app/flows/covid_travel_abroad_flow/outcomes/_travel_result_layout.erb
@@ -1,0 +1,27 @@
+<div class="travel-abroad__heading">
+  <%= render "govuk_publishing_components/components/heading", {
+    text: data[:title],
+    font_size: "l",
+  } %>
+</div>
+
+<div class="govuk-grid-row travel-abroad__section">
+  <div class="govuk-grid-column-one-third travel-abroad__reasons">
+    <p class="govuk-body govuk-body-s">Because you said</p>
+    <ul class="govuk-list govuk-list--bullet govuk-body-s">
+      <% data[:reasons].each do |reason| %>
+        <li><%= reason %></li>
+      <% end %>
+      <% if calculator.travelling_with_children.include?("zero_to_four") %>
+        <li>You are travelling with someone aged 4 and under</li>
+      <% end %>
+      <% if calculator.travelling_with_children.include?("five_to_seventeen") %>
+        <li>You are travelling with someone aged 5 to 17</li>
+      <% end %>
+    </ul>
+  </div>
+
+  <div class="govuk-grid-column-two-thirds">
+    <%= data[:content] %>
+  </div>
+</div>

--- a/app/flows/covid_travel_abroad_flow/outcomes/results.erb
+++ b/app/flows/covid_travel_abroad_flow/outcomes/results.erb
@@ -34,4 +34,18 @@
       </div>
     </div>
   <% end %>
+    <% if calculator.vaccination_status == "none" %>
+      <%= render partial: "not_fully_vaxed", locals: { calculator: calculator } %>
+    <% else %>
+      <%= render partial: "fully_vaxed", locals: { calculator: calculator } %>
+    <% end %>
+
+    <% if calculator.travelling_with_children.include?("zero_to_four") %>
+      <%= render partial: "children_zero_to_four" %>
+    <% end %>
+
+    <% if calculator.travelling_with_children.include?("five_to_seventeen") %>
+      <%= render partial: "children_five_to_seventeen" %>
+    <% end %>
+
 <% end %>

--- a/app/flows/covid_travel_abroad_flow/outcomes/results.erb
+++ b/app/flows/covid_travel_abroad_flow/outcomes/results.erb
@@ -15,4 +15,23 @@
       font_size: "l",
     } %>
   </div>
+
+  <% calculator.country_locations.each do |country| %>
+    <div class="govuk-grid-row travel-abroad__country">
+      <div class="govuk-grid-column-one-third travel-abroad__reasons">
+        <p class="govuk-body govuk-body-s">Because you said</p>
+        <ul class="govuk-list govuk-list--bullet govuk-body-s">
+          <% if calculator.transit_countries.include?(country.slug) %>
+            <li>You are travelling through <%= country.title %></li>
+          <% else %>
+            <li>You are travelling to <%= country.title %></li>
+          <% end %>
+        </ul>
+      </div>
+
+      <div class="govuk-grid-column-two-thirds">
+        <%= render partial: "country", locals: { calculator: calculator, country: country } %>
+      </div>
+    </div>
+  <% end %>
 <% end %>

--- a/app/flows/covid_travel_abroad_flow/outcomes/results.erb
+++ b/app/flows/covid_travel_abroad_flow/outcomes/results.erb
@@ -1,3 +1,18 @@
-<% govspeak_for :body do %>
-Placeholder
+<% html_for :body do %>
+  <%= render "govuk_publishing_components/components/print_link" %>
+
+  <%= render "govuk_publishing_components/components/signup_link", {
+    heading: "What you need to do may change",
+    link_text: "Sign up for email updates about travel",
+    link_href: "/fix-me",
+    background: true,
+    margin_bottom: 8
+  } %>
+
+  <div class="travel-abroad__heading">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "Travelling abroad from England",
+      font_size: "l",
+    } %>
+  </div>
 <% end %>

--- a/app/flows/covid_travel_abroad_flow/outcomes/results.erb
+++ b/app/flows/covid_travel_abroad_flow/outcomes/results.erb
@@ -45,6 +45,9 @@
     <% if calculator.travelling_with_children.include?("five_to_seventeen") %>
       <%= render partial: "red_list_children_five_to_seventeen" %>
     <% end %>
+
+    <%= render partial: "exempt_medical" %>
+    <%= render partial: "exempt_compassionate" %>
   <% else %>
     <% if calculator.vaccination_status == "none" %>
       <%= render partial: "not_fully_vaxed", locals: { calculator: calculator } %>
@@ -60,5 +63,8 @@
       <%= render partial: "children_five_to_seventeen" %>
     <% end %>
 
+    <%= render partial: "exempt_job" %>
+    <%= render partial: "medical_treatment" %>
   <% end %>
+  <p class="govuk-body">There may be <a href="https://Jupiter1:Jupiter1@testhostingspace.com/travel-sbfgxq/" class="govuk-link">other things you need to do when travelling abroad</a>.</p>
 <% end %>

--- a/app/flows/covid_travel_abroad_flow/outcomes/results.erb
+++ b/app/flows/covid_travel_abroad_flow/outcomes/results.erb
@@ -1,0 +1,3 @@
+<% govspeak_for :body do %>
+Placeholder
+<% end %>

--- a/app/flows/covid_travel_abroad_flow/outcomes/results.erb
+++ b/app/flows/covid_travel_abroad_flow/outcomes/results.erb
@@ -34,6 +34,18 @@
       </div>
     </div>
   <% end %>
+
+  <% if calculator.travelling_to_red_list_country? %>
+    <%= render partial: "return_from_red_list", locals: { calculator: calculator } %>
+
+    <% if calculator.travelling_with_children.include?("zero_to_four") %>
+      <%= render partial: "red_list_children_zero_to_four" %>
+    <% end %>
+
+    <% if calculator.travelling_with_children.include?("five_to_seventeen") %>
+      <%= render partial: "red_list_children_five_to_seventeen" %>
+    <% end %>
+  <% else %>
     <% if calculator.vaccination_status == "none" %>
       <%= render partial: "not_fully_vaxed", locals: { calculator: calculator } %>
     <% else %>
@@ -48,4 +60,5 @@
       <%= render partial: "children_five_to_seventeen" %>
     <% end %>
 
+  <% end %>
 <% end %>

--- a/app/flows/covid_travel_abroad_flow/questions/any_other_countries.erb
+++ b/app/flows/covid_travel_abroad_flow/questions/any_other_countries.erb
@@ -1,0 +1,11 @@
+<% text_for :title do %>
+  Will you be going to any other countries?
+<% end %>
+
+<% govspeak_for :body do %>
+<% end %>
+
+<% options(
+  "yes": "Yes",
+  "no": "No",
+) %>

--- a/app/flows/covid_travel_abroad_flow/questions/going_to_countries_within_10_days.erb
+++ b/app/flows/covid_travel_abroad_flow/questions/going_to_countries_within_10_days.erb
@@ -1,0 +1,22 @@
+<% text_for :title do %>
+  Will you be going to any red list countries within 10 days before you return to England?
+<% end %>
+
+<% govspeak_for :body do %>
+  <%= render "govuk_publishing_components/components/details", {
+    title: "Why we're asking this question:"
+  } do %>
+    Different rules apply if you've been in a red list country within 10 days of returning to England.
+  <% end %>
+
+  These are the red list countries you said you're going to:
+
+ <% calculator.red_list_country_titles.each do |country| %>
+   - <%= country %>
+ <% end %>
+<% end %>
+
+<% options(
+  "yes": "Yes",
+  "no": "No",
+) %>

--- a/app/flows/covid_travel_abroad_flow/questions/transit_countries.erb
+++ b/app/flows/covid_travel_abroad_flow/questions/transit_countries.erb
@@ -1,0 +1,14 @@
+<% text_for :title do %>
+  Are you travelling through any of these countries on the way to your destination?
+<% end %>
+
+<% govspeak_for :body do %>
+<% end %>
+
+<% text_for :hint do %>
+  Select all that apply:
+<% end %>
+
+<% countries = calculator.transit_country_options.dup %>
+<% countries[:none] = "No" %>
+<%= options(countries) %>

--- a/app/flows/covid_travel_abroad_flow/questions/travelling_with_children.erb
+++ b/app/flows/covid_travel_abroad_flow/questions/travelling_with_children.erb
@@ -1,0 +1,16 @@
+<% text_for :title do %>
+  Are you travelling with anyone aged 17 or under?
+<% end %>
+
+<% govspeak_for :body do %>
+<% end %>
+
+<% text_for :hint do %>
+  Select all that apply:
+<% end %>
+
+<% options(
+  "zero_to_four": "Yes, aged 0 to 4",
+  "five_to_seventeen": "Yes, aged 5 to 17",
+  "none": "No",
+) %>

--- a/app/flows/covid_travel_abroad_flow/questions/vaccination_status.erb
+++ b/app/flows/covid_travel_abroad_flow/questions/vaccination_status.erb
@@ -1,0 +1,18 @@
+<% text_for :title do %>
+  Vaccination status
+<% end %>
+
+<% govspeak_for :body do %>
+  <a href="https://www.gov.uk/guidance/countries-with-approved-covid-19-vaccination-programmes-and-proof-of-vaccination#approved-vaccines">Approved COVID-19 vaccine programmes</a>
+<% end %>
+
+<% text_for :hint do %>
+  Select one of the following options:
+<% end %>
+
+<% options(
+  "vaccinated": "I had my second dose of an approved COVID-19 vaccine 14 or more days ago",
+  "in_trial": "I'm taking part in an approved COVID-19 vaccine trial in the UK",
+  "exempt": "I cannot have a COVID-19 vaccination for a medical reason approved by a clinician",
+  "none": "None of the above",
+) %>

--- a/app/flows/covid_travel_abroad_flow/questions/which_country.erb
+++ b/app/flows/covid_travel_abroad_flow/questions/which_country.erb
@@ -1,3 +1,12 @@
 <% text_for :title do %>
+  <% calculator ||= nil %>
+  <% if calculator && calculator.countries.count >= 1 %>
+    Which other countries will you be going to?
+  <% else %>
     Which countries will you be going to?
+  <% end %>
+<% end %>
+
+<% text_for :error_message do %>
+  You've already selected this country
 <% end %>

--- a/app/flows/covid_travel_abroad_flow/questions/which_country.erb
+++ b/app/flows/covid_travel_abroad_flow/questions/which_country.erb
@@ -1,0 +1,3 @@
+<% text_for :title do %>
+    Which countries will you be going to?
+<% end %>

--- a/app/flows/covid_travel_abroad_flow/start.erb
+++ b/app/flows/covid_travel_abroad_flow/start.erb
@@ -1,0 +1,37 @@
+<% text_for :title do %>
+  Travelling from and to England during coronavirus (COVID-19): check what you need to do
+<% end %>
+
+<% govspeak_for :body do %>
+  <p>If you're a British citizen travelling from and to England during coronavirus (COVID-19), there are things you need to do before you travel and after you arrive.</p>
+
+  <p>Use this tool to find out:</p>
+
+  <ul>
+    <li>entry requirements for the country you're going to or travelling through</li>
+    <li>what tests you need to take and when</li>
+    <li>when you need to quarantine</li>
+    <li>what you need to do to travel with children</li>
+    <li>what you need to do before and after you travel to England</li>
+    <li>whether you're exempt from any rules</li>
+  </ul>
+<% end %>
+
+<% govspeak_for :post_body do %>
+  <%= render "govuk_publishing_components/components/heading", {
+    text: "If you're travelling within the UK, Channel Islands and the Isle of Man",
+    font_size: "m",
+    margin_bottom: 4,
+  } %>
+
+  <p>Check the rules on travel from England if you're travelling to:</p>
+
+  <ul class="govuk-list govuk-list--bullet">
+    <li><a href="https://www.nidirect.gov.uk/articles/coronavirus-covid-19-international-travel-advice">Northern Ireland</a></li>
+    <li><a href="https://www.gov.scot/publications/coronavirus-covid-19-guidance-on-travel-and-transport">Scotland</a></li>
+    <li><a href="https://gov.wales/foreign-travel-and-returning-home">Wales</a></li>
+    <li><a href="https://covid19.gov.im/travel/travel-to-the-isle-of-man">the Isle of Man</a></li>
+    <li>the Channel Islands (<a href="https://www.gov.je/Health/Coronavirus/Travel/Pages/CoronavirusTravelAdvice.aspx">Jersey</a> and <a href="https://covid19.gov.gg/guidance/travel">Guernsey</a>)</li>
+  </ul>
+  <p>If you're travelling to England from within the UK, Ireland, the Channel Islands or the Isle of Man and haven't been anywhere else within the 10 days before you arrive, there are no entry requirements for coming into England.</p>
+<% end %>

--- a/app/models/world_location.rb
+++ b/app/models/world_location.rb
@@ -62,6 +62,21 @@ class WorldLocation
     value
   end
 
+  def self.travel_rules
+    @travel_rules ||= YAML.load_file(Rails.root.join("config/smart_answers/covid_travel_abroad_data.yml"))
+  end
+
+  def covid_status
+    # Once the world location api returns the covid status, we should be able
+    # to replace this line with:
+    # location.fetch("england_coronavirus_travel", "")
+    rules = self.class.travel_rules["results"].select { |country| country["details"]["slug"] == slug }.first
+
+    return if rules.blank?
+
+    rules["england_coronavirus_travel"]["covid_status"]
+  end
+
   def initialize(location)
     @title = location.fetch("title", "")
     @details = location.fetch("details", {})

--- a/app/views/smart_answers/custom_result_full_width.erb
+++ b/app/views/smart_answers/custom_result_full_width.erb
@@ -1,0 +1,39 @@
+<% outcome = @presenter.current_node %>
+<% content_for :outcome_title do %>
+  <% if outcome.title.present? %><%= outcome.title %><% else %>Outcome<% end %>
+<% end %>
+<% content_for :head do %>
+  <meta name="robots" content="noindex">
+<% end %>
+
+<div id="result-info" class="outcome">
+  <%= render 'smart_answers/shared/debug' %>
+  <%= render "govuk_publishing_components/components/title", {
+    title: "Information based on your answers",
+    context: @presenter.title + ":",
+    context_inside: true,
+  } %>
+
+  <div class="govuk-!-margin-bottom-6" data-module="track-results" data-flow-name="<%= @name %>">
+    <% if outcome.title.present? %>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: outcome.title,
+        margin_bottom: 6
+      } %>
+    <% end %>
+
+    <%= outcome.body %>
+  </div>
+
+  <% if outcome.next_steps.present? %>
+    <div class="govuk-!-margin-bottom-6">
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "Next steps",
+        margin_bottom: 6
+      } %>
+      <%= outcome.next_steps %>
+    </div>
+  <% end %>
+
+  <%= render 'smart_answers/shared/previous_answers' %>
+</div>

--- a/config/smart_answers/covid_travel_abroad_data.yml
+++ b/config/smart_answers/covid_travel_abroad_data.yml
@@ -1,0 +1,18 @@
+---
+results:
+  - title: Italy
+    details:
+      slug: italy
+    england_coronavirus_travel:
+      covid_status: green
+      next_covid_status:
+      next_covid_status_applies_at:
+      status_out_of_date: false
+  - title: South Africa
+    details:
+      slug: south-africa
+    england_coronavirus_travel:
+      covid_status: red
+      next_covid_status:
+      next_covid_status_applies_at:
+      status_out_of_date: false

--- a/lib/smart_answer/calculators/covid_travel_abroad_calculator.rb
+++ b/lib/smart_answer/calculators/covid_travel_abroad_calculator.rb
@@ -42,6 +42,10 @@ module SmartAnswer::Calculators
       transit_country_options
     end
 
+    def travelling_to_red_list_country?
+      going_to_countries_within_10_days == "yes"
+    end
+
     def red_list_country_titles
       red_list_countries.map do |country|
         location(country).title

--- a/lib/smart_answer/calculators/covid_travel_abroad_calculator.rb
+++ b/lib/smart_answer/calculators/covid_travel_abroad_calculator.rb
@@ -56,5 +56,9 @@ module SmartAnswer::Calculators
       world_location = location(slug)
       world_location.covid_status == "red"
     end
+
+    def countries_with_content_headers_converted
+      %w[denmark spain]
+    end
   end
 end

--- a/lib/smart_answer/calculators/covid_travel_abroad_calculator.rb
+++ b/lib/smart_answer/calculators/covid_travel_abroad_calculator.rb
@@ -1,7 +1,7 @@
 module SmartAnswer::Calculators
   class CovidTravelAbroadCalculator
     attr_reader :transit_countries, :travelling_with_children
-    attr_accessor :countries, :vaccination_status, :any_other_countries
+    attr_accessor :countries, :vaccination_status, :any_other_countries, :going_to_countries_within_10_days
 
     MAX_COUNTRIES = 99
 
@@ -34,6 +34,21 @@ module SmartAnswer::Calculators
       end
 
       transit_country_options
+    end
+
+    def red_list_country_titles
+      red_list_countries.map do |country|
+        location(country).title
+      end
+    end
+
+    def red_list_countries
+      countries.map { |country| country if red_list_country?(country) }.compact
+    end
+
+    def red_list_country?(slug)
+      world_location = location(slug)
+      world_location.covid_status == "red"
     end
   end
 end

--- a/lib/smart_answer/calculators/covid_travel_abroad_calculator.rb
+++ b/lib/smart_answer/calculators/covid_travel_abroad_calculator.rb
@@ -1,7 +1,9 @@
 module SmartAnswer::Calculators
   class CovidTravelAbroadCalculator
     attr_reader :travelling_with_children
-    attr_accessor :countries, :vaccination_status
+    attr_accessor :countries, :vaccination_status, :any_other_countries
+
+    MAX_COUNTRIES = 99
 
     def initialize
       @countries = []

--- a/lib/smart_answer/calculators/covid_travel_abroad_calculator.rb
+++ b/lib/smart_answer/calculators/covid_travel_abroad_calculator.rb
@@ -1,6 +1,7 @@
 module SmartAnswer::Calculators
   class CovidTravelAbroadCalculator
     attr_reader :travelling_with_children
+    attr_accessor :vaccination_status
 
     def initialize
       @travelling_with_children = []

--- a/lib/smart_answer/calculators/covid_travel_abroad_calculator.rb
+++ b/lib/smart_answer/calculators/covid_travel_abroad_calculator.rb
@@ -1,0 +1,15 @@
+module SmartAnswer::Calculators
+  class CovidTravelAbroadCalculator
+    attr_reader :travelling_with_children
+
+    def initialize
+      @travelling_with_children = []
+    end
+
+    def travelling_with_children=(travelling_with_children)
+      travelling_with_children.split(",").each do |response|
+        @travelling_with_children << response
+      end
+    end
+  end
+end

--- a/lib/smart_answer/calculators/covid_travel_abroad_calculator.rb
+++ b/lib/smart_answer/calculators/covid_travel_abroad_calculator.rb
@@ -1,9 +1,10 @@
 module SmartAnswer::Calculators
   class CovidTravelAbroadCalculator
     attr_reader :travelling_with_children
-    attr_accessor :vaccination_status
+    attr_accessor :countries, :vaccination_status
 
     def initialize
+      @countries = []
       @travelling_with_children = []
     end
 

--- a/lib/smart_answer/calculators/covid_travel_abroad_calculator.rb
+++ b/lib/smart_answer/calculators/covid_travel_abroad_calculator.rb
@@ -15,6 +15,12 @@ module SmartAnswer::Calculators
       WorldLocation.find(slug)
     end
 
+    def country_locations
+      countries.map do |country|
+        location(country)
+      end
+    end
+
     def travelling_with_children=(travelling_with_children)
       travelling_with_children.split(",").each do |response|
         @travelling_with_children << response

--- a/lib/smart_answer/calculators/covid_travel_abroad_calculator.rb
+++ b/lib/smart_answer/calculators/covid_travel_abroad_calculator.rb
@@ -10,6 +10,10 @@ module SmartAnswer::Calculators
       @travelling_with_children = []
     end
 
+    def location(slug)
+      WorldLocation.find(slug)
+    end
+
     def travelling_with_children=(travelling_with_children)
       travelling_with_children.split(",").each do |response|
         @travelling_with_children << response

--- a/lib/smart_answer/calculators/covid_travel_abroad_calculator.rb
+++ b/lib/smart_answer/calculators/covid_travel_abroad_calculator.rb
@@ -1,12 +1,13 @@
 module SmartAnswer::Calculators
   class CovidTravelAbroadCalculator
-    attr_reader :travelling_with_children
+    attr_reader :transit_countries, :travelling_with_children
     attr_accessor :countries, :vaccination_status, :any_other_countries
 
     MAX_COUNTRIES = 99
 
     def initialize
       @countries = []
+      @transit_countries = []
       @travelling_with_children = []
     end
 
@@ -18,6 +19,21 @@ module SmartAnswer::Calculators
       travelling_with_children.split(",").each do |response|
         @travelling_with_children << response
       end
+    end
+
+    def transit_countries=(transit_countries)
+      transit_countries.split(",").each do |country|
+        @transit_countries << country
+      end
+    end
+
+    def transit_country_options
+      transit_country_options = {}
+      countries.map do |country|
+        transit_country_options[country] = location(country).title
+      end
+
+      transit_country_options
     end
   end
 end

--- a/test/flows/covid_travel_abroad_flow_test.rb
+++ b/test/flows/covid_travel_abroad_flow_test.rb
@@ -293,6 +293,16 @@ class CovidTravelAbroadFlowTest < ActiveSupport::TestCase
         add_responses travelling_with_children: "five_to_seventeen"
         assert_rendered_outcome text: "Returning to England with young people aged 5 to 17"
       end
+
+      should "render the exempt medical guidance" do
+        assert_rendered_outcome text: "Exemptions for medical reasons"
+      end
+
+      should "render the exempt compassionate guidance" do
+        assert_rendered_outcome text: "Exemptions for compassionate reasons"
+      end
+    end
+
     context "content without a red list country" do
       setup do
         add_responses which_country: "spain",
@@ -320,6 +330,14 @@ class CovidTravelAbroadFlowTest < ActiveSupport::TestCase
       should "render travelling with children five to seventeen guidance when user is travelling with children" do
         add_responses travelling_with_children: "five_to_seventeen"
         assert_rendered_outcome text: "Returning to England with young people aged 5 to 17"
+      end
+
+      should "render the exempt jobs guidance" do
+        assert_rendered_outcome text: "Exemptions because of your job"
+      end
+
+      should "render the arriving for urgent medical treatment guidance" do
+        assert_rendered_outcome text: "Returning to England to receive urgent medical treatment"
       end
     end
   end

--- a/test/flows/covid_travel_abroad_flow_test.rb
+++ b/test/flows/covid_travel_abroad_flow_test.rb
@@ -270,6 +270,29 @@ class CovidTravelAbroadFlowTest < ActiveSupport::TestCase
       end
     end
 
+    context "content with a red list country" do
+      setup do
+        add_responses which_country: "spain",
+                      any_other_countries_1: "no",
+                      going_to_countries_within_10_days: "yes",
+                      vaccination_status: "vaccinated",
+                      travelling_with_children: "none"
+        SmartAnswer::Calculators::CovidTravelAbroadCalculator.any_instance.stubs(:red_list_countries).returns(%w[spain])
+      end
+
+      should "render red list country guidance" do
+        assert_rendered_outcome text: "Returning to England after visiting a red list country"
+      end
+
+      should "render travelling with children zero to four guidance when user is travelling with children" do
+        add_responses travelling_with_children: "zero_to_four"
+        assert_rendered_outcome text: "Returning to England with children aged 4 and under"
+      end
+
+      should "render travelling with children five to seventeen guidance when user is travelling with children" do
+        add_responses travelling_with_children: "five_to_seventeen"
+        assert_rendered_outcome text: "Returning to England with young people aged 5 to 17"
+      end
     context "content without a red list country" do
       setup do
         add_responses which_country: "spain",

--- a/test/flows/covid_travel_abroad_flow_test.rb
+++ b/test/flows/covid_travel_abroad_flow_test.rb
@@ -25,7 +25,61 @@ class CovidTravelAbroadFlowTest < ActiveSupport::TestCase
     context "next_node" do
       should "have a next node of any_other_countries_1 " \
                 "for any response " do
-        assert_next_node :vaccination_status, for_response: "spain"
+        assert_next_node :any_other_countries_1, for_response: "spain"
+      end
+    end
+  end
+
+  context "question: any_other_countries_1" do
+    setup do
+      testing_node :any_other_countries_1
+      add_responses which_country: "spain"
+    end
+
+    should "render question" do
+      assert_rendered_question
+    end
+
+    context "next_node" do
+      should "have a next node of vaccination_status " \
+                "for a 'no' response " \
+                "when which country is 'spain' " do
+        assert_next_node :vaccination_status, for_response: "no"
+      end
+
+      should "have a next node of which_1_country " \
+                "for a 'yes' response " \
+                "when which country is 'spain' " do
+        assert_next_node :which_1_country, for_response: "yes"
+      end
+    end
+  end
+
+  context "question: which_1_country" do
+    setup do
+      testing_node :which_1_country
+      add_responses which_country: "spain",
+                    any_other_countries_1: "yes"
+    end
+
+    should "render question" do
+      assert_rendered_question
+    end
+
+    context "validations" do
+      should "be invalid for a country that has already been chosen" do
+        assert_invalid_response "spain"
+      end
+
+      should "be valid for a country that has not already been chosen" do
+        assert_valid_response "italy"
+      end
+    end
+
+    context "next_node" do
+      should "have a next node of any_other_countries_2 " \
+                "for any response " do
+        assert_next_node :any_other_countries_2, for_response: "italy"
       end
     end
   end
@@ -33,7 +87,8 @@ class CovidTravelAbroadFlowTest < ActiveSupport::TestCase
   context "question: vaccination_status" do
     setup do
       testing_node :vaccination_status
-      add_responses which_country: "spain"
+      add_responses which_country: "spain",
+                    any_other_countries_1: "no"
     end
 
     should "render question" do
@@ -52,6 +107,7 @@ class CovidTravelAbroadFlowTest < ActiveSupport::TestCase
     setup do
       testing_node :travelling_with_children
       add_responses which_country: "spain",
+                    any_other_countries_1: "no",
                     vaccination_status: "vaccinated"
     end
 

--- a/test/flows/covid_travel_abroad_flow_test.rb
+++ b/test/flows/covid_travel_abroad_flow_test.rb
@@ -269,6 +269,35 @@ class CovidTravelAbroadFlowTest < ActiveSupport::TestCase
         assert_rendered_outcome text: "You should read the Poland entry requirements"
       end
     end
+
+    context "content without a red list country" do
+      setup do
+        add_responses which_country: "spain",
+                      any_other_countries_1: "no",
+                      transit_countries: "none",
+                      going_to_countries_within_10_days: "no",
+                      vaccination_status: "vaccinated",
+                      travelling_with_children: "none"
+      end
+
+      should "render vaccinated guidance when user is fully vaccinated" do
+        assert_rendered_outcome text: "Returning to England if you're fully vaccinated"
+      end
+
+      should "render unvaccinated guidance when user is not fully vaccinated" do
+        add_responses vaccination_status: "none"
+        assert_rendered_outcome text: "Returning to England if you're not fully vaccinated"
+      end
+
+      should "render travelling with children zero to four guidance when user is travelling with children" do
+        add_responses travelling_with_children: "zero_to_four"
+        assert_rendered_outcome text: "Returning to England with children aged 4 and under"
+      end
+
+      should "render travelling with children five to seventeen guidance when user is travelling with children" do
+        add_responses travelling_with_children: "five_to_seventeen"
+        assert_rendered_outcome text: "Returning to England with young people aged 5 to 17"
+      end
     end
   end
 end

--- a/test/flows/covid_travel_abroad_flow_test.rb
+++ b/test/flows/covid_travel_abroad_flow_test.rb
@@ -11,10 +11,28 @@ class CovidTravelAbroadFlowTest < ActiveSupport::TestCase
   should "render start page" do
     assert_rendered_start_page
   end
-  
+
+  context "question: vaccination_status" do
+    setup do
+      testing_node :vaccination_status
+    end
+
+    should "render question" do
+      assert_rendered_question
+    end
+
+    context "next_node" do
+      should "have a next node of travelling_with_children " \
+                "for any response " do
+        assert_next_node :travelling_with_children, for_response: "vaccinated"
+      end
+    end
+  end
+
   context "question: travelling_with_children" do
     setup do
       testing_node :travelling_with_children
+      add_responses vaccination_status: "vaccinated"
     end
 
     should "render question" do

--- a/test/flows/covid_travel_abroad_flow_test.rb
+++ b/test/flows/covid_travel_abroad_flow_test.rb
@@ -52,6 +52,15 @@ class CovidTravelAbroadFlowTest < ActiveSupport::TestCase
                 "when which country is 'spain' " do
         assert_next_node :which_1_country, for_response: "yes"
       end
+
+      should "have a next node of transit_countries " \
+               "for a 'no' response " \
+               "when more than one country has been selected " do
+        add_responses which_country: "spain",
+                      any_other_countries_1: "yes",
+                      which_1_country: "italy"
+        assert_next_node :transit_countries, for_response: "no"
+      end
     end
   end
 
@@ -80,6 +89,34 @@ class CovidTravelAbroadFlowTest < ActiveSupport::TestCase
       should "have a next node of any_other_countries_2 " \
                 "for any response " do
         assert_next_node :any_other_countries_2, for_response: "italy"
+      end
+    end
+  end
+
+  context "question: transit_countries" do
+    setup do
+      testing_node :transit_countries
+      add_responses which_country: "spain",
+                    any_other_countries_1: "yes",
+                    which_1_country: "italy",
+                    any_other_countries_2: "no"
+    end
+
+    should "render question" do
+      assert_rendered_question
+    end
+
+    context "next_node" do
+      should "have a next node of vaccination_status " \
+                "for a 'none' response " \
+                "if not travelling to a red list country" do
+        assert_next_node :vaccination_status, for_response: "none"
+      end
+
+      should "have a next node of vaccination_status " \
+                "for a country response " \
+                "if not travelling to a red list country" do
+        assert_next_node :vaccination_status, for_response: "spain"
       end
     end
   end

--- a/test/flows/covid_travel_abroad_flow_test.rb
+++ b/test/flows/covid_travel_abroad_flow_test.rb
@@ -7,4 +7,8 @@ class CovidTravelAbroadFlowTest < ActiveSupport::TestCase
   setup do
     testing_flow CovidTravelAbroadFlow
   end
+
+  should "render start page" do
+    assert_rendered_start_page
+  end
 end

--- a/test/flows/covid_travel_abroad_flow_test.rb
+++ b/test/flows/covid_travel_abroad_flow_test.rb
@@ -1,0 +1,10 @@
+require "test_helper"
+require "support/flow_test_helper"
+
+class CovidTravelAbroadFlowTest < ActiveSupport::TestCase
+  include FlowTestHelper
+
+  setup do
+    testing_flow CovidTravelAbroadFlow
+  end
+end

--- a/test/flows/covid_travel_abroad_flow_test.rb
+++ b/test/flows/covid_travel_abroad_flow_test.rb
@@ -11,4 +11,21 @@ class CovidTravelAbroadFlowTest < ActiveSupport::TestCase
   should "render start page" do
     assert_rendered_start_page
   end
+  
+  context "question: travelling_with_children" do
+    setup do
+      testing_node :travelling_with_children
+    end
+
+    should "render question" do
+      assert_rendered_question
+    end
+
+    context "next_node" do
+      should "have a next node of results " \
+                "for any response " do
+        assert_next_node :results, for_response: "zero_to_four"
+      end
+    end
+  end
 end

--- a/test/flows/covid_travel_abroad_flow_test.rb
+++ b/test/flows/covid_travel_abroad_flow_test.rb
@@ -6,15 +6,34 @@ class CovidTravelAbroadFlowTest < ActiveSupport::TestCase
 
   setup do
     testing_flow CovidTravelAbroadFlow
+    stub_worldwide_api_has_locations(%w[spain italy poland])
   end
 
   should "render start page" do
     assert_rendered_start_page
   end
 
+  context "question: which_country" do
+    setup do
+      testing_node :which_country
+    end
+
+    should "render question" do
+      assert_rendered_question
+    end
+
+    context "next_node" do
+      should "have a next node of any_other_countries_1 " \
+                "for any response " do
+        assert_next_node :vaccination_status, for_response: "spain"
+      end
+    end
+  end
+
   context "question: vaccination_status" do
     setup do
       testing_node :vaccination_status
+      add_responses which_country: "spain"
     end
 
     should "render question" do
@@ -32,7 +51,8 @@ class CovidTravelAbroadFlowTest < ActiveSupport::TestCase
   context "question: travelling_with_children" do
     setup do
       testing_node :travelling_with_children
-      add_responses vaccination_status: "vaccinated"
+      add_responses which_country: "spain",
+                    vaccination_status: "vaccinated"
     end
 
     should "render question" do

--- a/test/flows/covid_travel_abroad_flow_test.rb
+++ b/test/flows/covid_travel_abroad_flow_test.rb
@@ -113,10 +113,47 @@ class CovidTravelAbroadFlowTest < ActiveSupport::TestCase
         assert_next_node :vaccination_status, for_response: "none"
       end
 
+      should "have a next node of going_to_countries_within_10_days " \
+                "for a 'none' response " \
+                "if travelling to a red list country" do
+        SmartAnswer::Calculators::CovidTravelAbroadCalculator.any_instance.stubs(:red_list_countries).returns(%w[spain])
+        assert_next_node :going_to_countries_within_10_days, for_response: "none"
+      end
+
       should "have a next node of vaccination_status " \
                 "for a country response " \
                 "if not travelling to a red list country" do
         assert_next_node :vaccination_status, for_response: "spain"
+      end
+
+      should "have a next node of going_to_countries_within_10_days " \
+                "for a country response " \
+                "if travelling to a red list country" do
+        SmartAnswer::Calculators::CovidTravelAbroadCalculator.any_instance.stubs(:red_list_countries).returns(%w[spain])
+        assert_next_node :going_to_countries_within_10_days, for_response: "spain"
+      end
+    end
+  end
+
+  context "question: going_to_countries_within_10_days" do
+    setup do
+      testing_node :going_to_countries_within_10_days
+      add_responses which_country: "spain",
+                    any_other_countries_1: "yes",
+                    which_1_country: "poland",
+                    any_other_countries_2: "no",
+                    transit_countries: "none"
+      SmartAnswer::Calculators::CovidTravelAbroadCalculator.any_instance.stubs(:red_list_countries).returns(%w[spain])
+    end
+
+    should "render question" do
+      assert_rendered_question
+    end
+
+    context "next_node" do
+      should "have a next node of vaccination_status " \
+                "for any response " do
+        assert_next_node :vaccination_status, for_response: "no"
       end
     end
   end

--- a/test/unit/calculators/covid_travel_abroad_calculator_test.rb
+++ b/test/unit/calculators/covid_travel_abroad_calculator_test.rb
@@ -84,5 +84,19 @@ module SmartAnswer::Calculators
         assert_equal %w[Spain Italy], @calculator.red_list_country_titles
       end
     end
+
+    context "travelling_to_red_list_country?" do
+      should "return true if going to any country on the red list" do
+        @calculator.going_to_countries_within_10_days = "yes"
+
+        assert @calculator.travelling_to_red_list_country?
+      end
+
+      should "return false if not going to any country on the red list" do
+        @calculator.going_to_countries_within_10_days = "no"
+
+        assert_not @calculator.travelling_to_red_list_country?
+      end
+    end
   end
 end

--- a/test/unit/calculators/covid_travel_abroad_calculator_test.rb
+++ b/test/unit/calculators/covid_travel_abroad_calculator_test.rb
@@ -4,6 +4,16 @@ module SmartAnswer::Calculators
   class CovidTravelAbroadCalculatorTest < ActiveSupport::TestCase
     setup do
       @calculator = CovidTravelAbroadCalculator.new
+
+      stub_worldwide_api_has_locations(%w[spain italy poland])
+    end
+
+    context "location" do
+      should "find a country if it exists" do
+        country = @calculator.location("spain")
+
+        assert_equal "spain", country.slug
+      end
     end
 
     context "travelling_with_children=" do

--- a/test/unit/calculators/covid_travel_abroad_calculator_test.rb
+++ b/test/unit/calculators/covid_travel_abroad_calculator_test.rb
@@ -30,5 +30,35 @@ module SmartAnswer::Calculators
       end
     end
 
+    context "transit_countries=" do
+      should "add a single country" do
+        @calculator.transit_countries = "spain"
+
+        assert_equal %w[spain], @calculator.transit_countries
+      end
+
+      should "add more than one country" do
+        @calculator.transit_countries = "spain,italy"
+
+        assert_equal %w[spain italy], @calculator.transit_countries
+      end
+    end
+
+    context "transit_country_options" do
+      should "add a single country" do
+        @calculator.countries = %w[spain]
+        expected = { spain: "Spain" }
+
+        assert_equal expected.with_indifferent_access, @calculator.transit_country_options
+      end
+
+      should "add more than one country" do
+        @calculator.countries = %w[spain italy]
+        expected = { spain: "Spain", italy: "Italy" }
+
+        assert_equal expected.with_indifferent_access, @calculator.transit_country_options
+      end
+    end
+
   end
 end

--- a/test/unit/calculators/covid_travel_abroad_calculator_test.rb
+++ b/test/unit/calculators/covid_travel_abroad_calculator_test.rb
@@ -16,6 +16,15 @@ module SmartAnswer::Calculators
       end
     end
 
+    context "country_locations" do
+      should "find a country if it exists" do
+        @calculator.countries << "spain"
+        country = @calculator.location("spain")
+
+        assert_equal [country], @calculator.country_locations
+      end
+    end
+
     context "travelling_with_children=" do
       should "add a single response" do
         @calculator.travelling_with_children = "zero_to_four"

--- a/test/unit/calculators/covid_travel_abroad_calculator_test.rb
+++ b/test/unit/calculators/covid_travel_abroad_calculator_test.rb
@@ -1,0 +1,24 @@
+require_relative "../../test_helper"
+
+module SmartAnswer::Calculators
+  class CovidTravelAbroadCalculatorTest < ActiveSupport::TestCase
+    setup do
+      @calculator = CovidTravelAbroadCalculator.new
+    end
+
+    context "travelling_with_children=" do
+      should "add a single response" do
+        @calculator.travelling_with_children = "zero_to_four"
+
+        assert_equal %w[zero_to_four], @calculator.travelling_with_children
+      end
+
+      should "add more than one response" do
+        @calculator.travelling_with_children = "zero_to_four,five_to_seventeen"
+
+        assert_equal %w[zero_to_four five_to_seventeen], @calculator.travelling_with_children
+      end
+    end
+
+  end
+end

--- a/test/unit/calculators/covid_travel_abroad_calculator_test.rb
+++ b/test/unit/calculators/covid_travel_abroad_calculator_test.rb
@@ -60,5 +60,20 @@ module SmartAnswer::Calculators
       end
     end
 
+    context "red_list_country_titles" do
+      should "add a single country" do
+        @calculator.countries = %w[spain]
+        @calculator.stubs(:red_list_countries).returns(%w[spain])
+
+        assert_equal %w[Spain], @calculator.red_list_country_titles
+      end
+
+      should "add more than one country" do
+        @calculator.countries = %w[spain italy poland]
+        @calculator.stubs(:red_list_countries).returns(%w[spain italy])
+
+        assert_equal %w[Spain Italy], @calculator.red_list_country_titles
+      end
+    end
   end
 end

--- a/test/unit/world_location_test.rb
+++ b/test/unit/world_location_test.rb
@@ -272,4 +272,28 @@ class WorldLocationTest < ActiveSupport::TestCase
       end
     end
   end
+
+  context "england_coronavirus_travel" do
+    setup do
+      stub_worldwide_api_has_location("italy")
+      WorldLocation.stubs(:travel_rules).returns({
+        "results" => [
+          {
+            "title" => "Italy",
+            "details" => {
+              "slug" => "italy",
+            },
+            "england_coronavirus_travel" => {
+              "covid_status" => "red",
+            },
+          },
+        ],
+      })
+      @location = WorldLocation.find("italy")
+    end
+
+    should "find the covid status for a location" do
+      assert_equal "red", @location.covid_status
+    end
+  end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/uOaSZemK
Makes the code added in  https://github.com/alphagov/smart-answers/pull/5674 production-ready.

# What's changed?

Creates a new smart-answer to help users find the travel rules that pertain to their trip.

The results page links users to specific content for each country on the FCDO foreign travel advice pages as well as displaying rules for returning to England.

The "returning to England" rules will pulled from the WorldLocation API before this smart-answer is published. Until then, a YAML file has been added to the config so that the appropriate methods can be added to the WorldLocation model.

The url of the smart-answer is a placeholder. The content designers want the url to match the title of the smart-answer and that hasn't been decided yet. Once the title and slug are decided, the flow classes and files will need to be renamed to match.

# Why?
The rules for travelling abroad are very complicated. User research has shown that allowing users to customise the content makes it slightly easier to find the rules that apply to their journey.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
