### PR TITLE
Add explanation for travelling through/transiting

### DIFF
--- a/app/flows/check_travel_during_coronavirus_flow/questions/transit_countries.erb
+++ b/app/flows/check_travel_during_coronavirus_flow/questions/transit_countries.erb
@@ -3,6 +3,7 @@
 <% end %>
 
 <% govspeak_for :body do %>
+  Select any countries that you’re travelling through without stopping or leaving the airport. This is sometimes called ‘transiting’. If you’re not sure whether you’re entering or transiting through a country, you should check the rules for that country from the results page of this tool.
 <% end %>
 
 <% text_for :hint do %>


### PR DESCRIPTION
https://trello.com/c/zC35i6xg

# What's changed?

Add an explanation of what we mean when we ask if user 'travelling through' a country,

# Expected changes

[Rendered version](https://smart-answer-transiting-h63arv.herokuapp.com/check-travel-during-coronavirus/transit-countries?any_other_countries_1=yes&any_other_countries_2=no&which_1_country=andorra&which_country=afghanistan)

|Before|After|
|:------|:----|
|![Screenshot 2022-01-28 at 14 18 13](https://user-images.githubusercontent.com/5793815/151563422-d02ed16e-171e-4e4c-a8e6-b5d338a1f6a7.png)|![Screenshot 2022-01-28 at 14 17 44](https://user-images.githubusercontent.com/5793815/151563479-27d8208d-9826-4a1a-8944-d07300093c48.png)|




⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
