### PR TITLE
Guidance changes on inbound results page

### DIFF
--- a/app/flows/covid_travel_abroad_flow/outcomes/_fully_vaxed.erb
+++ b/app/flows/covid_travel_abroad_flow/outcomes/_fully_vaxed.erb
@@ -20,12 +20,9 @@
   <p class="govuk-body">You must:</p>
 
   <ul class="govuk-list govuk-list--bullet">
-    <li><a href="https://www.gov.uk/find-travel-test-provider" class="govuk-link">take a PCR or rapid lateral flow COVID-19 test</a> - to be taken in the 48 hours before you travel to England</li>
-    <li><a href="https://www.gov.uk/find-travel-test-provider" class="govuk-link">book and pay for a COVID-19 PCR test</a> - to be taken after arrival before the end of day 2</li>
+    <li><a href="https://www.gov.uk/find-travel-test-provider" class="govuk-link">book and pay for a COVID-19 PCR or rapid lateral flow test</a> - you must take it after arrival before the end of day 2</li>
     <li><a href="https://www.gov.uk/provide-journey-contact-details-before-travel-uk" class="govuk-link">complete a passenger locator form</a> - to be completed in the 48 hours before you arrive in England</li>
   </ul>
-
-  <p class="govuk-body">You must use a private test provider. You cannot use a free NHS test.</p>
 
   <p class="govuk-body">You will need to enter your COVID-19 test booking reference number on your passenger locator form.</p>
 
@@ -36,17 +33,11 @@
     margin_bottom: 4,
   } %>
 
-  <p class="govuk-body">You must take the COVID-19 PCR test you booked before travel on or before day 2 (the day you arrive is day 0).</p>
+  <p class="govuk-body">You must take the COVID-19 test that you booked before travelling. You need to take it within 2 days of arriving (the day you arrive is day 0).</p>
 
-  <p class="govuk-body">You must <a href="https://www.gov.uk/guidance/how-to-quarantine-when-you-arrive-in-england" class="govuk-link">quarantine at home or the place you're staying</a> while you wait for your test result.</p>
+  <p class="govuk-body">If you take a rapid lateral flow test and you test positive, you must take a PCR test.</p>
 
-  <p class="govuk-body">If the test result is negative, you can end your quarantine.</p>
-
-  <p class="govuk-body">If the test is positive or unclear, you must <a href="https://www.nhs.uk/conditions/coronavirus-covid-19/self-isolation-and-treatment/when-to-self-isolate-and-what-to-do" class="govuk-link">self-isolate</a> for 10 full days (the day of the test is day 0).</p>
-
-  <p class="govuk-body">If the test is unclear, you can choose to take another private test.</p>
-
-  <p class="govuk-body">If you haven't received your test result after 13 days, you can end your quarantine (the day you arrive is day 0).</p>
+  <p class="govuk-body">If your PCR test result is positive, you must self-isolate. See guidance on <a href="https://www.gov.uk/guidance/how-to-quarantine-when-you-arrive-in-england#how-to-quarantine-or-self-isolate">how to self-isolate after testing positive on your day 2 test</a>.</p>
 <% end %>
 
 <%


### PR DESCRIPTION
## What

Update the smart answer content to reflect the January rule change on testing for fully vaxed arrivals into England.  See [this document](https://docs.google.com/document/d/1MmG5GX03IOsKTbwTvKTTk4JkDabZOTybtawZpqke6Nw/edit)

## Why

The [travelling to England guidance][1] rules on testing for vaxed arrivals changed on 9 Jan.

[1]: https://www.gov.uk/guidance/travel-to-england-from-another-country-during-coronavirus-covid-19

[Trello](https://trello.com/c/MkhQS2qq/509-innout-reflect-9-jan-dft-guidance-changes-in-inbound-results)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
