### PR TITLE
Add missing govuk-list and govuk-list--bullet styles

### DIFF
--- a/app/flows/check_travel_during_coronavirus_flow/outcomes/_return_from_ireland_and_other_countries.erb
+++ b/app/flows/check_travel_during_coronavirus_flow/outcomes/_return_from_ireland_and_other_countries.erb
@@ -6,7 +6,7 @@
   } %>
   <p class="govuk-body">There are no entry requirements if:</p>
 
-  <ul>
+  <ul class="govuk-list govuk-list--bullet">
     <li>you’re travelling to England from Ireland after going to another country</li>
     <li>you’ve been in Ireland or anywhere else in the <a href="/government/publications/common-travel-area-guidance" class="govuk-link">Common Travel Area</a> for 10 days or more</li>
   </ul>


### PR DESCRIPTION
Add missing `govuk-list` and `govuk-list--bullet` styles to the list in the `check_travel_during_coronavirus` flow.

## Before
<img width="1039" alt="Screenshot 2022-02-16 at 10 12 37" src="https://user-images.githubusercontent.com/44037625/154243505-bfdd342c-ea80-49c7-be08-3190183d5cc5.png">

## After
<img width="1039" alt="Screenshot 2022-02-16 at 10 13 47" src="https://user-images.githubusercontent.com/44037625/154243516-eb7dc192-5632-477e-a7db-e6a1fc91dffd.png">

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
