### PR TITLE
Revert "Change gds::worldwide_api to retrieve information inside VPC"

### DIFF
--- a/app/models/world_location.rb
+++ b/app/models/world_location.rb
@@ -15,12 +15,11 @@ class WorldLocation
 
   def self.all
     cache_fetch("all") do
-      world_locations = WorldwideApi
-                        .endpoint
-                        .world_locations
-                        .with_subsequent_pages
-                        .select { |r| valid_world_location_format?(r.to_hash) }
-                        .map { |r| new(r.to_hash) }
+      world_locations = GdsApi.worldwide
+                              .world_locations
+                              .with_subsequent_pages
+                              .select { |r| valid_world_location_format?(r.to_hash) }
+                              .map { |r| new(r.to_hash) }
 
       raise NoLocationsFromWorldwideApiError if world_locations.empty?
 
@@ -30,9 +29,7 @@ class WorldLocation
 
   def self.find(location_slug)
     cache_fetch("find_#{location_slug}") do
-      location = WorldwideApi
-                 .endpoint
-                 .world_location(location_slug).to_hash
+      location = GdsApi.worldwide.world_location(location_slug).to_hash
       new(location)
     rescue GdsApi::HTTPNotFound
       nil

--- a/app/models/worldwide_organisation.rb
+++ b/app/models/worldwide_organisation.rb
@@ -2,9 +2,7 @@ class WorldwideOrganisation
   attr_reader :title, :web_url, :offices, :sponsors, :main_office, :other_offices
 
   def self.for_location(location_slug)
-    organisations = WorldwideApi
-                    .endpoint
-                    .organisations_for_world_location(location_slug).map do |response|
+    organisations = GdsApi.worldwide.organisations_for_world_location(location_slug).map do |response|
       new(response.to_hash) if response.present?
     end
     organisations.compact

--- a/lib/worldwide_api.rb
+++ b/lib/worldwide_api.rb
@@ -1,9 +1,0 @@
-class WorldwideApi
-  def self.endpoint
-    if !Rails.env.production? || ENV["HEROKU_APP_NAME"].present?
-      GdsApi::Worldwide.new(Plek.new.website_root)
-    else
-      GdsApi::Worldwide.new(Plek.find("whitehall-frontend"))
-    end
-  end
-end


### PR DESCRIPTION
After discussing with @kevindew we have decided to continue consuming these APIs via the public endpoint rather than using an internal endpoint.

The reasoning is that we prefer all requests to frontend applications to go through Fastly and router. This is particularly useful because Fastly caches requests to the APIs, and we have seen an incident in the past where these APIs could not handle high volumes of requests (and so require caching). We believe these APIs should probably not be served by frontend apps, and instead should be served by a different backend service, but this is out of scope of the replatforming project.

Reverts alphagov/smart-answers#5812