### PR TITLE
Display upcoming COVID status changes on the results page

### DIFF
--- a/app/flows/check_travel_during_coronavirus_flow/outcomes/_country.erb
+++ b/app/flows/check_travel_during_coronavirus_flow/outcomes/_country.erb
@@ -5,6 +5,10 @@
   margin_bottom: 4,
 } %>
 
+<% if country.next_covid_status.present? %>
+  <%= render partial: "country/status_change", locals: { country: country } %>
+<% end %>
+
 <% if calculator.countries_with_content_headers_converted.include?(country.slug) %>
   <p class="govuk-body">You should read the following sections of the <%= country.title %> entry requirements guidance on:</p>
 

--- a/app/flows/check_travel_during_coronavirus_flow/outcomes/country/_status_change.erb
+++ b/app/flows/check_travel_during_coronavirus_flow/outcomes/country/_status_change.erb
@@ -1,0 +1,14 @@
+<%
+  next_status_date = country.next_covid_status_applies_at.to_s(:govuk_date)
+  next_status_time = country.next_covid_status_applies_at.to_s(:govuk_time)
+%>
+
+<% if country.next_covid_status == "red" %>
+  <%= render "govuk_publishing_components/components/warning_text", {
+    text: "#{country.title} will move to the red list for travel to England at #{next_status_time} on #{next_status_date}. Until then you should follow the rules below for returning to England."
+  } %>
+<% else %>
+  <%= render "govuk_publishing_components/components/warning_text", {
+    text: "#{country.title} will be removed from the red list for travel to England at #{next_status_time} on #{next_status_date}. Until then you should follow the rules below for returning to England."
+  } %>
+<% end %>

--- a/app/models/world_location.rb
+++ b/app/models/world_location.rb
@@ -89,19 +89,23 @@ class WorldLocation
   end
 
   def current_covid_status_data
-    current_statuses = covid_status_data_for_location.select do |status|
+    current_statuses = covid_status_data_for_location&.select do |status|
       start_date = Time.zone.parse(status["covid_status_applies_at"])
       start_date.past?
     end
+
+    return if current_statuses.blank?
 
     current_statuses.max_by { |status| status["covid_status_applies_at"] }
   end
 
   def next_covid_status_data
-    future_statuses = covid_status_data_for_location.select do |status|
+    future_statuses = covid_status_data_for_location&.select do |status|
       start_date = Time.zone.parse(status["covid_status_applies_at"])
       start_date.future?
     end
+
+    return if future_statuses.blank?
 
     future_statuses.min_by { |status| status["covid_status_applies_at"] }
   end

--- a/app/models/world_location.rb
+++ b/app/models/world_location.rb
@@ -78,6 +78,16 @@ class WorldLocation
     current_covid_status_data&.dig("covid_status")
   end
 
+  def next_covid_status
+    next_covid_status_data&.dig("covid_status")
+  end
+
+  def next_covid_status_applies_at
+    Time.zone.parse(next_covid_status_data["covid_status_applies_at"])
+  rescue NoMethodError, TypeError
+    nil
+  end
+
   def current_covid_status_data
     current_statuses = covid_status_data_for_location.select do |status|
       start_date = Time.zone.parse(status["covid_status_applies_at"])
@@ -85,6 +95,15 @@ class WorldLocation
     end
 
     current_statuses.max_by { |status| status["covid_status_applies_at"] }
+  end
+
+  def next_covid_status_data
+    future_statuses = covid_status_data_for_location.select do |status|
+      start_date = Time.zone.parse(status["covid_status_applies_at"])
+      start_date.future?
+    end
+
+    future_statuses.min_by { |status| status["covid_status_applies_at"] }
   end
 
   def covid_status_data_for_location

--- a/app/models/world_location.rb
+++ b/app/models/world_location.rb
@@ -66,17 +66,6 @@ class WorldLocation
     @travel_rules ||= YAML.load_file(Rails.root.join("config/smart_answers/check_travel_during_coronavirus_data.yml"))
   end
 
