### PR TITLE
Amend vaccination question and destination of link

### DIFF
--- a/app/flows/check_travel_during_coronavirus_flow/questions/vaccination_status.erb
+++ b/app/flows/check_travel_during_coronavirus_flow/questions/vaccination_status.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% govspeak_for :body do %>
-  <a href="https://www.gov.uk/guidance/countries-with-approved-covid-19-vaccination-programmes-and-proof-of-vaccination#approved-vaccines">Approved COVID-19 vaccine programmes</a>
+  <a href="https://www.gov.uk/guidance/countries-with-approved-covid-19-vaccination-programmes-and-proof-of-vaccination">Approved COVID-19 vaccine programmes</a>
 <% end %>
 
 <% text_for :hint do %>
@@ -12,7 +12,7 @@
 
 <% options(
   "3371ccf8123dfadf": "I will have had a second dose of an approved COVID-19 vaccine 14 or more days before I travel",
-  "e9e286f8822bc330": "I'm taking part in an approved COVID-19 vaccine trial in the UK",
+  "e9e286f8822bc330": "I'm taking part in an approved COVID-19 vaccine trial",
   "529202127233d442": "I cannot have a COVID-19 vaccination for a medical reason approved by a clinician",
   "9ddc7655bfd0d477": "None of the above",
 ) %>


### PR DESCRIPTION
Vaccine trials can take place outside of UK, and following a change to the guidance linked from under the question,
we should link users to the top of a page rather than a deep link.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

[Trello card](https://trello.com/c/7HPbrq1A/629-amend-vaccination-question-and-destination-of-link-mvp)