### PR TITLE
SSP rebate January placeholder

### DIFF
--- a/app/flows/business_coronavirus_support_finder_flow/outcomes/results.erb
+++ b/app/flows/business_coronavirus_support_finder_flow/outcomes/results.erb
@@ -11,16 +11,8 @@
     $CTA
     ### Statutory Sick Pay rebate
 
-    You can claim back Statutory Sick Pay (SSP) you’ve paid for employees who are off sick, self isolating or shielding because of coronavirus on or before 30 September 2021. You can claim up to 2 weeks of SSP for every eligible employee.
+    From January 2022 you’ll be able to reclaim SSP for employees who were recently off work because of COVID-19. This page will be updated in January with information on how to claim.
 
-    You’re eligible to claim if your business is both:
-
-    - based in the UK
-    - has had fewer than 250 employees since 28 February 2020
-
-    You must submit or amend claims on or before 31 December 2021.
-
-    [Claim back Statutory Sick Pay paid to employees because of coronavirus](/guidance/claim-back-statutory-sick-pay-paid-to-employees-due-to-coronavirus-covid-19)
     $CTA
   <% end %>
 


### PR DESCRIPTION
This reflects that SSP rebate is not currently open for claims. It will reopen in mid-January 2022. The original content should be used with new dates.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
