### PR TITLE
Update radio button for check-benefits-support flow

### DIFF
--- a/app/flows/check_benefits_support_flow.rb
+++ b/app/flows/check_benefits_support_flow.rb
@@ -143,7 +143,7 @@ class CheckBenefitsSupportFlow < SmartAnswer::Flow
       end
     end
 
-    checkbox_question :children_with_disability do
+    radio :children_with_disability do
       option :yes
       option :no
 


### PR DESCRIPTION
A binary yes-no question was accidentally added as a checkbox rather than a radio button.