### PR TITLE
Uprating for maternity, paternity and adoption pay calculator

### DIFF
--- a/config/smart_answers/rates/maternity_paternity_adoption.yml
+++ b/config/smart_answers/rates/maternity_paternity_adoption.yml
@@ -27,5 +27,8 @@
   end_date: 2020-04-04
   lower_earning_limit_rate: 118
 - start_date: 2020-04-05
-  end_date: 2100-04-03
+  end_date: 2022-04-02
   lower_earning_limit_rate: 120
+- start_date: 2020-04-03
+  end_date: 2100-04-03
+  lower_earning_limit_rate: 123

--- a/config/smart_answers/rates/maternity_paternity_adoption.yml
+++ b/config/smart_answers/rates/maternity_paternity_adoption.yml
@@ -29,6 +29,6 @@
 - start_date: 2020-04-05
   end_date: 2022-04-02
   lower_earning_limit_rate: 120
-- start_date: 2020-04-03
+- start_date: 2022-04-03
   end_date: 2100-04-03
   lower_earning_limit_rate: 123

--- a/config/smart_answers/rates/maternity_paternity_birth.yml
+++ b/config/smart_answers/rates/maternity_paternity_birth.yml
@@ -34,4 +34,4 @@
   lower_earning_limit_rate: 120
 - start_date: 2022-04-03
   end_date: 2100-04-03
-  lower_earning_limit_rate: 120
+  lower_earning_limit_rate: 123

--- a/config/smart_answers/rates/maternity_paternity_birth.yml
+++ b/config/smart_answers/rates/maternity_paternity_birth.yml
@@ -30,5 +30,8 @@
   end_date: 2020-04-04
   lower_earning_limit_rate: 118
 - start_date: 2020-04-05
+  end_date: 2022-04-02
+  lower_earning_limit_rate: 120
+- start_date: 2022-04-03
   end_date: 2100-04-03
   lower_earning_limit_rate: 120

--- a/lib/smart_answer/calculators/maternity_pay_calculator.rb
+++ b/lib/smart_answer/calculators/maternity_pay_calculator.rb
@@ -314,7 +314,8 @@ module SmartAnswer::Calculators
         { min: uprating_date(2018), max: uprating_date(2019), amount: 145.18 },
         { min: uprating_date(2019), max: uprating_date(2020), amount: 148.68 },
         { min: uprating_date(2020), max: uprating_date(2021), amount: 151.20 },
-        { min: uprating_date(2021), max: uprating_date(2200), amount: 151.97 },
+        { min: uprating_date(2021), max: uprating_date(2022), amount: 151.97 },
+        { min: uprating_date(2022), max: uprating_date(2200), amount: 156.66 },
         ### Change year in future
       ]
       rate = rates.find { |r| r[:min] <= date && date < r[:max] } || rates.last


### PR DESCRIPTION
Uprating 2022: rates changing from 151.97 to 156.66 for all

Lower earnings eligibility limit increase from £120 a week to £123 average for all

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
