### PR TITLE
[DO NOT MERGE] Add config to remove vaccination status from url

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,7 +25,8 @@
       <%= render "govuk_publishing_components/components/meta_tags",
         content_item: content_item,
         strip_dates_pii: true,
-        strip_postcode_pii: true %>
+        strip_postcode_pii: true,
+        strip_vaccination_status_pii: true %>
     <% end %>
     <% if @meta_section %>
       <meta name="govuk:section" content="<%= @meta_section %>">

--- a/test/unit/calculators/check_travel_during_coronavirus_calculator_test.rb
+++ b/test/unit/calculators/check_travel_during_coronavirus_calculator_test.rb
@@ -16,6 +16,12 @@ module SmartAnswer::Calculators
       end
     end
 
+    context "vaccination_status" do
+      should "have a vaccination_status question" do
+        assert_equal true, @calculator.respond_to?(:vaccination_status)
+      end
+    end
+
     context "country_locations" do
       should "find a country if it exists" do
         @calculator.countries << "spain"


### PR DESCRIPTION
This adds the flag that's checked by the publishing components gem so that vaccination status is stripped from the URL saved in GA. It also adds a test to check that the validation status exists and hasn't been renamed. This has been done to make sure that this can't be changed without something breaking. If it were renamed there's a chance it would silently fail and expose data. 

Linked - https://github.com/alphagov/govuk_publishing_components/pull/2582/

[Trello](https://trello.com/c/DInfO64C/540-mvp-innout-decide-what-to-do-from-a-data-privacy-angle)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
