### PR TITLE
Update links to reflect page titles in Minimum wage calculator

### DIFF
--- a/app/flows/am_i_getting_minimum_wage_flow/outcomes/current_payment_above.erb
+++ b/app/flows/am_i_getting_minimum_wage_flow/outcomes/current_payment_above.erb
@@ -10,7 +10,11 @@
   <% if calculator.potential_underpayment? %>
     If you have had money taken from your pay for things you need for your job or not been paid for any additional time you work outside of your shift you might have been underpaid. You can contact Acas or make a complaint to HMRC.
   <% else %>
-    Read the guidance on the [National Minimum Wage](/national-minimum-wage) and [how the National Minimum Wage is calculated](/minimum-wage-different-types-work).
+    <% if calculator.eligible_for_living_wage? %>
+      Read the guidance on the [National Minimum and Living Wage](/national-minimum-wage).
+    <% else %>
+      Read the guidance on the [National Minimum Wage](/national-minimum-wage) and [how the National Minimum Wage is calculated](/minimum-wage-different-types-work).
+    <% end %>
   <% end %>
 
   <%= render partial: 'shared/minimum_wage_flow/acas_information' %>

--- a/app/flows/am_i_getting_minimum_wage_flow/outcomes/past_payment_above.erb
+++ b/app/flows/am_i_getting_minimum_wage_flow/outcomes/past_payment_above.erb
@@ -6,7 +6,11 @@
   <% if calculator.potential_underpayment? %>
     If you had money taken from your pay for things you need for your job or not been paid for any additional time you work outside of your shift you might have been underpaid. You can contact Acas or make a complaint to HMRC.
   <% else %>
-    Read the guidance on the [National Minimum Wage](/national-minimum-wage) and [how the National Minimum Wage is calculated](/minimum-wage-different-types-work).
+    <% if calculator.eligible_for_living_wage? %>
+      Read the guidance on the [National Minimum and Living Wage](/national-minimum-wage).
+    <% else %>
+      Read the guidance on the [National Minimum Wage](/national-minimum-wage) and [how the National Minimum Wage is calculated](/minimum-wage-different-types-work).
+    <% end %>
   <% end%>
 
   <%= render partial: 'shared/minimum_wage_flow/acas_information' %>

--- a/app/flows/minimum_wage_calculator_employers_flow/outcomes/current_payment_above.erb
+++ b/app/flows/minimum_wage_calculator_employers_flow/outcomes/current_payment_above.erb
@@ -11,7 +11,7 @@
     As you’ve taken money from the worker’s pay for things they need for their job or not been paying the worker for any additional time they worked outside of their shift, this might mean you’ve underpaid them.
   <% end%>
 
-  Read the guidance on [how to calculate the National Minimum Wage](/national-minimum-wage/employers-and-the-minimum-wage).
+  Read the guidance on [how to calculate the National Minimum and Living Wage](/national-minimum-wage/employers-and-the-minimum-wage).
 
   <%= render partial: 'shared/minimum_wage_flow/acas_information' %>
 <% end %>

--- a/app/flows/minimum_wage_calculator_employers_flow/outcomes/current_payment_below.erb
+++ b/app/flows/minimum_wage_calculator_employers_flow/outcomes/current_payment_below.erb
@@ -16,7 +16,7 @@
     * not paid the worker for any additional time they worked outside their shift
   <% end %>
 
-  Read the guidance on [how to calculate the National Minimum Wage](/national-minimum-wage/employers-and-the-minimum-wage).
+  Read the guidance on [how to calculate the National Minimum and Living Wage](/national-minimum-wage/employers-and-the-minimum-wage).
 
   <%= render partial: 'shared/minimum_wage_flow/acas_information' %>
 <% end %>


### PR DESCRIPTION
National Living Wage was introduced in 2016.
This updates the links on all outcome pages which conditionally show "National Minimum Wage" or "National Living Wage".

Note: Link text to /minimum-wage-different-types-work is not changed as it refers to Minimum Wage only.

**Before**
<kbd><img width="524" alt="Screenshot 2022-03-18 at 09 08 30" src="https://user-images.githubusercontent.com/38078064/159368879-98395cb8-f2a3-40c9-a81a-e31c42255430.png"></kbd>

**After**

<kbd><img width="526" alt="Screenshot 2022-03-22 at 09 21 30" src="https://user-images.githubusercontent.com/38078064/160105089-bc726dda-ae2f-4e2f-9066-ead576f188ac.png"></kbd>

<kbd><img width="428" alt="Screenshot 2022-03-22 at 09 22 03" src="https://user-images.githubusercontent.com/38078064/159448223-0a804e4e-bfd6-4812-bda9-ea7bead8ff4e.png"></kbd>


https://trello.com/c/3pqdnnqn/902-content-update-on-national-minimum-and-living-wage-calculator-outcome-page

--

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
