### PR TITLE
Remove vaccination-status from Google Analytics

### DIFF
--- a/app/assets/javascripts/modules/track-responses.js
+++ b/app/assets/javascripts/modules/track-responses.js
@@ -10,14 +10,25 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.$module.addEventListener('submit', this.handleFormSubmit.bind(this))
   }
 
+  TrackResponses.prototype.filterLabel = function () {
+    return 'vaccination-status'
+  }
+
+  TrackResponses.prototype.filterResponse = function (questionKey, label) {
+    var filteredLabel = label
+    if (this.filterLabel() === questionKey) {
+      filteredLabel = '[FILTERED]'
+    }
+    return { transport: 'beacon', label: filteredLabel }
+  }
+
   TrackResponses.prototype.handleFormSubmit = function (event) {
     var submittedForm = event.target
     var questionKey = this.getQuestionKey(submittedForm)
     var responseLabels = this.getResponseLabels(submittedForm)
 
     for (var i = 0; i < responseLabels.length; i++) {
-      var label = responseLabels[i]
-      var options = { transport: 'beacon', label: label }
+      var options = this.filterResponse(questionKey, responseLabels[i])
       GOVUK.analytics.trackEvent('response_submission', questionKey, options)
     }
   }

--- a/spec/javascripts/modules/track-responses.spec.js
+++ b/spec/javascripts/modules/track-responses.spec.js
@@ -82,6 +82,17 @@ describe('Track responses', function () {
       )
     })
 
+    it('filters out sensitive responses', function () {
+      spyOn(tracker, 'filterLabel').and.returnValue('question-key')
+
+      form.querySelector('input[value="accommodation"]').click()
+      form.dispatchEvent(new Event('submit'))
+
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+        'response_submission', 'question-key', { transport: 'beacon', label: '[FILTERED]' }
+      )
+    })
+
     it('track events sends value of checkbox when no label is set', function () {
       form.querySelector('input[value="furniture"]').click()
       form.dispatchEvent(new Event('submit'))
@@ -173,6 +184,17 @@ describe('Track responses', function () {
       )
     })
 
+    it('filters out sensitive responses', function () {
+      spyOn(tracker, 'filterLabel').and.returnValue('question-key')
+
+      form.querySelector('input[value="accommodation"]').click()
+      form.dispatchEvent(new Event('submit'))
+
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+        'response_submission', 'question-key', { transport: 'beacon', label: '[FILTERED]' }
+      )
+    })
+
     it('track event triggered when no response is made', function () {
       form.dispatchEvent(new Event('submit'))
 
@@ -241,6 +263,17 @@ describe('Track responses', function () {
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
         'response_submission', 'question-key', { transport: 'beacon', label: 'Accommodation label' }
+      )
+    })
+
+    it('filters out sensitive responses', function () {
+      spyOn(tracker, 'filterLabel').and.returnValue('question-key')
+
+      form.querySelector('select[name="select_question"]').value = 'accommodation'
+      form.dispatchEvent(new Event('submit'))
+
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+        'response_submission', 'question-key', { transport: 'beacon', label: '[FILTERED]' }
       )
     })
 


### PR DESCRIPTION
### What

Remove the response to vaccination-status in the covid-travel-abroad flow from all data that we send to Google Analytics.

### Why

A users vaccination status is considered health data so we should remove it from being exposed outside of the application.

### Before

<img width="1789" alt="Screenshot 2022-01-19 at 16 23 19" src="https://user-images.githubusercontent.com/44037625/150175628-89e3070d-00e6-4411-8b60-246c3d79d853.png">

### After

<img width="1789" alt="Screenshot 2022-01-19 at 16 21 57" src="https://user-images.githubusercontent.com/44037625/150175592-aae1d36f-2298-4d27-b34c-22e034ee7779.png">

[Trello](https://trello.com/c/DInfO64C/540-innout-decide-what-to-do-from-a-data-privacy-angle)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
