### PR TITLE
Add high potential individual visa to "Check if you need a UK visa"

### DIFF
--- a/app/flows/check_uk_visa_flow/outcomes/visa_types/_high_potential_individual.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/visa_types/_high_potential_individual.erb
@@ -1,0 +1,16 @@
+##If you have a qualification from an eligible university
+
+You may be eligible for a [High Potential Individual (HPI) visa](/high-potential-individual-visa).
+
+###Eligibility
+
+The eligibility criteria include:
+
+- having been awarded a qualification by an eligible university in the last 5 years
+- usually proving that you can read, write, speak and understand English
+
+###How long you can stay
+
+An HPI visa usually lasts for 2 years. If you have a PhD or other doctoral qualification, it will last for 3 years.
+
+If you want to stay longer you must switch to another type of visa.

--- a/config/smart_answers/check_uk_visa_data.yml
+++ b/config/smart_answers/check_uk_visa_data.yml
@@ -13,6 +13,7 @@
           condition: passport_country_in_youth_mobility_scheme_list?
         - name: uk_ancestry_visa
           condition: passport_country_in_uk_ancestry_visa_list?
+        - name: high_potential_individual
     arts:
       title: You need a visa to work in arts or culture
       visas:
@@ -28,6 +29,7 @@
           condition: passport_country_in_uk_ancestry_visa_list?
         - name: representative_of_overseas_business_arts
         - name: work_experience_scheme
+        - name: high_potential_individual
     business:
       title: You need a visa to start a business
       visas:
@@ -41,6 +43,7 @@
           condition: passport_country_in_youth_mobility_scheme_list?
         - name: uk_ancestry_visa
           condition: passport_country_in_uk_ancestry_visa_list?
+        - name: high_potential_individual
     digital:
       title: You need a visa to work in digital technology
       visas:
@@ -53,6 +56,7 @@
           condition: passport_country_in_youth_mobility_scheme_list?
         - name: uk_ancestry_visa
           condition: passport_country_in_uk_ancestry_visa_list?
+        - name: high_potential_individual
     health:
       title: You need a visa to work in health and care
       visas:
@@ -67,6 +71,7 @@
           condition: passport_country_in_uk_ancestry_visa_list?
         - name: temporary_worker_government_authorised_exchange_health
         - name: work_experience_scheme
+        - name: high_potential_individual
     other:
       title: You need a visa to work in the UK
       visas:
@@ -84,6 +89,7 @@
         - name: temporary_worker_international_agreement_work
         - name: secondment_worker_visa
           condition: eligible_for_secondment_visa?
+        - name: high_potential_individual
     religious:
       title: You need a visa as a religious worker
       visas:

--- a/test/flows/check_uk_visa_flow_test.rb
+++ b/test/flows/check_uk_visa_flow_test.rb
@@ -765,10 +765,10 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
       test_bno_outcome_guidance
       test_country_in_youth_mobility_outcome_guidance
       test_country_in_uk_ancestry_visa
-      test_visa_count("canada", 6)
-      test_visa_count("china", 4)
-      test_visa_count("british-national-overseas", 7)
-      test_visa_count("stateless-or-refugee", 4)
+      test_visa_count("canada", 7)
+      test_visa_count("china", 5)
+      test_visa_count("british-national-overseas", 8)
+      test_visa_count("stateless-or-refugee", 5)
     end
 
     context "what_type_of_work: arts" do
@@ -782,10 +782,10 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
       test_stateless_or_refugee_outcome_guidance
       test_bno_outcome_guidance
       test_country_in_youth_mobility_outcome_guidance
-      test_visa_count("canada", 8)
-      test_visa_count("china", 6)
-      test_visa_count("british-national-overseas", 9)
-      test_visa_count("stateless-or-refugee", 6)
+      test_visa_count("canada", 9)
+      test_visa_count("china", 7)
+      test_visa_count("british-national-overseas", 10)
+      test_visa_count("stateless-or-refugee", 7)
     end
 
     context "what_type_of_work: business" do
@@ -800,10 +800,10 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
       test_bno_outcome_guidance
       test_country_in_youth_mobility_outcome_guidance
       test_country_in_uk_ancestry_visa_with_business_information
-      test_visa_count("canada", 6)
-      test_visa_count("china", 4)
-      test_visa_count("british-national-overseas", 7)
-      test_visa_count("stateless-or-refugee", 4)
+      test_visa_count("canada", 7)
+      test_visa_count("china", 5)
+      test_visa_count("british-national-overseas", 8)
+      test_visa_count("stateless-or-refugee", 5)
     end
 
     context "what_type_of_work: digital" do
@@ -818,10 +818,10 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
       test_bno_outcome_guidance
       test_country_in_youth_mobility_outcome_guidance
       test_country_in_uk_ancestry_visa
-      test_visa_count("canada", 5)
-      test_visa_count("china", 3)
-      test_visa_count("british-national-overseas", 6)
-      test_visa_count("stateless-or-refugee", 3)
+      test_visa_count("canada", 6)
+      test_visa_count("china", 4)
+      test_visa_count("british-national-overseas", 7)
+      test_visa_count("stateless-or-refugee", 4)
     end
 
     context "what_type_of_work: health" do
@@ -836,10 +836,10 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
       test_bno_outcome_guidance
       test_country_in_youth_mobility_outcome_guidance
       test_country_in_uk_ancestry_visa
-      test_visa_count("canada", 7)
-      test_visa_count("china", 5)
-      test_visa_count("british-national-overseas", 8)
-      test_visa_count("stateless-or-refugee", 5)
+      test_visa_count("canada", 8)
+      test_visa_count("china", 6)
+      test_visa_count("british-national-overseas", 9)
+      test_visa_count("stateless-or-refugee", 6)
     end
 
     context "what_type_of_work: other" do
@@ -854,10 +854,10 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
       test_bno_outcome_guidance
       test_country_in_youth_mobility_outcome_guidance
       test_country_in_uk_ancestry_visa
-      test_visa_count("canada", 9)
-      test_visa_count("china", 7)
-      test_visa_count("british-national-overseas", 10)
-      test_visa_count("stateless-or-refugee", 7)
+      test_visa_count("canada", 10)
+      test_visa_count("china", 8)
+      test_visa_count("british-national-overseas", 11)
+      test_visa_count("stateless-or-refugee", 8)
     end
 
     context "what_type_of_work: religious" do


### PR DESCRIPTION
## What

https://trello.com/c/MPjKWyRm/1296-add-high-potential-individual-visa-to-check-if-you-need-a-uk-visa-smart-answer

Add a new visa called the 'high potential individual (HPI) visa'. It needs to be shown to users on the [work outcome](https://github.com/alphagov/smart-answers/blob/main/app/flows/check_uk_visa_flow/outcomes/outcome_work_y.erb). It should be shown to all users who have reached the work outcome after selecting one of these options on the [‘Are you planning to work in any of these types of job?’ question](https://www.gov.uk/check-uk-visa/y/usa/work/longer_than_six_months):

- Health and care professional
- Digital technology professional
- Academic or researcher
- Work in arts or culture
- I want to start a business
- I want to do another type of job - show me other work visas

It should not be shown to users who have selected:

- Professional sportsperson or 
- Religious worker options.

## Why

So that users who are eligible for this visa know they can apply for it.