### PR TITLE
Remove self-isolating content

### DIFF
--- a/app/flows/check_travel_during_coronavirus_flow/outcomes/_not_fully_vaxed.erb
+++ b/app/flows/check_travel_during_coronavirus_flow/outcomes/_not_fully_vaxed.erb
@@ -47,11 +47,7 @@
     margin_bottom: 4,
   } %>
 
-  <p class="govuk-body">If the test result is positive or unclear, you must <a href="https://www.nhs.uk/conditions/coronavirus-covid-19/self-isolation-and-treatment/when-to-self-isolate-and-what-to-do" class="govuk-link">self-isolate</a> for 10 days (the day you took the test is day 0). You can stop self-isolating at the start of day 6 if you get 2 negative rapid lateral flow test results on days 5 and 6 and do not have a temperature. Tests must be at least 24 hours apart. If either test is positive, wait 24 hours before testing again.</p>
-
-  <%= render "govuk_publishing_components/components/inset_text", {
-    text: "From 24 February, there will be no legal requirement to self-isolate if you get a positive test result. Stay at home if you can and avoid contact with other people. "
-  } %>
+  <p class="govuk-body">Stay at home and avoid contact with other people. <a href="/government/publications/covid-19-people-with-covid-19-and-their-contacts" class="govuk-link">Find out what to do if you’ve had a positive or unclear COVID-19 test result.</a></p>
 
   <%= render "govuk_publishing_components/components/heading", {
     text: "If the test result is negative",
@@ -60,7 +56,7 @@
     margin_bottom: 4,
   } %>
 
-  <p class="govuk-body">If the test result is negative, you do not need to take any further tests and do not need to self-isolate.</p>
+  <p class="govuk-body">If the test result is negative, you do not need to take any further tests.</p>
 <% end %>
 
 <%


### PR DESCRIPTION
Trello: https://trello.com/c/QWq3zedQ
Follows on from: https://github.com/alphagov/smart-answers/commit/f8bfb85c02f86bc798d11f349a71ffb675f56dbf

# What's changed
Remove self-isolating content from not fully vaccinated results page.

# Why?

From 24/02/2022, it is no longer a legal requirement to self-isolate after a positive COVID-19 test.

# Expected changes

|Before|After|
|:------|:----|
|<img width="740" alt="Screenshot 2022-02-24 at 11 36 42" src="https://user-images.githubusercontent.com/5793815/155517184-44264e94-c1c9-4837-8132-51d4c750a81a.png">|<img width="745" alt="Screenshot 2022-02-24 at 11 51 22" src="https://user-images.githubusercontent.com/5793815/155518871-2b53f4f8-460d-4707-8f78-650a5a27c42a.png">|



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