-  def covid_status
-    # Once the world location api returns the covid status, we should be able
-    # to replace this line with:
-    # location.fetch("england_coronavirus_travel", "")
-    rules = self.class.travel_rules["results"].select { |country| country["details"]["slug"] == slug }.first
-
-    return if rules.blank?
-
-    rules["england_coronavirus_travel"]["covid_status"]
-  end
-
   def initialize(location)
     @title = location.fetch("title", "")
     @details = location.fetch("details", {})
@@ -84,6 +73,30 @@ class WorldLocation
   end
 
   alias_method :name, :title
+
+  def covid_status
+    current_covid_status_data&.dig("covid_status")
+  end
+
+  def current_covid_status_data
+    current_statuses = covid_status_data_for_location.select do |status|
+      start_date = Time.zone.parse(status["covid_status_applies_at"])
+      start_date.past?
+    end
+
+    current_statuses.max_by { |status| status["covid_status_applies_at"] }
+  end
+
+  def covid_status_data_for_location
+    # Once the world location api returns the covid status, we should be able
+    # to replace this line with:
+    # location.fetch("england_coronavirus_travel", "")
+    rules = self.class.travel_rules["results"].select { |country| country["details"]["slug"] == slug }.first
+
+    return if rules.blank?
+
+    rules["england_coronavirus_travel"]
+  end
 
   def ==(other)
     other.is_a?(self.class) && other.slug == @slug

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -13,6 +13,7 @@
 shared_formats = {
   govuk_date: "%-d %B %Y", # '4 December 2009'
   govuk_date_with_day: "%A, %d %B %Y", # 'Friday, 4 December 2009'
+  govuk_time: "%l:%M%P", # '2:30am'
 }
 
 Time::DATE_FORMATS.merge! shared_formats

--- a/config/smart_answers/check_travel_during_coronavirus_data.yml
+++ b/config/smart_answers/check_travel_during_coronavirus_data.yml
@@ -4,15 +4,15 @@ results:
     details:
       slug: italy
     england_coronavirus_travel:
-      covid_status: green
-      next_covid_status:
-      next_covid_status_applies_at:
-      status_out_of_date: false
+      - covid_status: not_red
+        covid_status_applies_at: "2021-12-20T:02:00.000+00:00"
+      - covid_status: red
+        covid_status_applies_at: "2022-02-20T:02:30.000+00:00"
   - title: South Africa
     details:
       slug: south-africa
     england_coronavirus_travel:
-      covid_status: red
-      next_covid_status:
-      next_covid_status_applies_at:
-      status_out_of_date: false
+      - covid_status: red
+        covid_status_applies_at: "2021-12-20T:02:00.000+00:00"
+      - covid_status: not_red
+        covid_status_applies_at: "2022-02-20T:16:00.000+00:00"

--- a/test/flows/check_travel_during_coronavirus_flow_test.rb
+++ b/test/flows/check_travel_during_coronavirus_flow_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 require "support/flow_test_helper"
 
-class CheckTravelDuringCoronavirusTest < ActiveSupport::TestCase
+class CheckTravelDuringCoronavirusFlowTest < ActiveSupport::TestCase
   include FlowTestHelper
 
   setup do

--- a/test/flows/check_travel_during_coronavirus_test.rb
+++ b/test/flows/check_travel_during_coronavirus_test.rb
@@ -218,6 +218,89 @@ class CheckTravelDuringCoronavirusTest < ActiveSupport::TestCase
       assert_rendered_outcome text: "You are travelling through"
     end
 
