### PR TITLE
Update zendesk gem and call to remove deprecation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,7 +123,7 @@ GEM
       null_logger
       plek (>= 1.9.0)
       rest-client (~> 2.0)
-    gds_zendesk (3.2.0)
+    gds_zendesk (3.3.0)
       null_logger (~> 0)
       zendesk_api (~> 1.27)
     globalid (1.0.0)
@@ -165,7 +165,7 @@ GEM
       puma
       selenium-webdriver (>= 3.142)
     hashdiff (1.0.1)
-    hashie (4.1.0)
+    hashie (5.0.0)
     htmlentities (4.3.4)
     http-accept (1.7.0)
     http-cookie (1.0.4)
@@ -397,11 +397,11 @@ GEM
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.5.4)
-    zendesk_api (1.28.0)
+    zendesk_api (1.35.0)
       faraday (>= 0.9.0, < 2.0.0)
-      hashie (>= 3.5.2, < 5.0.0)
+      hashie (>= 3.5.2, < 6.0.0)
       inflection
-      mime-types
+      mini_mime
       multipart-post (~> 2.0)
 
 PLATFORMS

--- a/lib/support_ticket.rb
+++ b/lib/support_ticket.rb
@@ -18,8 +18,8 @@ class SupportTicket
                 end
   end
 
-  def self.send(*args)
-    new(*args).send
+  def self.send(subject:, body:, requester_email:)
+    new(subject: subject, body: body, requester_email: requester_email).send
   end
 
   attr_reader :subject, :body, :requester_email
@@ -41,6 +41,6 @@ class SupportTicket
   end
 
   def send
-    self.class.client.ticket.create!(payload)
+    self.class.client.zendesk_client.tickets.create!(payload)
   end
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Removes a deprecation in calls to zendesk client that will be a problem in ruby 3+

See: https://github.com/alphagov/gds_zendesk/pull/45