### PR TITLE
Content change to c19 travel smart answer

### DIFF
--- a/app/flows/check_travel_during_coronavirus_flow/outcomes/_not_fully_vaxed.erb
+++ b/app/flows/check_travel_during_coronavirus_flow/outcomes/_not_fully_vaxed.erb
@@ -36,7 +36,7 @@
     margin_bottom: 4,
   } %>
 
-  <p class="govuk-body">If the test result is positive or unclear, you must <a href="https://www.nhs.uk/conditions/coronavirus-covid-19/self-isolation-and-treatment/when-to-self-isolate-and-what-to-do" class="govuk-link">self-isolate</a> for 10 days (the day you took the test is day 0).</p>
+  <p class="govuk-body">If the test result is positive or unclear, you must <a href="https://www.nhs.uk/conditions/coronavirus-covid-19/self-isolation-and-treatment/when-to-self-isolate-and-what-to-do" class="govuk-link">self-isolate</a> for 10 days (the day you took the test is day 0). You can stop self-isolating at the start of day 6 if you get 2 negative rapid lateral flow test results on days 5 and 6 and do not have a temperature. Tests must be at least 24 hours apart. If either test is positive, wait 24 hours before testing again.</p>
 
   <%= render "govuk_publishing_components/components/heading", {
     text: "If the test result is negative",

--- a/app/flows/check_travel_during_coronavirus_flow/outcomes/results.erb
+++ b/app/flows/check_travel_during_coronavirus_flow/outcomes/results.erb
@@ -71,12 +71,12 @@
       <%= render "govuk_publishing_components/components/inset_text", {
       } do %>
         <p class="govuk-body">
-          Find out <a href="https://travel-abroad-coronavirus.herokuapp.com/travel-abroad-step-by-step" class="govuk-link">other things you may need to do to travel abroad</a>. These may include:
+          Find out <a href="https://travel-abroad-coronavirus.herokuapp.com/travel-abroad-step-by-step" class="govuk-link">other things you may need to do before you travel abroad</a>. These may include:
         </p>
         <ul class="govuk-list govuk-list--bullet">
-          <li>renewing your passport</li>
+          <li>renewing your passport in time</li>
           <li>getting travel insurance</li>
-          <li>making sure you have the right driving documents</li>
+          <li>checking you have the right driving documents</li>
         </ul>
       <% end %>
     </div>

--- a/app/flows/check_travel_during_coronavirus_flow/questions/which_country.erb
+++ b/app/flows/check_travel_during_coronavirus_flow/questions/which_country.erb
@@ -1,10 +1,6 @@
 <% text_for :title do %>
   <% calculator ||= nil %>
-  <% if calculator && calculator.countries.count >= 1 %>
-    Which other countries will you be going to?
-  <% else %>
-    Which countries will you be going to?
-  <% end %>
+  Which country will you be going to?
 <% end %>
 
 <% text_for :error_message do %>

--- a/app/flows/check_travel_during_coronavirus_flow/start.erb
+++ b/app/flows/check_travel_during_coronavirus_flow/start.erb
@@ -12,7 +12,7 @@
   <p>Use this tool to find out:</p>
 
   <ul>
-    <li>entry requirements for a country you’re going to or travelling through</li>
+    <li>where to find entry requirements for a country you’re going to or travelling through</li>
     <li>what you need to do before and after you return to England</li>
     <li>whether you need take any tests and when</li>
     <li>what you need to do to travel with children</li>


### PR DESCRIPTION
Makes some changes to the c19 travel smart answer as requested in this [doc ](https://docs.google.com/document/d/1dLMwe-Ee_Txo0jVMNG6creV_Kdh_tan-rf2J_gtRBd4/edit#).

I noticed some weirdness in how the initial question in 'your answers' becomes 'Which other country will you be going to?' as opposed to  'Which country will you be going to?' as we would expect.  I discussed this with Graham @gclssvglx, we think fixing it right now may be unnecessary given the multi-country select feature we plan to implement later. 

[Trello](https://trello.com/c/LUeE9FAO/641-final-content-changes-to-smart-answer)

<img width="576" alt="Screenshot 2022-02-10 at 15 32 17" src="https://user-images.githubusercontent.com/41922771/153447720-eec20d0b-c071-4cb6-8b4b-c4bffc327c8c.png">
<img width="637" alt="Screenshot 2022-02-10 at 16 12 30" src="https://user-images.githubusercontent.com/41922771/153448778-8e3126c3-50fb-4c05-872c-e66151c83ed4.png">
<img width="659" alt="Screenshot 2022-02-10 at 15 33 44" src="https://user-images.githubusercontent.com/41922771/153448546-e7aaa81a-6127-4866-9749-9690f07a0158.png">
<img width="630" alt="Screenshot 2022-02-10 at 15 39 46" src="https://user-images.githubusercontent.com/41922771/153448554-0962de7a-db02-447a-bb84-209c078b4bb2.png">
<img width="685" alt="Screenshot 2022-02-10 at 15 39 52" src="https://user-images.githubusercontent.com/41922771/153448562-ed5af30b-f6ae-40f5-911b-91de8dcd9ef2.png">



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
