### PR TITLE
Remove test data from YAML

### DIFF
--- a/app/models/world_location.rb
+++ b/app/models/world_location.rb
@@ -118,6 +118,9 @@ class WorldLocation
     # Once the world location api returns the covid status, we should be able
     # to replace this line with:
     # location.fetch("england_coronavirus_travel", "")
+
+    return if self.class.travel_rules.blank?
+
     rules = self.class.travel_rules["results"].select { |country| country["details"]["slug"] == slug }.first
 
     return if rules.blank?

--- a/config/smart_answers/check_travel_during_coronavirus_data.yml
+++ b/config/smart_answers/check_travel_during_coronavirus_data.yml
@@ -1,16 +1,17 @@
 ---
-results:
-  - title: Portugal
-    details:
-      slug: portugal
-    england_coronavirus_travel:
-      - covid_status: not_red
-        covid_status_applies_at: "2021-12-20T:02:00.000+00:00"
-      - covid_status: red
-        covid_status_applies_at: "2022-02-23T:02:30.000+00:00"
-  - title: South Africa
-    details:
-      slug: south-africa
-    england_coronavirus_travel:
-      - covid_status: red
-        covid_status_applies_at: "2021-12-20T:02:00.000+00:00"
+# Results for each country should be added in the following format:
+# results:
+#   - title: Country name
+#     details:
+#       slug: country-slug
+#     england_coronavirus_travel:
+#       - covid_status: not_red
+#         covid_status_applies_at: "2021-12-20T:02:00.000+00:00"
+#       - covid_status: red
+#         covid_status_applies_at: "2022-02-23T:02:30.000+00:00"
+#   - title: Another country name
+#     details:
+#       slug: another-country-slug
+#     england_coronavirus_travel:
+#       - covid_status: red
+#         covid_status_applies_at: "2021-12-20T:02:00.000+00:00"


### PR DESCRIPTION
Trello: https://trello.com/c/KvdEp3GF

# What's changed and why? 
The coronavirus travel smart-answer is going live, so we need to remove the test data from the YAML file.

A comment has been added with the expected structure of the data so that it is easy to add new entries in the future.

# Expected changes

|Before|After|
|:------|:----|
|![Screenshot 2022-02-15 at 14 13 58](https://user-images.githubusercontent.com/5793815/154079985-d1100077-b6e6-4513-a84a-c683d20429f7.png)|![Screenshot 2022-02-15 at 14 14 15](https://user-images.githubusercontent.com/5793815/154080033-36353598-0990-4c68-b51f-9358865b6b17.png)|



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
