### PR TITLE
Update 'If your partner is South Korean' section

### DIFF
--- a/app/flows/marriage_abroad_flow/outcomes/countries/south-korea/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/south-korea/_opposite_sex.erb
@@ -16,8 +16,8 @@ You’ll need to fill in an [‘Affidavit for Marriage’](/government/publicati
 
 You’ll need to provide supporting documents, including:
 
-- your partner’s Family Relationship Certificate and Marriage Status Certificate - these can be obtained from a local district office anywhere in South Korea and must be translated into English and notarised by a lawyer in Korea
-- your partner’s valid Korean ID card
+- your partner’s Family Relationship Certificate, issued in English - they can get this online through [the Supreme Court of Korea](https://efamily.scourt.go.kr/index.jsp) or in person at a local district office anywhere in South Korea
+- your partner’s valid Korean ID card or Korean passport
 - your partner’s proof of termination of any prior marriage(s)
 
 ###Legalisation and translation


### PR DESCRIPTION
https://govuk.zendesk.com/agent/tickets/4882878
https://trello.com/c/wgRPOKrv/3918-changes-to-getting-married-abroad-smart-answer-south-korea

Some changes to the 'If your partner is South Korean' section:

1) Removing the mention of a ‘Marriage Status Certificate’, which is no longer accepted.

2) A Family Relationship Certificate can be issued in English, so we don’t need to tell users to get it translated and notarised.

3) You can get the certificate online as well as in person, so adding a link to that web portal.

4) Adding a Korean passport as an alternative acceptable form of ID.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
