### PR TITLE
Change content around summary text and vaccine exemption

### DIFF
--- a/app/flows/check_travel_during_coronavirus_flow/outcomes/_fully_vaxed.erb
+++ b/app/flows/check_travel_during_coronavirus_flow/outcomes/_fully_vaxed.erb
@@ -12,17 +12,35 @@
 
   <p class="govuk-body">You do not need to take any COVID-19 tests before you travel to England or after you arrive.</p>
 
-  <p class="govuk-body">You must be able to prove that you’ve been fully vaccinated. If you live in England, you can prove your vaccination status using the <a href="https://www.gov.uk/guidance/nhs-covid-pass" class="govuk-link">NHS COVID Pass</a>.</p>
+  <p class="govuk-body">You must <a href="/provide-journey-contact-details-before-travel-uk" class="govuk-link">complete a passenger locator form</a> in the 48 hours before you arrive in England.</p>
 
-  <p class="govuk-body">If you were vaccinated in another country or territory, see <a href="https://www.gov.uk/guidance/countries-with-approved-covid-19-vaccination-programmes-and-proof-of-vaccination#countries-with-an-approved-proof-of-vaccination-and-examples-of-proof-required" class="govuk-link">examples of what you can use as proof of vaccination</a>.</p>
+  <%= render "govuk_publishing_components/components/heading", {
+    text: "Proof of vaccination",
+    heading_level: 3,
+    font_size: "m",
+    margin_bottom: 4,
+  } %>
 
-  <p class="govuk-body">You must <a href="https://www.gov.uk/provide-journey-contact-details-before-travel-uk" class="govuk-link">complete a passenger locator form</a> in the 48 hours before you arrive in England.</p>
+  <p class="govuk-body">You must be able to prove that you’ve been fully vaccinated against COVID-19. If you live in England, you can prove your vaccination status using the <a href="/guidance/nhs-covid-pass" class="govuk-link">NHS COVID Pass</a>.</p>
+
+  <p class="govuk-body">If you were vaccinated in another country or territory, see <a href="/guidance/countries-with-approved-covid-19-vaccination-programmes-and-proof-of-vaccination#countries-with-an-approved-proof-of-vaccination-and-examples-of-proof-required" class="govuk-link">examples of what you can use as proof of vaccination</a>.</p>
+
+  <%= render "govuk_publishing_components/components/heading", {
+    text: "Proof that you cannot have a COVID-19 vaccination",
+    heading_level: 3,
+    font_size: "m",
+    margin_bottom: 4,
+  } %>
+
+  <p class="govuk-body">If you cannot have a COVID-19 vaccination for a medical reason approved by a clinician, you will need to show proof using your <a href ="/guidance/nhs-covid-pass" class="govuk-link">NHS COVID Pass</a>.</p>
+
+  <p class="govuk-body">If you do not have proof in your NHS COVID Pass, you will need to <a href="/guidance/covid-19-medical-exemptions-proving-you-are-unable-to-get-vaccinated" class="govuk-link">apply using the NHS COVID Pass service on 119</a> and ask for a medical exemptions application form.</p>
 <% end %>
 
 <%
   data = {
-    title: "Returning to England if you’re fully vaccinated",
-    reasons: ['You are fully vaccinated'],
+    title: "Returning to England if you’re fully vaccinated or cannot have a COVID-19 vaccination",
+    reasons: ['You are fully vaccinated or cannot have a COVID-19 vaccination'],
     content: content
   }
 %>

--- a/app/flows/check_travel_during_coronavirus_flow/outcomes/_fully_vaxed.erb
+++ b/app/flows/check_travel_during_coronavirus_flow/outcomes/_fully_vaxed.erb
@@ -40,7 +40,6 @@
 <%
   data = {
     title: "Returning to England if you’re fully vaccinated or cannot have a COVID-19 vaccination",
-    reasons: ['You are fully vaccinated or cannot have a COVID-19 vaccination'],
     content: content
   }
 %>

--- a/app/flows/check_travel_during_coronavirus_flow/outcomes/_not_fully_vaxed.erb
+++ b/app/flows/check_travel_during_coronavirus_flow/outcomes/_not_fully_vaxed.erb
@@ -51,7 +51,6 @@
 <%
   data = {
     title: "Returning to England if you’re not fully vaccinated",
-    reasons: ['You are not fully vaccinated'],
     content: content
   }
 %>

--- a/app/flows/check_travel_during_coronavirus_flow/outcomes/_return_from_ireland_only.erb
+++ b/app/flows/check_travel_during_coronavirus_flow/outcomes/_return_from_ireland_only.erb
@@ -9,7 +9,6 @@
 <%
   data = {
     title: "Returning to England from Ireland",
-    reasons: [],
     content: content
   }
 %>

