### PR TITLE
Remove "before you start" text for check_travel_during_coronavirus flow

### DIFF
--- a/app/flows/check_travel_during_coronavirus_flow/start.erb
+++ b/app/flows/check_travel_during_coronavirus_flow/start.erb
@@ -24,13 +24,11 @@
   $CTA
 <% end %>
 
-<% govspeak_for :post_body do %>
-  <%= render "govuk_publishing_components/components/heading", {
-    text: "Travelling to England from within the UK, Channel Islands and the Isle of Man",
-    font_size: "m",
-    margin_bottom: 4,
-  } %>
+<% text_for :post_header do %>
+  Travelling to England from within the UK, Channel Islands and the Isle of Man
+<% end %>
 
+<% govspeak_for :post_body do %>
   <p>If you’re travelling to England from within the Common Travel Area (England, Scotland, Wales and Northern Ireland, Ireland, the Channel Islands and the Isle of Man) and haven’t been anywhere else within the 10 days before you arrive, there are no entry requirements for coming into England.</p>
   <p>If you’ve been to a country or territory outside the Common Travel Area within the 10 days before you arrive in England, you must follow the rules for entering England from that country. You can use this tool to find out those rules.</p>
 <% end %>

--- a/app/presenters/start_node_presenter.rb
+++ b/app/presenters/start_node_presenter.rb
@@ -19,6 +19,11 @@ class StartNodePresenter < NodePresenter
     @renderer.content_for(:body)
   end
 
+  def post_header
+    custom_header_text = @renderer.content_for(:post_header)
+    custom_header_text.presence || "Before you start"
+  end
+
   def post_body
     @renderer.content_for(:post_body)
   end

--- a/app/views/smart_answers/landing.html.erb
+++ b/app/views/smart_answers/landing.html.erb
@@ -48,10 +48,12 @@
       <% unless start_node.post_body.blank? %>
         <section>
           <div id="before-you-start">
-            <%= render "govuk_publishing_components/components/heading", {
-              text: "Before you start",
-              padding: true
-            } %>
+            <% unless start_node.node_name == :check_travel_during_coronavirus %>
+              <%= render "govuk_publishing_components/components/heading", {
+                text: "Before you start",
+                padding: true
+              } %>
+            <% end %>
             <%= start_node.post_body %>
           </div>
         </section>

--- a/app/views/smart_answers/landing.html.erb
+++ b/app/views/smart_answers/landing.html.erb
@@ -48,12 +48,10 @@
       <% unless start_node.post_body.blank? %>
         <section>
           <div id="before-you-start">
-            <% unless start_node.node_name == :check_travel_during_coronavirus %>
-              <%= render "govuk_publishing_components/components/heading", {
-                text: "Before you start",
-                padding: true
-              } %>
-            <% end %>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: start_node.post_header, 
+              padding: true
+            } %>
             <%= start_node.post_body %>
           </div>
         </section>


### PR DESCRIPTION
This is hacky. I assume we don't want to add this in but would like to hear thoughts

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
