### PR TITLE
Update start page header size

### DIFF
--- a/app/flows/check_travel_during_coronavirus_flow/start.erb
+++ b/app/flows/check_travel_during_coronavirus_flow/start.erb
@@ -54,7 +54,7 @@
 
   <%= render "govuk_publishing_components/components/heading", {
     text: "Travelling to England from outside the Common Travel Area",
-    heading_level: 3,
+    heading_level: 2,
     font_size: "m",
     margin_bottom: 4,
   } %>


### PR DESCRIPTION
Update the header size of the `Travelling to England from outside the Common Travel Area` on the `check_travel_during_coronavirus` flow start page for consistency.

|Before|After|
|:----|:----|
|<img width="1039" alt="Screenshot 2022-02-16 at 11 58 57" src="https://user-images.githubusercontent.com/44037625/154260408-a7e2f4ed-4185-40e3-9db6-bb67e5e54d9e.png">|<img width="1039" alt="Screenshot 2022-02-16 at 11 59 44" src="https://user-images.githubusercontent.com/44037625/154260412-b4e89c5b-04d0-4ccf-8fdd-b547408e3ae2.png">|

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
