### PR TITLE
Move (opens in a new tab) to be part of the link

### DIFF
--- a/app/flows/check_benefits_support_flow/questions/over_state_pension_age.erb
+++ b/app/flows/check_benefits_support_flow/questions/over_state_pension_age.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% text_for :hint do %>
-  You can <a href="https://www.gov.uk/state-pension-age" class="govuk-link" rel="noreferrer noopener" target="_blank">check your state pension age</a> if you're not sure (opens in a new tab).
+  You can <a href="https://www.gov.uk/state-pension-age" class="govuk-link" rel="noreferrer noopener" target="_blank">check your state pension age (opens in new tab)</a> if you're not sure.
 <% end %>
 
 <% options(


### PR DESCRIPTION
Better for accessibility and in-keeping with design system recommendations: https://design-system.service.gov.uk/styles/typography/#links.

<img width="821" alt="Screenshot 2022-06-10 at 12 31 59" src="https://user-images.githubusercontent.com/5963488/173056023-0a29dec3-df7e-407d-96ca-e009733d1af1.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
