### PR TITLE
Set status of coronavirus travel flow to published

### DIFF
--- a/app/flows/check_travel_during_coronavirus_flow.rb
+++ b/app/flows/check_travel_during_coronavirus_flow.rb
@@ -2,7 +2,7 @@ class CheckTravelDuringCoronavirusFlow < SmartAnswer::Flow
   def define
     name "check-travel-during-coronavirus"
     content_id "b46df1e7-e770-43ab-8b4c-ce402736420c"
-    status :draft
+    status :published
     response_store :query_parameters
 
     country_select "which_country".to_sym, exclude_countries: [] do


### PR DESCRIPTION
Trello: https://trello.com/c/9Qs2jt6m


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
