### PR TITLE
Update redundancy calculator rates for 2022

### DIFF
--- a/config/smart_answers/rates/redundancy_pay.yml
+++ b/config/smart_answers/rates/redundancy_pay.yml
@@ -39,3 +39,7 @@
   end_date: 2022-04-05
   max: "16,320"
   rate: 544
+- start_date: 2022-04-06
+  end_date: 2023-04-05
+  max: "17,130"
+  rate: 571

--- a/test/unit/calculators/redundancy_calculator_test.rb
+++ b/test/unit/calculators/redundancy_calculator_test.rb
@@ -46,7 +46,8 @@ module SmartAnswer::Calculators
         assert_equal "15,240", RedundancyCalculator.redundancy_rates(Date.new(2018, 4, 6)).max
         assert_equal "15,750", RedundancyCalculator.redundancy_rates(Date.new(2019, 4, 6)).max
         assert_equal "16,140", RedundancyCalculator.redundancy_rates(Date.new(2020, 4, 6)).max
-        assert_equal "16,320", RedundancyCalculator.redundancy_rates(Date.new(Time.zone.today.year, 12, 31)).max
+        assert_equal "16,320", RedundancyCalculator.redundancy_rates(Date.new(2021, 4, 6)).max
+        assert_equal "17,130", RedundancyCalculator.redundancy_rates(Date.new(Time.zone.today.year, 12, 31)).max
       end
 
       should "use the most recent rate for far future dates" do


### PR DESCRIPTION
It's uprating time! [Trello](https://trello.com/c/djp5QQOw/891-uprating-deploy-any-time-before-6-april-redundancy-pay-update-figures-on-2-calculators)


For:

* https://www.gov.uk/calculate-your-redundancy-pay
* https://www.gov.uk/calculate-employee-redundancy-pay 


Previews:

* https://smart-answer-redundancy-tfysmz.herokuapp.com/calculate-your-redundancy-pay
* https://smart-answer-redundancy-tfysmz.herokuapp.com/calculate-employee-redundancy-pay

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
