### PR TITLE
Update check-benefits-support results to only show results user is eligible for

### DIFF
--- a/app/flows/check_benefits_support_flow/outcomes/results.erb
+++ b/app/flows/check_benefits_support_flow/outcomes/results.erb
@@ -1,4 +1,10 @@
 <% govspeak_for :body do %>
+  <% if calculator.number_of_benefits > 0 %>
+    Based on your answers you may be eligible to apply for these <%= calculator.number_of_benefits %> things.
+  <% else %>
+    Based on your answers you are not eligible to apply for any benefits.
+  <% end %>
+
   <% calculator.benefits_for_outcome.each do |benefit| %>
    <%= render "components/result-item", { title: benefit["title"], url: benefit["url"] } %>
 

--- a/app/flows/check_benefits_support_flow/outcomes/results.erb
+++ b/app/flows/check_benefits_support_flow/outcomes/results.erb
@@ -1,3 +1,7 @@
 <% govspeak_for :body do %>
-  Results!
+  <% calculator.benefits_for_outcome.each do |benefit| %>
+   <%= render "components/result-item", { title: benefit["title"], url: benefit["url"] } %>
+
+    ---
+  <% end %>
 <% end %>

--- a/config/smart_answers/check_benefits_support_data.yml
+++ b/config/smart_answers/check_benefits_support_data.yml
@@ -66,6 +66,7 @@
     - name: 15hrs_free_childcare_3_4yr_olds
       title: 15hrs free childcare for 3 and 4yrs
       description:
+      condition: eligible_for_15hrs_free_childcare_3_4yr_olds?
       url: /help-with-childcare-costs/free-childcare-and-education-for-2-to-4-year-olds
       url_text: Anchor link text
       group: Help with childcare costs

--- a/config/smart_answers/check_benefits_support_data.yml
+++ b/config/smart_answers/check_benefits_support_data.yml
@@ -45,6 +45,7 @@
     - name: tax_free_childcare
       title: Tax-free childcare
       description:
+      condition: eligible_for_tax_free_childcare?
       url: /tax-free-childcare
       url_text: Anchor link text
       group: Help with childcare costs

--- a/config/smart_answers/check_benefits_support_data.yml
+++ b/config/smart_answers/check_benefits_support_data.yml
@@ -162,6 +162,7 @@
     - name: nhs_low_income_scheme
       title: NHS Low Income Scheme (LIS)
       description:
+      condition: eligible_for_nhs_low_income_scheme?
       url: https://www.nhs.uk/nhs-services/help-with-health-costs/nhs-low-income-scheme-lis/
       url_text: Anchor link text
       group: Healthcare support

--- a/config/smart_answers/check_benefits_support_data.yml
+++ b/config/smart_answers/check_benefits_support_data.yml
@@ -24,6 +24,7 @@
     - name: access_to_work
       title: Access to Work
       description:
+      condition: eligible_for_access_to_work?
       url: /access-to-work
       url_text: Anchor link text
       group: Supporting your income

--- a/config/smart_answers/check_benefits_support_data.yml
+++ b/config/smart_answers/check_benefits_support_data.yml
@@ -52,6 +52,7 @@
     - name: free_childcare_2yr_olds
       title: Free childcare 2yr olds
       description:
+      condition: eligible_for_free_childcare_2yr_olds?
       url: /help-with-childcare-costs/free-childcare-2-year-olds
       url_text: Anchor link text
       group: Help with childcare costs

--- a/config/smart_answers/check_benefits_support_data.yml
+++ b/config/smart_answers/check_benefits_support_data.yml
@@ -38,6 +38,7 @@
     - name: housing_benefit
       title: Housing Benefit
       description:
+      condition: eligible_for_housing_benefit?
       url: /housing-benefit
       url_text: Anchor link text
       group: Housing support

--- a/config/smart_answers/check_benefits_support_data.yml
+++ b/config/smart_answers/check_benefits_support_data.yml
@@ -80,6 +80,7 @@
     - name: 30hrs_free_childcare_3_4yrs_scotland
       title: 30hrs free childcare for 3 and 4yrs (Scotland)
       description:
+      condition: eligible_for_30hrs_free_childcare_3_4yrs_scotland?
       url: https://www.mygov.scot/childcare-costs-help/funded-early-learning-and-childcare
       url_text: Anchor link text
       group: Help with childcare costs

--- a/config/smart_answers/check_benefits_support_data.yml
+++ b/config/smart_answers/check_benefits_support_data.yml
@@ -3,6 +3,7 @@
     - name: employment_and_support_allowance
       title: Employment and Support Allowance (ESA)
       description:
+      condition: eligible_for_employment_and_support_allowance?
       url: /employment-support-allowance
       url_text: Anchor link text
       group: Supporting your income

--- a/config/smart_answers/check_benefits_support_data.yml
+++ b/config/smart_answers/check_benefits_support_data.yml
@@ -142,6 +142,7 @@
     - name: free_tv_licence
       title: Free TV licence
       description:
+      condition: eligible_for_free_tv_licence?
       url: /free-discount-tv-licence
       url_text: Anchor link text
       group: Help with your bills

--- a/config/smart_answers/check_benefits_support_data.yml
+++ b/config/smart_answers/check_benefits_support_data.yml
@@ -59,6 +59,7 @@
     - name: childcare_3_4yr_olds_wales
       title: Childcare 3 and 4 year olds Wales
       description:
+      condition: eligible_for_childcare_3_4yr_olds_wales?
       url: https://gov.wales/childcare-3-and-4-year-olds
       url_text: Anchor link text
       group: Help with childcare costs

--- a/config/smart_answers/check_benefits_support_data.yml
+++ b/config/smart_answers/check_benefits_support_data.yml
@@ -31,6 +31,7 @@
     - name: universal_credit
       title: Universal Credit
       description:
+      condition: eligible_for_universal_credit?
       url: /universal-credit
       url_text: Anchor link text
       group: Supporting your income

--- a/config/smart_answers/check_benefits_support_data.yml
+++ b/config/smart_answers/check_benefits_support_data.yml
@@ -122,6 +122,7 @@
     - name: personal_independence_payment
       title: Personal Independence Payment
       description:
+      condition: eligible_for_personal_independence_payment?
       url: /pip
       url_text: Anchor link text
       group: Supporting your income

--- a/config/smart_answers/check_benefits_support_data.yml
+++ b/config/smart_answers/check_benefits_support_data.yml
@@ -87,6 +87,7 @@
     - name: 2yr_old_childcare_Scotland
       title: 2yr old childcare (Scotland)
       description:
+      condition: eligible_for_2yr_old_childcare_scotland?
       url: https://www.mygov.scot/childcare-costs-help/funded-early-learning-and-childcare
       url_text: Anchor link text
       group: Help with childcare costs

--- a/config/smart_answers/check_benefits_support_data.yml
+++ b/config/smart_answers/check_benefits_support_data.yml
@@ -73,6 +73,7 @@
     - name: 30hrs_free_childcare_3_4yrs
       title: 30hrs free childcare for 3 and 4yrs
       description:
+      condition: eligible_for_30hrs_free_childcare_3_4yrs?
       url: /30-hours-free-childcare
       url_text: Anchor link text
       group: Help with childcare costs

--- a/config/smart_answers/check_benefits_support_data.yml
+++ b/config/smart_answers/check_benefits_support_data.yml
@@ -94,6 +94,7 @@
     - name: child_benefit
       title: Child Benefit
       description:
+      condition: eligible_for_child_benefit?
       url: /child-benefit
       url_text: Anchor link text
       group: Supporting your income

