### PR TITLE
End self assessment penalty interest rate of 3% on April 4th 2022

### DIFF
--- a/lib/smart_answer/calculators/self_assessment_penalties.rb
+++ b/lib/smart_answer/calculators/self_assessment_penalties.rb
@@ -43,7 +43,7 @@ module SmartAnswer::Calculators
     INTEREST_RATES = [
       { start_date: "2020-04-07", end_date: "2022-01-03", value: 0.026 },
       { start_date: "2022-01-04", end_date: "2022-02-20", value: 0.0275 },
-      { start_date: "2022-02-21", end_date: "2100-01-01", value: 0.03 },
+      { start_date: "2022-02-21", end_date: "2022-04-04", value: 0.03 },
     ].freeze
 
     def tax_year_range

--- a/test/unit/calculators/self_assessment_penalties_test.rb
+++ b/test/unit/calculators/self_assessment_penalties_test.rb
@@ -431,10 +431,18 @@ module SmartAnswer::Calculators
             end
           end
 
-          should "the user should have a late payment penalty as they are beyond the new deadline of 1st of April" do
-            @calculator.payment_date = Date.parse("2022-04-02")
-            assert_equal 500, @calculator.late_payment_penalty
-            assert_equal 48.70, @calculator.interest.to_f
+          context "late payment penalties after April 1st" do
+            should "before April 5th, the user should have a late payment penalty of 3%" do
+              @calculator.payment_date = Date.parse("2022-04-02")
+              assert_equal 500, @calculator.late_payment_penalty
+              assert_equal 48.70, @calculator.interest.to_f
+            end
+
+            should "after April 5th, the user should have a late payment penalty of 3.25%" do
+              @calculator.payment_date = Date.parse("2022-04-05")
+              assert_equal 500, @calculator.late_payment_penalty
+              assert_equal 51.23, @calculator.interest.to_f
+            end
           end
         end
 


### PR DESCRIPTION
As of April 5th 2022, the penalty interest rate for late self assessment
returns to the default of 3.25%.

[trello](https://trello.com/c/hInnhiQ9/1175-live-date-5-april-self-assessment-late-payment-calculator)
