### PR TITLE
Add ability to override the Before you start text

### DIFF
--- a/app/flows/check_travel_during_coronavirus_flow/start.erb
+++ b/app/flows/check_travel_during_coronavirus_flow/start.erb
@@ -24,13 +24,11 @@
   $CTA
 <% end %>
 
-<% govspeak_for :post_body do %>
-  <%= render "govuk_publishing_components/components/heading", {
-    text: "Travelling to England from within the UK, Channel Islands and the Isle of Man",
-    font_size: "m",
-    margin_bottom: 4,
-  } %>
+<% text_for :post_body_header do %>
+  Travelling to England from within the UK, Channel Islands and the Isle of Man
+<% end %>
 
+<% govspeak_for :post_body do %>
   <p>If you’re travelling to England from within the Common Travel Area (England, Scotland, Wales and Northern Ireland, Ireland, the Channel Islands and the Isle of Man) and haven’t been anywhere else within the 10 days before you arrive, there are no entry requirements for coming into England.</p>
   <p>If you’ve been to a country or territory outside the Common Travel Area within the 10 days before you arrive in England, you must follow the rules for entering England from that country. You can use this tool to find out those rules.</p>
 <% end %>

--- a/app/presenters/start_node_presenter.rb
+++ b/app/presenters/start_node_presenter.rb
@@ -19,6 +19,11 @@ class StartNodePresenter < NodePresenter
     @renderer.content_for(:body)
   end
 
+  def post_body_header
+    custom_header_text = @renderer.content_for(:post_body_header)
+    custom_header_text.presence || "Before you start"
+  end
+
   def post_body
     @renderer.content_for(:post_body)
   end

--- a/app/views/smart_answers/landing.html.erb
+++ b/app/views/smart_answers/landing.html.erb
@@ -49,7 +49,7 @@
         <section>
           <div id="before-you-start">
             <%= render "govuk_publishing_components/components/heading", {
-              text: "Before you start",
+              text: start_node.post_body_header,
               padding: true
             } %>
             <%= start_node.post_body %>

--- a/docs/design/erb-templates/landing-page-template.md
+++ b/docs/design/erb-templates/landing-page-template.md
@@ -51,4 +51,12 @@ Used to generate supplementary content (appearing below the start button). Expec
 <% end %>
 ```
 
+Optionally, it is possible to supply a custom header for this section. If supplied, this will override the default "Before you start" heading and can only be text. Example:
+
+```erb
+<% text_for :post_body_header do %>
+  Travelling to England from within the UK, Channel Islands and the Isle of Man
+<% end %>
+```
+
 [meta-description]: https://moz.com/learn/seo/meta-description

--- a/test/unit/start_node_presenter_test.rb
+++ b/test/unit/start_node_presenter_test.rb
@@ -56,5 +56,17 @@ module SmartAnswer
 
       assert_equal "Start now", @presenter.start_button_text
     end
+
+    test "#post_body_header returns custom text when supplied" do
+      @renderer.stubs(:content_for).with(:post_body_header).returns("post-body-header-text")
+
+      assert_equal "post-body-header-text", @presenter.post_body_header
+    end
+
+    test '#post_body_header returns "Before you start" when there is no custom header text' do
+      @renderer.stubs(:content_for).with(:post_body_header).returns("")
+
+      assert_equal "Before you start", @presenter.post_body_header
+    end
   end
 end


### PR DESCRIPTION
### What

The content designers would like to override the 'Before you start' text on the COVID travel Start page.

Unfortunately it is part of the Smart Answer landing template.

### Why

The desired content doesn't fit in with the current approach of a list of prerequisites, or pre-start information.

### Before

<img width="771" alt="Screenshot 2022-02-03 at 14 22 19" src="https://user-images.githubusercontent.com/44037625/152361134-df5a2902-1575-49d3-8df6-2c99d51d25f6.png">

### After

<img width="771" alt="Screenshot 2022-02-03 at 14 20 57" src="https://user-images.githubusercontent.com/44037625/152361174-26324498-fa8f-47d5-b801-19d021e3a92b.png">

Co-authored-by: Alex Newton <alex.newton@digital.cabinet-office.gov.uk>

[Trello](https://trello.com/c/TLpYQ1s4/588-mvp-if-possible-remove-the-before-you-start-text-from-the-start-page)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
