### PR TITLE
Vaccine exemption outbound content

### DIFF
--- a/app/flows/check_travel_during_coronavirus_flow/outcomes/_country.erb
+++ b/app/flows/check_travel_during_coronavirus_flow/outcomes/_country.erb
@@ -32,10 +32,12 @@
     <ul class="govuk-list govuk-list--bullet">
       <li><a href="https://www.gov.uk/foreign-travel-advice/<%= country.slug %>/entry-requirements#all-travellers" class="govuk-link" rel="noreferrer noopener" target="_blank">all travellers (opens in new tab)</a></li>
 
-      <% if calculator.vaccination_status == "none" %>
-        <li><a href="https://www.gov.uk/foreign-travel-advice/<%= country.slug %>/entry-requirements/#if-youre-not-fully-vaccinated" class="govuk-link" rel="noreferrer noopener" target="_blank">people who aren't fully vaccinated (opens in new tab)</a></li>
-      <% else %>
+      <% if calculator.vaccination_status == "3371ccf8123dfadf" || calculator.vaccination_status == "e9e286f8822bc330" %>
         <li><a href="https://www.gov.uk/foreign-travel-advice/<%= country.slug %>/entry-requirements/#if-youre-fully-vaccinated" class="govuk-link" rel="noreferrer noopener" target="_blank">fully vaccinated people (opens in new tab)</a></li>
+      <% end %>
+
+      <% if calculator.vaccination_status == "9ddc7655bfd0d477" %>
+        <li><a href="https://www.gov.uk/foreign-travel-advice/<%= country.slug %>/entry-requirements/#if-youre-not-fully-vaccinated" class="govuk-link" rel="noreferrer noopener" target="_blank">people who aren't fully vaccinated (opens in new tab)</a></li>
       <% end %>
 
       <% unless calculator.travelling_with_children == ["none"] %>

--- a/app/flows/check_travel_during_coronavirus_flow/outcomes/_exempt_vaccination.erb
+++ b/app/flows/check_travel_during_coronavirus_flow/outcomes/_exempt_vaccination.erb
@@ -1,0 +1,13 @@
+<div class="govuk-grid-row travel-abroad__section">
+  <div class="govuk-grid-column-one-third desktop-min-height"></div>
+  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body">
+      It’s up to the country you’re travelling to to decide
+      whether or not people who can’t have a COVID-19 vaccination
+      for a medical reason can follow the same entry requirements
+      as those who are fully vaccinated. You should
+      <a href="/government/publications/foreign-embassies-in-the-uk" class="govuk-link">contact the
+      embassy of the country you’re visiting</a> to find this out.
+    </p>
+  </div>
+</div>

--- a/app/flows/check_travel_during_coronavirus_flow/outcomes/results.erb
+++ b/app/flows/check_travel_during_coronavirus_flow/outcomes/results.erb
@@ -17,6 +17,10 @@
     </div>
   </div>
 
+  <% if calculator.vaccination_status == "529202127233d442" %>
+    <%= render partial: "exempt_vaccination"  %>
+  <% end %>
+
   <% calculator.country_locations.each do |country| %>
     <div class="govuk-grid-row travel-abroad__country">
       <div class="govuk-grid-column-one-third travel-abroad__reasons">

--- a/test/flows/check_travel_during_coronavirus_flow_test.rb
+++ b/test/flows/check_travel_during_coronavirus_flow_test.rb
@@ -248,6 +248,12 @@ class CheckTravelDuringCoronavirusFlowTest < ActiveSupport::TestCase
       assert_rendered_outcome text: "You are travelling through"
     end
 
+    should "render 'exempt vaccination content' if exempt from vaccination" do
+      add_responses vaccination_status: "529202127233d442"
+      assert_rendered_outcome text: "It’s up to the country you’re travelling to to decide
+      whether or not people who can’t have a COVID-19 vaccination"
+    end
+
     context "content for countries changing covid status" do
       should "render 'move to the red list' content for countries moving to the red list" do
         travel_to("2022-01-01") do

--- a/test/flows/check_travel_during_coronavirus_flow_test.rb
+++ b/test/flows/check_travel_during_coronavirus_flow_test.rb
@@ -356,6 +356,31 @@ class CheckTravelDuringCoronavirusFlowTest < ActiveSupport::TestCase
         assert_rendered_outcome text: "travelling through Spain"
       end
 
+      should "render link to fully vaccinated people guidance if fully vaccinated" do
+        add_responses vaccination_status: "3371ccf8123dfadf"
+        assert_rendered_outcome text: "fully vaccinated people (opens in new tab)"
+      end
+
+      should "render link to fully vaccinated people guidance if taking part in vaccine trial" do
+        add_responses vaccination_status: "e9e286f8822bc330"
+        assert_rendered_outcome text: "fully vaccinated people (opens in new tab)"
+      end
+
+      should "render link to people who aren't fully vaccinated guidance if not fully vaccinated" do
+        add_responses vaccination_status: "9ddc7655bfd0d477"
+        assert_rendered_outcome text: "people who aren't fully vaccinated (opens in new tab)"
+      end
+
+      should "not render link to fully vaccinated people guidance if exempt from vaccination" do
+        add_responses vaccination_status: "529202127233d442"
+        assert_no_match "fully vaccinated people (opens in new tab)", @test_flow.outcome_text
+      end
+
+      should "not render link to people who aren't fully vaccinated guidance if exempt from vaccination" do
+        add_responses vaccination_status: "529202127233d442"
+        assert_no_match "people who aren't fully vaccinated (opens in new tab)", @test_flow.outcome_text
+      end
+
       should "render guidance for people who aren't fully vaccinated" do
         add_responses vaccination_status: "9ddc7655bfd0d477"
         assert_rendered_outcome text: "Returning to England if you're not fully vaccinated"


### PR DESCRIPTION
[Trello](https://trello.com/c/vCXIFvDp/633-new-outbound-results-for-vax-exempt-mvp)

- Renders outbound exemption content for users that are exempt from vaccination.
- Hides 'fully vaccinated people' and 'people who aren't fully vaccinated' guidance links for users who are exempt from vaccination.

Further content updates for exemptions will be added in following tasks:
    https://trello.com/c/fPtwW9zX/635-content-changes-to-summary-text-because-you-said-mvp
    https://trello.com/c/3YfXGaqp/628-adding-inbound-results-for-people-exempt-from-vax-mvp

Vaccine trial outcomes will be updated in future.

<img width="1022" alt="outbound-results-exemptions" src="https://user-images.githubusercontent.com/5963488/153188591-48e35468-f223-4c8d-b84a-2656b795a484.png">




⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
