### PR TITLE
Add warning content about not having to isolate

### DIFF
--- a/app/flows/check_travel_during_coronavirus_flow/outcomes/_not_fully_vaxed.erb
+++ b/app/flows/check_travel_during_coronavirus_flow/outcomes/_not_fully_vaxed.erb
@@ -49,6 +49,10 @@
 
   <p class="govuk-body">If the test result is positive or unclear, you must <a href="https://www.nhs.uk/conditions/coronavirus-covid-19/self-isolation-and-treatment/when-to-self-isolate-and-what-to-do" class="govuk-link">self-isolate</a> for 10 days (the day you took the test is day 0). You can stop self-isolating at the start of day 6 if you get 2 negative rapid lateral flow test results on days 5 and 6 and do not have a temperature. Tests must be at least 24 hours apart. If either test is positive, wait 24 hours before testing again.</p>
 
+  <%= render "govuk_publishing_components/components/inset_text", {
+    text: "From 24 February, there will be no legal requirement to self-isolate if you get a positive test result. Stay at home if you can and avoid contact with other people. "
+  } %>
+
   <%= render "govuk_publishing_components/components/heading", {
     text: "If the test result is negative",
     heading_level: 4,


### PR DESCRIPTION
Trello: https://trello.com/c/QWq3zedQ

#  What's changed and why?

From 24/02/2022, it will no longer a legal requirement to self-isolate after a positive COVID-19 test. As we can't schedule changes to the content, we need to add a notice to users that the results are changing.

# Expected changes

|Before|After|
|:------|:----|
|![Screenshot 2022-02-23 at 16 21 06](https://user-images.githubusercontent.com/5793815/155361364-705181a1-a2f1-468e-934d-d7a918f24779.png)|![Screenshot 2022-02-23 at 16 13 09](https://user-images.githubusercontent.com/5793815/155362891-9d0cf97e-c91b-431a-b647-21ef2c79acb9.png)|


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
