### PR TITLE
Update 'apply for UK passport' link

### DIFF
--- a/app/flows/register_a_birth_flow/start.erb
+++ b/app/flows/register_a_birth_flow/start.erb
@@ -18,6 +18,6 @@
   - the birth will be recorded with the General Register Offices or at the National Records Office of Scotland
   - you can order a consular birth registration certificate
 
-  You can still [apply for a UK passport for your child](/apply-renew-passport) even if you do not register the birth in the UK.
+  You can still [apply for a UK passport for your child](/get-a-child-passport/first-child-passport) even if you do not register the birth in the UK.
 
 <% end %>


### PR DESCRIPTION
CHANGE
 You can still [apply for a UK passport for your child](/apply-renew-passport) even if you do not register the birth in the UK.

TO
 You can still [apply for a UK passport for your child](/get-a-child-passport/first-child-passport) even if you do not register the birth in the UK.

REASON
Linking straight through to the relevant page, rather than having users have to find their way around some links.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
