### PR TITLE
Updates list of countries with converted headers

### DIFF
--- a/lib/smart_answer/calculators/check_travel_during_coronavirus_calculator.rb
+++ b/lib/smart_answer/calculators/check_travel_during_coronavirus_calculator.rb
@@ -80,7 +80,35 @@ module SmartAnswer::Calculators
     end
 
     def countries_with_content_headers_converted
-      %w[spain germany]
+      %w[
+        burundi
+        cambodia
+        canada
+        colombia
+        croatia
+        cyprus
+        egypt
+        germany
+        guyana
+        india
+        italy
+        luxembourg
+        malta
+        nepal
+        new-zealand
+        norway
+        poland
+        portugal
+        saudi-arabia
+        singapore
+        slovenia
+        suriname
+        switzerland
+        thailand
+        turkey
+        usa
+        venezuela
+      ]
     end
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/ZegaI995

# What's changed?

Update the list of countries in the `countries_with_content_headers_converted` method ready for go live.
The full list is here: https://foreign-travel-spike.herokuapp.com/api/completed_locations.

# Why?
More countries have had their headers converted so we are able to point user to more specific content.

# Expected changes

|Before|After|
|:------|:----|
|![Screenshot 2022-02-15 at 11 45 46](https://user-images.githubusercontent.com/5793815/154056200-c58b1c8c-261f-456d-a636-ec644f0f5a46.png)|![Screenshot 2022-02-15 at 11 45 59](https://user-images.githubusercontent.com/5793815/154056253-70a20fce-1e21-42d3-ba22-69921a04d86f.png)|



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
