### PR TITLE
Update start.erb: calculate statutory sick pay

### DIFF
--- a/app/flows/calculate_statutory_sick_pay_flow/start.erb
+++ b/app/flows/calculate_statutory_sick_pay_flow/start.erb
@@ -19,7 +19,7 @@
 
   ##Sick leave because of coronavirus (COVID-19)
   
-  Do not use the calculator if your employee is self-isolating because of coronavirus. You'll need to [work out the SSP manually](/guidance/statutory-sick-pay-manually-calculate-your-employees-payments) instead.
+  Do not use the calculator if your employee became sick with COVID-19 on or before 24 March. You'll need to [work out the SSP manually](/guidance/statutory-sick-pay-manually-calculate-your-employees-payments) instead.
 
   ##Different periods of sick leave
 


### PR DESCRIPTION
Removing mention of self-isolation, and adding that you only have to calculate manually if the period of sickness was under the special provisions of the coronavirus act - which ended 25 March.

https://trello.com/c/U6z7a0Ia/48-content-update-to-calculate-statutory-sick-pay

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