+    context "content for countries changing covid status" do
+      should "render 'move to the red list' content for countries moving to the red list" do
+        travel_to("2022-01-01") do
+          WorldLocation.stubs(:travel_rules).returns({
+            "results" => [
+              {
+                "title" => "Poland",
+                "details" => {
+                  "slug" => "poland",
+                },
+                "england_coronavirus_travel" => [
+                  {
+                    "covid_status" => "not_red",
+                    "covid_status_applies_at" => "2021-12-20T:02:00.000+00:00",
+                  },
+                  {
+                    "covid_status" => "red",
+                    "covid_status_applies_at" => "2022-02-20T:02:00.000+00:00",
+                  },
+                ],
+              },
+            ],
+          })
+          assert_rendered_outcome text: "Poland will move to the red list for travel to England"
+        end
+      end
+
+      should "render 'removed from the red list' content for countries moving from the red list" do
+        travel_to("2022-01-01") do
+          WorldLocation.stubs(:travel_rules).returns({
+            "results" => [
+              {
+                "title" => "Poland",
+                "details" => {
+                  "slug" => "poland",
+                },
+                "england_coronavirus_travel" => [
+                  {
+                    "covid_status" => "red",
+                    "covid_status_applies_at" => "2021-12-20T:02:00.000+00:00",
+                  },
+                  {
+                    "covid_status" => "not_red",
+                    "covid_status_applies_at" => "2022-02-20T:02:00.000+00:00",
+                  },
+                ],
+              },
+            ],
+          })
+
+          add_responses going_to_countries_within_10_days: "no"
+          assert_rendered_outcome text: "Poland will be removed from the red list for travel to England"
+        end
+      end
+
+      should "not render changing status content if most recent status is in the past" do
+        travel_to("2022-03-01") do
+          WorldLocation.stubs(:travel_rules).returns({
+            "results" => [
+              {
+                "title" => "Poland",
+                "details" => {
+                  "slug" => "poland",
+                },
+                "england_coronavirus_travel" => [
+                  {
+                    "covid_status" => "red",
+                    "covid_status_applies_at" => "2021-12-20T:02:00.000+00:00",
+                  },
+                  {
+                    "covid_status" => "not_red",
+                    "covid_status_applies_at" => "2022-02-20T:02:00.000+00:00",
+                  },
+                ],
+              },
+            ],
+          })
+
+          assert_no_match "Poland will be removed from the red list for travel to England", @test_flow.outcome_text
+        end
+      end
+    end
+
     context "country specific content that has had the headers converted" do
       setup do
         SmartAnswer::Calculators::CheckTravelDuringCoronavirusCalculator.any_instance.stubs(:countries_with_content_headers_converted).returns(%w[spain italy])

--- a/test/unit/world_location_test.rb
+++ b/test/unit/world_location_test.rb
@@ -275,6 +275,7 @@ class WorldLocationTest < ActiveSupport::TestCase
 
   context "england_coronavirus_travel" do
     setup do
+      @future_status_date = "2022-02-20T:02:00.000+00:00"
       stub_worldwide_api_has_location("italy")
       WorldLocation.stubs(:travel_rules).returns({
         "results" => [
@@ -288,6 +289,10 @@ class WorldLocationTest < ActiveSupport::TestCase
                 "covid_status" => "red",
                 "covid_status_applies_at" => "2021-12-20T:02:00.000+00:00",
               },
+              {
+                "covid_status" => "not_red",
+                "covid_status_applies_at" => @future_status_date,
+              },
             ],
           },
         ],
@@ -298,6 +303,14 @@ class WorldLocationTest < ActiveSupport::TestCase
 
     should "find the current covid status for a location" do
       assert_equal "red", @location.covid_status
+    end
+
+    should "find the next covid status for a location" do
+      assert_equal "not_red", @location.next_covid_status
+    end
+
+    should "find the next covid status applies at date for a location" do
+      assert_equal Time.zone.parse(@future_status_date), @location.next_covid_status_applies_at
     end
   end
 end

--- a/test/unit/world_location_test.rb
+++ b/test/unit/world_location_test.rb
@@ -283,16 +283,20 @@ class WorldLocationTest < ActiveSupport::TestCase
             "details" => {
               "slug" => "italy",
             },
-            "england_coronavirus_travel" => {
-              "covid_status" => "red",
-            },
+            "england_coronavirus_travel" => [
+              {
+                "covid_status" => "red",
+                "covid_status_applies_at" => "2021-12-20T:02:00.000+00:00",
+              },
+            ],
           },
         ],
       })
       @location = WorldLocation.find("italy")
