### PR TITLE
Update Minimum Living Wage age

### DIFF
--- a/app/flows/am_i_getting_minimum_wage_flow/questions/how_old_are_you.erb
+++ b/app/flows/am_i_getting_minimum_wage_flow/questions/how_old_are_you.erb
@@ -9,7 +9,3 @@
 <% text_for :error_message do %>
   Please enter a whole number greater than 0
 <% end %>
-
-<% text_for :error_valid_age_for_living_wage? do %>
-  You must be 25 or over to get the National Living Wage
-<% end %>

--- a/lib/smart_answer/calculators/minimum_wage_calculator.rb
+++ b/lib/smart_answer/calculators/minimum_wage_calculator.rb
@@ -49,7 +49,8 @@ module SmartAnswer::Calculators
     end
 
     def valid_age_for_living_wage?(age)
-      age.to_i >= 25
+      (age.to_i >= 23 && date >= Date.parse("2021-04-01")) ||
+        age.to_i >= 25
     end
 
     def basic_rate

--- a/test/unit/calculators/minimum_wage_calculator_test.rb
+++ b/test/unit/calculators/minimum_wage_calculator_test.rb
@@ -90,13 +90,26 @@ module SmartAnswer::Calculators
       end
 
       context "for age for living wage" do
-        should "not accept ages below 25" do
-          assert_not @calculator.valid_age_for_living_wage?(24)
+        should "not accept ages below 23" do
+          assert_not @calculator.valid_age_for_living_wage?(22)
         end
 
-        should "accept ages 25 or above" do
-          assert @calculator.valid_age_for_living_wage?(25)
-          assert @calculator.valid_age_for_living_wage?(26)
+        should "accept ages 23 or above" do
+          assert @calculator.valid_age_for_living_wage?(23)
+          assert @calculator.valid_age_for_living_wage?(24)
+        end
+
+        context "when a date is before 1 April 2021" do
+          setup { @calculator.date = Date.parse("2020-04-01") }
+
+          should "not accept ages below 25" do
+            assert_not @calculator.valid_age_for_living_wage?(23)
+          end
+
+          should "accept ages 25 or above" do
+            assert @calculator.valid_age_for_living_wage?(25)
+            assert @calculator.valid_age_for_living_wage?(26)
+          end
         end
       end
     end
@@ -113,8 +126,17 @@ module SmartAnswer::Calculators
         end
       end
 
-      should "return false if age is lower than 24 or nil" do
+      should "return true if the age is 23 or over, and the date is on or after 2021-04-01" do
+        %w[23 24].each do |age|
+          @calculator.date = Date.parse("2021-04-01")
+          @calculator.age = age
+          assert @calculator.eligible_for_living_wage?
+        end
+      end
+
+      should "return false if age is lower than 24 or nil, and date is before 2021-04-01" do
         %w[nil 0 24].each do |age|
+          @calculator.date = Date.parse("2020-04-01")
           @calculator.age = age
           assert_not @calculator.eligible_for_living_wage?
         end


### PR DESCRIPTION
Since 2021-04-01 minimum living wage age changed from 25 to 23 but some parts of the calculator were never updated.

This caused to incorrectly display the outcome as "National Minimum Wage" instead of "National Living Wage" for those age 23 and 24. For example: https://www.gov.uk/am-i-getting-minimum-wage/y/current_payment/apprentice_over_19_second_year_onwards/23/7/40.0/480.0/no/no/no

It also removes text_for :error_valid_age_for_living_wage? block as we never validate it in the flow.

### How to test it

- for age below 23 "You appear to be getting the National Minimum Wage."
/am-i-getting-minimum-wage/y/current_payment/apprentice_over_19_second_year_onwards/22/7/40.0/380.0/no/no/no

- for age 23 and above "You appear to be getting the National Living Wage."
/am-i-getting-minimum-wage/y/current_payment/apprentice_over_19_second_year_onwards/23/7/40.0/380.0/no/no/no

https://trello.com/c/RoCl0SSO/875-draft-fix-national-living-wage-age-in-calculators

---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