--- a/config/smart_answers/check_benefits_support_data.yml
+++ b/config/smart_answers/check_benefits_support_data.yml
@@ -1,0 +1,146 @@
+---
+  benefits:
+    - name: employment_and_support_allowance
+      title: Employment and Support Allowance (ESA)
+      description:
+      url: /employment-support-allowance
+      url_text: Anchor link text
+      group: Supporting your income
+    - name: jobseekers_allowance
+      title: Jobseeker's Allowance (JSA)
+      description:
+      url: /jobseekers-allowance
+      url_text: Anchor link text
+      group: Supporting your income
+    - name: pension_credit
+      title: Pension Credit
+      description:
+      url: /pension-credit
+      url_text: Anchor link text
+      group: Supporting your income
+    - name: access_to_work
+      title: Access to Work
+      description:
+      url: /access-to-work
+      url_text: Anchor link text
+      group: Supporting your income
+    - name: universal_credit
+      title: Universal Credit
+      description:
+      url: /universal-credit
+      url_text: Anchor link text
+      group: Supporting your income
+    - name: housing_benefit
+      title: Housing Benefit
+      description:
+      url: /housing-benefit
+      url_text: Anchor link text
+      group: Housing support
+    - name: tax_free_childcare
+      title: Tax-free childcare
+      description:
+      url: /tax-free-childcare
+      url_text: Anchor link text
+      group: Help with childcare costs
+    - name: free_childcare_2yr_olds
+      title: Free childcare 2yr olds
+      description:
+      url: /help-with-childcare-costs/free-childcare-2-year-olds
+      url_text: Anchor link text
+      group: Help with childcare costs
+    - name: childcare_3_4yr_olds_wales
+      title: Childcare 3 and 4 year olds Wales
+      description:
+      url: https://gov.wales/childcare-3-and-4-year-olds
+      url_text: Anchor link text
+      group: Help with childcare costs
+    - name: 15hrs_free_childcare_3_4yr_olds
+      title: 15hrs free childcare for 3 and 4yrs
+      description:
+      url: /help-with-childcare-costs/free-childcare-and-education-for-2-to-4-year-olds
+      url_text: Anchor link text
+      group: Help with childcare costs
+    - name: 30hrs_free_childcare_3_4yrs
+      title: 30hrs free childcare for 3 and 4yrs
+      description:
+      url: /30-hours-free-childcare
+      url_text: Anchor link text
+      group: Help with childcare costs
+    - name: 30hrs_free_childcare_3_4yrs_scotland
+      title: 30hrs free childcare for 3 and 4yrs (Scotland)
+      description:
+      url: https://www.mygov.scot/childcare-costs-help/funded-early-learning-and-childcare
+      url_text: Anchor link text
+      group: Help with childcare costs
+    - name: 2yr_old_childcare_Scotland
+      title: 2yr old childcare (Scotland)
+      description:
+      url: https://www.mygov.scot/childcare-costs-help/funded-early-learning-and-childcare
+      url_text: Anchor link text
+      group: Help with childcare costs
+    - name: child_benefit
+      title: Child Benefit
+      description:
+      url: /child-benefit
+      url_text: Anchor link text
+      group: Supporting your income
+    - name: disability_living_allowance_for_children
+      title: Disability Living Allowance (DLA) for children
+      description:
+      url: /disability-living-allowance-children
+      url_text: Anchor link text
+      group: Help with childcare costs
+    - name: child_disability_payment_scotland
+      title: Child Disability Payment (Scotland)
+      description:
+      url: https://www.mygov.scot/child-disability-payment
+      url_text: Anchor link text
+      group: Help with childcare costs
+    - name: carers_allowance
+      title: Carer's Allowance
+      description:
+      url: /carers-allowance
+      url_text: Anchor link text
+      group: Supporting your income
+    - name: personal_independence_payment
+      title: Personal Independence Payment
+      description:
+      url: /pip
+      url_text: Anchor link text
+      group: Supporting your income
+    - name: attendance_allowance
+      title: Attendance Allowance
+      description:
+      url: /attendance-allowance
+      url_text: Anchor link text
+      group: Supporting your income
+    - name: council_tax_reduction
+      title: Council Tax reduction
+      description:
+      url: /apply-council-tax-reduction
+      url_text: Anchor link text
+      group: Help with your bills
+    - name: free_tv_licence
+      title: Free TV licence
+      description:
+      url: /free-discount-tv-licence
+      url_text: Anchor link text
+      group: Help with your bills
+    - name: budgeting_loan
+      title: Budgeting Loan
+      description:
+      url: /budgeting-help-benefits/eligibility
+      url_text: Anchor link text
+      group: Help with your bills
+    - name: universal_credit_advance
+      title: Universal credit advance
+      description:
+      url: /guidance/universal-credit-advances
+      url_text: Anchor link text
+      group: Supporting your income
+    - name: nhs_low_income_scheme
+      title: NHS Low Income Scheme (LIS)
+      description:
+      url: https://www.nhs.uk/nhs-services/help-with-health-costs/nhs-low-income-scheme-lis/
+      url_text: Anchor link text
+      group: Healthcare support

--- a/config/smart_answers/check_benefits_support_data.yml
+++ b/config/smart_answers/check_benefits_support_data.yml
@@ -155,6 +155,7 @@
     - name: universal_credit_advance
       title: Universal credit advance
       description:
+      condition: eligible_for_universal_credit_advance?
       url: /guidance/universal-credit-advances
       url_text: Anchor link text
       group: Supporting your income

--- a/config/smart_answers/check_benefits_support_data.yml
+++ b/config/smart_answers/check_benefits_support_data.yml
@@ -108,6 +108,7 @@
     - name: child_disability_payment_scotland
       title: Child Disability Payment (Scotland)
       description:
+      condition: eligible_for_child_disability_payment_scotland?
       url: https://www.mygov.scot/child-disability-payment
       url_text: Anchor link text
       group: Help with childcare costs

--- a/config/smart_answers/check_benefits_support_data.yml
+++ b/config/smart_answers/check_benefits_support_data.yml
@@ -101,6 +101,7 @@
     - name: disability_living_allowance_for_children
       title: Disability Living Allowance (DLA) for children
       description:
+      condition: eligible_for_disability_living_allowance_for_children?
       url: /disability-living-allowance-children
       url_text: Anchor link text
       group: Help with childcare costs

--- a/config/smart_answers/check_benefits_support_data.yml
+++ b/config/smart_answers/check_benefits_support_data.yml
@@ -10,6 +10,7 @@
     - name: jobseekers_allowance
       title: Jobseeker's Allowance (JSA)
       description:
+      condition: eligible_for_jobseekers_allowance?
       url: /jobseekers-allowance
       url_text: Anchor link text
       group: Supporting your income

--- a/config/smart_answers/check_benefits_support_data.yml
+++ b/config/smart_answers/check_benefits_support_data.yml
@@ -17,6 +17,7 @@
     - name: pension_credit
       title: Pension Credit
       description:
+      condition: eligible_for_pension_credit?
       url: /pension-credit
       url_text: Anchor link text
       group: Supporting your income

--- a/config/smart_answers/check_benefits_support_data.yml
+++ b/config/smart_answers/check_benefits_support_data.yml
@@ -115,6 +115,7 @@
     - name: carers_allowance
       title: Carer's Allowance
       description:
+      condition: eligible_for_carers_allowance?
       url: /carers-allowance
       url_text: Anchor link text
       group: Supporting your income

--- a/config/smart_answers/check_benefits_support_data.yml
+++ b/config/smart_answers/check_benefits_support_data.yml
@@ -129,6 +129,7 @@
     - name: attendance_allowance
       title: Attendance Allowance
       description:
