### PR TITLE
Uprating Married couple's allowance 2022

### DIFF
--- a/config/smart_answers/rates/married_couples_allowance.yml
+++ b/config/smart_answers/rates/married_couples_allowance.yml
@@ -43,3 +43,8 @@
   end_date: 2022-04-05
   maximum_married_couple_allowance: 9125
   minimum_married_couple_allowance: 3530
+
+- start_date: 2022-04-06
+  end_date: 2023-04-05
+  maximum_married_couple_allowance: 9415
+  minimum_married_couple_allowance: 3640

--- a/config/smart_answers/rates/personal_allowance.yml
+++ b/config/smart_answers/rates/personal_allowance.yml
@@ -64,7 +64,10 @@
 
 - start_date: 2022-04-06
   end_date: 2023-04-05
-  personal_allowance: 12500
-  higher_allowance_1: 12500
-  higher_allowance_2: 12500
+  personal_allowance: 12570
+  higher_allowance_1: 12570
+  higher_allowance_2: 12570
   income_limit_for_personal_allowances: 31400.0
+
+  # Note: higher_allowance_1 and higher_allowance_2 were dropped in 2016
+  # use the personal_allowance value to populate those figures

--- a/config/smart_answers/rates/personal_allowance.yml
+++ b/config/smart_answers/rates/personal_allowance.yml
@@ -61,3 +61,10 @@
   higher_allowance_1: 12500
   higher_allowance_2: 12500
   income_limit_for_personal_allowances: 30400.0
+
+- start_date: 2022-04-06
+  end_date: 2023-04-05
+  personal_allowance: 12500
+  higher_allowance_1: 12500
+  higher_allowance_2: 12500
+  income_limit_for_personal_allowances: 31400.0

--- a/test/unit/calculators/married_couple_allowance_calculator_test.rb
+++ b/test/unit/calculators/married_couple_allowance_calculator_test.rb
@@ -200,5 +200,27 @@ module SmartAnswer::Calculators
         assert_equal 3510, calculator.minimum_mca
       end
     end
+
+    test "rate values for 2021/22" do
+      travel_to("2021-06-01") do
+        calculator = MarriedCouplesAllowanceCalculator.new
+
+        assert_equal 12_500, calculator.personal_allowance
+        assert_equal 30_400.0, calculator.income_limit_for_personal_allowances
+        assert_equal 9125, calculator.maximum_mca
+        assert_equal 3530, calculator.minimum_mca
+      end
+    end
+
+    test "rate values for 2022/23" do
+      travel_to("2022-06-01") do
+        calculator = MarriedCouplesAllowanceCalculator.new
+
+        assert_equal 12_500, calculator.personal_allowance
+        assert_equal 31_400.0, calculator.income_limit_for_personal_allowances
+        assert_equal 9415, calculator.maximum_mca
+        assert_equal 3640, calculator.minimum_mca
+      end
+    end
   end
 end

--- a/test/unit/calculators/married_couple_allowance_calculator_test.rb
+++ b/test/unit/calculators/married_couple_allowance_calculator_test.rb
@@ -216,7 +216,7 @@ module SmartAnswer::Calculators
       travel_to("2022-06-01") do
         calculator = MarriedCouplesAllowanceCalculator.new
 
-        assert_equal 12_500, calculator.personal_allowance
+        assert_equal 12_570, calculator.personal_allowance
         assert_equal 31_400.0, calculator.income_limit_for_personal_allowances
         assert_equal 9415, calculator.maximum_mca
         assert_equal 3640, calculator.minimum_mca


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Uprating changes 2022. Updated min and max allowances and income limit.

Trello: https://trello.com/c/Wsn3Uni2/32-uprating-married-couples-allowance 
Zen: https://govuk.zendesk.com/agent/tickets/4880972 