### PR TITLE
Remove email signup link from results page

### DIFF
--- a/app/flows/check_travel_during_coronavirus_flow/outcomes/results.erb
+++ b/app/flows/check_travel_during_coronavirus_flow/outcomes/results.erb
@@ -1,14 +1,6 @@
 <% html_for :body do %>
   <%= render "govuk_publishing_components/components/print_link" %>
 
-  <%= render "govuk_publishing_components/components/signup_link", {
-    heading: "What you need to do may change",
-    link_text: "Send your travel results to your email address",
-    link_href: "/fix-me",
-    background: true,
-    margin_bottom: 8
-  } %>
-
   <div class="travel-abroad__heading">
     <%= render "govuk_publishing_components/components/heading", {
       text: "Travelling abroad from England",


### PR DESCRIPTION
Trello: https://trello.com/c/prcyPNpg

# What's changed?

Removes the email signup link from results page of the coronavirus
travel smart-answer. 

# Why?
The signup box takes up a lot of page space and
it is also not going to be possible for users to receive email alerts
for the results page.

# Expected changes

[Rendered version](https://smart-answer-remove-ema-e8oqab.herokuapp.com/check-travel-during-coronavirus/results?any_other_countries_1=yes&any_other_countries_2=yes&any_other_countries_3=no&going_to_countries_within_10_days=yes&transit_countries%5B%5D=none&travelling_with_children%5B%5D=zero_to_four&travelling_with_children%5B%5D=five_to_seventeen&vaccination_status=vaccinated&which_1_country=south-africa&which_2_country=denmark&which_country=afghanistan)

|Before|After|
|:------|:----|
|<img width="1628" alt="Screenshot 2022-01-27 at 16 41 32" src="https://user-images.githubusercontent.com/5793815/151404338-31b8f298-2f22-41f0-8f48-60b328e28bcb.png">|<img width="1628" alt="Screenshot 2022-01-27 at 16 40 59" src="https://user-images.githubusercontent.com/5793815/151404371-062a21f5-e7da-466d-a96b-6b8ea57fd27e.png">|



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