+      condition: eligible_for_attendance_allowance?
       url: /attendance-allowance
       url_text: Anchor link text
       group: Supporting your income

--- a/lib/smart_answer/calculators/check_benefits_support_calculator.rb
+++ b/lib/smart_answer/calculators/check_benefits_support_calculator.rb
@@ -140,5 +140,9 @@ module SmartAnswer::Calculators
     def eligible_for_universal_credit_advance?
       @over_state_pension_age == "no" && @assets_and_savings == "under_16000"
     end
+
+    def eligible_for_nhs_low_income_scheme?
+      @where_do_you_live != "northern-ireland"
+    end
   end
 end

--- a/lib/smart_answer/calculators/check_benefits_support_calculator.rb
+++ b/lib/smart_answer/calculators/check_benefits_support_calculator.rb
@@ -19,5 +19,11 @@ module SmartAnswer::Calculators
     def benefits_for_outcome
       benefit_data["benefits"].select { |benefit| benefit }.compact
     end
+
+    def eligible_for_employment_and_support_allowance?
+      @over_state_pension_age == "no" &&
+        @disability_or_health_condition == "yes" &&
+        disability_affecting_work != "no"
+    end
   end
 end

--- a/lib/smart_answer/calculators/check_benefits_support_calculator.rb
+++ b/lib/smart_answer/calculators/check_benefits_support_calculator.rb
@@ -11,5 +11,13 @@ module SmartAnswer::Calculators
                   :age_of_children,
                   :children_with_disability,
                   :assets_and_savings
+
+    def benefit_data
+      YAML.load_file(Rails.root.join("config/smart_answers/check_benefits_support_data.yml")).freeze
+    end
+
+    def benefits_for_outcome
+      benefit_data["benefits"].select { |benefit| benefit }.compact
+    end
   end
 end

--- a/lib/smart_answer/calculators/check_benefits_support_calculator.rb
+++ b/lib/smart_answer/calculators/check_benefits_support_calculator.rb
@@ -132,5 +132,9 @@ module SmartAnswer::Calculators
     def eligible_for_attendance_allowance?
       @over_state_pension_age == "no" && disability_or_health_condition == "yes"
     end
+
+    def eligible_for_free_tv_licence?
+      @over_state_pension_age == "yes"
+    end
   end
 end

--- a/lib/smart_answer/calculators/check_benefits_support_calculator.rb
+++ b/lib/smart_answer/calculators/check_benefits_support_calculator.rb
@@ -98,5 +98,15 @@ module SmartAnswer::Calculators
     def eligible_for_child_benefit?
       @children_living_with_you == "yes"
     end
+
+    def eligible_for_disability_living_allowance_for_children?
+      eligible_child_ages = %w[1_or_under 2 3_to_4 5_to_11 12_to_15]
+
+      %w[england wales].include?(@where_do_you_live) &&
+        @carer_disability_or_health_condition == "yes" &&
+        @children_living_with_you == "yes" &&
+        @age_of_children.split(",").any? { |age| eligible_child_ages.include?(age) } &&
+        @children_with_disability == "yes"
+    end
   end
 end

--- a/lib/smart_answer/calculators/check_benefits_support_calculator.rb
+++ b/lib/smart_answer/calculators/check_benefits_support_calculator.rb
@@ -94,5 +94,9 @@ module SmartAnswer::Calculators
         @children_living_with_you == "yes" &&
         @age_of_children.split(",").any?("2")
     end
+
+    def eligible_for_child_benefit?
+      @children_living_with_you == "yes"
+    end
   end
 end

--- a/lib/smart_answer/calculators/check_benefits_support_calculator.rb
+++ b/lib/smart_answer/calculators/check_benefits_support_calculator.rb
@@ -13,11 +13,13 @@ module SmartAnswer::Calculators
                   :assets_and_savings
 
     def benefit_data
-      YAML.load_file(Rails.root.join("config/smart_answers/check_benefits_support_data.yml")).freeze
+      @benefit_data ||= YAML.load_file(Rails.root.join("config/smart_answers/check_benefits_support_data.yml")).freeze
     end
 
     def benefits_for_outcome
-      benefit_data["benefits"].select { |benefit| benefit }.compact
+      @benefits_for_outcome ||= benefit_data["benefits"].select { |benefit|
+        benefit["condition"].nil? || send(benefit["condition"])
+      }.compact
     end
 
     def eligible_for_employment_and_support_allowance?

--- a/lib/smart_answer/calculators/check_benefits_support_calculator.rb
+++ b/lib/smart_answer/calculators/check_benefits_support_calculator.rb
@@ -25,5 +25,12 @@ module SmartAnswer::Calculators
         @disability_or_health_condition == "yes" &&
         disability_affecting_work != "no"
     end
+
+    def eligible_for_jobseekers_allowance?
+      @where_do_you_live != "northern-ireland" &&
+        @over_state_pension_age == "no" &&
+        @are_you_working != "yes_over_16_hours_per_week" &&
+        @disability_affecting_work != "yes_unable_to_work"
+    end
   end
 end

--- a/lib/smart_answer/calculators/check_benefits_support_calculator.rb
+++ b/lib/smart_answer/calculators/check_benefits_support_calculator.rb
@@ -70,5 +70,11 @@ module SmartAnswer::Calculators
         @children_living_with_you == "yes" &&
         @age_of_children.split(",").any?("3_to_4")
     end
+
+    def eligible_for_15hrs_free_childcare_3_4yr_olds?
+      @where_do_you_live == "england" &&
+        @children_living_with_you == "yes" &&
+        @age_of_children.split(",").any?("3_to_4")
+    end
   end
 end

--- a/lib/smart_answer/calculators/check_benefits_support_calculator.rb
+++ b/lib/smart_answer/calculators/check_benefits_support_calculator.rb
@@ -57,5 +57,11 @@ module SmartAnswer::Calculators
         @children_living_with_you == "yes" &&
         @age_of_children.split(",").any? { |age| eligible_child_ages.include?(age) }
     end
+
+    def eligible_for_free_childcare_2yr_olds?
+      @where_do_you_live == "england" &&
+        @children_living_with_you == "yes" &&
+        @age_of_children.split(",").any?("2")
+    end
   end
 end

--- a/lib/smart_answer/calculators/check_benefits_support_calculator.rb
+++ b/lib/smart_answer/calculators/check_benefits_support_calculator.rb
@@ -76,5 +76,11 @@ module SmartAnswer::Calculators
         @children_living_with_you == "yes" &&
         @age_of_children.split(",").any?("3_to_4")
     end
+
+    def eligible_for_30hrs_free_childcare_3_4yrs?
+      @are_you_working == "yes_over_16_hours_per_week" &&
+        @children_living_with_you == "yes" &&
+        @age_of_children.split(",").any?("3_to_4")
+    end
   end
 end

--- a/lib/smart_answer/calculators/check_benefits_support_calculator.rb
+++ b/lib/smart_answer/calculators/check_benefits_support_calculator.rb
@@ -22,6 +22,10 @@ module SmartAnswer::Calculators
       }.compact
     end
 
+    def number_of_benefits
+      benefits_for_outcome.size
+    end
+
     def eligible_for_employment_and_support_allowance?
       @over_state_pension_age == "no" &&
         @disability_or_health_condition == "yes" &&

--- a/lib/smart_answer/calculators/check_benefits_support_calculator.rb
+++ b/lib/smart_answer/calculators/check_benefits_support_calculator.rb
@@ -42,5 +42,9 @@ module SmartAnswer::Calculators
         @disability_or_health_condition == "yes" &&
         @disability_affecting_work != "yes_unable_to_work"
     end
