### PR TITLE
Remove question from benefits abroad question

### DIFF
--- a/app/flows/uk_benefits_abroad_flow.rb
+++ b/app/flows/uk_benefits_abroad_flow.rb
@@ -146,7 +146,7 @@ class UkBenefitsAbroadFlow < SmartAnswer::Flow
           end
         when "disability_benefits"
           if calculator.eea_country?
-            question :db_claiming_benefits? # Q30 going_abroad and Q29 already_abroad
+            question :worked_in_eea_or_switzerland?
           elsif calculator.going_abroad
             outcome :db_going_abroad_other_outcome # A36 going_abroad
           else
@@ -400,42 +400,6 @@ class UkBenefitsAbroadFlow < SmartAnswer::Flow
           question :which_country? # Shared question
         when "no"
           outcome :iidb_maybe_outcome # A30 already_abroad and A31 going_abroad
-        end
-      end
-    end
-
-    # Q30 going_abroad and Q29 already_abroad
-    radio :db_claiming_benefits? do
-      option :yes
-      option :no
-
-      next_node do |response|
-        if calculator.going_abroad
-          if response == "yes"
-            case calculator.country
-            when "ireland"
-              question :is_british_or_irish?
-            when "gibraltar"
-              outcome :db_going_abroad_gibraltar_outcome
-            else
-              question :worked_in_eea_or_switzerland? # A37 going_abroad
-            end
-          else
-            outcome :db_going_abroad_other_outcome # A36 going_abroad
-          end
-        elsif calculator.already_abroad
-          if response == "yes"
-            case calculator.country
-            when "ireland"
-              question :is_british_or_irish?
-            when "gibraltar"
-              outcome :db_already_abroad_gibraltar_outcome
-            else
-              question :worked_in_eea_or_switzerland? # A37 going_abroad
-            end
-          else
-            outcome :db_already_abroad_other_outcome # A35 already_abroad
-          end
         end
       end
     end
@@ -742,8 +706,6 @@ class UkBenefitsAbroadFlow < SmartAnswer::Flow
     outcome :db_already_abroad_temporary_outcome # A34 already_abroad
     outcome :db_already_abroad_other_outcome # A35 already_abroad
     outcome :db_already_abroad_eea_outcome # A36 already_abroad
-    outcome :db_already_abroad_gibraltar_outcome
-    outcome :db_going_abroad_gibraltar_outcome
     outcome :bb_already_abroad_eea_outcome # A37 already_abroad
     outcome :bb_already_abroad_ss_outcome  # A38 already_abroad
     outcome :bb_already_abroad_other_outcome # A39 already_abroad

