### PR TITLE
Add new outcome to the business_coronavirus_support_finder flow

### DIFF
--- a/app/flows/business_coronavirus_support_finder_flow/outcomes/results.erb
+++ b/app/flows/business_coronavirus_support_finder_flow/outcomes/results.erb
@@ -7,6 +7,17 @@
 
   You may be eligible for more than one scheme, whether your business is open or closed.
 
+  <% if calculator.show?(:omicron_hospitality_and_leisure_grant) %>
+    $CTA
+    ### Omicron Hospitality and Leisure Grant
+
+    Hospitality, leisure and accommodation businesses in England most impacted by Omicron can apply for one-off grants of up to £6,000. The amount you can get depends on the [‘rateable value’](https://www.gov.uk/correct-your-business-rates) of your business.
+
+    [Check if you’re eligible and apply for the Omicron Hospitality and Leisure Grant](https://www.gov.uk/guidance/check-if-youre-eligible-for-the-omicron-hospitality-and-leisure-grant).
+
+    $CTA
+  <% end %>
+
   <% if calculator.show?(:statutory_sick_rebate) %>
     $CTA
     ### Statutory Sick Pay rebate

--- a/lib/smart_answer/calculators/business_coronavirus_support_finder_calculator.rb
+++ b/lib/smart_answer/calculators/business_coronavirus_support_finder_calculator.rb
@@ -26,6 +26,10 @@ module SmartAnswer::Calculators
           calculator.non_domestic_property != "no" &&
           calculator.sectors.include?("retail_hospitality_or_leisure")
       },
+      omicron_hospitality_and_leisure_grant: lambda { |calculator|
+        calculator.business_based == "england" &&
+          calculator.sectors.include?("retail_hospitality_or_leisure")
+      },
       nursery_support: lambda { |calculator|
         calculator.business_based == "england" &&
           calculator.non_domestic_property != "no" &&

--- a/test/flows/business_coronavirus_support_finder_flow_test.rb
+++ b/test/flows/business_coronavirus_support_finder_flow_test.rb
@@ -225,5 +225,12 @@ class BusinessCoronavirusSupportFinderFlowTest < ActiveSupport::TestCase
 
       assert_rendered_outcome text: "You can be eligible for both Northern Ireland and UK-wide schemes."
     end
+
+    should "render omicron_hospitality_and_leisure_grant if business_based is set to england and sectors include retail_hospitality_or_leisure" do
+      add_responses sectors?: %w[retail_hospitality_or_leisure],
+                    non_domestic_property?: "not_sure"
+
+      assert_rendered_outcome text: "Omicron Hospitality and Leisure Grant"
+    end
   end
 end

--- a/test/unit/calculators/business_coronavirus_support_calculator_test.rb
+++ b/test/unit/calculators/business_coronavirus_support_calculator_test.rb
@@ -176,6 +176,27 @@ module SmartAnswer::Calculators
           assert_not @calculator.show?(:council_grants)
         end
       end
+
+      context "omicron_hospitality_and_leisure_grant" do
+        setup do
+          @calculator.business_based = "england"
+          @calculator.sectors = %w[retail_hospitality_or_leisure]
+        end
+
+        should "return true when criteria met" do
+          assert @calculator.show?(:omicron_hospitality_and_leisure_grant)
+        end
+
+        should "return false when in a devolved admininstration" do
+          @calculator.business_based = "scotland"
+          assert_not @calculator.show?(:omicron_hospitality_and_leisure_grant)
+        end
+
+        should "return false when not supported business sectors" do
+          @calculator.sectors = %w[none]
+          assert_not @calculator.show?(:omicron_hospitality_and_leisure_grant)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Add the new Omicron Hospitality and Leisure Grant that has been made available to the business_coronavirus_support_finder flow.

This allows businesses that have been negatively affected by the Omicron variant to access financial support.

The scheme needs to be displayed if the folliwing rules are true:

* The business is based in 'England'

* The type of business is 'Retail, hospitality or leisure'

For all other cases it is not shown.

When applicable, it should be shown as the first result in the 'Coronavirus schemes, grants and loans' section on the results page.

Please note that the content has already been checked and approved by the content team.

[Trello](https://trello.com/c/6ehmMCfd/538-add-new-answer-on-omicron-grant-to-find-coronavirus-financial-support-for-your-business-smart-answer)

[Google doc](https://docs.google.com/document/d/1nyBdHyE7STxVB3eplqPuYaTLX2NuqtGWVeA0lFCZz3c/edit?pli=1)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