+
+    def eligible_for_universal_credit?
+      @over_state_pension_age == "no" && @assets_and_savings == "under_16000"
+    end
   end
 end

--- a/lib/smart_answer/calculators/check_benefits_support_calculator.rb
+++ b/lib/smart_answer/calculators/check_benefits_support_calculator.rb
@@ -82,5 +82,11 @@ module SmartAnswer::Calculators
         @children_living_with_you == "yes" &&
         @age_of_children.split(",").any?("3_to_4")
     end
+
+    def eligible_for_30hrs_free_childcare_3_4yrs_scotland?
+      @where_do_you_live == "scotland" &&
+        @children_living_with_you == "yes" &&
+        @age_of_children.split(",").any?("3_to_4")
+    end
   end
 end

--- a/lib/smart_answer/calculators/check_benefits_support_calculator.rb
+++ b/lib/smart_answer/calculators/check_benefits_support_calculator.rb
@@ -88,5 +88,11 @@ module SmartAnswer::Calculators
         @children_living_with_you == "yes" &&
         @age_of_children.split(",").any?("3_to_4")
     end
+
+    def eligible_for_2yr_old_childcare_scotland?
+      @where_do_you_live == "scotland" &&
+        @children_living_with_you == "yes" &&
+        @age_of_children.split(",").any?("2")
+    end
   end
 end

--- a/lib/smart_answer/calculators/check_benefits_support_calculator.rb
+++ b/lib/smart_answer/calculators/check_benefits_support_calculator.rb
@@ -128,5 +128,9 @@ module SmartAnswer::Calculators
     def eligible_for_personal_independence_payment?
       @over_state_pension_age == "no" && @disability_or_health_condition == "yes"
     end
+
+    def eligible_for_attendance_allowance?
+      @over_state_pension_age == "no" && disability_or_health_condition == "yes"
+    end
   end
 end

--- a/lib/smart_answer/calculators/check_benefits_support_calculator.rb
+++ b/lib/smart_answer/calculators/check_benefits_support_calculator.rb
@@ -108,5 +108,15 @@ module SmartAnswer::Calculators
         @age_of_children.split(",").any? { |age| eligible_child_ages.include?(age) } &&
         @children_with_disability == "yes"
     end
+
+    def eligible_for_child_disability_payment_scotland?
+      eligible_child_ages = %w[1_or_under 2 3_to_4 5_to_11 12_to_15]
+
+      @where_do_you_live == "scotland" &&
+        @carer_disability_or_health_condition == "yes" &&
+        @children_living_with_you == "yes" &&
+        @age_of_children.split(",").any? { |age| eligible_child_ages.include?(age) } &&
+        @children_with_disability == "yes"
+    end
   end
 end

--- a/lib/smart_answer/calculators/check_benefits_support_calculator.rb
+++ b/lib/smart_answer/calculators/check_benefits_support_calculator.rb
@@ -50,5 +50,12 @@ module SmartAnswer::Calculators
     def eligible_for_housing_benefit?
       @over_state_pension_age == "yes"
     end
+
+    def eligible_for_tax_free_childcare?
+      eligible_child_ages = %w[1_or_under 2 3_to_4 5_to_11]
+      @are_you_working == "yes" &&
+        @children_living_with_you == "yes" &&
+        @age_of_children.split(",").any? { |age| eligible_child_ages.include?(age) }
+    end
   end
 end

--- a/lib/smart_answer/calculators/check_benefits_support_calculator.rb
+++ b/lib/smart_answer/calculators/check_benefits_support_calculator.rb
@@ -32,5 +32,9 @@ module SmartAnswer::Calculators
         @are_you_working != "yes_over_16_hours_per_week" &&
         @disability_affecting_work != "yes_unable_to_work"
     end
+
+    def eligible_for_pension_credit?
+      @over_state_pension_age == "no"
+    end
   end
 end

--- a/lib/smart_answer/calculators/check_benefits_support_calculator.rb
+++ b/lib/smart_answer/calculators/check_benefits_support_calculator.rb
@@ -118,5 +118,11 @@ module SmartAnswer::Calculators
         @age_of_children.split(",").any? { |age| eligible_child_ages.include?(age) } &&
         @children_with_disability == "yes"
     end
+
+    def eligible_for_carers_allowance?
+      @where_do_you_live != "northern-ireland" &&
+        @carer_disability_or_health_condition == "yes" &&
+        @unpaid_care_hours == "yes"
+    end
   end
 end

--- a/lib/smart_answer/calculators/check_benefits_support_calculator.rb
+++ b/lib/smart_answer/calculators/check_benefits_support_calculator.rb
@@ -46,5 +46,9 @@ module SmartAnswer::Calculators
     def eligible_for_universal_credit?
       @over_state_pension_age == "no" && @assets_and_savings == "under_16000"
     end
+
+    def eligible_for_housing_benefit?
+      @over_state_pension_age == "yes"
+    end
   end
 end

--- a/lib/smart_answer/calculators/check_benefits_support_calculator.rb
+++ b/lib/smart_answer/calculators/check_benefits_support_calculator.rb
@@ -63,5 +63,12 @@ module SmartAnswer::Calculators
         @children_living_with_you == "yes" &&
         @age_of_children.split(",").any?("2")
     end
+
+    def eligible_for_childcare_3_4yr_olds_wales?
+      @where_do_you_live == "wales" &&
+        @are_you_working == "yes_under_16_hours_per_week" &&
+        @children_living_with_you == "yes" &&
+        @age_of_children.split(",").any?("3_to_4")
+    end
   end
 end

--- a/lib/smart_answer/calculators/check_benefits_support_calculator.rb
+++ b/lib/smart_answer/calculators/check_benefits_support_calculator.rb
@@ -136,5 +136,9 @@ module SmartAnswer::Calculators
     def eligible_for_free_tv_licence?
       @over_state_pension_age == "yes"
     end
+
+    def eligible_for_universal_credit_advance?
+      @over_state_pension_age == "no" && @assets_and_savings == "under_16000"
+    end
   end
 end

--- a/lib/smart_answer/calculators/check_benefits_support_calculator.rb
+++ b/lib/smart_answer/calculators/check_benefits_support_calculator.rb
@@ -36,5 +36,11 @@ module SmartAnswer::Calculators
     def eligible_for_pension_credit?
       @over_state_pension_age == "no"
     end
+
+    def eligible_for_access_to_work?
+      @where_do_you_live != "northern-ireland" &&
+        @disability_or_health_condition == "yes" &&
+        @disability_affecting_work != "yes_unable_to_work"
+    end
   end
 end

--- a/lib/smart_answer/calculators/check_benefits_support_calculator.rb
+++ b/lib/smart_answer/calculators/check_benefits_support_calculator.rb
@@ -124,5 +124,9 @@ module SmartAnswer::Calculators
         @carer_disability_or_health_condition == "yes" &&
         @unpaid_care_hours == "yes"
     end
+
+    def eligible_for_personal_independence_payment?
+      @over_state_pension_age == "no" && @disability_or_health_condition == "yes"
+    end
   end
 end

--- a/test/flows/check_benefits_support_flow_test.rb
+++ b/test/flows/check_benefits_support_flow_test.rb
@@ -259,8 +259,8 @@ class CheckBenefitsSupportFlowTest < ActiveSupport::TestCase
                     assets_and_savings: "under_16000"
     end
 
-    should "render the results outcome" do
-      assert_rendered_outcome text: "Results!"
+    should "render the results outcome with number of eligible benefits" do
+      assert_rendered_outcome text: "Based on your answers you may be eligible to apply for these 6 things."
     end
   end
 end

