### PR TITLE
Fix and update self assessment calculator

### DIFF
--- a/lib/smart_answer/calculators/self_assessment_penalties.rb
+++ b/lib/smart_answer/calculators/self_assessment_penalties.rb
@@ -202,7 +202,7 @@ module SmartAnswer::Calculators
       covid_easement_first_year = (tax_year == "2019-20" && filing_date < Date.parse("2021-03-01"))
       covid_easement_second_year = (tax_year == "2020-21" && filing_date < Date.parse("2022-03-01"))
 
-      covid_easement_first_year || covid_easement_second_year
+      (covid_easement_first_year || covid_easement_second_year) && submission_method == "online"
     end
 
     def payment_deadline

--- a/lib/smart_answer/calculators/self_assessment_penalties.rb
+++ b/lib/smart_answer/calculators/self_assessment_penalties.rb
@@ -40,6 +40,12 @@ module SmartAnswer::Calculators
       },
     }.freeze
 
+    INTEREST_RATES = [
+      { start_date: "2020-04-07", end_date: "2022-01-03", value: 0.026 },
+      { start_date: "2022-01-04", end_date: "2022-02-20", value: 0.0275 },
+      { start_date: "2022-02-21", end_date: "2100-01-01", value: 0.03 },
+    ].freeze
+
     def tax_year_range
       case tax_year
       when "2014-15"
@@ -214,15 +220,12 @@ module SmartAnswer::Calculators
     end
 
     def daily_rate(date)
-      # Rate decreased to 2.6% on 7 April 2020
-      rate_change_date = Date.new(2020, 4, 7)
-      # Rate increased to 2.75% on 4 january 2022
-      second_rate_change_date = Date.new(2022, 1, 4)
+      rate_for_date = INTEREST_RATES.find do |rate|
+        date >= Time.zone.parse(rate[:start_date]) && date <= Time.zone.parse(rate[:end_date])
+      end
 
-      if date >= second_rate_change_date
-        0.0275 / 365.0
-      elsif date >= rate_change_date
-        0.026 / 365.0
+      if rate_for_date.present?
+        rate_for_date[:value] / 365.0
       else
         0.0325 / 365.0
       end

--- a/test/unit/calculators/self_assessment_penalties_test.rb
+++ b/test/unit/calculators/self_assessment_penalties_test.rb
@@ -423,18 +423,18 @@ module SmartAnswer::Calculators
 
               @calculator.payment_date = Date.parse("2022-02-28")
               assert_equal 0, @calculator.late_payment_penalty
-              assert_equal 21.1, @calculator.interest.to_f
+              assert_equal 21.58, @calculator.interest.to_f
 
               @calculator.payment_date = Date.parse("2022-04-01")
               assert_equal 0, @calculator.late_payment_penalty
-              assert_equal 45.21, @calculator.interest.to_f
+              assert_equal 47.88, @calculator.interest.to_f
             end
           end
 
           should "the user should have a late payment penalty as they are beyond the new deadline of 1st of April" do
             @calculator.payment_date = Date.parse("2022-04-02")
             assert_equal 500, @calculator.late_payment_penalty
-            assert_equal 45.96, @calculator.interest.to_f
+            assert_equal 48.70, @calculator.interest.to_f
           end
         end
 

--- a/test/unit/calculators/self_assessment_penalties_test.rb
+++ b/test/unit/calculators/self_assessment_penalties_test.rb
@@ -483,6 +483,17 @@ module SmartAnswer::Calculators
       setup do
         @calculator.submission_method = "paper"
       end
+
+      context "filed during Covid easement" do
+        setup do
+          @calculator.filing_date = Date.parse("2021-01-28")
+        end
+
+        should "not benefit from the extended deadline" do
+          assert_not @calculator.paid_on_time?
+        end
+      end
+
       context "filed and paid on time" do
         setup do
           @calculator.filing_date = Date.parse("2014-10-30")


### PR DESCRIPTION
Contains two changes, firstly it fixes a bug where covid easement was being applied for paper submissions, which is incorrect. Secondly, interest rates have been updated backdated to the 21st February 2022.

Trello:
https://trello.com/c/B79tAlpm/1134-self-assessment-penalty-calculator-interest-rate-change-and-covid-easement-error  

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