--- a/app/flows/check_travel_during_coronavirus_flow/outcomes/_return_from_red_list.erb
+++ b/app/flows/check_travel_during_coronavirus_flow/outcomes/_return_from_red_list.erb
@@ -47,7 +47,6 @@
 <%
   data = {
     title: "Returning to England after visiting a red list country",
-    reasons: ['You will be in a red list country within 10 days of returning to England'],
     content: content
   }
 %>

--- a/app/flows/check_travel_during_coronavirus_flow/outcomes/_travel_result_layout.erb
+++ b/app/flows/check_travel_during_coronavirus_flow/outcomes/_travel_result_layout.erb
@@ -7,21 +7,14 @@
 
 <div class="govuk-grid-row travel-abroad__section">
   <div class="govuk-grid-column-one-third travel-abroad__reasons">
-    <p class="govuk-body govuk-body-s">Because you said</p>
-    <ul class="govuk-list govuk-list--bullet govuk-body-s">
-      <% data[:reasons].each do |reason| %>
-        <li><%= reason %></li>
-      <% end %>
-      <% if calculator.travelling_with_young_people? %>
-        <li>You are travelling with someone aged 17 and under</li>
-      <% end %>
-      <% if calculator.travelling_with_children.include?("zero_to_four") %>
-        <li>You are travelling with someone aged 4 and under</li>
-      <% end %>
-      <% if calculator.travelling_with_children.include?("five_to_seventeen") %>
-        <li>You are travelling with someone aged 5 to 17</li>
-      <% end %>
-    </ul>
+    <% if calculator.summary_text_fields.any? %>
+      <p class="govuk-body govuk-body-s">Because you said:</p>
+      <ul class="govuk-list govuk-list--bullet govuk-body-s">
+        <% calculator.summary_text_fields.each do |field| %>
+          <li><%= t("check_travel_during_coronavirus.summary_text.#{field}") %></li>
+        <% end %>
+      </ul>
+    <% end %>
   </div>
 
   <div class="govuk-grid-column-two-thirds">

--- a/app/flows/check_travel_during_coronavirus_flow/outcomes/results.erb
+++ b/app/flows/check_travel_during_coronavirus_flow/outcomes/results.erb
@@ -24,14 +24,16 @@
   <% calculator.country_locations.each do |country| %>
     <div class="govuk-grid-row travel-abroad__country">
       <div class="govuk-grid-column-one-third travel-abroad__reasons">
-        <p class="govuk-body govuk-body-s">Because you said</p>
-        <ul class="govuk-list govuk-list--bullet govuk-body-s">
-          <% if calculator.transit_countries.include?(country.slug) %>
-            <li>You are travelling through <%= country.title %></li>
-          <% else %>
-            <li>You are travelling to <%= country.title %></li>
-          <% end %>
-        </ul>
+        <% unless calculator.travelling_to_ireland? && calculator.single_journey? %>
+          <p class="govuk-body govuk-body-s">Because you said:</p>
+          <ul class="govuk-list govuk-list--bullet govuk-body-s">
+            <% if calculator.transit_countries.include?(country.slug) %>
+              <li>You are travelling through <%= country.title %></li>
+            <% else %>
+              <li>You are travelling to <%= country.title %></li>
+            <% end %>
+          </ul>
+        <% end %>
       </div>
 
       <div class="govuk-grid-column-two-thirds">

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,6 +37,7 @@ module SmartAnswers
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     config.i18n.enforce_available_locales = false
     config.i18n.default_locale = :"en-GB"
+    config.i18n.load_path += Dir[Rails.root.join("config/locales/**/*.yml")]
     config.i18n.fallbacks = true
 
     # Configure the default encoding used in templates for Ruby 1.9.

--- a/config/locales/en/check_travel_during_coronavirus.yml
+++ b/config/locales/en/check_travel_during_coronavirus.yml
@@ -1,0 +1,9 @@
+en:
+  check_travel_during_coronavirus:
+    summary_text:
+      fully_vaxed: You are fully vaccinated or cannot have a COVID-19 vaccination
+      not_vaxed: You are not fully vaccinated
+      red_list: You will be in a red list country within 10 days of returning to England
+      young_person: You are travelling with someone aged 17 and under
+      zero_to_four: You are travelling with someone aged 4 and under
+      five_to_seventeen: You are travelling with someone aged 5 to 17

--- a/lib/smart_answer/calculators/check_travel_during_coronavirus_calculator.rb
+++ b/lib/smart_answer/calculators/check_travel_during_coronavirus_calculator.rb
@@ -22,6 +22,22 @@ module SmartAnswer::Calculators
       end
     end
 
