### PR TITLE
(Uprating) Minimum wage calculator 2022

### DIFF
--- a/app/flows/am_i_getting_minimum_wage_flow/questions/what_would_you_like_to_check.erb
+++ b/app/flows/am_i_getting_minimum_wage_flow/questions/what_would_you_like_to_check.erb
@@ -4,5 +4,5 @@
 
 <% options(
   "current_payment": "If you're getting the National Minimum Wage or the National Living Wage",
-  "past_payment": "If an employer owes you payments from last year (April 2020 to March 2021)"
+  "past_payment": "If an employer owes you payments from last year (April 2021 to March 2022)"
 ) %>

--- a/app/flows/am_i_getting_minimum_wage_flow/start.erb
+++ b/app/flows/am_i_getting_minimum_wage_flow/start.erb
@@ -15,5 +15,5 @@
 
   ^You must be at least 23 years old to get the National Living Wage.^
 
-  Check [National Minimum Wage and National Living Wage rates](/national-minimum-wage-rates) before March 2021.
+  Check [National Minimum Wage and National Living Wage rates](/national-minimum-wage-rates) before March 2022.
 <% end %>

--- a/app/flows/minimum_wage_calculator_employers_flow/questions/what_would_you_like_to_check.erb
+++ b/app/flows/minimum_wage_calculator_employers_flow/questions/what_would_you_like_to_check.erb
@@ -4,5 +4,5 @@
 
 <% options(
   "current_payment": "If you’re paying a worker the National Minimum Wage or the National Living Wage",
-  "past_payment": "If you owe a worker payments from last year (April 2020 to March 2021)"
+  "past_payment": "If you owe a worker payments from last year (April 2021 to March 2022)"
 ) %>

--- a/app/flows/minimum_wage_calculator_employers_flow/start.erb
+++ b/app/flows/minimum_wage_calculator_employers_flow/start.erb
@@ -15,5 +15,5 @@
 
   ^Your employee must be at least 23 years old to get the National Living Wage.^
 
-Check [National Minimum Wage and National Living Wage rates](/national-minimum-wage-rates) before March 2021.
+Check [National Minimum Wage and National Living Wage rates](/national-minimum-wage-rates) before March 2022.
 <% end %>

--- a/app/flows/shared/minimum_wage_flow.rb
+++ b/app/flows/shared/minimum_wage_flow.rb
@@ -6,7 +6,7 @@ class MinimumWageFlow < SmartAnswer::Flow
       option "past_payment"
 
       on_response do |response|
-        date = Date.parse("2020-04-01") if response == "past_payment"
+        date = Date.parse("2021-04-01") if response == "past_payment"
         self.calculator = SmartAnswer::Calculators::MinimumWageCalculator.new(date: date)
         self.accommodation_charge = nil
       end

--- a/config/smart_answers/rates/minimum_wage.yml
+++ b/config/smart_answers/rates/minimum_wage.yml
@@ -242,7 +242,7 @@
   :apprentice_rate: 4.15
   :accommodation_rate: 8.20
 - :start_date: 2021-04-01
-  :end_date: 3000-01-01
+  :end_date: 2022-03-31
   :minimum_rates:
   - :min_age: 0
     :max_age: 18
@@ -258,3 +258,20 @@
     :rate: 8.91
   :apprentice_rate: 4.30
   :accommodation_rate: 8.36
+- :start_date: 2022-04-01
+  :end_date: 3000-01-01
+  :minimum_rates:
+  - :min_age: 0
+    :max_age: 18
+    :rate: 4.81
+  - :min_age: 18
+    :max_age: 21
+    :rate: 6.83
+  - :min_age: 21
+    :max_age: 23
+    :rate: 9.18
+  - :min_age: 23
+    :max_age: 1000
+    :rate: 9.50
+  :apprentice_rate: 4.81
+  :accommodation_rate: 8.70

--- a/test/unit/calculators/minimum_wage_calculator_test.rb
+++ b/test/unit/calculators/minimum_wage_calculator_test.rb
@@ -546,6 +546,48 @@ module SmartAnswer::Calculators
           assert_equal 6.00, @calculator.free_accommodation_rate
         end
       end
+
+      context "from 1 Apr 2022" do
+        setup do
+          @calculator = MinimumWageCalculator.new(date: Date.parse("2022-04-01"))
+        end
+
+        should "be correct for those under 18" do
+          [0, 17].each do |age|
+            @calculator.age = age
+            assert_equal 4.81, @calculator.per_hour_minimum_wage
+          end
+        end
+
+        should "be correct for 18 to 20 year olds" do
+          [18, 20].each do |age|
+            @calculator.age = age
+            assert_equal 6.83, @calculator.per_hour_minimum_wage
+          end
+        end
+
+        should "be correct for 21 to 22 year olds" do
+          [21, 22].each do |age|
+            @calculator.age = age
+            assert_equal 9.18, @calculator.per_hour_minimum_wage
+          end
+        end
+
+        should "be correct for those aged 23 and over" do
+          [23, 100].each do |age|
+            @calculator.age = age
+            assert_equal 9.50, @calculator.per_hour_minimum_wage
+          end
+        end
+
+        should "have correct apprentice rate" do
+          assert_equal 4.81, @calculator.apprentice_rate
+        end
+
+        should "have correct accommodation rate" do
+          assert_equal 8.7, @calculator.free_accommodation_rate
+        end
+      end
     end
 
     context "accommodation adjustment" do


### PR DESCRIPTION
National Living Wage for those aged 23 and over will increase
from £8.91 per hour to £9.50 per hour.

National Minimum Wage will also increase:
- for 21 to 22 year olds – from £8.36 per hour to £9.18
- for 18 to 20 year olds – from £6.56 per hour to £6.83
- for those under 18 – from £4.62 per hour to £4.81
- for apprentices – from £4.30 per hour to £4.81

Accommodation offset rates will also change:
- daily – from £8.36 to £8.70

https://trello.com/c/eoazcTDo/868-deploy-on-1-april-national-minimum-wage-and-living-wage-calculators

---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
