### PR TITLE
Link directly to www.nidirect.gov.uk/contacts/district-registrars-nor…

### DIFF
--- a/app/flows/marriage_abroad_flow/outcomes/countries/taiwan/ceremony_country/partner_british/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/taiwan/ceremony_country/partner_british/_opposite_sex.erb
@@ -10,7 +10,7 @@ The local Household Registration Office may tell you that you need a CNI in orde
 
 To get a CNI, you must travel to the UK and make an appointment at a [local register office](/register-offices) to give notice of your marriage. A CNI costs £35.
 
-^Contact a local register office to find out what you need to do if you’re in [Scotland](http://www.nrscotland.gov.uk/files/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages/), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).^
+^Contact a local register office to find out what you need to do if you’re in [Scotland](http://www.nrscotland.gov.uk/files/registration/reglist.pdf), [Northern Ireland](https://www.nidirect.gov.uk/contacts/district-registrars-northern-ireland), [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages/), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).^
 
 ###Get your documents legalised, authorised and translated
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/taiwan/ceremony_country/partner_british/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/taiwan/ceremony_country/partner_british/_same_sex.erb
@@ -10,7 +10,7 @@ The local Household Registration Office may tell you that you need a CNI in orde
 
 To get a CNI, you must travel to the UK and make an appointment at a [local register office](/register-offices) to give notice of your marriage. A CNI costs £35.
 
-^Contact a local register office to find out what you need to do if you’re in [Scotland](http://www.nrscotland.gov.uk/files/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages/), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).^
+^Contact a local register office to find out what you need to do if you’re in [Scotland](http://www.nrscotland.gov.uk/files/registration/reglist.pdf), [Northern Ireland](https://www.nidirect.gov.uk/contacts/district-registrars-northern-ireland), [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages/), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).^
 
 ###Get your documents legalised, authorised and translated
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/taiwan/ceremony_country/partner_local/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/taiwan/ceremony_country/partner_local/_opposite_sex.erb
@@ -10,7 +10,7 @@ The local Household Registration Office may tell you that you need a CNI in orde
 
 To get a CNI, you must travel to the UK and make an appointment at a [local register office](/register-offices) to give notice of your marriage. A CNI costs £35.
 
-^Contact a local register office to find out what you need to do if you’re in [Scotland](http://www.nrscotland.gov.uk/files/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages/), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).^
+^Contact a local register office to find out what you need to do if you’re in [Scotland](http://www.nrscotland.gov.uk/files/registration/reglist.pdf), [Northern Ireland](https://www.nidirect.gov.uk/contacts/district-registrars-northern-ireland), [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages/), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).^
 
 ###Get your documents legalised, authorised and translated
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/taiwan/ceremony_country/partner_local/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/taiwan/ceremony_country/partner_local/_same_sex.erb
@@ -10,7 +10,7 @@ The local Household Registration Office may tell you that you need a CNI in orde
 
 To get a CNI, you must travel to the UK and make an appointment at a [local register office](/register-offices) to give notice of your marriage. A CNI costs £35.
 
-^Contact a local register office to find out what you need to do if you’re in [Scotland](http://www.nrscotland.gov.uk/files/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages/), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).^
+^Contact a local register office to find out what you need to do if you’re in [Scotland](http://www.nrscotland.gov.uk/files/registration/reglist.pdf), [Northern Ireland](https://www.nidirect.gov.uk/contacts/district-registrars-northern-ireland), [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages/), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).^
 
 ###Get your documents legalised, authorised and translated
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/taiwan/ceremony_country/partner_other/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/taiwan/ceremony_country/partner_other/_opposite_sex.erb
@@ -10,7 +10,7 @@ The local Household Registration Office may tell you that you need a CNI in orde
 
 To get a CNI, you must travel to the UK and make an appointment at a [local register office](/register-offices) to give notice of your marriage. A CNI costs £35.
 
-^Contact a local register office to find out what you need to do if you’re in [Scotland](http://www.nrscotland.gov.uk/files/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages/), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).^
+^Contact a local register office to find out what you need to do if you’re in [Scotland](http://www.nrscotland.gov.uk/files/registration/reglist.pdf), [Northern Ireland](https://www.nidirect.gov.uk/contacts/district-registrars-northern-ireland), [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages/), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).^
 
 ###Get your documents legalised, authorised and translated
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/taiwan/ceremony_country/partner_other/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/taiwan/ceremony_country/partner_other/_same_sex.erb
@@ -10,7 +10,7 @@ The local Household Registration Office may tell you that you need a CNI in orde
 
 To get a CNI, you must travel to the UK and make an appointment at a [local register office](/register-offices) to give notice of your marriage. A CNI costs £35.
 
-^Contact a local register office to find out what you need to do if you’re in [Scotland](http://www.nrscotland.gov.uk/files/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages/), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).^
+^Contact a local register office to find out what you need to do if you’re in [Scotland](http://www.nrscotland.gov.uk/files/registration/reglist.pdf), [Northern Ireland](https://www.nidirect.gov.uk/contacts/district-registrars-northern-ireland), [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages/), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).^
 
 ###Get your documents legalised, authorised and translated
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/taiwan/third_country/partner_british/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/taiwan/third_country/partner_british/_opposite_sex.erb
@@ -10,7 +10,7 @@ The local Household Registration Office may tell you that you need a CNI in orde
 
 To get a CNI, you must travel to the UK and make an appointment at a [local register office](/register-offices) to give notice of your marriage. A CNI costs £35.
 
-^Contact a local register office to find out what you need to do if you’re in [Scotland](http://www.nrscotland.gov.uk/files/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages/), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).^
+^Contact a local register office to find out what you need to do if you’re in [Scotland](http://www.nrscotland.gov.uk/files/registration/reglist.pdf), [Northern Ireland](https://www.nidirect.gov.uk/contacts/district-registrars-northern-ireland), [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages/), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).^
 
 ###Get your documents legalised, authorised and translated
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/taiwan/third_country/partner_british/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/taiwan/third_country/partner_british/_same_sex.erb
@@ -10,7 +10,7 @@ The local Household Registration Office may tell you that you need a CNI in orde
 
 To get a CNI, you must travel to the UK and make an appointment at a [local register office](/register-offices) to give notice of your marriage. A CNI costs £35.
 
-^Contact a local register office to find out what you need to do if you’re in [Scotland](http://www.nrscotland.gov.uk/files/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages/), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).^
+^Contact a local register office to find out what you need to do if you’re in [Scotland](http://www.nrscotland.gov.uk/files/registration/reglist.pdf), [Northern Ireland](https://www.nidirect.gov.uk/contacts/district-registrars-northern-ireland), [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages/), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).^
 
 ###Get your documents legalised, authorised and translated
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/taiwan/third_country/partner_local/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/taiwan/third_country/partner_local/_opposite_sex.erb
@@ -10,7 +10,7 @@ The local Household Registration Office may tell you that you need a CNI in orde
 
 To get a CNI, you must travel to the UK and make an appointment at a [local register office](/register-offices) to give notice of your marriage. A CNI costs £35.
 
-^Contact a local register office to find out what you need to do if you’re in [Scotland](http://www.nrscotland.gov.uk/files/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages/), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).^
+^Contact a local register office to find out what you need to do if you’re in [Scotland](http://www.nrscotland.gov.uk/files/registration/reglist.pdf), [Northern Ireland](https://www.nidirect.gov.uk/contacts/district-registrars-northern-ireland), [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages/), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).^
 
 ###Get your documents legalised, authorised and translated
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/taiwan/third_country/partner_local/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/taiwan/third_country/partner_local/_same_sex.erb
@@ -10,7 +10,7 @@ The local Household Registration Office may tell you that you need a CNI in orde
 
 To get a CNI, you must travel to the UK and make an appointment at a [local register office](/register-offices) to give notice of your marriage. A CNI costs £35.
 
-^Contact a local register office to find out what you need to do if you’re in [Scotland](http://www.nrscotland.gov.uk/files/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages/), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).^
+^Contact a local register office to find out what you need to do if you’re in [Scotland](http://www.nrscotland.gov.uk/files/registration/reglist.pdf), [Northern Ireland](https://www.nidirect.gov.uk/contacts/district-registrars-northern-ireland), [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages/), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).^
 
 ###Get your documents legalised, authorised and translated
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/taiwan/third_country/partner_other/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/taiwan/third_country/partner_other/_opposite_sex.erb
@@ -10,7 +10,7 @@ The local Household Registration Office may tell you that you need a CNI in orde
 
 To get a CNI, you must travel to the UK and make an appointment at a [local register office](/register-offices) to give notice of your marriage. A CNI costs £35.
 
-^Contact a local register office to find out what you need to do if you’re in [Scotland](http://www.nrscotland.gov.uk/files/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages/), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).^
+^Contact a local register office to find out what you need to do if you’re in [Scotland](http://www.nrscotland.gov.uk/files/registration/reglist.pdf), [Northern Ireland](https://www.nidirect.gov.uk/contacts/district-registrars-northern-ireland), [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages/), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).^
 
 ###Get your documents legalised, authorised and translated
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/taiwan/third_country/partner_other/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/taiwan/third_country/partner_other/_same_sex.erb
@@ -10,7 +10,7 @@ The local Household Registration Office may tell you that you need a CNI in orde
 
 To get a CNI, you must travel to the UK and make an appointment at a [local register office](/register-offices) to give notice of your marriage. A CNI costs £35.
 
-^Contact a local register office to find out what you need to do if you’re in [Scotland](http://www.nrscotland.gov.uk/files/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages/), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).^
+^Contact a local register office to find out what you need to do if you’re in [Scotland](http://www.nrscotland.gov.uk/files/registration/reglist.pdf), [Northern Ireland](https://www.nidirect.gov.uk/contacts/district-registrars-northern-ireland), [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages/), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).^
 
 ###Get your documents legalised, authorised and translated
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/taiwan/uk/partner_british/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/taiwan/uk/partner_british/_opposite_sex.erb
@@ -10,7 +10,7 @@ The local Household Registration Office may tell you that you need a CNI in orde
 
 To get a CNI, make an appointment at your [local register office](/register-offices) in the UK to give notice of your marriage. A CNI costs £35.
 
-^Contact your local register office to find out what you need to do if you live in [Scotland](http://www.nrscotland.gov.uk/files/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages/), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).^
+^Contact your local register office to find out what you need to do if you live in [Scotland](http://www.nrscotland.gov.uk/files/registration/reglist.pdf), [Northern Ireland](https://www.nidirect.gov.uk/contacts/district-registrars-northern-ireland), [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages/), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).^
 
 ###Get your documents legalised, authorised and translated
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/taiwan/uk/partner_british/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/taiwan/uk/partner_british/_same_sex.erb
@@ -10,7 +10,7 @@ The local Household Registration Office may tell you that you need a CNI in orde
 
 To get a CNI, make an appointment at your [local register office](/register-offices) in the UK to give notice of your marriage. A CNI costs £35.
 
-^Contact your local register office to find out what you need to do if you live in [Scotland](http://www.nrscotland.gov.uk/files/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages/), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).^
+^Contact your local register office to find out what you need to do if you live in [Scotland](http://www.nrscotland.gov.uk/files/registration/reglist.pdf), [Northern Ireland](https://www.nidirect.gov.uk/contacts/district-registrars-northern-ireland), [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages/), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).^
 
 ###Get your documents legalised, authorised and translated
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/taiwan/uk/partner_local/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/taiwan/uk/partner_local/_opposite_sex.erb
@@ -10,7 +10,7 @@ The local Household Registration Office may tell you that you need a CNI in orde
 
 To get a CNI, make an appointment at your [local register office](/register-offices) in the UK to give notice of your marriage. A CNI costs £35.
 
-^Contact your local register office to find out what you need to do if you live in [Scotland](http://www.nrscotland.gov.uk/files/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages/), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).^
+^Contact your local register office to find out what you need to do if you live in [Scotland](http://www.nrscotland.gov.uk/files/registration/reglist.pdf), [Northern Ireland](https://www.nidirect.gov.uk/contacts/district-registrars-northern-ireland), [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages/), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).^
 
 ###Get your documents legalised, authorised and translated
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/taiwan/uk/partner_local/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/taiwan/uk/partner_local/_same_sex.erb
@@ -10,7 +10,7 @@ The local Household Registration Office may tell you that you need a CNI in orde
 
 To get a CNI, make an appointment at your [local register office](/register-offices) in the UK to give notice of your marriage. A CNI costs £35.
 
-^Contact your local register office to find out what you need to do if you live in [Scotland](http://www.nrscotland.gov.uk/files/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages/), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).^
+^Contact your local register office to find out what you need to do if you live in [Scotland](http://www.nrscotland.gov.uk/files/registration/reglist.pdf), [Northern Ireland](https://www.nidirect.gov.uk/contacts/district-registrars-northern-ireland), [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages/), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).^
 
 ###Get your documents legalised, authorised and translated
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/taiwan/uk/partner_other/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/taiwan/uk/partner_other/_opposite_sex.erb
@@ -10,7 +10,7 @@ The local Household Registration Office may tell you that you need a CNI in orde
 
 To get a CNI, make an appointment at your [local register office](/register-offices) in the UK to give notice of your marriage. A CNI costs £35.
 
-^Contact your local register office to find out what you need to do if you live in [Scotland](http://www.nrscotland.gov.uk/files/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages/), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).^
+^Contact your local register office to find out what you need to do if you live in [Scotland](http://www.nrscotland.gov.uk/files/registration/reglist.pdf), [Northern Ireland](https://www.nidirect.gov.uk/contacts/district-registrars-northern-ireland), [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages/), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).^
 
 ###Get your documents legalised, authorised and translated
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/taiwan/uk/partner_other/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/taiwan/uk/partner_other/_same_sex.erb
@@ -10,7 +10,7 @@ The local Household Registration Office may tell you that you need a CNI in orde
 
 To get a CNI, make an appointment at your [local register office](/register-offices) in the UK to give notice of your marriage. A CNI costs £35.
 
-^Contact your local register office to find out what you need to do if you live in [Scotland](http://www.nrscotland.gov.uk/files/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages/), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).^
+^Contact your local register office to find out what you need to do if you live in [Scotland](http://www.nrscotland.gov.uk/files/registration/reglist.pdf), [Northern Ireland](https://www.nidirect.gov.uk/contacts/district-registrars-northern-ireland), [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages/), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).^
 
 ###Get your documents legalised, authorised and translated
 


### PR DESCRIPTION
Link directly to www.nidirect.gov.uk/contacts/district-registrars-nor…thern-ireland

http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm
is redirecting to https://www.nidirect.gov.uk/contacts/district-registrars-northern-ireland
We should link directly to that page.

It got flagged in Broken links report: https://trello.com/c/m1Zmcrk9/904-smart-answers-broken-links

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
