### PR TITLE
Add Secondment Worker visa to Check UK Visa outcomes

### DIFF
--- a/app/flows/check_uk_visa_flow.rb
+++ b/app/flows/check_uk_visa_flow.rb
@@ -182,15 +182,18 @@ class CheckUkVisaFlow < SmartAnswer::Flow
       option :six_months_or_less
       option :longer_than_six_months
 
-      next_node do |response|
-        case response
-        when "longer_than_six_months"
+      on_response do |response|
+        calculator.length_of_stay = response
+      end
+
+      next_node do
+        if calculator.staying_for_over_six_months?
           if calculator.study_visit?
             outcome :outcome_study_y # outcome 2 study y
           elsif calculator.work_visit?
             question :what_type_of_work?
           end
-        when "six_months_or_less"
+        elsif calculator.staying_for_six_months_or_less?
           if calculator.study_visit?
             if calculator.passport_country_in_electronic_visa_waiver_list?
               outcome :outcome_study_waiver

--- a/app/flows/check_uk_visa_flow/outcomes/visa_types/_secondment_worker_visa.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/visa_types/_secondment_worker_visa.erb
@@ -1,0 +1,14 @@
+##If you’re coming to work as part of a high-value contract between your overseas employer and a UK organisation
+
+You may be eligible for a [Secondment Worker visa](/secondment-worker-visa).
+
+###Eligibility
+
+The eligibility criteria include:
+
++ working in an eligible job
++ having worked for your overseas employer for at least 12 months outside the UK
+
+###How long you can stay
+
+You can stay in the UK on a Secondment Worker visa for a maximum of 2 years.

--- a/config/smart_answers/check_uk_visa_data.yml
+++ b/config/smart_answers/check_uk_visa_data.yml
@@ -82,6 +82,8 @@
         - name: temporary_worker_government_authorised_exchange
         - name: temporary_worker_international_agreement_service
         - name: temporary_worker_international_agreement_work
+        - name: secondment_worker_visa
+          condition: eligible_for_secondment_visa?
     religious:
       title: You need a visa as a religious worker
       visas:

--- a/lib/smart_answer/calculators/uk_visa_calculator.rb
+++ b/lib/smart_answer/calculators/uk_visa_calculator.rb
@@ -7,7 +7,8 @@ module SmartAnswer::Calculators
                 :travelling_to_cta_answer,
                 :passing_through_uk_border_control_answer,
                 :travel_document_type,
-                :travelling_visiting_partner_family_member_answer
+                :travelling_visiting_partner_family_member_answer,
+                :length_of_stay
 
     attr_accessor :what_type_of_work
 
@@ -189,6 +190,14 @@ module SmartAnswer::Calculators
       elsif work_visit?
         "work"
       end