--- a/test/unit/calculators/checks_benefits_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_support_calculator_test.rb
@@ -475,6 +475,26 @@ module SmartAnswer::Calculators
           assert_not calculator.eligible_for_free_tv_licence?
         end
       end
+
+      context "#eligible_for_universal_credit_advance?" do
+        should "return true if eligible for Universal Credit Advance" do
+          calculator = CheckBenefitsSupportCalculator.new
+          calculator.over_state_pension_age = "no"
+          calculator.assets_and_savings = "under_16000"
+          assert calculator.eligible_for_universal_credit_advance?
+        end
+
+        should "return false if not eligible for Universal Credit Advance" do
+          calculator = CheckBenefitsSupportCalculator.new
+          calculator.over_state_pension_age = "yes"
+          calculator.assets_and_savings = "under_16000"
+          assert_not calculator.eligible_for_universal_credit_advance?
+
+          calculator.over_state_pension_age = "no"
+          calculator.assets_and_savings = "over_16000"
+          assert_not calculator.eligible_for_universal_credit_advance?
+        end
+      end
     end
   end
 end

--- a/test/unit/calculators/checks_benefits_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_support_calculator_test.rb
@@ -355,6 +355,37 @@ module SmartAnswer::Calculators
           assert_not calculator.eligible_for_disability_living_allowance_for_children?
         end
       end
+
+      context "#eligible_for_child_disability_payment_scotland?" do
+        should "return true if eligible for Child Disability Payment Scotland" do
+          calculator = CheckBenefitsSupportCalculator.new
+          calculator.where_do_you_live = "scotland"
+          calculator.carer_disability_or_health_condition = "yes"
+          calculator.children_living_with_you = "yes"
+          calculator.children_with_disability = "yes"
+          %w[1_or_under 2 3_to_4 5_to_11 12_to_15].each do |age|
+            calculator.age_of_children = age
+            assert calculator.eligible_for_child_disability_payment_scotland?
+          end
+        end
+
+        should "return false if not eligible for Child Disability Payment Scotland" do
+          calculator = CheckBenefitsSupportCalculator.new
+          calculator.where_do_you_live = "wales"
+          calculator.carer_disability_or_health_condition = "yes"
+          calculator.children_living_with_you = "yes"
+          calculator.age_of_children = "1_or_under"
+          calculator.children_with_disability = "yes"
+          assert_not calculator.eligible_for_child_disability_payment_scotland?
+
+          calculator.where_do_you_live = "scotland"
+          calculator.carer_disability_or_health_condition = "yes"
+          calculator.children_living_with_you = "yes"
+          calculator.age_of_children = "1_or_under"
+          calculator.children_with_disability = "no"
+          assert_not calculator.eligible_for_child_disability_payment_scotland?
+        end
+      end
     end
   end
 end

--- a/test/unit/calculators/checks_benefits_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_support_calculator_test.rb
@@ -201,6 +201,31 @@ module SmartAnswer::Calculators
           assert_not calculator.eligible_for_childcare_3_4yr_olds_wales?
         end
       end
+
+      context "#eligible_for_15hrs_free_childcare_3_4yr_olds?" do
+        should "return true if eligible for 15 Hours Free Childcare for 3 and 4 Year Olds" do
+          calculator = CheckBenefitsSupportCalculator.new
+          calculator.where_do_you_live = "england"
+          calculator.children_living_with_you = "yes"
+          calculator.age_of_children = "3_to_4"
+          assert calculator.eligible_for_15hrs_free_childcare_3_4yr_olds?
+        end
+
+        should "return false if not eligible for Childcare 3 and 4 Year Olds Wales" do
+          calculator = CheckBenefitsSupportCalculator.new
+          calculator.where_do_you_live = "scotland"
+          assert_not calculator.eligible_for_15hrs_free_childcare_3_4yr_olds?
+
+          calculator.where_do_you_live = "england"
+          calculator.children_living_with_you = "no"
+          assert_not calculator.eligible_for_15hrs_free_childcare_3_4yr_olds?
+
+          calculator.where_do_you_live = "england"
+          calculator.children_living_with_you = "yes"
+          calculator.age_of_children = "2, 18_and_over"
+          assert_not calculator.eligible_for_15hrs_free_childcare_3_4yr_olds?
+        end
+      end
     end
   end
 end

--- a/test/unit/calculators/checks_benefits_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_support_calculator_test.rb
@@ -413,6 +413,30 @@ module SmartAnswer::Calculators
           end
         end
       end
+
+      context "#eligible_for_personal_independence_payment?" do
+        should "return true if eligible for Personal Independence Payment" do
+          calculator = CheckBenefitsSupportCalculator.new
+          calculator.over_state_pension_age = "no"
+          calculator.disability_or_health_condition = "yes"
+          assert calculator.eligible_for_personal_independence_payment?
+        end
+
+        should "return false if not eligible for Personal Independence Payment" do
+          calculator = CheckBenefitsSupportCalculator.new
+          calculator.over_state_pension_age = "no"
+          calculator.disability_or_health_condition = "no"
+          assert_not calculator.eligible_for_personal_independence_payment?
+
+          calculator.over_state_pension_age = "yes"
+          calculator.disability_or_health_condition = "yes"
+          assert_not calculator.eligible_for_personal_independence_payment?
+
+          calculator.over_state_pension_age = "yes"
+          calculator.disability_or_health_condition = "no"
+          assert_not calculator.eligible_for_personal_independence_payment?
+        end
+      end
     end
   end
 end

--- a/test/unit/calculators/checks_benefits_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_support_calculator_test.rb
@@ -124,6 +124,31 @@ module SmartAnswer::Calculators
           assert_not calculator.eligible_for_housing_benefit?
         end
       end
+
+      context "#eligible_for_tax_free_childcare?" do
+        should "return true if eligible for Tax Free Childcare" do
+          calculator = CheckBenefitsSupportCalculator.new
+          calculator.are_you_working = "yes"
+          calculator.children_living_with_you = "yes"
+          %w[1_or_under 2 3_to_4 5_to_11].each do |age|
+            calculator.age_of_children = age
+            assert calculator.eligible_for_tax_free_childcare?
+          end
+        end
+
+        should "return false if not eligible for Tax Free Childcare" do
+          calculator = CheckBenefitsSupportCalculator.new
+          calculator.are_you_working = "no"
+          assert_not calculator.eligible_for_tax_free_childcare?
+
+          calculator.are_you_working = "yes"
+          calculator.children_living_with_you = "yes"
+          %w[12_to_15 16_to_17 18_and_over].each do |age|
+            calculator.age_of_children = age
+            assert_not calculator.eligible_for_tax_free_childcare?
+          end
+        end
+      end
     end
   end
 end

--- a/test/unit/calculators/checks_benefits_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_support_calculator_test.rb
@@ -49,6 +49,20 @@ module SmartAnswer::Calculators
           assert_not calculator.eligible_for_jobseekers_allowance?
         end
       end
+
+      context "#eligible_for_pension_credit?" do
+        should "return true if eligible for Pension Credit" do
+          calculator = CheckBenefitsSupportCalculator.new
+          calculator.over_state_pension_age = "no"
+          assert calculator.eligible_for_pension_credit?
+        end
+
+        should "return false if not eligible for Pension Credit" do
+          calculator = CheckBenefitsSupportCalculator.new
+          calculator.over_state_pension_age = "yes"
+          assert_not calculator.eligible_for_pension_credit?
+        end
+      end
     end
   end
 end

