### PR TITLE
Fix ArgumentError for broken links report

### DIFF
--- a/lib/tasks/links.rake
+++ b/lib/tasks/links.rake
@@ -12,7 +12,7 @@ namespace :links do
     Rails.logger.info "Sending broken link report"
 
     SupportTicket.send(
-      subject: "Smart Answers Broken Link Report: #{Time.zone.today.to_s(:govuk_date)}",
+      subject: "Smart Answers Broken Link Report: #{Time.zone.today.to_fs(:govuk_date)}",
       body: BrokenLinkReport.for_erb_files_at(SMART_ANSWER_FLOW_PATH),
       requester_email: args.requester_email,
     )


### PR DESCRIPTION
A critical alert fired due to the `smart_answers_broken_link` job failing in prod.

The job failed due to an `ArgumentError: wrong number of arguments (given 1, expected 0)`.

The error occured on line 15 because of `Time.zone.today.to_s(:govuk_date)`.

This has been fixed by changing `to_s` to `to_fs`. This converts to a [formatted string](https://api.rubyonrails.org/classes/Time.html#method-i-to_fs).

Using to_s with an arugment on Time::DATE_FORMATS seems to have been deprecated. The fix has been used elsewhere in this application in response to deprecation warnings as part of the [upgrade to Rails 7.0.2.4](https://github.com/alphagov/smart-answers/commit/86905c9ed285a2d00881f6a1448eef4bdba6579f).

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
