### PR TITLE
Don't display deep link for young people when answering "no" to young people question

### DIFF
--- a/app/flows/check_travel_during_coronavirus_flow/outcomes/_country.erb
+++ b/app/flows/check_travel_during_coronavirus_flow/outcomes/_country.erb
@@ -40,7 +40,7 @@
         <li><a href="https://www.gov.uk/foreign-travel-advice/<%= country.slug %>/entry-requirements/#if-youre-not-fully-vaccinated" class="govuk-link" rel="noreferrer noopener" target="_blank">people who aren't fully vaccinated (opens in new tab)</a></li>
       <% end %>
 
-      <% unless calculator.travelling_with_children == ["none"] %>
+      <% if calculator.travelling_with_children? || calculator.travelling_with_young_people? %>
         <li><a href="https://www.gov.uk/foreign-travel-advice/<%= country.slug %>/entry-requirements/#children-and-young-people" class="govuk-link" rel="noreferrer noopener" target="_blank">travelling with children and young people (opens in new tab)</a></li>
       <% end %>
 

--- a/lib/smart_answer/calculators/check_travel_during_coronavirus_calculator.rb
+++ b/lib/smart_answer/calculators/check_travel_during_coronavirus_calculator.rb
@@ -28,6 +28,10 @@ module SmartAnswer::Calculators
       end
     end
 
+    def travelling_with_children?
+      travelling_with_children.any? && travelling_with_children != %w[none]
+    end
+
     def travelling_with_young_people?
       travelling_with_young_people == "yes"
     end

--- a/test/flows/check_travel_during_coronavirus_flow_test.rb
+++ b/test/flows/check_travel_during_coronavirus_flow_test.rb
@@ -395,6 +395,59 @@ class CheckTravelDuringCoronavirusFlowTest < ActiveSupport::TestCase
         assert_rendered_outcome text: "travelling with children and young people"
       end
 
+      should "not render guidance for travelling with young people if not travelling with children or unders 18s" do
+        add_responses travelling_with_young_people: "no"
+        assert_no_match "travelling with children and young people", @test_flow.outcome_text
+      end
+
+      should "render guidance for people travelling with children when travelling to a red list country" do
+        travel_to("2022-02-01") do
+          WorldLocation.stubs(:travel_rules).returns({
+            "results" => [
+              {
+                "title" => "Spain",
+                "details" => {
+                  "slug" => "spain",
+                },
+                "england_coronavirus_travel" => [
+                  {
+                    "covid_status" => "red",
+                    "covid_status_applies_at" => "2021-12-20T:02:00.000+00:00",
+                  },
+                ],
+              },
+            ],
+          })
+          add_responses which_country: "spain",
+                        travelling_with_children: "zero_to_four"
+          assert_rendered_outcome text: "travelling with children and young people"
+        end
+      end
+
+      should "render not guidance for people travelling with children when travelling to a red list country if not travelling with children" do
+        travel_to("2022-02-01") do
+          WorldLocation.stubs(:travel_rules).returns({
+            "results" => [
+              {
+                "title" => "Spain",
+                "details" => {
+                  "slug" => "spain",
+                },
+                "england_coronavirus_travel" => [
+                  {
+                    "covid_status" => "red",
+                    "covid_status_applies_at" => "2021-12-20T:02:00.000+00:00",
+                  },
+                ],
+              },
+            ],
+          })
+          add_responses which_country: "spain",
+                        travelling_with_children: "none"
+          assert_no_match "travelling with children and young people", @test_flow.outcome_text
+        end
+      end
+
       should "render other guidance for entering" do
         assert_rendered_outcome text: "There may also be other requirements for entering"
       end

--- a/test/unit/calculators/check_travel_during_coronavirus_calculator_test.rb
+++ b/test/unit/calculators/check_travel_during_coronavirus_calculator_test.rb
@@ -39,6 +39,18 @@ module SmartAnswer::Calculators
       end
     end
 
+    context "travelling_with_children?" do
+      should "be false when not travelling with children" do
+        @calculator.travelling_with_children = "none"
+        assert_not @calculator.travelling_with_children?
+      end
+
+      should "be true when travelling with children" do
+        @calculator.travelling_with_children = "zero_to_four"
+        assert @calculator.travelling_with_children?
+      end
+    end
+
     context "transit_countries=" do
       should "add a single country" do
         @calculator.transit_countries = "spain"


### PR DESCRIPTION
Trello: https://trello.com/c/br4EuCOn
Follows on from: https://github.com/alphagov/smart-answers/pull/5757/commits/d109a25fe51ce082e083a5b3dfcd120e7afcf8ce

# What's changed?
Hides the deep link for "travelling with young people" when the user is travelling to non-red list country that has had their content headers converted and they are not travelling with young people.

# Why?

This is a bug. The result was not updated when a new generic question about travelling under 18s was added to the non-red list flow.

# Expected changes

|Before|After|
|:------|:----|
|<img width="1071" alt="Screenshot 2022-02-10 at 11 50 33" src="https://user-images.githubusercontent.com/5793815/153403955-9b057043-b59e-4491-8561-d8e382f43498.png">|<img width="1071" alt="Screenshot 2022-02-10 at 11 50 56" src="https://user-images.githubusercontent.com/5793815/153403977-e9e4cf53-4a47-4fa7-b649-e50babc61912.png">|



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
