### PR TITLE
Honour Content Store Cache-Control Header

### DIFF
--- a/app/controllers/flow_controller.rb
+++ b/app/controllers/flow_controller.rb
@@ -56,7 +56,7 @@ private
     if flow.response_store == :session
       response.headers["Cache-Control"] = "no-store"
     elsif Rails.configuration.set_http_cache_control_expiry_time
-      expires_in(30.minutes, public: true)
+      expires_in(5.minutes, public: true)
     end
   end
 end

--- a/app/services/content_item_retriever.rb
+++ b/app/services/content_item_retriever.rb
@@ -1,7 +1,10 @@
 class ContentItemRetriever
   def self.fetch(slug)
     item_hash = Rails.cache.fetch("ContentItemRetriever/#{slug}", expires_in: 30.minutes) do
-      GdsApi.content_store.content_item("/#{slug}").to_hash
+      res = GdsApi.content_store.content_item("/#{slug}")
+      h = res.to_h
+      h["cache_control"] = res.cache_control
+      h
     end
 
     item_hash.with_indifferent_access

--- a/test/functional/flow_controller_test.rb
+++ b/test/functional/flow_controller_test.rb
@@ -6,7 +6,7 @@ class FlowControllerTest < ActionController::TestCase
 
   setup do
     setup_fixture_flows
-    Rails.application.config.stubs(:set_http_cache_control_expiry_time).returns(true)
+    enable_page_caching
   end
 
   teardown { teardown_fixture_flows }
@@ -22,7 +22,7 @@ class FlowControllerTest < ActionController::TestCase
       assert_select "meta[name=robots][content=noindex]", count: 0
     end
 
-    should "have cache headers set to 30 mins" do
+    should "have cache headers set to 5 mins" do
       get :landing, params: { id: "radio-sample" }
       assert_cached_response
     end
@@ -197,13 +197,5 @@ class FlowControllerTest < ActionController::TestCase
       assert_redirected_to "/radio-sample/y"
       assert_cached_response
     end
-  end
-
-  def assert_cached_response
-    assert_equal "max-age=1800, public", @response.header["Cache-Control"]
-  end
-
-  def assert_uncached_response
-    assert_equal "no-store", @response.header["Cache-Control"]
   end
 end

--- a/test/functional/smart_answers_controller_salary_question_test.rb
+++ b/test/functional/smart_answers_controller_salary_question_test.rb
@@ -61,11 +61,11 @@ class SmartAnswersControllerSalaryQuestionTest < ActionController::TestCase
           assert_select ".govuk-summary-list", /How much\?\s+£1 per month/
         end
 
-        should "have cache headers set to 30 mins for inner pages" do
+        should "have cache headers set to 5 mins for inner pages" do
           Rails.application.config.stubs(:set_http_cache_control_expiry_time).returns(true)
 
           get :show, params: { id: "salary-sample", started: "y", responses: "1.0-month" }
-          assert_equal "max-age=1800, public", @response.header["Cache-Control"]
+          assert_equal "max-age=300, public", @response.header["Cache-Control"]
         end
       end
     end

--- a/test/functional/smart_answers_controller_test_helper.rb
+++ b/test/functional/smart_answers_controller_test_helper.rb
@@ -19,4 +19,17 @@ module SmartAnswersControllerTestHelper
     params[:response] = response if response
     get :show, params: params.merge(other_params)
   end
+
+  def assert_cached_response(age: 5.minutes.to_i, public: true)
+    shared_cache = public ? "public" : "private"
+    assert_equal "max-age=#{age}, #{shared_cache}", @response.header["Cache-Control"]
+  end
+
+  def assert_uncached_response
+    assert_equal "no-store", @response.header["Cache-Control"]
+  end
+
+  def enable_page_caching
+    Rails.application.config.stubs(:set_http_cache_control_expiry_time).returns(true)
+  end
 end

--- a/test/unit/services/content_item_retriever_test.rb
+++ b/test/unit/services/content_item_retriever_test.rb
@@ -37,6 +37,17 @@ class ContentItemRetrieverTest < ActiveSupport::TestCase
         stub_request(:get, @request_url).to_return(response)
 
         content_item = ContentItemRetriever.fetch(@slug)
+        @content_store_response["cache_control"] = {}
+
+        assert_equal content_item, @content_store_response
+      end
+
+      should "use cache-control header" do
+        response = { status: 200, body: @content_store_response.to_json, headers: { "Cache-Control" => "max-age: 300, public" } }
+        stub_request(:get, @request_url).to_return(response)
+
+        content_item = ContentItemRetriever.fetch(@slug)
+        @content_store_response["cache_control"] = { "max-age" => true, "public" => true }
 
         assert_equal content_item, @content_store_response
       end


### PR DESCRIPTION
Partially implements [RFC 144](https://github.com/alphagov/govuk-rfcs/blob/main/rfc-144-consistent-cache-expiry.md)

https://trello.com/c/OaUhq6uI/722

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

