### PR TITLE
Filter vaccination_status response from change link event

### DIFF
--- a/app/flows/check_travel_during_coronavirus_flow.rb
+++ b/app/flows/check_travel_during_coronavirus_flow.rb
@@ -97,6 +97,8 @@ class CheckTravelDuringCoronavirusFlow < SmartAnswer::Flow
     radio :vaccination_status do
       options { calculator.vaccination_option_keys }
 
+      redact true
+
       on_response do |response|
         calculator.vaccination_status = response
       end

--- a/app/presenters/node_presenter.rb
+++ b/app/presenters/node_presenter.rb
@@ -18,4 +18,8 @@ class NodePresenter
   def view_template_path
     @node.view_template_path
   end
+
+  def redacted?
+    @node.redact
+  end
 end

--- a/app/presenters/question_presenter.rb
+++ b/app/presenters/question_presenter.rb
@@ -71,6 +71,14 @@ class QuestionPresenter < NodePresenter
     value
   end
 
+  def change_link_track_label(value)
+    if redacted?
+      "#{title} / [FILTERED]"
+    else
+      "#{title} / #{response_label(value)}"
+    end
+  end
+
   def partial_template_name
     "#{@node.class.name.demodulize.underscore}_question"
   end

--- a/app/views/smart_answers/shared/_previous_answers.html.erb
+++ b/app/views/smart_answers/shared/_previous_answers.html.erb
@@ -36,7 +36,7 @@
           "module": "gem-track-click",
           "track-category": "Smart Answer Change Link",
           "track-action":  "Link clicked",
-          "track-label": "#{question.title} / #{question.response_label(accepted_response)}"
+          "track-label": question.change_link_track_label(accepted_response)
         }
       }
     }

--- a/lib/smart_answer/node.rb
+++ b/lib/smart_answer/node.rb
@@ -98,6 +98,10 @@ module SmartAnswer
       next_node.to_sym
     end
 
+    def redact(filter = false) # rubocop:disable Style/OptionalBooleanParameter
+      @redact ||= filter
+    end
+
   private
 
     def next_node_block

--- a/test/unit/node_presenter_test.rb
+++ b/test/unit/node_presenter_test.rb
@@ -26,4 +26,20 @@ class NodePresenterTest < ActiveSupport::TestCase
       assert_equal "view", node_presenter.view_template_path
     end
   end
+
+  context "#redacted?" do
+    should "return true if node is redacted" do
+      node = OpenStruct.new(name: :foo_bar, slug: "foo-bar", view_template_path: "view", redact: true)
+      node_presenter = NodePresenter.new(node, nil)
+
+      assert_equal true, node_presenter.redacted?
+    end
+
+    should "return false if node is not redacted" do
+      node = OpenStruct.new(name: :foo_bar, slug: "foo-bar", view_template_path: "view", redact: false)
+      node_presenter = NodePresenter.new(node, nil)
+
+      assert_equal false, node_presenter.redacted?
+    end
+  end
 end

--- a/test/unit/node_test.rb
+++ b/test/unit/node_test.rb
@@ -189,5 +189,15 @@ module SmartAnswer
         assert_equal :done, next_node
       end
     end
+
+    context "#redact" do
+      should "return true if question is redacted" do
+        assert_equal true, @node.redact(true)
+      end
+
+      should "return false if question is not redacted" do
+        assert_equal false, @node.redact
+      end
+    end
   end
 end

--- a/test/unit/question_presenter_test.rb
+++ b/test/unit/question_presenter_test.rb
@@ -148,5 +148,23 @@ module SmartAnswer
     test "#view_template_path returns the question view template name" do
       assert_equal "smart_answers/question", @presenter.view_template_path
     end
+
+    test "#change_link_track_label filters change link label text for vaccination_status question" do
+      @presenter.stubs(:redacted?).returns(true)
+      @renderer.stubs(:content_for).with(:title).returns("title-text")
+
+      value = :vaccination_status
+
+      assert_equal "#{@presenter.title} / [FILTERED]", @presenter.change_link_track_label(value)
+    end
+
+    test "#change_link_track_label includes response in change link label text for all questions //
+          other than vaccination_status" do
+      @renderer.stubs(:content_for).with(:title).returns("title-text")
+
+      value = :which_country
+
+      assert_equal "#{@presenter.title} / #{@presenter.response_label(value)}", @presenter.change_link_track_label(value)
+    end
   end
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/r4lZ5FYx/712-link-tracking-hide-vaccination-status-value-from-being-sent-to-ga-when-change-answer-link-is-clicked)

The `vaccination_status` response is health data. Despite having no personally identifing questions in this Smart Answer, we are required to prevent health data from being sent to Google Analytics.

### Redacting vaccination_status from travel flow / country question response remains on the label

<img width="1067" alt="change-link-vax-status-and-country-change" src="https://user-images.githubusercontent.com/5963488/156340667-f4dfc9d1-621e-4cc5-b18f-a0e63048fcaa.png">

### Non travel flow 


![tracking-non-travel-flow](https://user-images.githubusercontent.com/5963488/156340792-e3115f18-b34d-45dd-afab-1b1770db8758.png)

### Non travel flow checkbox question 
<img width="1038" alt="change-link-tracking-checkbox-question" src="https://user-images.githubusercontent.com/5963488/156340846-ce98db5c-8499-4a94-ba69-afa65c96ff64.png">

Co-authored-by: Leena Gupte <leena.gupte@digital.cabinet-office.gov.uk> as a result of approach suggested on [this branch](https://github.com/alphagov/smart-answers/commit/991964cf3691c8da5afb707ccf0bceee87acbf81)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
