### PR TITLE
Add results page content and update result card component

### DIFF
--- a/app/assets/stylesheets/components/_result-card.scss
+++ b/app/assets/stylesheets/components/_result-card.scss
@@ -1,6 +1,6 @@
 .app-c-result-card {
   position: relative;
-  padding: govuk-spacing(3) govuk-spacing(4) govuk-spacing(5);
+  padding: govuk-spacing(5) govuk-spacing(4);
   border: 1px solid $govuk-border-colour;
   margin-bottom: govuk-spacing(4);
 
@@ -10,7 +10,7 @@
     top: -1px;
     left: -1px;
     right: -1px;
-    height: 7px;
+    height: 5px;
     background: govuk-colour('blue');
   }
 

--- a/app/flows/check_benefits_support_flow/outcomes/results.erb
+++ b/app/flows/check_benefits_support_flow/outcomes/results.erb
@@ -1,13 +1,39 @@
-<% govspeak_for :body do %>
+<% text_for :body do %>
   <% if calculator.number_of_benefits > 0 %>
-    Based on your answers you may be eligible to apply for these <%= calculator.number_of_benefits %> things.
+    <p class="govuk-body">Based on your answers, you may be eligible for the following <span style="font-weight: bold"><%= calculator.number_of_benefits %> things</span>.</p>
   <% else %>
-    Based on your answers, you may not be eligible for any benefits.
+    <p class="govuk-body">Based on your answers, you may not be eligible for any benefits.</p>
   <% end %>
 
-  <% calculator.benefits_for_outcome.each do |benefit| %>
-   <%= render "components/result-card", { title: benefit["title"], description: benefit["description"], url: benefit["url"], url_text: benefit["url_text"] } %>
+  <div class="govuk-!-margin-top-8 govuk-!-margin-bottom-9">
+    <% calculator.benefits_for_outcome.each do |benefit| %>
+      <%= render "components/result-card", { title: benefit["title"], description: benefit["description"], url: benefit["url"], url_text: benefit["url_text"] } %>
+    <% end %>
+  </div>
 
-    ---
-  <% end %>
+  <%= render "govuk_publishing_components/components/inset_text", {
+    text: "At the moment, not all payments and help you might be able to claim have been included."
+  } %>
+
+  <div class="govuk-!-margin-bottom-9">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "Other benefits and financial support",
+      heading_level: 2,
+      margin_bottom: 4,
+      font_size: "m"
+    } %>
+
+    <p class="govuk-body">If you're getting certain benefits or tax credits you may be <a class="govuk-link" href="/guidance/cost-of-living-payment">eligible for a cost of living payment</a>. You do not need to apply. If you’re eligible, you’ll be paid automatically.</p>
+
+    <p class="govuk-body">You can also find out more by:</p>
+
+    <%= render "govuk_publishing_components/components/list", {
+    visible_counters: true,
+    items: [
+      sanitize("browsing <a class=\"govuk-link\" href=\"/browse/benefits\">information on benefits</a>"),
+      sanitize("reading about <a class=\"govuk-link\" href=\"https://costoflivingsupport.campaign.gov.uk/\">what the government is doing to support people with the cost of living</a>"),
+      sanitize("<a class=\"govuk-link\" href=\"/benefits-calculators\">using a benefits calculator</a>"),
+    ]
+    } %>
+  </div>
 <% end %>

--- a/app/flows/check_benefits_support_flow/start.erb
+++ b/app/flows/check_benefits_support_flow/start.erb
@@ -7,7 +7,7 @@
 <% end %>
 
 <% govspeak_for :body do %>
-  You might be able to get money to help with your living costs. You can apply for benefits or financial support If you are eligible. 
+  You might be able to get money to help with your living costs. You can apply for benefits or financial support if you are eligible. 
 <% end %>
 
 <% text_for :start_button_text do %>

--- a/app/views/components/_result-card.html.erb
+++ b/app/views/components/_result-card.html.erb
@@ -12,9 +12,9 @@
     font_size: "m"
   } %>
 
-  <p class="govuk-body app-c-result-card__description">
-    <%= description %>
-  </p>
+  <div class="govuk-body app-c-result-card__description">
+    <%= sanitize(description) %>
+  </div>
 
   <%= link_to url_text, url,
   class: "govuk-link app-c-result-card__link",

--- a/test/flows/check_benefits_support_flow_test.rb
+++ b/test/flows/check_benefits_support_flow_test.rb
@@ -233,7 +233,7 @@ class CheckBenefitsSupportFlowTest < ActiveSupport::TestCase
     end
 
     should "render the results outcome with number of eligible benefits" do
-      assert_rendered_outcome text: "Based on your answers you may be eligible to apply for these 9 things."
+      assert_rendered_outcome text: "Based on your answers, you may be eligible for the following 9 things."
     end
   end
 end


### PR DESCRIPTION
The PR will:

- Update result-card component based on design feedback and requirements to have multiple lines of text
- Update the result page content with the content provided
- Update test based on new content
- Fix typo on start page

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
