### PR TITLE
11 April upratng for /state-pension-through-partner smart answer

### DIFF
--- a/app/flows/state_pension_through_partner_flow/outcomes/age_dependent_pension_outcome.erb
+++ b/app/flows/state_pension_through_partner_flow/outcomes/age_dependent_pension_outcome.erb
@@ -31,11 +31,11 @@
 
   **Example**
 
-  You’ll reach State Pension age on 6 March 2022. This is in the tax year 6 April 2021 to 5 April 2022.
+  You’ll reach State Pension age on 6 March 2023. This is in the tax year 6 April 2022 to 5 April 2023.
 
   You got married in 1975 and chose to pay National Insurance contributions at a reduced rate.
 
-  Your State Pension will be worked out differently if your reduced rate election still applied to you in 1986.
+  Your State Pension will be worked out differently if your reduced rate election still applied to you in 1987.
 
   $E
 

--- a/app/flows/state_pension_through_partner_flow/outcomes/married_woman_and_state_pension_outcome.erb
+++ b/app/flows/state_pension_through_partner_flow/outcomes/married_woman_and_state_pension_outcome.erb
@@ -16,11 +16,11 @@
 
   **Example**
 
-  You’ll reach State Pension age on 6 March 2022. This is in the tax year 6 April 2021 to 5 April 2022.
+  You’ll reach State Pension age on 6 March 2023. This is in the tax year 6 April 2022 to 5 April 2023.
 
   You got married in 1975 and chose to pay National Insurance contributions at a reduced rate.
 
-  Your State Pension will be worked out differently if your reduced rate election still applied to you in 1986.
+  Your State Pension will be worked out differently if your reduced rate election still applied to you in 1987.
 
   $E
 

--- a/app/flows/state_pension_through_partner_flow/outcomes/married_woman_no_state_pension_outcome.erb
+++ b/app/flows/state_pension_through_partner_flow/outcomes/married_woman_no_state_pension_outcome.erb
@@ -15,11 +15,11 @@
   $E
   **Example**
 
-  You’ll reach State Pension age on 6 March 2022. This is in the tax year 6 April 2021 to 5 April 2022.
+  You’ll reach State Pension age on 6 March 2023. This is in the tax year 6 April 2022 to 5 April 2023.
 
   You got married in 1975 and chose to pay National Insurance contributions at a reduced rate.
 
-  Your State Pension will be worked out differently if your reduced rate election still applied to you in 1986.
+  Your State Pension will be worked out differently if your reduced rate election still applied to you in 1987.
 
   $E
 

--- a/config/smart_answers/rates/state_pension.yml
+++ b/config/smart_answers/rates/state_pension.yml
@@ -45,6 +45,11 @@
   lower_weekly_rate: 80.45
 
 - start_date: 2021-04-12
-  end_date: 2100-04-13
+  end_date: 2022-04-10
   weekly_rate: 137.60
   lower_weekly_rate: 82.45
+
+- start_date: 2022-04-11
+  end_date: 2100-04-13
+  weekly_rate: 141.85
+  lower_weekly_rate: 85.00


### PR DESCRIPTION
Changs for and not before 11 April - no departmental fact check needed, but I'd like to see a post 11 April preview.
Changes to rates, plus the dates in 3 outcomes.
More detail on the work in Zen and Trello
ZEN
https://govuk.zendesk.com/agent/tickets/4888135
CONTENT TRELLO
https://trello.com/c/WfpPmwlc/3756-11-apr-uprating-your-partners-national-insurance-record-and-your-state-pension
PRODUCT TRELLO
https://trello.com/c/UUm7q52M/43-smart-answer-uprating-11-april-your-partners-national-insurance-record-and-your-state-pension

https://trello.com/c/UUm7q52M/923-smart-answer-uprating-11-april-your-partners-national-insurance-record-and-your-state-pension

modified:   app/flows/state_pension_through_partner_flow/outcomes/age_dependent_pension_outcome.erb
modified:   app/flows/state_pension_through_partner_flow/outcomes/married_woman_and_state_pension_outcome.erb
modified:   app/flows/state_pension_through_partner_flow/outcomes/married_woman_no_state_pension_outcome.erb
modified:   config/smart_answers/rates/state_pension.yml

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
