### PR TITLE
Start page content changes to reflect 11 Feb rules

### DIFF
--- a/app/flows/check_travel_during_coronavirus_flow/start.erb
+++ b/app/flows/check_travel_during_coronavirus_flow/start.erb
@@ -3,32 +3,32 @@
 <% end %>
 
 <% govspeak_for :body do %>
-  <p>If you're travelling from and to England during coronavirus (COVID-19), there are things you need to do before you travel and after you arrive.</p>
+  <p>If you’re travelling from and to England during coronavirus (COVID-19), there are things you need to do before you travel and after you arrive.</p>
+
+  $CTA
+  <p>There are different rules if you’re <a href="https://www.gov.scot/publications/coronavirus-covid-19-international-travel-quarantine/">travelling to Scotland</a>, <a href="https://gov.wales/arriving-wales-overseas">travelling to Wales</a> or <a href="https://www.nidirect.gov.uk/articles/coronavirus-covid-19-international-travel-advice">travelling to Northern Ireland</a>.</p>
+  $CTA
 
   <p>Use this tool to find out:</p>
 
   <ul>
-    <li>entry requirements for the country you're going to or travelling through</li>
-    <li>whether a country you’re going to or travelling through is on the red list</li>
-    <li>what tests you need to take and when</li>
-    <li>when you need to quarantine</li>
-    <li>what you need to do to travel with children</li>
+    <li>entry requirements for a country you’re going to or travelling through</li>
     <li>what you need to do before and after you return to England</li>
-    <li>whether you're exempt from any rules</li>
+    <li>whether you need take any tests and when</li>
+    <li>what you need to do to travel with children</li>
+    <li>whether you’re exempt from any rules</li>
+    <li>whether a country you’re going to or travelling through is on the red list</li>
   </ul>
 
   <p>You will be asked a series of questions so we can show you information relevant to your journey and circumstances.</p>
-
-  $CTA
-  There are different rules if you're <a href="https://www.gov.scot/publications/coronavirus-covid-19-international-travel-quarantine/">travelling to Scotland</a>, <a href="https://gov.wales/rules-international-travel-and-wales-coronavirus">travelling to Wales</a> or <a href="https://www.nidirect.gov.uk/articles/coronavirus-covid-19-travel-advice">travelling to Northern Ireland</a>
-  $CTA
 <% end %>
 
 <% text_for :post_body_header do %>
-  Travelling to England from within the UK, Channel Islands and the Isle of Man
+  Travelling to England from within the UK, Ireland, Channel Islands and the Isle of Man
 <% end %>
 
 <% govspeak_for :post_body do %>
   <p>If you’re travelling to England from within the Common Travel Area (England, Scotland, Wales and Northern Ireland, Ireland, the Channel Islands and the Isle of Man) and haven’t been anywhere else within the 10 days before you arrive, there are no entry requirements for coming into England.</p>
+
   <p>If you’ve been to a country or territory outside the Common Travel Area within the 10 days before you arrive in England, you must follow the rules for entering England from that country. You can use this tool to find out those rules.</p>
 <% end %>


### PR DESCRIPTION
## What

This change:

* Updates the start page to reflect the changes in testing rules from 11 Feb.

* Moves the call-to-action text on devolved nations higher so that it's more
prominent.

## Why

Rule testing requirements change from 11 Feb.

## Before

![screencapture-smart-answers-preview-herokuapp-check-travel-during-coronavirus-2022-02-07-09_15_24](https://user-images.githubusercontent.com/44037625/152759385-2488edf7-01bb-46e6-bdac-581cb85b0ffc.png)

## After

![screencapture-localhost-3010-check-travel-during-coronavirus-2022-02-07-11_13_18](https://user-images.githubusercontent.com/44037625/152777904-a3034a8d-4b61-44f4-b5f6-e6dce91b9672.png)

[Trello](https://trello.com/c/dJbuRthW/612-update-start-page-to-reflect-11-feb-rules-for-dft-fact-check)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
