### PR TITLE
Update outbound exemption content

### DIFF
--- a/app/flows/check_travel_during_coronavirus_flow/outcomes/_exempt_vaccination.erb
+++ b/app/flows/check_travel_during_coronavirus_flow/outcomes/_exempt_vaccination.erb
@@ -2,10 +2,9 @@
   <div class="govuk-grid-column-one-third desktop-min-height"></div>
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-body">
-      It’s up to the country you’re travelling to to decide
-      whether or not people who can’t have a COVID-19 vaccination
-      for a medical reason can follow the same entry requirements
-      as those who are fully vaccinated. You should
+      The country you’re travelling to decides its own rules for people who cannot
+      have a COVID-19 vaccination for a medical reason. You may not be able to
+      follow the same entry requirements as people who are fully vaccinated. You should
       <a href="/government/publications/foreign-embassies-in-the-uk" class="govuk-link">contact the
       embassy of the country you’re visiting</a> to find this out.
     </p>

--- a/test/flows/check_travel_during_coronavirus_flow_test.rb
+++ b/test/flows/check_travel_during_coronavirus_flow_test.rb
@@ -250,8 +250,7 @@ class CheckTravelDuringCoronavirusFlowTest < ActiveSupport::TestCase
 
     should "render 'exempt vaccination content' if exempt from vaccination" do
       add_responses vaccination_status: "529202127233d442"
-      assert_rendered_outcome text: "It’s up to the country you’re travelling to to decide
-      whether or not people who can’t have a COVID-19 vaccination"
+      assert_rendered_outcome text: "The country you’re travelling to decides its own rules"
     end
 
     context "content for countries changing covid status" do


### PR DESCRIPTION
An iteration on a [previous PR](https://github.com/alphagov/smart-answers/pull/5769) as FCDO suggested revised content. See comment in [this doc](https://docs.google.com/document/d/1ovFkxAVAOlfn2nuUnnVVEw_kJJfOA7syztrLIORlL1Y/edit).

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

[Trello](https://trello.com/c/vCXIFvDp/633-new-outbound-results-for-vax-exempt-mvp)

<img width="1161" alt="Screenshot 2022-02-10 at 14 58 15" src="https://user-images.githubusercontent.com/5963488/153435776-89a93aa5-7f40-4133-ad3e-41f134c51e5b.png">