+    def summary_text_fields
+      fields = []
+
+      return fields if travelling_to_ireland? && single_journey?
+
+      fields << (vaccination_status == "9ddc7655bfd0d477" ? "not_vaxed" : "fully_vaxed")
+      fields << "red_list" if travelling_to_red_list_country?
+      if travelling_with_children?
+        fields << travelling_with_children
+      elsif travelling_with_young_people?
+        fields << "young_person"
+      end
+
+      fields.flatten
+    end
+
     def travelling_with_children=(travelling_with_children)
       travelling_with_children.split(",").each do |response|
         @travelling_with_children << response

--- a/test/flows/check_travel_during_coronavirus_flow_test.rb
+++ b/test/flows/check_travel_during_coronavirus_flow_test.rb
@@ -563,7 +563,7 @@ class CheckTravelDuringCoronavirusFlowTest < ActiveSupport::TestCase
         assert_no_match "Returning to England if you’re fully vaccinated", @test_flow.outcome_text
       end
 
-      should "not render the summary text if only travelling to irealnd" do
+      should "not render the summary text if only travelling to Ireland" do
         assert_no_match "Because you said:", @test_flow.outcome_text
       end
 

--- a/test/flows/check_travel_during_coronavirus_flow_test.rb
+++ b/test/flows/check_travel_during_coronavirus_flow_test.rb
@@ -563,6 +563,10 @@ class CheckTravelDuringCoronavirusFlowTest < ActiveSupport::TestCase
         assert_no_match "Returning to England if you’re fully vaccinated", @test_flow.outcome_text
       end
 
+      should "not render the summary text if only travelling to irealnd" do
+        assert_no_match "Because you said:", @test_flow.outcome_text
+      end
+
       should "render Ireland country guidance and red list guidance if user also travelled to red list country" do
         add_responses any_other_countries_1: "yes",
                       which_1_country: "spain",

--- a/test/unit/calculators/check_travel_during_coronavirus_calculator_test.rb
+++ b/test/unit/calculators/check_travel_during_coronavirus_calculator_test.rb
@@ -120,5 +120,52 @@ module SmartAnswer::Calculators
       @calculator.countries = %w[spain]
       assert @calculator.single_journey?
     end
+
+    context "summary_text_fields" do
+      should "return an empty array if only travelling to ireland, even with other fields" do
+        @calculator.countries = %w[ireland]
+        @calculator.travelling_with_young_people = "yes"
+
+        assert_equal [], @calculator.summary_text_fields
+      end
+
+      should "not include young person if not travelling_with_young_people?" do
+        @calculator.travelling_with_young_people = "no"
+
+        assert_not @calculator.summary_text_fields.include?("young_person")
+      end
+
+      should "include young person if travelling_with_young_people?" do
+        @calculator.travelling_with_young_people = "yes"
+
+        assert @calculator.summary_text_fields.include?("young_person")
+      end
+
+      should "include responses to the travelling_with_children question" do
+        @calculator.travelling_with_children = "zero_to_four,five_to_seventeen"
+
+        %w[zero_to_four five_to_seventeen].each do |age|
+          assert @calculator.summary_text_fields.include?(age)
+        end
+      end
+
+      should "include the correct vaccination status for unvaccinated users" do
+        @calculator.vaccination_status = "9ddc7655bfd0d477"
+
+        assert @calculator.summary_text_fields.include?("not_vaxed")
+      end
+
+      should "include the correct vaccination status for vaccinated users" do
+        @calculator.vaccination_status = "529202127233d442"
+
+        assert @calculator.summary_text_fields.include?("fully_vaxed")
+      end
+
+      should "include red_list if travelling to a red list country" do
+        @calculator.going_to_countries_within_10_days = "yes"
+
+        assert @calculator.summary_text_fields.include?("red_list")
+      end
+    end
   end
 end


### PR DESCRIPTION
Some changes were agreed to the summary text if a user is coming from Ireland and only Ireland. This makes those changes, I had to include a new method to check if a user was only coming from Ireland to keep the frontend logic free.

This also adds a section to the "fully vaccinated" partial to include people who are exempt from vaccination.

## Ireland
<img width="782" alt="Screenshot 2022-02-09 at 09 40 49" src="https://user-images.githubusercontent.com/24547207/153220652-434ab1b3-79ac-45d9-9dd5-9d1ad3f21f94.png">

## Vax exempt
<img width="826" alt="Screenshot 2022-02-09 at 14 20 57" src="https://user-images.githubusercontent.com/24547207/153220697-901a67a8-23dd-45fc-9dc3-fdae21023c42.png">

## Trello 
https://trello.com/c/3YfXGaqp/628-adding-inbound-results-for-people-exempt-from-vax-mvp
https://trello.com/c/fPtwW9zX/635-content-changes-to-summary-text-because-you-said-mvp

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
