### PR TITLE
Fix margin issue in result-card component

### DIFF
--- a/app/assets/stylesheets/components/_result-card.scss
+++ b/app/assets/stylesheets/components/_result-card.scss
@@ -22,6 +22,10 @@
 
 .app-c-result-card__description {
   margin-bottom: govuk-spacing(6);
+
+  p:first-of-type {
+    margin-top: 0;
+  }
 }
 
 .app-c-result-card__link {


### PR DESCRIPTION
## What
Add new CSS rule to target for `p` element used in the result-card component

## Why
Margin was not consistent

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
