### PR TITLE
Add validation to transiting question

### DIFF
--- a/app/flows/check_travel_during_coronavirus_flow.rb
+++ b/app/flows/check_travel_during_coronavirus_flow.rb
@@ -64,6 +64,10 @@ class CheckTravelDuringCoronavirusFlow < SmartAnswer::Flow
         calculator.transit_countries = response unless response == "none"
       end
 
+      validate(:error_no_destination) do
+        calculator.transit_countries.size < calculator.countries.size
+      end
+
       next_node do
         if calculator.red_list_countries.any? && calculator.countries.length > 1
           question :going_to_countries_within_10_days

--- a/app/flows/check_travel_during_coronavirus_flow/questions/transit_countries.erb
+++ b/app/flows/check_travel_during_coronavirus_flow/questions/transit_countries.erb
@@ -10,6 +10,10 @@
   Select all that apply:
 <% end %>
 
+<% text_for :error_no_destination do %>
+  You must leave at least one country unselected
+<% end %>
+
 <% countries = calculator.transit_country_options.dup %>
 <% countries[:none] = "No" %>
 <%= options(countries) %>

--- a/test/flows/check_travel_during_coronavirus_flow_test.rb
+++ b/test/flows/check_travel_during_coronavirus_flow_test.rb
@@ -106,6 +106,16 @@ class CheckTravelDuringCoronavirusFlowTest < ActiveSupport::TestCase
       assert_rendered_question
     end
 
+    context "validations" do
+      should "be invalid if all countries are selected" do
+        assert_invalid_response "italy,spain"
+      end
+
+      should "be valid if at least one country is unselected" do
+        assert_valid_response "spain"
+      end
+    end
+
     context "next_node" do
       should "have a next node of vaccination_status " \
                 "for a 'none' response " \


### PR DESCRIPTION
Trello: https://trello.com/c/vp9op3Dd

# What's changed?

Validate that users cannot select all of their previously selected countries as transiting countries. At least one country must be unchecked to be considered a destination country.

# Why?

In the results, the guidance for transiting countries is much less than the guidance for destination countries. This check guards against users misreading the question, selecting all of the countries thinking that they are selecting destinations and only being provided with limited guidance.

# Expected changes

## New error
![Screenshot 2022-02-15 at 13 44 13](https://user-images.githubusercontent.com/5793815/154074668-24e5a6f0-2a9a-4215-899b-1c5f3fb91a45.png)

## Existing error (remains unchanged)
![Screenshot 2022-02-15 at 13 43 59](https://user-images.githubusercontent.com/5793815/154074674-ba41ae0d-c4fd-4aee-b84f-fe27de1b7a4b.png)



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
