### PR TITLE
Marriage abroad updates - Italy

### DIFF
--- a/app/flows/marriage_abroad_flow/outcomes/countries/italy/ceremony_country/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/italy/ceremony_country/_opposite_sex.erb
@@ -14,10 +14,10 @@ You need to prove you’re legally allowed to get married by getting a ‘Nulla 
 
 You’ll need to get a Nulla Osta if you’re in Italy.
 
-To get a Nulla Osta, [make an appointment at the British Embassy in Rome](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=33&service=10) to give notice of your marriage. Your partner doesn’t have to come with you if they are not a British citizen applying for their own
+To get a Nulla Osta, [make an appointment at the British Embassy in Rome](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=33&service=10) to give notice of your marriage. Your partner does not have to come with you if they are not a British citizen applying for their own
 Nulla Osta.
 
-If you can’t get to the embassy, download the [Nulla Osta application pack](/government/publications/nulla-osta-application-pack-for-marriages-in-italy), fill in the affirmation and notice of marriage and sign them in front of an [Italian notary](https://notaries-directory.eu/). You’ll have to pay a fee. Send the signed documents and supporting documents to the embassy.
+If you cannot get to the embassy, download the [Nulla Osta application pack](/government/publications/nulla-osta-application-pack-for-marriages-in-italy), fill in the affirmation and notice of marriage and sign them in front of an [Italian notary](https://notaries-directory.eu/) using the ‘vera di firma’ procedure. You’ll have to pay a fee. Send the signed documents and supporting documents to the embassy.
 
 $A
 British Embassy Rome
@@ -27,7 +27,7 @@ Italy
 $A
 
 
-You need to be in Italy for 3 full days immediately before you give notice. You can then give notice either at the embassy or by signing the forms in front of an Italian notary. This means if you arrive on Monday you can’t give notice until Friday.
+You need to be in Italy for 3 full days immediately before you give notice. You can then give notice either at the embassy or by signing the forms in front of an Italian notary. This means if you arrive on Monday you cannot give notice until Friday.
 
 It costs <%= format_money calculator.consular_fee(:receiving_notice_of_marriage) %> to give notice and <%= format_money calculator.consular_fee(:issuing_cni_or_nulla_osta) %> for the Nulla Osta. You can pay by card. If you want to pay in cash you need to pay in the [local currency](/government/publications/italy-consular-fees).
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/italy/ceremony_country/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/italy/ceremony_country/_same_sex.erb
@@ -12,9 +12,9 @@ You need to prove you’re legally allowed to register a civil partnership by ge
 
 You’ll need to get a Nulla Osta if you’re in Italy.
 
-To get a Nulla Osta, [make an appointment at the British Embassy in Rome](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=33&service=10) to give notice of your civil partnership. Your partner doesn’t have to come with you.
+To get a Nulla Osta, [make an appointment at the British Embassy in Rome](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=33&service=10) to give notice of your civil partnership. Your partner does not have to come with you if they are not a British citizen applying for their own Nulla Osta.
 
-If you can’t get to the embassy, download the [Nulla Osta application pack](/government/publications/nulla-osta-application-pack-for-marriages-in-italy), fill in the declaration and registration form and sign them in front of an [Italian notary](https://notaries-directory.eu/). You’ll have to pay a fee. Send the signed documents and supporting documents to the embassy.
+If you cannot get to the embassy, download the [Nulla Osta application pack](/government/publications/nulla-osta-application-pack-for-marriages-in-italy), fill in the declaration and registration form and sign them in front of an [Italian notary](https://notaries-directory.eu/) using the ‘vera di firma’ procedure. You’ll have to pay a fee. Send the signed documents and supporting documents to the embassy.
 
 $A
 British Embassy Rome

--- a/app/flows/marriage_abroad_flow/outcomes/countries/italy/ceremony_country/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/italy/ceremony_country/_same_sex.erb
@@ -23,7 +23,7 @@ Via XX Settembre 80/a
 Italy
 $A
 
-You need to be in Italy for 3 full days immediately before you give notice. You can then give notice either at the embassy or by signing the forms in front of an Italian notary. This means if you arrive on Monday you can’t give notice until Friday.
+You need to be in Italy for 3 full days immediately before you give notice. You can then give notice either at the embassy or by signing the forms in front of an Italian notary. This means if you arrive on Monday you cannot give notice until Friday.
 
 It costs <%= format_money calculator.consular_fee(:receiving_notice_of_civil_partnership) %> to give notice and <%= format_money calculator.consular_fee(:issuing_cni_or_nulla_osta) %> for the Nulla Osta. If you want to pay in cash you need to pay in the [local currency](/government/publications/italy-consular-fees).
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/italy/uk/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/italy/uk/_opposite_sex.erb
@@ -8,7 +8,9 @@ If you’re a woman, you must wait 300 days after divorcing or the death of your
 
 You need to prove you’re legally allowed to get married by getting a certificate of no impediment (CNI) and a statutory declaration.
 
-^Your partner will also need a CNI and statutory declaration if they’re British. If they’re not, the documents they need might be different.^
+Your partner will also need a CNI and statutory declaration if they’re British. If they’re not, the documents they need might be different.
+
+^If you’re in Italy temporarily and you do not want to return to the UK to get these documents, you can follow a different process and [get a Nulla Osta](/marriage-abroad/y/italy/ceremony_country/opposite_sex) in Italy instead. You need to put down your UK address on the Nulla Osta application form, not where you’re staying in Italy.
 
 ### Get a CNI and a statutory declaration
 
@@ -22,7 +24,7 @@ You’ll need to bring [certain documents](/marriages-civil-partnerships/documen
 
 Your notice will be publicly displayed in the register office for 28 days. You can collect your CNI after this if nobody registers an objection.
 
-Your CNI won’t expire if it was issued in England, Wales or Northern Ireland. CNIs issued in Scotland expire after 3 months. Check with your local register office to find out how long a CNI is valid if you live in the [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey.](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us)
+Your CNI will not expire if it was issued in England, Wales or Northern Ireland. CNIs issued in Scotland expire after 3 months. Check with your local register office to find out how long a CNI is valid if you live in the [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey.](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us)
 
 A CNI is valid for 6 months under Italian law.
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/italy/uk/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/italy/uk/_same_sex.erb
@@ -6,7 +6,9 @@ Contact the local Italian town hall (‘comune’) to find out about local civil
 
 You need to prove you’re legally allowed to register a civil partnership by getting a certificate of no impediment (CNI) and a statutory declaration.
 
-^Your partner will also need a CNI and statutory declaration if they’re British. If they’re not, the documents they need might be different.^
+Your partner will also need a CNI and statutory declaration if they’re British. If they’re not, the documents they need might be different.
+
+^If you’re in Italy temporarily and you do not want to return to the UK to get these documents, you can follow a different process and [get a Nulla Osta](/marriage-abroad/y/italy/ceremony_country/same_sex) in Italy instead. You need to put down your UK address on the Nulla Osta application form, not where you’re staying in Italy.
 
 ### Get a CNI and a statutory declaration
 


### PR DESCRIPTION
https://govuk.zendesk.com/agent/tickets/4813302
https://trello.com/c/oh87FbU2/3781-getting-married-abroad-update-italy-italian-notaries-and-explanations-content-change-request

This is just a few changes to improve consistency throughout the outcomes, and to help users with two things:

1) Get their Nulla Osta signed in front of a notary - making it clear what procedure they need to ask the notary for, as this has been a source of confusion even amongst the notaries
2) Notify users who live in the UK that they can get a Nulla Osta if they’re in Italy temporarily and don’t want to travel back to the UK before they get married