--- a/test/unit/calculators/checks_benefits_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_support_calculator_test.rb
@@ -27,6 +27,16 @@ module SmartAnswer::Calculators
         end
       end
 
+      context "#number_of_benefits" do
+        should "return the number of benefits for outcome" do
+          number_of_results = rand(1..10)
+          CheckBenefitsSupportCalculator.any_instance
+            .stubs(:benefits_for_outcome).returns(Array.new(number_of_results, {}))
+          calculator = CheckBenefitsSupportCalculator.new
+          assert_equal calculator.number_of_benefits, number_of_results
+        end
+      end
+
       context "#eligible_for_employment_and_support_allowance?" do
         should "return true if eligible for Employment and Support Allowance" do
           calculator = CheckBenefitsSupportCalculator.new

--- a/test/unit/calculators/checks_benefits_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_support_calculator_test.rb
@@ -437,6 +437,30 @@ module SmartAnswer::Calculators
           assert_not calculator.eligible_for_personal_independence_payment?
         end
       end
+
+      context "#eligible_for_attendance_allowance?" do
+        should "return true if eligible for Attendance Allowance" do
+          calculator = CheckBenefitsSupportCalculator.new
+          calculator.over_state_pension_age = "no"
+          calculator.disability_or_health_condition = "yes"
+          assert calculator.eligible_for_attendance_allowance?
+        end
+
+        should "return false if not eligible for Attendance Allowance" do
+          calculator = CheckBenefitsSupportCalculator.new
+          calculator.over_state_pension_age = "no"
+          calculator.disability_or_health_condition = "no"
+          assert_not calculator.eligible_for_attendance_allowance?
+
+          calculator.over_state_pension_age = "yes"
+          calculator.disability_or_health_condition = "yes"
+          assert_not calculator.eligible_for_attendance_allowance?
+
+          calculator.over_state_pension_age = "yes"
+          calculator.disability_or_health_condition = "no"
+          assert_not calculator.eligible_for_attendance_allowance?
+        end
+      end
     end
   end
 end

--- a/test/unit/calculators/checks_benefits_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_support_calculator_test.rb
@@ -23,6 +23,32 @@ module SmartAnswer::Calculators
           assert_not calculator.eligible_for_employment_and_support_allowance?
         end
       end
+
+      context "#eligible_for_jobseekers_allowance?" do
+        should "return true if eligible for Jobseeker's Allowance" do
+          calculator = CheckBenefitsSupportCalculator.new
+          calculator.where_do_you_live = "scotland"
+          calculator.over_state_pension_age = "no"
+          calculator.are_you_working = "no"
+          calculator.disability_affecting_work = "yes_limits_work"
+          assert calculator.eligible_for_jobseekers_allowance?
+
+          calculator.where_do_you_live = "england"
+          assert calculator.eligible_for_jobseekers_allowance?
+
+          calculator.disability_affecting_work = nil
+          assert calculator.eligible_for_jobseekers_allowance?
+        end
+
+        should "return false if not eligible for Jobseeker's Allowance" do
+          calculator = CheckBenefitsSupportCalculator.new
+          calculator.where_do_you_live = "northern-ireland"
+          calculator.over_state_pension_age = "yes"
+          calculator.are_you_working = "yes_over_16_hours_per_week"
+          calculator.disability_affecting_work = "yes_unable_to_work"
+          assert_not calculator.eligible_for_jobseekers_allowance?
+        end
+      end
     end
   end
 end

--- a/test/unit/calculators/checks_benefits_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_support_calculator_test.rb
@@ -461,6 +461,20 @@ module SmartAnswer::Calculators
           assert_not calculator.eligible_for_attendance_allowance?
         end
       end
+
+      context "#eligible_for_free_tv_licence?" do
+        should "return true if eligible for Free TV Licence" do
+          calculator = CheckBenefitsSupportCalculator.new
+          calculator.over_state_pension_age = "yes"
+          assert calculator.eligible_for_free_tv_licence?
+        end
+
+        should "return false if not eligible for Free TV Licence" do
+          calculator = CheckBenefitsSupportCalculator.new
+          calculator.over_state_pension_age = "no"
+          assert_not calculator.eligible_for_free_tv_licence?
+        end
+      end
     end
   end
 end

--- a/test/unit/calculators/checks_benefits_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_support_calculator_test.rb
@@ -1,0 +1,28 @@
+require_relative "../../test_helper"
+
+module SmartAnswer::Calculators
+  class CheckBenefitsSupportCalculatorTest < ActiveSupport::TestCase
+    context CheckBenefitsSupportCalculator do
+      context "#eligible_for_employment_and_support_allowance?" do
+        should "return true if eligible for Employment and Support Allowance" do
+          calculator = CheckBenefitsSupportCalculator.new
+          calculator.over_state_pension_age = "no"
+          calculator.disability_or_health_condition = "yes"
+          calculator.disability_affecting_work = "yes_unable_to_work"
+
+          assert calculator.eligible_for_employment_and_support_allowance?
+
+          calculator.disability_affecting_work = "yes_limits_work"
+          assert calculator.eligible_for_employment_and_support_allowance?
+        end
+
+        should "return false if not eligible for Employment and Support Allowance" do
+          calculator = CheckBenefitsSupportCalculator.new
+          calculator.over_state_pension_age = "no"
+          calculator.disability_or_health_condition = "no"
+          assert_not calculator.eligible_for_employment_and_support_allowance?
+        end
+      end
+    end
+  end
+end

--- a/test/unit/calculators/checks_benefits_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_support_calculator_test.rb
@@ -3,6 +3,30 @@ require_relative "../../test_helper"
 module SmartAnswer::Calculators
   class CheckBenefitsSupportCalculatorTest < ActiveSupport::TestCase
     context CheckBenefitsSupportCalculator do
+      context "#benefits_for_outcome" do
+        should "return array of eligible and non-conditional benefits" do
+          stubbed_benefit_data = {
+            "benefits" => [{ "title" => "eligible_benefit",
+                             "condition" => "eligible_for_employment_and_support_allowance?" },
+                           { "title" => "unconditional_benefit" },
+                           { "title" => "ineligile_benefit",
+                             "condition" => "eligible_for_jobseekers_allowance?" }],
+          }
+          expected_benefits = [
+            { "title" => "eligible_benefit",
+              "condition" => "eligible_for_employment_and_support_allowance?" },
+            { "title" => "unconditional_benefit" },
+          ]
+
+          YAML.stubs(:load_file).returns(stubbed_benefit_data)
+          calculator = CheckBenefitsSupportCalculator.new
+          calculator.stubs(:eligible_for_employment_and_support_allowance?).returns(true)
+          calculator.stubs(:eligible_for_jobseekers_allowance?).returns(false)
+
+          assert_equal calculator.benefits_for_outcome, expected_benefits
+        end
+      end
+
       context "#eligible_for_employment_and_support_allowance?" do
         should "return true if eligible for Employment and Support Allowance" do
           calculator = CheckBenefitsSupportCalculator.new

--- a/test/unit/calculators/checks_benefits_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_support_calculator_test.rb
@@ -307,6 +307,20 @@ module SmartAnswer::Calculators
           assert_not calculator.eligible_for_2yr_old_childcare_scotland?
         end
       end
+
+      context "#eligible_for_child_benefit?" do
+        should "return true if eligible for Child Benefit" do
+          calculator = CheckBenefitsSupportCalculator.new
+          calculator.children_living_with_you = "yes"
+          assert calculator.eligible_for_child_benefit?
+        end
+
+        should "return false if not eligible for Child Benefit" do
+          calculator = CheckBenefitsSupportCalculator.new
+          calculator.children_living_with_you = "no"
+          assert_not calculator.eligible_for_child_benefit?
+        end
+      end
     end
   end
 end

