### PR TITLE
Apply 30hrs_free_childcare_3_4yrs to England only

### DIFF
--- a/lib/smart_answer/calculators/check_benefits_support_calculator.rb
+++ b/lib/smart_answer/calculators/check_benefits_support_calculator.rb
@@ -123,7 +123,7 @@ module SmartAnswer::Calculators
     end
 
     def eligible_for_30hrs_free_childcare_3_4yrs?
-      %w[england northern-ireland].include?(@where_do_you_live) &&
+      @where_do_you_live == "england" &&
         @are_you_working != "no" &&
         @children_living_with_you == "yes" &&
         @age_of_children.split(",").any?("3_to_4")

--- a/test/unit/calculators/checks_benefits_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_support_calculator_test.rb
@@ -508,56 +508,48 @@ module SmartAnswer::Calculators
       context "#eligible_for_30hrs_free_childcare_3_4yrs?" do
         should "return true if eligible for 30 Hours Free Childcare for 3 and 4 Year Olds" do
           calculator = CheckBenefitsSupportCalculator.new
-          %w[england northern-ireland].each do |country|
-            calculator.where_do_you_live = country
-            %w[yes_over_16_hours_per_week yes_under_16_hours_per_week].each do |working_hours|
-              calculator.are_you_working = working_hours
-              calculator.children_living_with_you = "yes"
-              calculator.age_of_children = "3_to_4"
-              assert calculator.eligible_for_30hrs_free_childcare_3_4yrs?
-            end
+          calculator.where_do_you_live = "england"
+          %w[yes_over_16_hours_per_week yes_under_16_hours_per_week].each do |working_hours|
+            calculator.are_you_working = working_hours
+            calculator.children_living_with_you = "yes"
+            calculator.age_of_children = "3_to_4"
+            assert calculator.eligible_for_30hrs_free_childcare_3_4yrs?
           end
         end
 
         should "return false if not eligible for 30 Hours Free Childcare for 3 and 4 Year Olds - not working" do
           calculator = CheckBenefitsSupportCalculator.new
-          %w[england northern-ireland].each do |country|
-            calculator.where_do_you_live = country
-            calculator.are_you_working = "no"
-            calculator.children_living_with_you = "yes"
-            calculator.age_of_children = "3_to_4"
-            assert_not calculator.eligible_for_30hrs_free_childcare_3_4yrs?
-          end
+          calculator.where_do_you_live = "england"
+          calculator.are_you_working = "no"
+          calculator.children_living_with_you = "yes"
+          calculator.age_of_children = "3_to_4"
+          assert_not calculator.eligible_for_30hrs_free_childcare_3_4yrs?
         end
 
         should "return false if not eligible for 30 Hours Free Childcare for 3 and 4 Year Olds - no children" do
           calculator = CheckBenefitsSupportCalculator.new
-          %w[england northern-ireland].each do |country|
-            calculator.where_do_you_live = country
-            %w[yes_over_16_hours_per_week yes_under_16_hours_per_week].each do |working_hours|
-              calculator.are_you_working = working_hours
-              calculator.children_living_with_you = "no"
-              assert_not calculator.eligible_for_30hrs_free_childcare_3_4yrs?
-            end
+          calculator.where_do_you_live = "england"
+          %w[yes_over_16_hours_per_week yes_under_16_hours_per_week].each do |working_hours|
+            calculator.are_you_working = working_hours
+            calculator.children_living_with_you = "no"
+            assert_not calculator.eligible_for_30hrs_free_childcare_3_4yrs?
           end
         end
 
         should "return false if not eligible for 30 Hours Free Childcare for 3 and 4 Year Olds - older children" do
           calculator = CheckBenefitsSupportCalculator.new
-          %w[england northern-ireland].each do |country|
-            calculator.where_do_you_live = country
-            %w[yes_over_16_hours_per_week yes_under_16_hours_per_week].each do |working_hours|
-              calculator.are_you_working = working_hours
-              calculator.children_living_with_you = "yes"
-              calculator.age_of_children = "5 to 11"
-              assert_not calculator.eligible_for_30hrs_free_childcare_3_4yrs?
-            end
+          calculator.where_do_you_live = "england"
+          %w[yes_over_16_hours_per_week yes_under_16_hours_per_week].each do |working_hours|
+            calculator.are_you_working = working_hours
+            calculator.children_living_with_you = "yes"
+            calculator.age_of_children = "5 to 11"
+            assert_not calculator.eligible_for_30hrs_free_childcare_3_4yrs?
           end
         end
 
         should "return false if not eligible for 30 Hours Free Childcare for 3 and 4 Year Olds - wrong country" do
           calculator = CheckBenefitsSupportCalculator.new
-          %w[wales scotland].each do |country|
+          %w[wales scotland northern-ireland].each do |country|
             calculator.where_do_you_live = country
             %w[yes_over_16_hours_per_week yes_under_16_hours_per_week].each do |working_hours|
               calculator.are_you_working = working_hours


### PR DESCRIPTION
Updates the check-benefits-financial-support method eligible_for_30hrs_free_childcare_3_4yrs? to apply only to users living in England.