### PR TITLE
DO NOT MERGE - Change covid-travel-abroad flow to be session based

### DIFF
--- a/app/flows/covid_travel_abroad_flow.rb
+++ b/app/flows/covid_travel_abroad_flow.rb
@@ -3,7 +3,7 @@ class CovidTravelAbroadFlow < SmartAnswer::Flow
     name "covid-travel-abroad"
     content_id "b46df1e7-e770-43ab-8b4c-ce402736420c"
     status :draft
-    response_store :query_parameters
+    response_store :session
 
     country_select "which_country".to_sym, exclude_countries: [] do
       on_response do |response|


### PR DESCRIPTION
Currently, the `covid-travel-abroad` flow is query parameter based. Due to data and privacy concerns around vaccination status being in the URL, we should change this flow to be session based instead.

[Trello](https://trello.com/c/DInfO64C/540-innout-decide-what-to-do-from-a-data-privacy-angle)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
