### PR TITLE
Add vaccination_status comment to check_travel_during_coronavirus flow

### DIFF
--- a/app/flows/check_travel_during_coronavirus_flow.rb
+++ b/app/flows/check_travel_during_coronavirus_flow.rb
@@ -86,6 +86,10 @@ class CheckTravelDuringCoronavirusFlow < SmartAnswer::Flow
       end
     end
 
+    # ****** Important ******
+    # If you rename this question, please also update:
+    #   * the `strip-query-string-parameters` `meta` tag in app/views/layouts/application.html.erb, and
+    #   * `config.filter_parameters` in config/application.rb
     radio :vaccination_status do
       option "3371ccf8123dfadf".to_sym
       option "e9e286f8822bc330".to_sym


### PR DESCRIPTION
What

Add a comment against the vaccination_status question in the check_travel_during_coronavirus flow to remember to update other places where this question is referenced by name.

Why

Changing the name of this question without updating the stated elements will leak PII health data to Google Analytics and into the Rails log.

[Trello](https://trello.com/c/DInfO64C/540-mvp-innout-decide-what-to-do-from-a-data-privacy-angle)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
