### PR TITLE
Codify vaccination_status in check_travel_during_coronavirus flow

### DIFF
--- a/app/flows/check_travel_during_coronavirus_flow.rb
+++ b/app/flows/check_travel_during_coronavirus_flow.rb
@@ -87,10 +87,10 @@ class CheckTravelDuringCoronavirusFlow < SmartAnswer::Flow
     end
 
     radio :vaccination_status do
-      option :vaccinated
-      option :in_trial
-      option :exempt
-      option :none
+      option "3371ccf8123dfadf".to_sym
+      option "e9e286f8822bc330".to_sym
+      option "529202127233d442".to_sym
+      option "9ddc7655bfd0d477".to_sym
 
       on_response do |response|
         calculator.vaccination_status = response

--- a/app/flows/check_travel_during_coronavirus_flow/outcomes/results.erb
+++ b/app/flows/check_travel_during_coronavirus_flow/outcomes/results.erb
@@ -52,7 +52,7 @@
     <%= render partial: "exempt_medical" %>
     <%= render partial: "exempt_compassionate" %>
   <% else %>
-    <% if calculator.vaccination_status == "none" %>
+    <% if calculator.vaccination_status == "9ddc7655bfd0d477" %>
       <%= render partial: "not_fully_vaxed", locals: { calculator: calculator } %>
     <% else %>
       <%= render partial: "fully_vaxed", locals: { calculator: calculator } %>

--- a/app/flows/check_travel_during_coronavirus_flow/questions/vaccination_status.erb
+++ b/app/flows/check_travel_during_coronavirus_flow/questions/vaccination_status.erb
@@ -11,8 +11,8 @@
 <% end %>
 
 <% options(
-  "vaccinated": "I will have had a second dose of an approved COVID-19 vaccine 14 or more days before I travel",
-  "in_trial": "I'm taking part in an approved COVID-19 vaccine trial in the UK",
-  "exempt": "I cannot have a COVID-19 vaccination for a medical reason approved by a clinician",
-  "none": "None of the above",
+  "3371ccf8123dfadf": "I will have had a second dose of an approved COVID-19 vaccine 14 or more days before I travel",
+  "e9e286f8822bc330": "I'm taking part in an approved COVID-19 vaccine trial in the UK",
+  "529202127233d442": "I cannot have a COVID-19 vaccination for a medical reason approved by a clinician",
+  "9ddc7655bfd0d477": "None of the above",
 ) %>

--- a/test/flows/check_travel_during_coronavirus_flow_test.rb
+++ b/test/flows/check_travel_during_coronavirus_flow_test.rb
@@ -352,11 +352,11 @@ class CheckTravelDuringCoronavirusFlowTest < ActiveSupport::TestCase
 
       should "render guidance for people who aren't fully vaccinated" do
         add_responses vaccination_status: "9ddc7655bfd0d477"
-        assert_rendered_outcome text: "people who aren't fully vaccinated"
+        assert_rendered_outcome text: "Returning to England if you're not fully vaccinated"
       end
 
       should "render guidance for people who are fully vaccinated" do
-        assert_rendered_outcome text: "fully vaccinated people"
+        assert_rendered_outcome text: "Returning to England if you're fully vaccinated"
       end
 
       should "render guidance for people travelling with children" do

--- a/test/flows/check_travel_during_coronavirus_flow_test.rb
+++ b/test/flows/check_travel_during_coronavirus_flow_test.rb
@@ -172,7 +172,7 @@ class CheckTravelDuringCoronavirusFlowTest < ActiveSupport::TestCase
     context "next_node" do
       should "have a next node of travelling_with_young_people " \
                 "if the user is not travelling to a red list country " do
-        assert_next_node :travelling_with_young_people, for_response: "vaccinated"
+        assert_next_node :travelling_with_young_people, for_response: "3371ccf8123dfadf"
       end
 
       should "have a next node of travelling_with_children " \
@@ -180,7 +180,7 @@ class CheckTravelDuringCoronavirusFlowTest < ActiveSupport::TestCase
         add_responses which_country: "spain",
                       going_to_countries_within_10_days: "yes"
         SmartAnswer::Calculators::CheckTravelDuringCoronavirusCalculator.any_instance.stubs(:red_list_countries).returns(%w[spain])
-        assert_next_node :travelling_with_children, for_response: "vaccinated"
+        assert_next_node :travelling_with_children, for_response: "3371ccf8123dfadf"
       end
     end
   end
@@ -191,7 +191,7 @@ class CheckTravelDuringCoronavirusFlowTest < ActiveSupport::TestCase
       add_responses which_country: "spain",
                     any_other_countries_1: "no",
                     going_to_countries_within_10_days: "yes",
-                    vaccination_status: "vaccinated"
+                    vaccination_status: "3371ccf8123dfadf"
       SmartAnswer::Calculators::CheckTravelDuringCoronavirusCalculator.any_instance.stubs(:red_list_countries).returns(%w[spain])
     end
 
@@ -212,7 +212,7 @@ class CheckTravelDuringCoronavirusFlowTest < ActiveSupport::TestCase
       testing_node :travelling_with_young_people
       add_responses which_country: "spain",
                     any_other_countries_1: "no",
-                    vaccination_status: "vaccinated"
+                    vaccination_status: "3371ccf8123dfadf"
     end
 
     should "render question" do
@@ -232,7 +232,7 @@ class CheckTravelDuringCoronavirusFlowTest < ActiveSupport::TestCase
       testing_node :results
       add_responses which_country: "poland",
                     any_other_countries_1: "no",
-                    vaccination_status: "vaccinated",
+                    vaccination_status: "3371ccf8123dfadf",
                     travelling_with_young_people: "no"
     end
 