+    end
+
+    def staying_for_over_six_months?
+      @length_of_stay == "longer_than_six_months"
+    end
+
+    def staying_for_six_months_or_less?
+      @length_of_stay == "six_months_or_less"
     end
 
     EXCLUDE_COUNTRIES = %w[

--- a/lib/smart_answer/calculators/uk_visa_calculator.rb
+++ b/lib/smart_answer/calculators/uk_visa_calculator.rb
@@ -200,6 +200,10 @@ module SmartAnswer::Calculators
       @length_of_stay == "six_months_or_less"
     end
 
+    def eligible_for_secondment_visa?
+      work_visit? && staying_for_over_six_months? && @what_type_of_work == "other"
+    end
+
     EXCLUDE_COUNTRIES = %w[
       american-samoa
       british-antarctic-territory

--- a/test/flows/check_uk_visa_flow_test.rb
+++ b/test/flows/check_uk_visa_flow_test.rb
@@ -854,10 +854,10 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
       test_bno_outcome_guidance
       test_country_in_youth_mobility_outcome_guidance
       test_country_in_uk_ancestry_visa
-      test_visa_count("canada", 8)
-      test_visa_count("china", 6)
-      test_visa_count("british-national-overseas", 9)
-      test_visa_count("stateless-or-refugee", 6)
+      test_visa_count("canada", 9)
+      test_visa_count("china", 7)
+      test_visa_count("british-national-overseas", 10)
+      test_visa_count("stateless-or-refugee", 7)
     end
 
     context "what_type_of_work: religious" do

--- a/test/unit/calculators/uk_visa_calculator_test.rb
+++ b/test/unit/calculators/uk_visa_calculator_test.rb
@@ -523,6 +523,32 @@ module SmartAnswer
             assert_not calculator.travelling_to_elsewhere?
           end
         end
+
+        context "#staying_for_over_six_months?" do
+          should "return true if the applicant is staying for over 6 months" do
+            calculator = UkVisaCalculator.new
+            calculator.length_of_stay = "longer_than_six_months"
+            assert calculator.staying_for_over_six_months?
+          end
+          should "return false if the applicant is staying for less than 6 months" do
+            calculator = UkVisaCalculator.new
+            calculator.length_of_stay = "six_months_or_less"
+            assert_not calculator.staying_for_over_six_months?
+          end
+        end
+
+        context "#staying_for_six_months_or_less?" do
+          should "return true if the applicant is staying for 6 months or less" do
+            calculator = UkVisaCalculator.new
+            calculator.length_of_stay = "six_months_or_less"
+            assert calculator.staying_for_six_months_or_less?
+          end
+          should "return false if the applicant is staying for more than 6 months" do
+            calculator = UkVisaCalculator.new
+            calculator.length_of_stay = "longer_than_six_months"
+            assert_not calculator.staying_for_six_months_or_less?
+          end
+        end
       end
     end
   end

--- a/test/unit/calculators/uk_visa_calculator_test.rb
+++ b/test/unit/calculators/uk_visa_calculator_test.rb
@@ -549,6 +549,40 @@ module SmartAnswer
             assert_not calculator.staying_for_six_months_or_less?
           end
         end
+
+        context "eligible_for_secondment_visa?" do
+          should "return true if visiting for work, for longer than six months and doing 'other' work " do
+            calculator = UkVisaCalculator.new
+            calculator.purpose_of_visit_answer = "work"
+            calculator.length_of_stay = "longer_than_six_months"
+            calculator.what_type_of_work = "other"
+            assert calculator.eligible_for_secondment_visa?
+          end
+
+          should "return false if not visiting for work" do
+            calculator = UkVisaCalculator.new
+            calculator.purpose_of_visit_answer = "study"
+            calculator.length_of_stay = "longer_than_six_months"
+            calculator.what_type_of_work = "other"
+            assert_not calculator.eligible_for_secondment_visa?
+          end
+
+          should "return false if visiting for less than six months" do
+            calculator = UkVisaCalculator.new
+            calculator.purpose_of_visit_answer = "work"
+            calculator.length_of_stay = "six_months_or_less"
+            calculator.what_type_of_work = "other"
+            assert_not calculator.eligible_for_secondment_visa?
+          end
+
+          should "return false if not doing 'other' work " do
+            calculator = UkVisaCalculator.new
+            calculator.purpose_of_visit_answer = "work"
+            calculator.length_of_stay = "longer_than_six_months"
+            calculator.what_type_of_work = "health"
+            assert_not calculator.eligible_for_secondment_visa?
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
This PR adds a new potential UK Visa option to the Check UK Visa smart answer.

For applicants who are coming to the UK to work, for longer than 6 months, and with a work category of "other", they may be eligible for a Secondment Worker Visa.

e.g `check-uk-visa/y/afghanistan/work/longer_than_six_months/other`

### Before
![Screenshot 2022-04-08 at 11 57 36](https://user-images.githubusercontent.com/13475227/162422652-4a38285a-0aa5-4347-93f6-1f0b4c9b007d.png)

### After
![Screenshot 2022-04-08 at 11 57 25](https://user-images.githubusercontent.com/13475227/162422701-5d21d2d2-112e-4a73-9d28-9c6ce6b2c2b4.png)

![Screenshot 2022-04-08 at 11 57 19](https://user-images.githubusercontent.com/13475227/162422745-ea7f3e9a-cd09-443c-b255-8daad934c266.png)

[trello](https://trello.com/c/VSkh88kp/1187-11-april-check-if-you-need-a-uk-visa-add-new-secondment-worker-visa-outcome)