### PR TITLE
Display upcoming COVID status changes on the results page

### DIFF
--- a/app/flows/check_travel_during_coronavirus_flow/outcomes/_country.erb
+++ b/app/flows/check_travel_during_coronavirus_flow/outcomes/_country.erb
@@ -5,6 +5,10 @@
   margin_bottom: 4,
 } %>
 
+<% if country.next_covid_status.present? %>
+  <%= render partial: "country/status_change", locals: { country: country } %>
+<% end %>
+
 <% if calculator.countries_with_content_headers_converted.include?(country.slug) %>
   <p class="govuk-body">You should read the following sections of the <%= country.title %> entry requirements guidance on:</p>
 

--- a/app/flows/check_travel_during_coronavirus_flow/outcomes/country/_status_change.erb
+++ b/app/flows/check_travel_during_coronavirus_flow/outcomes/country/_status_change.erb
@@ -1,0 +1,14 @@
+<%
+  next_status_date = country.next_covid_status_applies_at.strftime("%l:%M %P")
+  next_status_time = country.next_covid_status_applies_at.strftime("%d %B %Y")
+%>
+
+<% if country.next_covid_status == "red" %>
+  <%= render "govuk_publishing_components/components/warning_text", {
+    text: "#{country.title} will move to the red list for travel to England at #{next_status_date} on #{next_status_time}. Until then you should follow the rules below for returning to England."
+  } %>
+<% else %>
+  <%= render "govuk_publishing_components/components/warning_text", {
+    text: "#{country.title} will be removed from the red list for travel to England at #{next_status_date} on #{next_status_time}. Until then you should follow the rules below for returning to England."
+  } %>
+<% end %>

--- a/app/models/world_location.rb
+++ b/app/models/world_location.rb
@@ -67,14 +67,28 @@ class WorldLocation
   end
 
   def covid_status
-    # Once the world location api returns the covid status, we should be able
+    covid_statuses&.dig("covid_status")
+  end
+
+  def next_covid_status
+    covid_statuses&.dig("next_covid_status")
+  end
+
+  def next_covid_status_applies_at
+    Time.zone.parse(covid_statuses["next_covid_status_applies_at"])
+  rescue NoMethodError, TypeError
+    nil
+  end
+
+  def covid_statuses
+    # Once the world location api returns the covid statuses, we should be able
     # to replace this line with:
     # location.fetch("england_coronavirus_travel", "")
     rules = self.class.travel_rules["results"].select { |country| country["details"]["slug"] == slug }.first
 
     return if rules.blank?
 
-    rules["england_coronavirus_travel"]["covid_status"]
+    rules["england_coronavirus_travel"]
   end
 
   def initialize(location)

--- a/config/smart_answers/check_travel_during_coronavirus_data.yml
+++ b/config/smart_answers/check_travel_during_coronavirus_data.yml
@@ -4,15 +4,23 @@ results:
     details:
       slug: italy
     england_coronavirus_travel:
-      covid_status: green
-      next_covid_status:
-      next_covid_status_applies_at:
+      covid_status: not_red
+      next_covid_status: red
+      next_covid_status_applies_at: "2022-02-20T:02:00.000+00:00"
       status_out_of_date: false
   - title: South Africa
     details:
       slug: south-africa
     england_coronavirus_travel:
       covid_status: red
+      next_covid_status: not_red
+      next_covid_status_applies_at: "2022-02-20T:02:00.000+00:00"
+      status_out_of_date: false
+  - title: Spain
+    details:
+      slug: spain
+    england_coronavirus_travel:
+      covid_status: not_red
       next_covid_status:
       next_covid_status_applies_at:
       status_out_of_date: false

--- a/test/flows/check_travel_during_coronavirus_test.rb
+++ b/test/flows/check_travel_during_coronavirus_test.rb
@@ -218,6 +218,48 @@ class CheckTravelDuringCoronavirusTest < ActiveSupport::TestCase
       assert_rendered_outcome text: "You are travelling through"
     end
 
+    context "content for countries changing covid status" do
+      should "render 'move to the red list' content for countries moving to the red list" do
+        WorldLocation.stubs(:travel_rules).returns({
+          "results" => [
+            {
+              "title" => "Poland",
+              "details" => {
+                "slug" => "poland",
+              },
+              "england_coronavirus_travel" => {
+                "covid_status" => "not_red",
+                "next_covid_status" => "red",
+                "next_covid_status_applies_at" => "2022-02-20T:02:00.000+00:00",
+              },
+            },
+          ],
+        })
+        assert_rendered_outcome text: "Poland will move to the red list for travel to England"
+      end
+
+      should "render 'removed from the red list' content for countries moving from the red list" do
+        WorldLocation.stubs(:travel_rules).returns({
+          "results" => [
+            {
+              "title" => "Poland",
+              "details" => {
+                "slug" => "poland",
+              },
+              "england_coronavirus_travel" => {
+                "covid_status" => "red",
+                "next_covid_status" => "not_red",
+                "next_covid_status_applies_at" => "2022-02-20T:02:00.000+00:00",
+              },
+            },
+          ],
+        })
+
+        add_responses going_to_countries_within_10_days: "no"
+        assert_rendered_outcome text: "Poland will be removed from the red list for travel to England"
+      end
+    end
+
     context "country specific content that has had the headers converted" do
       setup do
         SmartAnswer::Calculators::CheckTravelDuringCoronavirusCalculator.any_instance.stubs(:countries_with_content_headers_converted).returns(%w[spain italy])


### PR DESCRIPTION
Trello: https://trello.com/c/7sslimxM

# What's changed?
Displays a warning on the Check Travel During Coronavirus results page if the COVID status of a country is changing.

# Expected changes

[Rendered version](https://smart-answer-display-st-piyhub.herokuapp.com/check-travel-during-coronavirus/results?any_other_countries_1=yes&any_other_countries_2=yes&any_other_countries_3=no&going_to_countries_within_10_days=yes&transit_countries%5B%5D=none&travelling_with_children%5B%5D=none&vaccination_status=vaccinated&which_1_country=italy&which_2_country=south-africa&which_country=afghanistan)

|Before|After|
|:------|:----|
|<img width="1049" alt="Screenshot 2022-01-20 at 17 09 09" src="https://user-images.githubusercontent.com/5793815/150391952-dd1637aa-99fa-477a-9bed-6edc0e3a322b.png">|<img width="1037" alt="Screenshot 2022-01-20 at 17 09 24" src="https://user-images.githubusercontent.com/5793815/150391975-5b496c82-44e3-410a-9523-2dccd192668f.png">|



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
