### PR TITLE
Amend vaccination question on covid-travel-abroad flow

### DIFF
--- a/app/flows/covid_travel_abroad_flow/questions/vaccination_status.erb
+++ b/app/flows/covid_travel_abroad_flow/questions/vaccination_status.erb
@@ -11,7 +11,7 @@
 <% end %>
 
 <% options(
-  "vaccinated": "I had my second dose of an approved COVID-19 vaccine 14 or more days ago",
+  "vaccinated": "I will have had a second dose of an approved COVID-19 vaccine 14 or more days before I travel",
   "in_trial": "I'm taking part in an approved COVID-19 vaccine trial in the UK",
   "exempt": "I cannot have a COVID-19 vaccination for a medical reason approved by a clinician",
   "none": "None of the above",


### PR DESCRIPTION
### What
Change tense of vaccination question to allow for users haven't yet have 2 does but will have by the time they travel.

### Why
During UR a user was surprised that booster doses not mentioned (they've been v high profile recently), and another observed that the current answer options don't provide for someone currently un/partially vaxed but who will be fully by date of travel.

[Trello](https://trello.com/c/gTyPwWc0/514-innout-amend-vax-question-following-ur-evidence)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