--- a/test/unit/calculators/checks_benefits_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_support_calculator_test.rb
@@ -280,6 +280,33 @@ module SmartAnswer::Calculators
           assert_not calculator.eligible_for_30hrs_free_childcare_3_4yrs_scotland?
         end
       end
+
+      context "#eligible_for_2yr_old_childcare_scotland?" do
+        should "return true if eligible for 2 Year Old Childcare Scotland" do
+          calculator = CheckBenefitsSupportCalculator.new
+          calculator.where_do_you_live = "scotland"
+          calculator.children_living_with_you = "yes"
+          calculator.age_of_children = "2"
+          assert calculator.eligible_for_2yr_old_childcare_scotland?
+        end
+
+        should "return false if not eligible for 2 Year Old Childcare Scotland" do
+          calculator = CheckBenefitsSupportCalculator.new
+          calculator.where_do_you_live = "england"
+          calculator.children_living_with_you = "yes"
+          calculator.age_of_children = "2"
+          assert_not calculator.eligible_for_2yr_old_childcare_scotland?
+
+          calculator.where_do_you_live = "scotland"
+          calculator.children_living_with_you = "no"
+          assert_not calculator.eligible_for_2yr_old_childcare_scotland?
+
+          calculator.where_do_you_live = "scotland"
+          calculator.children_living_with_you = "yes"
+          calculator.age_of_children = "1_or_under,3_to_4,18_and_over"
+          assert_not calculator.eligible_for_2yr_old_childcare_scotland?
+        end
+      end
     end
   end
 end

--- a/test/unit/calculators/checks_benefits_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_support_calculator_test.rb
@@ -226,6 +226,33 @@ module SmartAnswer::Calculators
           assert_not calculator.eligible_for_15hrs_free_childcare_3_4yr_olds?
         end
       end
+
+      context "#eligible_for_30hrs_free_childcare_3_4yrs?" do
+        should "return true if eligible for 30 Hours Free Childcare for 3 and 4 Year Olds" do
+          calculator = CheckBenefitsSupportCalculator.new
+          calculator.are_you_working = "yes_over_16_hours_per_week"
+          calculator.children_living_with_you = "yes"
+          calculator.age_of_children = "3_to_4"
+          assert calculator.eligible_for_30hrs_free_childcare_3_4yrs?
+        end
+
+        should "return false if not eligible for 30 Hours Free Childcare for 3 and 4 Year Olds" do
+          calculator = CheckBenefitsSupportCalculator.new
+          calculator.are_you_working = "no"
+          calculator.children_living_with_you = "yes"
+          calculator.age_of_children = "3_to_4"
+          assert_not calculator.eligible_for_30hrs_free_childcare_3_4yrs?
+
+          calculator.are_you_working = "yes"
+          calculator.children_living_with_you = "no"
+          assert_not calculator.eligible_for_30hrs_free_childcare_3_4yrs?
+
+          calculator.are_you_working = "yes"
+          calculator.children_living_with_you = "yes"
+          calculator.age_of_children = "1_or_under,2,18_and_over"
+          assert_not calculator.eligible_for_30hrs_free_childcare_3_4yrs?
+        end
+      end
     end
   end
 end

--- a/test/unit/calculators/checks_benefits_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_support_calculator_test.rb
@@ -170,6 +170,37 @@ module SmartAnswer::Calculators
           assert_not calculator.eligible_for_free_childcare_2yr_olds?
         end
       end
+
+      context "#eligible_for_childcare_3_4yr_olds_wales??" do
+        should "return true if eligible for Childcare 3 and 4 Year Olds Wales" do
+          calculator = CheckBenefitsSupportCalculator.new
+          calculator.where_do_you_live = "wales"
+          calculator.are_you_working = "yes_under_16_hours_per_week"
+          calculator.children_living_with_you = "yes"
+          calculator.age_of_children = "3_to_4"
+          assert calculator.eligible_for_childcare_3_4yr_olds_wales?
+        end
+
+        should "return false if not eligible for Childcare 3 and 4 Year Olds Wales" do
+          calculator = CheckBenefitsSupportCalculator.new
+          calculator.where_do_you_live = "scotland"
+          assert_not calculator.eligible_for_childcare_3_4yr_olds_wales?
+
+          calculator.where_do_you_live = "wales"
+          calculator.are_you_working = "no"
+          assert_not calculator.eligible_for_childcare_3_4yr_olds_wales?
+
+          calculator.where_do_you_live = "wales"
+          calculator.are_you_working = "yes_over_16_hours_per_week"
+          assert_not calculator.eligible_for_childcare_3_4yr_olds_wales?
+
+          calculator.where_do_you_live = "wales"
+          calculator.are_you_working = "yes_under_16_hours_per_week"
+          calculator.children_living_with_you = "yes"
+          calculator.age_of_children = "1_or_under, 3_to_4"
+          assert_not calculator.eligible_for_childcare_3_4yr_olds_wales?
+        end
+      end
     end
   end
 end

--- a/test/unit/calculators/checks_benefits_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_support_calculator_test.rb
@@ -90,6 +90,26 @@ module SmartAnswer::Calculators
           assert_not calculator.eligible_for_access_to_work?
         end
       end
+
+      context "#eligible_for_universal_credit?" do
+        should "return true if eligible for Universal Credit" do
+          calculator = CheckBenefitsSupportCalculator.new
+          calculator.over_state_pension_age = "no"
+          calculator.assets_and_savings = "under_16000"
+
+          assert calculator.eligible_for_universal_credit?
+        end
+
+        should "return false if not eligible for Universal Credit" do
+          calculator = CheckBenefitsSupportCalculator.new
+          calculator.over_state_pension_age = "yes"
+          assert_not calculator.eligible_for_universal_credit?
+
+          calculator.over_state_pension_age = "no"
+          calculator.assets_and_savings = "over_16000"
+          assert_not calculator.eligible_for_universal_credit?
+        end
+      end
     end
   end
 end

--- a/test/unit/calculators/checks_benefits_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_support_calculator_test.rb
@@ -110,6 +110,20 @@ module SmartAnswer::Calculators
           assert_not calculator.eligible_for_universal_credit?
         end
       end
+
+      context "#eligible_for_housing_benefit?" do
+        should "return true if eligible for Housing Benefit" do
+          calculator = CheckBenefitsSupportCalculator.new
+          calculator.over_state_pension_age = "yes"
+          assert calculator.eligible_for_housing_benefit?
+        end
+
+        should "return false if not eligible for Housing Benefit" do
+          calculator = CheckBenefitsSupportCalculator.new
+          calculator.over_state_pension_age = "no"
+          assert_not calculator.eligible_for_housing_benefit?
+        end
+      end
     end
   end
 end

--- a/test/unit/calculators/checks_benefits_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_support_calculator_test.rb
@@ -321,6 +321,40 @@ module SmartAnswer::Calculators
           assert_not calculator.eligible_for_child_benefit?
         end
       end
