### PR TITLE
Add missing hyperlink to country guidance

### DIFF
--- a/app/flows/check_travel_during_coronavirus_flow/outcomes/_country.erb
+++ b/app/flows/check_travel_during_coronavirus_flow/outcomes/_country.erb
@@ -22,7 +22,7 @@
 <% end %>
 
 <% if calculator.countries_with_content_headers_converted.include?(country.slug) %>
-  <p class="govuk-body">You should read the <%= country.title %> entry requirements guidance. Based on your answers, relevant sections are:</p>
+  <p class="govuk-body">You should read the <a href="https://www.gov.uk/foreign-travel-advice/<%= country.slug %>/entry-requirements" class="govuk-link" rel="noreferrer noopener" target="_blank"><%= country.title %> entry requirements guidance (opens in new tab)</a>. Based on your answers, relevant sections are:</p>
 
   <% if calculator.transit_countries.include?(country.slug) %>
     <ul class="govuk-list govuk-list--bullet">

--- a/test/flows/check_travel_during_coronavirus_flow_test.rb
+++ b/test/flows/check_travel_during_coronavirus_flow_test.rb
@@ -308,7 +308,7 @@ class CheckTravelDuringCoronavirusFlowTest < ActiveSupport::TestCase
       end
 
       should "render the specific country guidance" do
-        assert_rendered_outcome text: "You should read the Italy entry requirements guidance. Based on your answers, relevant sections are:"
+        assert_rendered_outcome text: "You should read the Italy entry requirements guidance (opens in new tab). Based on your answers, relevant sections are:"
       end
 
       should "render transiting guidance for transit countries" do


### PR DESCRIPTION
Follows on from: https://github.com/alphagov/smart-answers/pull/5735

# What's changed?

Add missing hyperlink to country guidance in the coronavirus travel smart-answer

# Why?
The hyperlink was missed in: https://github.com/alphagov/smart-answers/commit/a374edbb4f6b1cc7e5244a2ccf836e2fd482fb88

# Expected changes

[Rendered version](https://smart-answer-add-hyperl-9gj0mb.herokuapp.com/check-travel-during-coronavirus/results?any_other_countries_1=yes&any_other_countries_2=yes&any_other_countries_3=no&going_to_countries_within_10_days=yes&transit_countries%5B%5D=none&travelling_with_children%5B%5D=zero_to_four&travelling_with_children%5B%5D=five_to_seventeen&vaccination_status=vaccinated&which_1_country=spain&which_2_country=south-africa&which_country=afghanistan)

|Before|After|
|:------|:----|
|<img width="1152" alt="Screenshot 2022-01-27 at 13 17 42" src="https://user-images.githubusercontent.com/5793815/151367340-50d855d1-0822-4c61-82f1-6f3573725291.png">|<img width="1152" alt="Screenshot 2022-01-27 at 13 17 24" src="https://user-images.githubusercontent.com/5793815/151367427-28ea45bf-5bfe-4ec5-be17-50c238debe07.png">|



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