@@ -351,7 +351,7 @@ class CheckTravelDuringCoronavirusFlowTest < ActiveSupport::TestCase
       end
 
       should "render guidance for people who aren't fully vaccinated" do
-        add_responses vaccination_status: "none"
+        add_responses vaccination_status: "9ddc7655bfd0d477"
         assert_rendered_outcome text: "people who aren't fully vaccinated"
       end
 
@@ -375,7 +375,7 @@ class CheckTravelDuringCoronavirusFlowTest < ActiveSupport::TestCase
                       any_other_countries_1: "no",
                       transit_countries: "none",
                       going_to_countries_within_10_days: "no",
-                      vaccination_status: "vaccinated",
+                      vaccination_status: "3371ccf8123dfadf",
                       travelling_with_young_people: "no"
       end
 
@@ -405,7 +405,7 @@ class CheckTravelDuringCoronavirusFlowTest < ActiveSupport::TestCase
         add_responses which_country: "spain",
                       any_other_countries_1: "no",
                       going_to_countries_within_10_days: "yes",
-                      vaccination_status: "vaccinated",
+                      vaccination_status: "3371ccf8123dfadf",
                       travelling_with_children: "none"
       end
 
@@ -442,7 +442,7 @@ class CheckTravelDuringCoronavirusFlowTest < ActiveSupport::TestCase
                       any_other_countries_1: "no",
                       transit_countries: "none",
                       going_to_countries_within_10_days: "no",
-                      vaccination_status: "vaccinated",
+                      vaccination_status: "3371ccf8123dfadf",
                       travelling_with_young_people: "no"
       end
 
@@ -451,7 +451,7 @@ class CheckTravelDuringCoronavirusFlowTest < ActiveSupport::TestCase
       end
 
       should "render unvaccinated guidance when user is not fully vaccinated" do
-        add_responses vaccination_status: "none"
+        add_responses vaccination_status: "9ddc7655bfd0d477"
         assert_rendered_outcome text: "Returning to England if you're not fully vaccinated"
       end
 
@@ -471,7 +471,7 @@ class CheckTravelDuringCoronavirusFlowTest < ActiveSupport::TestCase
                       any_other_countries_1: "no",
                       transit_countries: "none",
                       going_to_countries_within_10_days: "no",
-                      vaccination_status: "vaccinated",
+                      vaccination_status: "3371ccf8123dfadf",
                       travelling_with_children: "none"
       end
 
@@ -505,7 +505,7 @@ class CheckTravelDuringCoronavirusFlowTest < ActiveSupport::TestCase
         add_responses any_other_countries_1: "yes",
                       which_1_country: "spain",
                       any_other_countries_2: "no",
-                      vaccination_status: "none"
+                      vaccination_status: "9ddc7655bfd0d477"
 
         assert_rendered_outcome text: "If you’ve been in Ireland for at 10 days or more before travelling to England"
         assert_rendered_outcome text: "Returning to England if you're not fully vaccinated"


### PR DESCRIPTION
## What

Currently the `vaccination_status` question in the `check_travel_during_coronavirus` flow has the following possible responses:

* "vaccinated": "I will have had a second dose of an approved COVID-19 vaccine 14 or more days before I travel"
* "in_trial": "I'm taking part in an approved COVID-19 vaccine trial in the UK"
* "exempt": "I cannot have a COVID-19 vaccination for a medical reason approved by a clinician"
* "none": "None of the above"

As this flow is URL-based, we would see something like this `vaccination_status=vaccinated` in the URL when the question is answered.

We need to obfuscate (codify) the response in the URL. For example:

* "123456": "I will have had a second dose of an approved COVID-19 vaccine 14 or more days before I travel"
* "234567": "I'm taking part in an approved COVID-19 vaccine trial in the UK"
* "345678": "I cannot have a COVID-19 vaccination for a medical reason approved by a clinician"
* "456789": "None of the above"

`SecureRandom.hex(8)` has been used to generate the obfuscated codes as this is unlikely to generate duplicates if more response values are added, are long enough to unique and short enough to be human usable.

## Why

Vaccination status is considered PII Health data and so we need to replace this question/response as plain text from the URL with a codified version.

## Before

<img width="1061" alt="Screenshot 2022-02-08 at 08 10 08" src="https://user-images.githubusercontent.com/44037625/152946493-e52aaba6-36fc-4ecd-abce-ddabce70ddea.png">

<img width="1009" alt="Screenshot 2022-02-08 at 08 22 50" src="https://user-images.githubusercontent.com/44037625/152946815-2a2979f6-c988-495b-bbf7-032cc63d92ef.png">

<img width="1009" alt="Screenshot 2022-02-08 at 09 50 57" src="https://user-images.githubusercontent.com/44037625/152962210-6041797e-3a9f-432b-8d49-39411087b2f2.png">

## After

<img width="1061" alt="Screenshot 2022-02-08 at 08 08 38" src="https://user-images.githubusercontent.com/44037625/152946471-0c133a04-ab2e-4abc-86e0-4a2201f8296b.png">

<img width="1009" alt="Screenshot 2022-02-08 at 08 22 28" src="https://user-images.githubusercontent.com/44037625/152946838-e48756d9-d910-421c-a1fa-3750b0d448f1.png">

<img width="1009" alt="Screenshot 2022-02-08 at 09 50 11" src="https://user-images.githubusercontent.com/44037625/152962179-b3ff61ae-d5c3-462f-a1f8-f4984101655c.png">

[Trello](https://trello.com/c/wwMtYcRM/621-codify-vaccinationstatus)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
