### PR TITLE
Add new outcome for check-uk-visa for Ukraine (Option 2)

### DIFF
--- a/app/flows/check_uk_visa_flow.rb
+++ b/app/flows/check_uk_visa_flow.rb
@@ -18,6 +18,8 @@ class CheckUkVisaFlow < SmartAnswer::Flow
       next_node do
         if calculator.passport_country_is_israel?
           question :israeli_document_type?
+        elsif calculator.passport_country_is_ukraine?
+          outcome :outcome_temporary_guidance_for_leaving_ukraine
         elsif calculator.passport_country_is_estonia?
           question :what_sort_of_passport?
         elsif calculator.passport_country_is_latvia?
@@ -303,6 +305,7 @@ class CheckUkVisaFlow < SmartAnswer::Flow
     outcome :outcome_study_waiver_taiwan
     outcome :outcome_study_no_visa_needed
     outcome :outcome_study_y
+    outcome :outcome_temporary_guidance_for_leaving_ukraine
     outcome :outcome_transit_leaving_airport
     outcome :outcome_transit_leaving_airport_direct_airside_transit_visa
     outcome :outcome_transit_not_leaving_airport

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_temporary_guidance_for_leaving_ukraine.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_temporary_guidance_for_leaving_ukraine.erb
@@ -1,0 +1,9 @@
+<% text_for :title do %>
+  Check the temporary visa guidance for leaving Ukraine
+<% end %>
+
+<% govspeak_for :body do %>
+  If you usually live in Ukraine and you’re coming to the UK because of the Russian invasion, [check whether you can use one of the temporary visas to come to the UK](/guidance/support-for-family-members-of-british-nationals-in-ukraine-and-ukrainian-nationals-in-ukraine-and-the-uk).
+
+  If you’re a Ukrainian citizen but you do not usually live in Ukraine, and you’re coming to the UK for another reason, [follow the guidance as usual for the purpose of your visit](/check-uk-visa/y/ukraine).
+<% end %>

--- a/lib/smart_answer/calculators/uk_visa_calculator.rb
+++ b/lib/smart_answer/calculators/uk_visa_calculator.rb
@@ -79,6 +79,10 @@ module SmartAnswer::Calculators
       @passport_country == "israel"
     end
 
+    def passport_country_is_ukraine?
+      @passport_country == "ukraine"
+    end
+
     def passport_country_is_taiwan?
       @passport_country == "taiwan"
     end

--- a/test/flows/check_uk_visa_flow_test.rb
+++ b/test/flows/check_uk_visa_flow_test.rb
@@ -28,6 +28,7 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
                                       "hong-kong",
                                       "macao",
                                       "taiwan",
+                                      "ukraine",
                                       "venezuela",
                                       @electronic_visa_waiver_country,
                                       @direct_airside_transit_visa_country,
@@ -73,6 +74,10 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
 
       should "have a next node of outcome_no_visa_needed_ireland for an 'ireland' response" do
         assert_next_node :outcome_no_visa_needed_ireland, for_response: "ireland"
+      end
+
+      should "have a next node of outcome_temporary_guidance_for_leaving_ukraine for an 'ukraine' response" do
+        assert_next_node :outcome_temporary_guidance_for_leaving_ukraine, for_response: "ukraine"
       end
 
       should "have a next node of purpose_of_visit? for a different country" do


### PR DESCRIPTION
Option 2
Add a new outcome for check-uk-visa for Ukraine passports.
* Note this is not viable as the outcome copy attempts to link back into the question flow, essentially linking to itself

[trello](https://trello.com/c/SY5ZyORO/3233-4-march-tbc-check-if-you-need-a-visa-updates-for-ukrainian-nationals)