### PR TITLE
Add meta tag for redacting vaccination_status

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,6 +27,7 @@
         strip_dates_pii: true,
         strip_postcode_pii: true %>
     <% end %>
+    <meta name="govuk:static-analytics:strip-query-string-parameters" content="vaccination_status">
     <% if @meta_section %>
       <meta name="govuk:section" content="<%= @meta_section %>">
     <% end %>


### PR DESCRIPTION
## What

Remove the users response to the `vaccination_status` question from the data that we send to Google Analytics in the `check_travel_during-coronavirous` flow.

We use the [`queryStringParametersToStrip`](https://github.com/alphagov/govuk_publishing_components/blob/aa58d1666e18dab29bb813ef34102cc73b02a81d/app/assets/javascripts/govuk_publishing_components/analytics/pii.js#L25) function in the [`pii.js`](https://github.com/alphagov/govuk_publishing_components/blob/aa58d1666e18dab29bb813ef34102cc73b02a81d/app/assets/javascripts/govuk_publishing_components/analytics/pii.js) component from [`govuk_publishing_components`](https://github.com/alphagov/govuk_publishing_components) to achieve this.

This function allows us to add a `meta` tag where appropriate.  For example:

```html
<meta name="govuk:static-analytics:strip-query-string-parameters" content="query_string_param_name_to_strip">
```

The param will then be redacted.  For example:

```
https://www.gov.uk?query_string_param_name_to_strip=[query_string_param_name_to_strip]
```


## Why

A users vaccination status is considered health data, so we should not expose it outside of the application.

## Before

![Screenshot 2022-02-08 at 11 28 54](https://user-images.githubusercontent.com/44037625/152979548-f008b3fa-ce73-4765-924f-44fd6b051884.png)

## After

![Screenshot 2022-02-08 at 11 27 30](https://user-images.githubusercontent.com/44037625/152979493-7e514b37-66e3-413d-8bca-1903f0c8520b.png)

[Trello](https://trello.com/c/DInfO64C/540-mvp-innout-decide-what-to-do-from-a-data-privacy-angle)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