+      travel_to("2022-01-01")
     end
 
-    should "find the covid status for a location" do
+    should "find the current covid status for a location" do
       assert_equal "red", @location.covid_status
     end
   end

--- a/test/unit/world_location_test.rb
+++ b/test/unit/world_location_test.rb
@@ -276,7 +276,6 @@ class WorldLocationTest < ActiveSupport::TestCase
   context "england_coronavirus_travel" do
     setup do
       @future_status_date = "2022-02-20T:02:00.000+00:00"
-      stub_worldwide_api_has_location("italy")
       WorldLocation.stubs(:travel_rules).returns({
         "results" => [
           {
@@ -297,20 +296,45 @@ class WorldLocationTest < ActiveSupport::TestCase
           },
         ],
       })
-      @location = WorldLocation.find("italy")
       travel_to("2022-01-01")
     end
 
-    should "find the current covid status for a location" do
-      assert_equal "red", @location.covid_status
+    context "covid statuses exist" do
+      setup do
+        stub_worldwide_api_has_location("italy")
+        @location = WorldLocation.find("italy")
+      end
+
+      should "find the current covid status for a location" do
+        assert_equal "red", @location.covid_status
+      end
+
+      should "find the next covid status for a location" do
+        assert_equal "not_red", @location.next_covid_status
+      end
+
+      should "find the next covid status applies at date for a location" do
+        assert_equal Time.zone.parse(@future_status_date), @location.next_covid_status_applies_at
+      end
     end
 
-    should "find the next covid status for a location" do
-      assert_equal "not_red", @location.next_covid_status
-    end
+    context "covid statuses do not exist" do
+      setup do
+        stub_worldwide_api_has_location("spain")
+        @location = WorldLocation.find("spain")
+      end
 
-    should "find the next covid status applies at date for a location" do
-      assert_equal Time.zone.parse(@future_status_date), @location.next_covid_status_applies_at
+      should "return covid status of nil if covid statuses unknown for location" do
+        assert_nil @location.covid_status
+      end
+
+      should "return a next covid status of nil if covid statuses unknown for location" do
+        assert_nil @location.next_covid_status
+      end
+
+      should "return a next covid status date of nil if covid statuses unknown for location" do
+        assert_nil @location.next_covid_status_applies_at
+      end
     end
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/7sslimxM
Supersedes: #5728

# What's changed?
Displays a warning on the Check Travel During Coronavirus results page if the COVID status of a country is changing.

The format of the Coronavirus travel data YAML file has also changed to support programmatically updating the COVID status of a world location.

# Why?
The World Location API won't contain COVID status information in time for the MVP smartanswer to be released, so we need to be able to get up to date status information from the YAML file. Updating the format of the YAML in this ways allows status changes to update automatically, and avoid the need for late night deployments.

# Expected changes

[Rendered version](https://smart-answer-automate-c-yfzsvn.herokuapp.com/check-travel-during-coronavirus/results?any_other_countries_1=yes&any_other_countries_2=yes&any_other_countries_3=no&going_to_countries_within_10_days=yes&transit_countries%5B%5D=none&travelling_with_children%5B%5D=none&vaccination_status=vaccinated&which_1_country=italy&which_2_country=south-africa&which_country=afghanistan)

|Before|After|
|:------|:----|
|<img width="1049" alt="Screenshot 2022-01-20 at 17 09 09" src="https://user-images.githubusercontent.com/5793815/150391952-dd1637aa-99fa-477a-9bed-6edc0e3a322b.png">|<img width="1037" alt="Screenshot 2022-01-21 at 17 02 21" src="https://user-images.githubusercontent.com/5793815/150570914-646e1c1c-49d9-4ebf-a2b7-c87158cf6849.png">|

## Mobile view
<img width="366" alt="Screenshot 2022-01-21 at 17 45 12" src="https://user-images.githubusercontent.com/5793815/150575119-71ee018e-c5da-4ced-88f9-ccdd5eed29a5.png">




⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
