### PR TITLE
Change the Ukraine inbound rules for unvaxed travellers returning to England

### DIFF
--- a/app/flows/check_travel_during_coronavirus_flow/outcomes/_not_fully_vaxed.erb
+++ b/app/flows/check_travel_during_coronavirus_flow/outcomes/_not_fully_vaxed.erb
@@ -13,10 +13,21 @@
   <p class="govuk-body">You must:</p>
 
   <ul class="govuk-list govuk-list--bullet">
-    <li><a href="https://www.gov.uk/guidance/coronavirus-covid-19-testing-for-people-travelling-to-england" class="govuk-link">take a pre-departure COVID-19 test</a> within the 3 days before you travel to England</li>
+    <% if calculator.travelling_to_ukraine? %>
+      <% if calculator.multiple_journey? %>
+        <li><a href="https://www.gov.uk/guidance/coronavirus-covid-19-testing-for-people-travelling-to-england" class="govuk-link">take a pre-departure COVID-19 test</a> within the 2 days before you travel to England (you do not need to take this test if you’re travelling to England from Ukraine)</li>
+      <% end %>
+    <% else %>
+      <li><a href="https://www.gov.uk/guidance/coronavirus-covid-19-testing-for-people-travelling-to-england" class="govuk-link">take a pre-departure COVID-19 test</a> within the 2 days before you travel to England</li>
+    <% end %>
+
     <li><a href="https://www.gov.uk/find-travel-test-provider" class="govuk-link">book and pay for a PCR test</a> to take on or before day 2 after you arrive in England</li>
     <li><a href="https://www.gov.uk/provide-journey-contact-details-before-travel-uk" class="govuk-link">complete a passenger locator form</a> within the 48 hours before you arrive in England</li>
   </ul>
+
+  <% if calculator.travelling_to_ukraine? && calculator.single_journey? %>
+    <p class="govuk-body">You do not need to take a pre-departure COVID-19 test before you travel to England. This is because of the political situation in Ukraine.</p>
+  <% end %>
 
   <p class="govuk-body">You will need to enter the booking reference for the PCR test you booked in the passenger locator form.</p>
 

--- a/lib/smart_answer/calculators/check_travel_during_coronavirus_calculator.rb
+++ b/lib/smart_answer/calculators/check_travel_during_coronavirus_calculator.rb
@@ -82,8 +82,16 @@ module SmartAnswer::Calculators
       countries.include?("ireland")
     end
 
+    def travelling_to_ukraine?
+      countries.include?("ukraine")
+    end
+
     def single_journey?
       countries.size == 1
+    end
+
+    def multiple_journey?
+      countries.size > 1
     end
 
     def red_list_country_titles

--- a/test/unit/calculators/check_travel_during_coronavirus_calculator_test.rb
+++ b/test/unit/calculators/check_travel_during_coronavirus_calculator_test.rb
@@ -121,6 +121,16 @@ module SmartAnswer::Calculators
       assert @calculator.single_journey?
     end
 
+    should "return true for travelling_to_ukraine? if ukraine has been selected" do
+      @calculator.countries = %w[spain ukraine poland]
+      assert @calculator.travelling_to_ukraine?
+    end
+
+    should "return true for multiple_journey? if travelling to more than one country" do
+      @calculator.countries = %w[spain poland]
+      assert @calculator.multiple_journey?
+    end
+
     context "summary_text_fields" do
       should "return an empty array if only travelling to ireland, even with other fields" do
         @calculator.countries = %w[ireland]


### PR DESCRIPTION
### What
Reflect that un-vaccinated travellers from Ukraine no longer need to get tested when returning to England.

Change all `take a pre-departure COVID-19 test within the 3 days before you travel to England` instances to `2 days`.

### Why
The rules changed on 18 Feb.

### Travelling only to the Ukraine
|Before|After|
|:---|:---|
|<img width="1012" alt="Screenshot 2022-02-21 at 16 08 09" src="https://user-images.githubusercontent.com/44037625/154991266-a0460dbd-35ec-41fa-a9c0-ba8ce621c84f.png">|<img width="1012" alt="Screenshot 2022-02-21 at 16 07 35" src="https://user-images.githubusercontent.com/44037625/154991281-f1f169a0-eaac-4ba3-9b30-d90b76b38058.png">|

### Travelling to the Ukraine and one or more other countries
|Before|After|
|:---|:---|
|<img width="1012" alt="Screenshot 2022-02-21 at 16 05 51" src="https://user-images.githubusercontent.com/44037625/154991308-a97c5a19-0450-4893-90f9-a0ef0018698f.png">|<img width="1012" alt="Screenshot 2022-02-21 at 16 04 35" src="https://user-images.githubusercontent.com/44037625/154991330-4aebe999-9f40-4905-aeca-b2300211c3c3.png">|

Trello: https://trello.com/c/pGwvgYvT/693-change-ukraine-inbound-rules-for-unvaxed

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