+
+      context "#eligible_for_disability_living_allowance_for_children?" do
+        should "return true if eligible for Disability Living Allowance for Children" do
+          calculator = CheckBenefitsSupportCalculator.new
+          %w[england wales].each do |country|
+            calculator.where_do_you_live = country
+            calculator.carer_disability_or_health_condition = "yes"
+            calculator.children_living_with_you = "yes"
+            calculator.children_with_disability = "yes"
+            %w[1_or_under 2 3_to_4 5_to_11 12_to_15].each do |age|
+              calculator.age_of_children = age
+              assert calculator.eligible_for_disability_living_allowance_for_children?
+            end
+          end
+        end
+
+        should "return false if not eligible for Disability Living Allowance for Children" do
+          calculator = CheckBenefitsSupportCalculator.new
+          calculator.where_do_you_live = "scotland"
+          assert_not calculator.eligible_for_disability_living_allowance_for_children?
+
+          calculator.where_do_you_live = "england"
+          calculator.carer_disability_or_health_condition = "yes"
+          calculator.children_living_with_you = "yes"
+          calculator.age_of_children = "1_or_under"
+          calculator.children_with_disability = "no"
+          assert_not calculator.eligible_for_disability_living_allowance_for_children?
+
+          calculator.where_do_you_live = "england"
+          calculator.carer_disability_or_health_condition = "yes"
+          calculator.children_living_with_you = "no"
+          assert_not calculator.eligible_for_disability_living_allowance_for_children?
+        end
+      end
     end
   end
 end

--- a/test/unit/calculators/checks_benefits_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_support_calculator_test.rb
@@ -253,6 +253,33 @@ module SmartAnswer::Calculators
           assert_not calculator.eligible_for_30hrs_free_childcare_3_4yrs?
         end
       end
+
+      context "#eligible_for_30hrs_free_childcare_3_4yrs_scotland?" do
+        should "return true if eligible for 30 Hours Free Childcare for 3 and 4 Year Olds Scotland" do
+          calculator = CheckBenefitsSupportCalculator.new
+          calculator.where_do_you_live = "scotland"
+          calculator.children_living_with_you = "yes"
+          calculator.age_of_children = "3_to_4"
+          assert calculator.eligible_for_30hrs_free_childcare_3_4yrs_scotland?
+        end
+
+        should "return false if not eligible for 30 Hours Free Childcare for 3 and 4 Year Olds Scotland" do
+          calculator = CheckBenefitsSupportCalculator.new
+          calculator.where_do_you_live = "england"
+          calculator.children_living_with_you = "yes"
+          calculator.age_of_children = "3_to_4"
+          assert_not calculator.eligible_for_30hrs_free_childcare_3_4yrs_scotland?
+
+          calculator.where_do_you_live = "scotland"
+          calculator.children_living_with_you = "no"
+          assert_not calculator.eligible_for_30hrs_free_childcare_3_4yrs_scotland?
+
+          calculator.where_do_you_live = "scotland"
+          calculator.children_living_with_you = "yes"
+          calculator.age_of_children = "1_or_under,2,18_and_over"
+          assert_not calculator.eligible_for_30hrs_free_childcare_3_4yrs_scotland?
+        end
+      end
     end
   end
 end

--- a/test/unit/calculators/checks_benefits_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_support_calculator_test.rb
@@ -495,6 +495,22 @@ module SmartAnswer::Calculators
           assert_not calculator.eligible_for_universal_credit_advance?
         end
       end
+
+      context "#eligible_for_nhs_low_income_scheme?" do
+        should "return true if eligible for NHS Low Income Scheme" do
+          %w[england wales scotland].each do |country|
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.where_do_you_live = country
+            assert calculator.eligible_for_nhs_low_income_scheme?
+          end
+        end
+
+        should "return false if not eligible for NHS Low Income Scheme" do
+          calculator = CheckBenefitsSupportCalculator.new
+          calculator.where_do_you_live = "northern-ireland"
+          assert_not calculator.eligible_for_nhs_low_income_scheme?
+        end
+      end
     end
   end
 end

--- a/test/unit/calculators/checks_benefits_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_support_calculator_test.rb
@@ -386,6 +386,33 @@ module SmartAnswer::Calculators
           assert_not calculator.eligible_for_child_disability_payment_scotland?
         end
       end
+
+      context "#eligible_for_carers_allowance?" do
+        should "return true if eligible for Carer's Allowance" do
+          calculator = CheckBenefitsSupportCalculator.new
+          %w[england wales scotland].each do |country|
+            calculator.where_do_you_live = country
+            calculator.carer_disability_or_health_condition = "yes"
+            calculator.unpaid_care_hours = "yes"
+            assert calculator.eligible_for_carers_allowance?
+          end
+        end
+
+        should "return false if not eligible for Carer's Allowance" do
+          calculator = CheckBenefitsSupportCalculator.new
+          calculator.where_do_you_live = "northern-ireland"
+          calculator.carer_disability_or_health_condition = "yes"
+          calculator.unpaid_care_hours = "yes"
+          assert_not calculator.eligible_for_carers_allowance?
+
+          %w[england wales scotland].each do |country|
+            calculator.where_do_you_live = country
+            calculator.carer_disability_or_health_condition = "yes"
+            calculator.unpaid_care_hours = "no"
+            assert_not calculator.eligible_for_carers_allowance?
+          end
+        end
+      end
     end
   end
 end

--- a/test/unit/calculators/checks_benefits_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_support_calculator_test.rb
@@ -149,6 +149,27 @@ module SmartAnswer::Calculators
           end
         end
       end
+
+      context "# eligible_for_free_childcare_2yr_olds?" do
+        should "return true if eligible for Free Childcare 2 Year Olds" do
+          calculator = CheckBenefitsSupportCalculator.new
+          calculator.where_do_you_live = "england"
+          calculator.children_living_with_you = "yes"
+          calculator.age_of_children = "2"
+          assert calculator.eligible_for_free_childcare_2yr_olds?
+        end
+
+        should "return false if not eligible for Free Childcare 2 Year Olds" do
+          calculator = CheckBenefitsSupportCalculator.new
+          calculator.where_do_you_live = "scotland"
+          assert_not calculator.eligible_for_free_childcare_2yr_olds?
+
+          calculator.where_do_you_live = "england"
+          calculator.children_living_with_you = "yes"
+          calculator.age_of_children = "1_or_under"
+          assert_not calculator.eligible_for_free_childcare_2yr_olds?
+        end
+      end
     end
   end
 end

--- a/test/unit/calculators/checks_benefits_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_support_calculator_test.rb
@@ -63,6 +63,33 @@ module SmartAnswer::Calculators
           assert_not calculator.eligible_for_pension_credit?
         end
       end
+
+      context "#eligible_for_access_to_work?" do
+        should "return true if eligible for Access to Work" do
+          calculator = CheckBenefitsSupportCalculator.new
+          calculator.where_do_you_live = "wales"
+          calculator.disability_or_health_condition = "yes"
+          calculator.disability_affecting_work = "no"
+          assert calculator.eligible_for_access_to_work?
+
+          calculator.disability_affecting_work = "yes_limits_work"
+          assert calculator.eligible_for_access_to_work?
+        end
+
+        should "return false if not eligible for Access to Work" do
+          calculator = CheckBenefitsSupportCalculator.new
+          calculator.where_do_you_live = "northern-ireland"
+          assert_not calculator.eligible_for_access_to_work?
+
+          calculator.where_do_you_live = "wales"
+          calculator.disability_or_health_condition = "no"
+          assert_not calculator.eligible_for_access_to_work?
+
+          calculator.disability_or_health_condition = "yes"
+          calculator.disability_affecting_work = "yes_unable_to_work"
+          assert_not calculator.eligible_for_access_to_work?
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This PR adds a yml file holding information on each possible result .

One key is `condition`, which corresponds to a method on the calculator with the same name as the key's value.

If a benefit does not have a condition, or if the user input from the flow passes the logic check in the corresponding method, the benefit is selected.

A single view is used to iterate over and display all selected benefits. This view is currently using the `result_item` partial which will be replaced by a new custom partial when developed.



