### PR TITLE
Update check-financial-benefit-support results page

### DIFF
--- a/app/flows/check_benefits_support_flow/outcomes/results.erb
+++ b/app/flows/check_benefits_support_flow/outcomes/results.erb
@@ -6,7 +6,7 @@
   <% end %>
 
   <% calculator.benefits_for_outcome.each do |benefit| %>
-   <%= render "components/result-item", { title: benefit["title"], url: benefit["url"] } %>
+   <%= render "components/result-card", { title: benefit["title"], description: benefit["description"], url: benefit["url"], url_text: benefit["url_text"] } %>
 
     ---
   <% end %>

--- a/app/flows/check_benefits_support_flow/outcomes/results.erb
+++ b/app/flows/check_benefits_support_flow/outcomes/results.erb
@@ -2,7 +2,7 @@
   <% if calculator.number_of_benefits > 0 %>
     Based on your answers you may be eligible to apply for these <%= calculator.number_of_benefits %> things.
   <% else %>
-    Based on your answers you are not eligible to apply for any benefits.
+    Based on your answers, you may not be eligible for any benefits.
   <% end %>
 
   <% calculator.benefits_for_outcome.each do |benefit| %>


### PR DESCRIPTION
This PR updates the results page for the check-financial-benefit-support to use the new results-card component introduced in https://github.com/alphagov/smart-answers/pull/5930 and updates the copy should a user see no results.

<img width="680" alt="Screenshot 2022-06-09 at 17 14 38" src="https://user-images.githubusercontent.com/13475227/172895029-67b94f00-dcf6-4841-98db-ca59d4b04a69.png">