### PR TITLE
Honour `RAILS_LOG_TO_STDOUT` for GdsApi client logs.

### DIFF
--- a/config/initializers/gds_api.rb
+++ b/config/initializers/gds_api.rb
@@ -1,5 +1,0 @@
-require "gds_api/base"
-
-GdsApi::Base.default_options = {
-  logger: Logger.new(Rails.root.join("log/#{Rails.env}.api_client.log")),
-}


### PR DESCRIPTION
All of our logs need to go to stdout/stderr when running on k8s.

See https://github.com/alphagov/publisher/pull/1603 for context. This is essentially the same change.

https://trello.com/c/Jef1t4xU

Rollout: needs alphagov/govuk-puppet#11673 to be fully rolled out to Production before merging.

Pair: @nsabri1