### PR TITLE
New SSP rebate date of mid-January

### DIFF
--- a/app/flows/business_coronavirus_support_finder_flow/outcomes/results.erb
+++ b/app/flows/business_coronavirus_support_finder_flow/outcomes/results.erb
@@ -22,7 +22,7 @@
     $CTA
     ### Statutory Sick Pay rebate
 
-    From 19 January 2022 you’ll be able to reclaim SSP for employees who were recently off work because of COVID-19. This page will be updated in January with information on how to claim.
+    From mid-January 2022 you’ll be able to reclaim SSP for employees who were recently off work because of COVID-19. This page will be updated in January with information on how to claim.
 
     $CTA
   <% end %>


### PR DESCRIPTION
Change to SSP rebate outcome to say that a new claim will be opening from mid-January rather than 19 January specifically. This was requested by C-19.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
