### PR TITLE
Accommodate clocks changing in tests

### DIFF
--- a/test/unit/world_location_test.rb
+++ b/test/unit/world_location_test.rb
@@ -80,7 +80,7 @@ class WorldLocationTest < ActiveSupport::TestCase
           end
         end
 
-        travel_to(1.week.from_now + 1.hour) do
+        travel_to(1.week.from_now + 2.hours) do
           assert_raises GdsApi::TimedOutException do
             WorldLocation.all
           end
@@ -178,7 +178,7 @@ class WorldLocationTest < ActiveSupport::TestCase
           end
         end
 
-        travel_to(1.week.from_now + 1.hour) do
+        travel_to(1.week.from_now + 2.hours) do
           assert_raises GdsApi::TimedOutException do
             WorldLocation.find("rohan")
           end


### PR DESCRIPTION
There is an odd problem that occurs one week before the clocks go forward for BST.

Two of the [tests] fail with:

```
Failure:
WorldLocationTest#test_: finding a location by slug caching the result should use the stale value from the cache on error for a week.  [/var/lib/jenkins/workspace/smartanswers_main/test/unit/world_location_test.rb:182]:
GdsApi::TimedOutException expected but nothing was raised.

rails test test/unit/world_location_test.rb:170

F

Failure:
WorldLocationTest#test_: loading all locations caching the results should use the stale value from the cache on error for a week.  [/var/lib/jenkins/workspace/smartanswers_main/test/unit/world_location_test.rb:84]:
GdsApi::TimedOutException expected but nothing was raised.

rails test test/unit/world_location_test.rb:71
```

The actual failure is occuring because of this line:

```
travel_to(1.week.from_now + 1.hour)
```

If we look in the console, these two things are not the same:

```
irb(main):001:0> 1.week.from_now + 1.hour
=> Mon, 28 Mar 2022 16:35:29.184705000 BST +01:00
irb(main):002:0> 169.hours.from_now
=> Mon, 28 Mar 2022 17:35:38.146865000 BST +01:00
```

169 hours should be the same as 1 week + 1 hour. However, at the weekend we are losing one hour due to the clocks going forward, so in this test, in 1 week and 1 hour the cache won't have been emptied.

This problem only occurs for one week every year. Rather than doing something clever to get around the time difference, to keep it simple, while still testing cache duration i.e. anytime after 1 week, the interval has been increased by an hour.

Paired with @Rosa-Fox 

[tests]: https://ci.integration.publishing.service.gov.uk/job/smartanswers/job/main/5905/console

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
