### PR TITLE
Add result card app component to smart answers

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -33,6 +33,7 @@ $govuk-new-link-styles: true;
 @import "govuk_publishing_components/components/warning-text";
 
 @import "components/autocomplete";
+@import "components/result-card";
 @import "components/result-item";
 @import "components/result-sections";
 @import "components/user_intent_banner";

--- a/app/assets/stylesheets/components/_result-card.scss
+++ b/app/assets/stylesheets/components/_result-card.scss
@@ -1,0 +1,29 @@
+.app-c-result-card {
+  position: relative;
+  padding: govuk-spacing(3) govuk-spacing(4) govuk-spacing(5);
+  border: 1px solid $govuk-border-colour;
+  margin-bottom: govuk-spacing(4);
+
+  &:before {
+    position: absolute;
+    content: "";
+    top: -1px;
+    left: -1px;
+    right: -1px;
+    height: 7px;
+    background: govuk-colour('blue');
+  }
+
+  @include govuk-media-query($from: tablet) {
+    padding: govuk-spacing(4) govuk-spacing(6) govuk-spacing(6);
+    margin-bottom: govuk-spacing(6);
+  }
+}
+
+.app-c-result-card__description {
+  margin-bottom: govuk-spacing(6);
+}
+
+.app-c-result-card__link {
+  @include govuk-font($size: 19, $weight: bold);
+}

--- a/app/views/components/_result-card.html.erb
+++ b/app/views/components/_result-card.html.erb
@@ -1,0 +1,27 @@
+<%
+  title ||= nil
+  description ||= nil
+  url ||= nil
+  url_text ||= nil
+%>
+<div class="app-c-result-card">
+  <%= render "govuk_publishing_components/components/heading", {
+    text: title,
+    heading_level: 2,
+    margin_bottom: 2,
+    font_size: "m"
+  } %>
+
+  <p class="govuk-body app-c-result-card__description">
+    <%= description %>
+  </p>
+
+  <%= link_to url_text, url,
+  class: "govuk-link app-c-result-card__link",
+  data: {
+    module: "gem-track-click",
+    "track-action": "Cost of living results",
+    "track-category": "SmartAnswerClicked",
+    "track-label": url
+  } %>
+</div>

--- a/app/views/components/docs/result-card.yml
+++ b/app/views/components/docs/result-card.yml
@@ -1,0 +1,11 @@
+name: Result card
+description: Presents a card style component with a title, description and link
+shared_accessibility_criteria:
+  - link
+examples:
+  default:
+    data:
+      title: Tax-Free childcare
+      description: You may be able to get up to £2,000 a year for each of your children to help with the costs of childcare.
+      url: /tax-free-childcare
+      url_text: Check if you’re eligible for Tax-Free childcare


### PR DESCRIPTION
## What
Add a new result card component intended for use on the results page.

## Why
The custom design uses visual grouping to bring clarity to the results, to help improve legibility and readability of the results page.

## Visual
<img width="663" alt="result-card-component" src="https://user-images.githubusercontent.com/28779939/172613627-6853f7bc-01c0-40dd-aa51-9b1681a11fa3.png">

### Trello
https://trello.com/c/6gjI5Ami/22-finalise-results-page
https://trello.com/c/6oJJ00i8/78-create-new-component-for-benefits-results-item

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️