### PR TITLE
Add additional question and outcome for Ukraine passport holders (option 3)

### DIFF
--- a/app/flows/check_uk_visa_flow.rb
+++ b/app/flows/check_uk_visa_flow.rb
@@ -18,6 +18,8 @@ class CheckUkVisaFlow < SmartAnswer::Flow
       next_node do
         if calculator.passport_country_is_israel?
           question :israeli_document_type?
+        elsif calculator.passport_country_is_ukraine?
+          question :are_you_fleeing_conflict?
         elsif calculator.passport_country_is_estonia?
           question :what_sort_of_passport?
         elsif calculator.passport_country_is_latvia?
@@ -76,6 +78,20 @@ class CheckUkVisaFlow < SmartAnswer::Flow
 
       next_node do |_|
         question :purpose_of_visit?
+      end
+    end
+
+    # Q1g
+    radio :are_you_fleeing_conflict? do
+      option :yes
+      option :no
+
+      next_node do |response|
+        if response == "yes"
+          outcome :outcome_ukraine_family_visa_scheme
+        else
+          question :purpose_of_visit?
+        end
       end
     end
 
@@ -312,6 +328,7 @@ class CheckUkVisaFlow < SmartAnswer::Flow
     outcome :outcome_transit_to_the_republic_of_ireland
     outcome :outcome_tourism_n
     outcome :outcome_tourism_visa_partner
+    outcome :outcome_ukraine_family_visa_scheme
     outcome :outcome_visit_waiver
     outcome :outcome_visit_waiver_taiwan
     outcome :outcome_work_m

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_ukraine_family_visa_scheme.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_ukraine_family_visa_scheme.erb
@@ -1,0 +1,7 @@
+<% text_for :title do %>
+  Check the temporary visa guidance for leaving Ukraine
+<% end %>
+
+<% govspeak_for :body do %>
+  [Check whether you can use one of the temporary visas to come to the UK](/guidance/support-for-family-members-of-british-nationals-in-ukraine-and-ukrainian-nationals-in-ukraine-and-the-uk).
+<% end %>

--- a/app/flows/check_uk_visa_flow/questions/are_you_fleeing_conflict.erb
+++ b/app/flows/check_uk_visa_flow/questions/are_you_fleeing_conflict.erb
@@ -1,0 +1,8 @@
+<% text_for :title do %>
+  Are you trying to leave Ukraine because of the Russian invasion?
+<% end %>
+
+<% options(
+  "yes": "Yes",
+  "no": "No"
+) %>

--- a/lib/smart_answer/calculators/uk_visa_calculator.rb
+++ b/lib/smart_answer/calculators/uk_visa_calculator.rb
@@ -79,6 +79,10 @@ module SmartAnswer::Calculators
       @passport_country == "israel"
     end
 
+    def passport_country_is_ukraine?
+      @passport_country == "ukraine"
+    end
+
     def passport_country_is_taiwan?
       @passport_country == "taiwan"
     end

--- a/test/flows/check_uk_visa_flow_test.rb
+++ b/test/flows/check_uk_visa_flow_test.rb
@@ -28,6 +28,7 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
                                       "hong-kong",
                                       "macao",
                                       "taiwan",
+                                      "ukraine",
                                       "venezuela",
                                       @electronic_visa_waiver_country,
                                       @direct_airside_transit_visa_country,
@@ -73,6 +74,10 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
 
       should "have a next node of outcome_no_visa_needed_ireland for an 'ireland' response" do
         assert_next_node :outcome_no_visa_needed_ireland, for_response: "ireland"
+      end
+
+      should "have a next node of are_you_fleeing_conflict for an 'Ukraine' response" do
+        assert_next_node :are_you_fleeing_conflict?, for_response: "ukraine"
       end
 
       should "have a next node of purpose_of_visit? for a different country" do
@@ -128,6 +133,27 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
     context "next_node" do
       should "have a next node of purpose_of_visit?" do
         assert_next_node :purpose_of_visit?, for_response: "passport"
+      end
+    end
+  end
+
+  context "question: are_you_fleeing_conflict?" do
+    setup do
+      testing_node :are_you_fleeing_conflict?
+      add_responses what_passport_do_you_have?: "ukraine"
+    end
+
+    should "render the question" do
+      assert_rendered_question
+    end
+
+    context "next_node" do
+      should "have an outcome of outcome_ukraine_family_visa_scheme? if answered yes" do
+        assert_next_node :outcome_ukraine_family_visa_scheme, for_response: "yes"
+      end
+
+      should "have a next node of purpose_of_visit? if answered no" do
+        assert_next_node :purpose_of_visit?, for_response: "no"
       end
     end
   end


### PR DESCRIPTION
Option 3:
Adds a new radio button for Ukraine passports asking if they are fleeing conflict.
If yes, directed to a new outcome with guidance
If no, redirected back to the general flow
https://trello.com/c/SY5ZyORO/3233-4-march-tbc-check-if-you-need-a-visa-updates-for-ukrainian-nationals