### PR TITLE
Remove link from text on results page

### DIFF
--- a/app/flows/check_travel_during_coronavirus_flow/outcomes/_country.erb
+++ b/app/flows/check_travel_during_coronavirus_flow/outcomes/_country.erb
@@ -22,7 +22,7 @@
 <% end %>
 
 <% if calculator.countries_with_content_headers_converted.include?(country.slug) %>
-  <p class="govuk-body">You should read the <a href="https://www.gov.uk/foreign-travel-advice/<%= country.slug %>/entry-requirements" class="govuk-link" rel="noreferrer noopener" target="_blank"><%= country.title %> entry requirements guidance (opens in new tab)</a>. Based on your answers, relevant sections are:</p>
+  <p class="govuk-body">You should read the <%= country.title %> entry requirements guidance. Based on your answers, relevant sections are:</p>
 
   <% if calculator.transit_countries.include?(country.slug) %>
     <ul class="govuk-list govuk-list--bullet">

--- a/test/flows/check_travel_during_coronavirus_flow_test.rb
+++ b/test/flows/check_travel_during_coronavirus_flow_test.rb
@@ -308,7 +308,7 @@ class CheckTravelDuringCoronavirusFlowTest < ActiveSupport::TestCase
       end
 
       should "render the specific country guidance" do
-        assert_rendered_outcome text: "You should read the Italy entry requirements guidance (opens in new tab). Based on your answers, relevant sections are:"
+        assert_rendered_outcome text: "You should read the Italy entry requirements guidance. Based on your answers, relevant sections are:"
       end
 
       should "render transiting guidance for transit countries" do


### PR DESCRIPTION
In line with latest content advice

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
