### PR TITLE
Add margin option to autocomplete component

### DIFF
--- a/app/views/components/_autocomplete.html.erb
+++ b/app/views/components/_autocomplete.html.erb
@@ -4,12 +4,15 @@
   label ||= nil
   value ||= nil
   options ||= []
+  local_assigns[:margin_bottom] ||= 6
+  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
 
   error_id = "error-#{SecureRandom.hex(4)}"
   error_items ||= []
 
   classes = %w(app-c-autocomplete govuk-form-group)
   classes << "govuk-form-group--error" if error_items.any?
+  classes << shared_helper.get_margin_bottom
 
   if !options.any? || !label
     raise ArgumentError, "The autocomplete component needs at least one option and a label in order to render."

--- a/app/views/components/docs/autocomplete.yml
+++ b/app/views/components/docs/autocomplete.yml
@@ -30,3 +30,9 @@ examples:
       options: ['France', 'Germany', 'Sweden', 'Switzerland', 'United Kingdom', 'United States', 'The Separate Customs Territory of Taiwan, Penghu, Kinmen, and Matsu (Chinese Taipei)']
       error_items:
         - text: There is a problem with this input
+  with_margin_bottom:
+    description: The component accepts a number for margin bottom from 0 to 9 (0px to 60px) using the [GOV.UK Frontend spacing scale](https://design-system.service.gov.uk/styles/spacing/#the-responsive-spacing-scale). The default margin bottom is 30px (govuk spacing 6).
+    data:
+      label: 'Countries'
+      options: ['France', 'Germany', 'Sweden', 'Switzerland', 'United Kingdom', 'United States', 'The Separate Customs Territory of Taiwan, Penghu, Kinmen, and Matsu (Chinese Taipei)']
+      margin_bottom: 9

--- a/test/components/autocomplete_test.rb
+++ b/test/components/autocomplete_test.rb
@@ -71,4 +71,25 @@ class AutocompleteTest < ComponentTestCase
     assert_select ".app-c-autocomplete .govuk-form-group--error"
     assert_select ".govuk-error-message", text: "There is a problem with this input"
   end
+
+  tests "has the default bottom margin" do
+    render_component(
+      id: "basic-autocomplete",
+      label: "Countries",
+      options: ["United Kingdom", "United States"],
+    )
+
+    assert_select ".app-c-autocomplete.govuk-\!-margin-bottom-6"
+  end
+
+  tests "accepts a different bottom margin" do
+    render_component(
+      id: "basic-autocomplete",
+      label: "Countries",
+      options: ["United Kingdom", "United States"],
+      margin_bottom: 9,
+    )
+
+    assert_select ".app-c-autocomplete.govuk-\!-margin-bottom-9"
+  end
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Add an option to the autocomplete component to allow a custom margin bottom to be set. Uses the standard shared_helper approach from the gem to do margin bottom.

## Why
We're going to need to reduce the margin where we're about to use it but the design isn't finalised to having a flexible option for margin bottom seems the best way forward.

## Visual changes

![Screenshot 2022-03-02 at 16 53 38](https://user-images.githubusercontent.com/861310/156409561-09f65aab-8656-4f28-aba2-ac0bcffe3618.png)

Trello card: https://trello.com/c/i3brOfzz/431-add-multiple-country-select-question-type-to-smart-answers