--- a/app/flows/uk_benefits_abroad_flow/outcomes/db_already_abroad_gibraltar_outcome.erb
+++ b/app/flows/uk_benefits_abroad_flow/outcomes/db_already_abroad_gibraltar_outcome.erb
@@ -1,7 +1,0 @@
-<% govspeak_for :body do %>
-  You might be able to carry on getting [Attendance Allowance](/attendance-allowance), [Carer's Allowance](/carers-allowance), [PIP](/pip) (daily living component) or Disability Living Allowance (care component).
-
-  You can only get Carer’s Allowance if the person you care for gets a qualifying benefit.
-
-  Tell the [Exportability Team](/exportability-team) at the Pension, Disability and Carers Service that you’re moving abroad.
-<% end %>

--- a/app/flows/uk_benefits_abroad_flow/outcomes/db_going_abroad_gibraltar_outcome.erb
+++ b/app/flows/uk_benefits_abroad_flow/outcomes/db_going_abroad_gibraltar_outcome.erb
@@ -1,7 +1,0 @@
-<% govspeak_for :body do %>
-  You might be able to carry on getting Attendance Allowance](/attendance-allowance), [Carer's Allowance](/carers-allowance), [PIP](/pip) (daily living component) or Disability Living Allowance (care component).
-
-  You can only get Carer’s Allowance if the person you care for gets a qualifying benefit.
-
-  Tell the [Exportability Team](/exportability-team) at the Pension, Disability and Carers Service that you’re moving abroad.
-<% end %>

--- a/test/flows/uk_benefits_abroad_flow_test.rb
+++ b/test/flows/uk_benefits_abroad_flow_test.rb
@@ -249,8 +249,8 @@ class UkBenefitsAbroadFlowTest < ActiveSupport::TestCase
                           db_how_long_abroad?: "permanent"
           end
 
-          should "have a next node of db_claiming_benefits? for any response in EEA country" do
-            assert_next_node :db_claiming_benefits?, for_response: "liechtenstein"
+          should "have a next node of worked_in_eea_or_switzerland? for any EEA country" do
+            assert_next_node :worked_in_eea_or_switzerland?, for_response: "liechtenstein"
           end
 
           should "have a next node of db_going_abroad_other_outcome for any response not in EEA country if going_abroad" do
@@ -671,62 +671,6 @@ class UkBenefitsAbroadFlowTest < ActiveSupport::TestCase
       end
     end
 
-    context "question: db_claiming_benefits?" do
-      setup do
-        testing_node :db_claiming_benefits?
-        add_responses going_or_already_abroad?: "going_abroad",
-                      which_benefit?: "disability_benefits",
-                      db_how_long_abroad?: "permanent",
-                      which_country?: "liechtenstein"
-      end
-
-      should "render the question" do
-        assert_rendered_question
-      end
-
-      context "next_node" do
-        should "have a next node of is_british_or_irish? for a 'yes' response if country is ireland and going_abroad" do
-          add_responses which_country?: "ireland"
-          assert_next_node :is_british_or_irish?, for_response: "yes"
-        end
-
-        should "have a next node of db_going_abroad_gibraltar_outcome for a 'yes' response if country is gibraltar and going_abroad" do
-          add_responses which_country?: "gibraltar"
-          assert_next_node :db_going_abroad_gibraltar_outcome, for_response: "yes"
-        end
-
-        should "have a next node of worked_in_eea_or_switzerland? for a 'yes' response if country is not ireland or gibraltar and going_abroad" do
-          assert_next_node :worked_in_eea_or_switzerland?, for_response: "yes"
-        end
-
-        should "have a next node of db_going_abroad_other_outcome for a 'no' response and going_abroad" do
-          assert_next_node :db_going_abroad_other_outcome, for_response: "no"
-        end
-
-        should "have a next node of is_british_or_irish? for a 'yes' response if country is ireland if already_abroad" do
-          add_responses going_or_already_abroad?: "already_abroad",
-                        which_country?: "ireland"
-          assert_next_node :is_british_or_irish?, for_response: "yes"
-        end
-
-        should "have a next node of db_already_abroad_gibraltar_outcome for a 'yes' response if country is gibraltar and already_abroad" do
-          add_responses going_or_already_abroad?: "already_abroad",
-                        which_country?: "gibraltar"
-          assert_next_node :db_already_abroad_gibraltar_outcome, for_response: "yes"
-        end
-
-        should "have a next node of worked_in_eea_or_switzerland? for a 'yes' response if country is in EEA and is not ireland or gibraltar and already_abroad" do
-          add_responses going_or_already_abroad?: "already_abroad"
-          assert_next_node :worked_in_eea_or_switzerland?, for_response: "yes"
-        end
-
-        should "have a next node of db_already_abroad_other_outcome for a 'no' response if already_abroad" do
-          add_responses going_or_already_abroad?: "already_abroad"
-          assert_next_node :db_already_abroad_other_outcome, for_response: "no"
-        end
-      end
-    end
-
     context "question: is_claiming_benefits?" do
       setup do
         testing_node :is_claiming_benefits?
@@ -1002,18 +946,16 @@ class UkBenefitsAbroadFlowTest < ActiveSupport::TestCase
           assert_next_node :esa_already_abroad_eea_outcome, for_response: "before_jan_2021"
         end
 
-        should "have a next node of db_going_abroad_eea_outcome for a 'before_jan_2021' response if benefit is disability_benefits and going_abroad" do
+        should "have a next node of db_going_abroad_eea_outcome for a 'before_jan_2021' response going_abroad" do
           add_responses which_benefit?: "disability_benefits",
-                        db_how_long_abroad?: "permanent",
-                        db_claiming_benefits?: "yes"
+                        db_how_long_abroad?: "permanent"
           assert_next_node :db_going_abroad_eea_outcome, for_response: "before_jan_2021"
         end
 
-        should "have a next node of db_already_abroad_eea_outcome for a 'before_jan_2021' response if benefit is disability_benefits and already_abroad" do
+        should "have a next node of db_already_abroad_eea_outcome for a 'before_jan_2021' response if already_abroad" do
           add_responses going_or_already_abroad?: "already_abroad",
                         which_benefit?: "disability_benefits",
-                        db_how_long_abroad?: "permanent",
-                        db_claiming_benefits?: "yes"
+                        db_how_long_abroad?: "permanent"
           assert_next_node :db_already_abroad_eea_outcome, for_response: "before_jan_2021"
         end
 
@@ -1063,18 +1005,16 @@ class UkBenefitsAbroadFlowTest < ActiveSupport::TestCase
           assert_next_node :esa_already_abroad_eea_outcome, for_response: "before_jan_2021"
         end
 
-        should "have a next node of db_going_abroad_eea_outcome for a 'before_jan_2021' response if benefit is disability_benefits and going_abroad" do
+        should "have a next node of db_going_abroad_eea_outcome for a 'before_jan_2021' response if going_abroad" do
           add_responses which_benefit?: "disability_benefits",
-                        db_how_long_abroad?: "permanent",
-                        db_claiming_benefits?: "yes"
+                        db_how_long_abroad?: "permanent"
           assert_next_node :db_going_abroad_eea_outcome, for_response: "before_jan_2021"
         end
 
-        should "have a next node of db_already_abroad_eea_outcome for a 'before_jan_2021' response if benefit is disability_benefits and already_abroad" do
+        should "have a next node of db_already_abroad_eea_outcome for a 'before_jan_2021' response if already_abroad" do
           add_responses going_or_already_abroad?: "already_abroad",
                         which_benefit?: "disability_benefits",
-                        db_how_long_abroad?: "permanent",
-                        db_claiming_benefits?: "yes"
+                        db_how_long_abroad?: "permanent"
           assert_next_node :db_already_abroad_eea_outcome, for_response: "before_jan_2021"
         end
 
@@ -1101,18 +1041,16 @@ class UkBenefitsAbroadFlowTest < ActiveSupport::TestCase
             assert_next_node :esa_already_abroad_other_outcome, for_response: response
           end
 
-          should "have a next node of db_going_abroad_other_outcome for a '#{response}' response if benefit is disability_benefits and going_abroad" do
+          should "have a next node of db_going_abroad_other_outcome for a '#{response}' response if going_abroad" do
             add_responses which_benefit?: "disability_benefits",
-                          db_how_long_abroad?: "permanent",
-                          db_claiming_benefits?: "yes"
+                          db_how_long_abroad?: "permanent"
             assert_next_node :db_going_abroad_other_outcome, for_response: response
           end
 
-          should "have a next node of db_already_abroad_other_outcome for a '#{response}' response if benefit is disability_benefits and already_abroad" do
+          should "have a next node of db_already_abroad_other_outcome for a '#{response}' response if already_abroad" do
             add_responses going_or_already_abroad?: "already_abroad",
                           which_benefit?: "disability_benefits",
-                          db_how_long_abroad?: "permanent",
-                          db_claiming_benefits?: "yes"
+                          db_how_long_abroad?: "permanent"
             assert_next_node :db_already_abroad_other_outcome, for_response: response
           end
         end
@@ -1154,11 +1092,10 @@ class UkBenefitsAbroadFlowTest < ActiveSupport::TestCase
           assert_next_node :esa_already_abroad_eea_outcome, for_response: "yes"
         end
 
-        should "have a next node of db_going_abroad_ireland_outcome for a 'yes' response if benefit is disability_benefits" do
+        should "have a next node of db_going_abroad_eea_outcome for a 'yes' response" do
           add_responses which_benefit?: "disability_benefits",
-                        db_how_long_abroad?: "permanent",
-                        db_claiming_benefits?: "yes"
-          assert_next_node :db_going_abroad_ireland_outcome, for_response: "yes"
+                        db_how_long_abroad?: "permanent"
+          assert_next_node :db_going_abroad_eea_outcome, for_response: "before_jan_2021"
         end
 
         should "have a next node of worked_in_eea_or_switzerland? for a 'no' response" do


### PR DESCRIPTION
A content request stated the question `db_claiming_benefits?` should be
removed and the prior question should redirect straight to
`worked_in_eea_or_switzerland?`. As part of this work, two outcomes have
been removed as they only apply to the removed questions. These are:

* db_already_abroad_gibraltar_outcome
* db_going_abroad_gibraltar_outcome

Trello:
https://trello.com/c/cMys4nRQ/980-remove-question-from-benefits-abroad-smart-answer

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
