### PR TITLE
Remove call to action

### DIFF
--- a/app/flows/report_a_lost_or_stolen_passport_flow/outcomes/report_lost_or_stolen_passport.erb
+++ b/app/flows/report_a_lost_or_stolen_passport_flow/outcomes/report_lost_or_stolen_passport.erb
@@ -1,15 +1,15 @@
 <% govspeak_for :body do %>
 You can cancel your passport immediately by [reporting it online](https://www.loststolenpassport.service.gov.uk/report/passport-holder).
 
-You’ll need to provide a UK mobile number. If you don’t have one, you can use an email address and a landline number.
+You’ll need to provide a UK mobile number. If you do not have one, you can use an email address and a landline number.
 
 You'll need to [apply for a replacement passport](/renew-adult-passport/overview) if you want one.
 
-^If you [replace your passport using the paper application form](/renew-adult-passport/replace), fill in section 3 to report your missing passport - you don’t need to report it online as well.^
+
 
 %You can’t use the [1-day Premium service](/get-a-passport-urgently) if you’re replacing a lost passport.%
 
-###Help cancelling your passport
+##Help cancelling your passport
 
 [Contact the Passport Adviceline](/passport-advice-line) if you need help.
 


### PR DESCRIPTION
Removed callout about using a paper form as it's no longer accurate. Also made some small style changes.

[Trello](https://trello.com/c/KX0joCOp/45-deploy-update-to-lost-passport-smart-answer)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
