### PR TITLE
Add better test descriptions to check-benefits-support-calculator-tests

### DIFF
--- a/test/unit/calculators/checks_benefits_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_support_calculator_test.rb
@@ -407,23 +407,30 @@ module SmartAnswer::Calculators
       end
 
       context "#eligible_for_pension_credit_northern_ireland?" do
-        should "return true if eligible for Pension Credit (NI)" do
-          calculator = CheckBenefitsSupportCalculator.new
-          calculator.where_do_you_live = "northern-ireland"
-          calculator.over_state_pension_age = "yes"
-          assert calculator.eligible_for_pension_credit_northern_ireland?
+        context "when eligible" do
+          should "be true if country is NI and over state pension age" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.where_do_you_live = "northern-ireland"
+            calculator.over_state_pension_age = "yes"
+            assert calculator.eligible_for_pension_credit_northern_ireland?
+          end
         end
 
-        should "return false if not eligible for Pension Credit (NI)" do
-          calculator = CheckBenefitsSupportCalculator.new
-          calculator.where_do_you_live = "northern-ireland"
-          calculator.over_state_pension_age = "no"
-          assert_not calculator.eligible_for_pension_credit_northern_ireland?
-
-          %w[england wales scotland].each do |country|
-            calculator.where_do_you_live = country
-            calculator.over_state_pension_age = "yes"
+        context "when ineligible" do
+          should "be false if country is NI and UNDER state pension age" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.where_do_you_live = "northern-ireland"
+            calculator.over_state_pension_age = "no"
             assert_not calculator.eligible_for_pension_credit_northern_ireland?
+          end
+
+          should "be false if country is not NI" do
+            %w[england wales scotland].each do |country|
+              calculator = CheckBenefitsSupportCalculator.new
+              calculator.where_do_you_live = country
+              calculator.over_state_pension_age = "yes"
+              assert_not calculator.eligible_for_pension_credit_northern_ireland?
+            end
           end
         end
       end

--- a/test/unit/calculators/checks_benefits_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_support_calculator_test.rb
@@ -777,33 +777,38 @@ module SmartAnswer::Calculators
         end
       end
 
-      context "# eligible_for_free_childcare_2yr_olds?" do
-        should "return true if eligible for Free Childcare 2 Year Olds" do
-          calculator = CheckBenefitsSupportCalculator.new
-          %w[england wales].each do |country|
-            calculator.where_do_you_live = country
-            calculator.children_living_with_you = "yes"
-            calculator.age_of_children = "2"
-            assert calculator.eligible_for_free_childcare_2yr_olds?
+      context "#eligible_for_free_childcare_2yr_olds?" do
+        context "when eligible" do
+          should "be true if country is England or Wales, with a child aged 2" do
+            %w[england wales].each do |country|
+              calculator = CheckBenefitsSupportCalculator.new
+              calculator.where_do_you_live = country
+              calculator.children_living_with_you = "yes"
+              calculator.age_of_children = "2"
+              assert calculator.eligible_for_free_childcare_2yr_olds?
+            end
           end
         end
 
-        should "return false if not eligible for Free Childcare 2 Year Olds" do
-          calculator = CheckBenefitsSupportCalculator.new
-          calculator.where_do_you_live = "scotland"
-          calculator.children_living_with_you = "yes"
-          calculator.age_of_children = "2"
-          assert_not calculator.eligible_for_free_childcare_2yr_olds?
+        context "when ineligible" do
+          should "be false if country is England or Wales with a child that is not 2" do
+            %w[england wales].each do |country|
+              calculator = CheckBenefitsSupportCalculator.new
+              calculator.where_do_you_live = country
+              calculator.children_living_with_you = "yes"
+              calculator.age_of_children = "1,3_to_4"
+              assert_not calculator.eligible_for_free_childcare_2yr_olds?
+            end
+          end
 
-          calculator.where_do_you_live = "northern-ireland"
-          calculator.children_living_with_you = "yes"
-          calculator.age_of_children = "2"
-          assert_not calculator.eligible_for_free_childcare_2yr_olds?
-
-          calculator.where_do_you_live = "england"
-          calculator.children_living_with_you = "yes"
-          calculator.age_of_children = "1_or_under,3_to_4"
-          assert_not calculator.eligible_for_free_childcare_2yr_olds?
+          should "be false if country is Scotland or Northern Ireland with a child aged 2" do
+            %w[scotland northern-ireland].each do |country|
+              calculator = CheckBenefitsSupportCalculator.new
+              calculator.where_do_you_live = country
+              calculator.age_of_children = "2"
+              assert_not calculator.eligible_for_free_childcare_2yr_olds?
+            end
+          end
         end
       end
 

--- a/test/unit/calculators/checks_benefits_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_support_calculator_test.rb
@@ -948,31 +948,38 @@ module SmartAnswer::Calculators
       end
 
       context "#eligible_for_funded_early_learning_and_childcare?" do
-        should "return true if eligible for Funded Early Learning and Childcare" do
-          calculator = CheckBenefitsSupportCalculator.new
-          calculator.where_do_you_live = "scotland"
-          calculator.children_living_with_you = "yes"
-          %w[2 3_to_4].each do |age|
-            calculator.age_of_children = age
-            assert calculator.eligible_for_funded_early_learning_and_childcare?
+        context "when eligible" do
+          should "be true if country is Scotland, with child aged 2 or 3 to 4" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.where_do_you_live = "scotland"
+            calculator.children_living_with_you = "yes"
+            %w[2 3_to_4].each do |age|
+              calculator.age_of_children = age
+              assert calculator.eligible_for_funded_early_learning_and_childcare?
+            end
           end
         end
 
-        should "return false if not eligible for Funded Early Learning and Childcare" do
-          calculator = CheckBenefitsSupportCalculator.new
-          calculator.where_do_you_live = "england"
-          calculator.children_living_with_you = "yes"
-          calculator.age_of_children = "2"
-          assert_not calculator.eligible_for_funded_early_learning_and_childcare?
+        context "when ineligible" do
+          should "be false if country is Scotland, with child not aged 2 or 3 to 4" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.where_do_you_live = "scotland"
+            calculator.children_living_with_you = "yes"
+            calculator.age_of_children = "5_to_11"
+            assert_not calculator.eligible_for_funded_early_learning_and_childcare?
+          end
 
-          calculator.where_do_you_live = "scotland"
-          calculator.children_living_with_you = "no"
-          assert_not calculator.eligible_for_funded_early_learning_and_childcare?
-
-          calculator.where_do_you_live = "scotland"
-          calculator.children_living_with_you = "yes"
-          calculator.age_of_children = "1_or_under,18_to_19"
-          assert_not calculator.eligible_for_funded_early_learning_and_childcare?
+          should "be false is country is not Scotland with child aged 2 or 3 to 4" do
+            %w[england wales northern-ireland].each do |country|
+              calculator = CheckBenefitsSupportCalculator.new
+              calculator.where_do_you_live = country
+              calculator.children_living_with_you = "yes"
+              %w[2 3_to_4].each do |age|
+                calculator.age_of_children = age
+                assert_not calculator.eligible_for_funded_early_learning_and_childcare?
+              end
+            end
+          end
         end
       end
 

--- a/test/unit/calculators/checks_benefits_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_support_calculator_test.rb
@@ -1282,26 +1282,36 @@ module SmartAnswer::Calculators
       end
 
       context "#eligible_for_attendance_allowance?" do
-        should "return true if eligible for Attendance Allowance" do
-          calculator = CheckBenefitsSupportCalculator.new
-          calculator.over_state_pension_age = "yes"
-          calculator.disability_or_health_condition = "yes"
-          assert calculator.eligible_for_attendance_allowance?
+        context "when eligible" do
+          should "be true if over state pension age with a health condition" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.over_state_pension_age = "yes"
+            calculator.disability_or_health_condition = "yes"
+            assert calculator.eligible_for_attendance_allowance?
+          end
         end
 
-        should "return false if not eligible for Attendance Allowance" do
-          calculator = CheckBenefitsSupportCalculator.new
-          calculator.over_state_pension_age = "no"
-          calculator.disability_or_health_condition = "no"
-          assert_not calculator.eligible_for_attendance_allowance?
+        context "when ineligible" do
+          should "be false if over state pension age WITHOUT a health condition" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.over_state_pension_age = "yes"
+            calculator.disability_or_health_condition = "no"
+            assert_not calculator.eligible_for_attendance_allowance?
+          end
 
-          calculator.over_state_pension_age = "no"
-          calculator.disability_or_health_condition = "yes"
-          assert_not calculator.eligible_for_attendance_allowance?
+          should "be false if UNDER state pension age with a health condition" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.over_state_pension_age = "no"
+            calculator.disability_or_health_condition = "yes"
+            assert_not calculator.eligible_for_attendance_allowance?
+          end
 
-          calculator.over_state_pension_age = "yes"
-          calculator.disability_or_health_condition = "no"
-          assert_not calculator.eligible_for_attendance_allowance?
+          should "be false if UNDER state pension age WIHTOUT a health condition" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.over_state_pension_age = "no"
+            calculator.disability_or_health_condition = "no"
+            assert_not calculator.eligible_for_attendance_allowance?
+          end
         end
       end
 

--- a/test/unit/calculators/checks_benefits_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_support_calculator_test.rb
@@ -1098,42 +1098,92 @@ module SmartAnswer::Calculators
       end
 
       context "#eligible_for_personal_independence_payment?" do
-        should "return true if eligible for Personal Independence Payment (scenario 1)" do
-          calculator = CheckBenefitsSupportCalculator.new
+        context "when eligible" do
+          should "be true if country is not NI, under state pension age, without health condition and with child aged 16 to 19 with a health condition" do
+            %w[england wales scotland].each do |country|
+              calculator = CheckBenefitsSupportCalculator.new
+              calculator.where_do_you_live = country
+              calculator.over_state_pension_age = "no"
+              calculator.disability_or_health_condition = "no"
+              calculator.children_living_with_you = "yes"
+              %w[16_to_17 18_to_19].each do |age|
+                calculator.age_of_children = age
+                calculator.children_with_disability = "yes"
+                assert calculator.eligible_for_personal_independence_payment?
+              end
+            end
+          end
+
+          should "be true if country is not NI, under state pension age and with a health condition" do
+            %w[england wales scotland].each do |country|
+              calculator = CheckBenefitsSupportCalculator.new
+              calculator.where_do_you_live = country
+              calculator.over_state_pension_age = "no"
+              calculator.disability_or_health_condition = "yes"
+              assert calculator.eligible_for_personal_independence_payment?
+            end
+          end
+        end
+
+        context "when ineligible" do
+          should "be false if county is NI, under state pension age, without health condition and with child aged 16 to 19" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.where_do_you_live = "northern-ireland"
+            calculator.over_state_pension_age = "no"
+            calculator.disability_or_health_condition = "no"
+            calculator.children_living_with_you = "yes"
+            %w[16_to_17 18_to_19].each do |age|
+              calculator.age_of_children = age
+              assert_not calculator.eligible_for_personal_independence_payment?
+            end
+          end
+
+          should "be false if country is NI, under state pension age and with a health condition" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.where_do_you_live = "northern-ireland"
+            calculator.over_state_pension_age = "no"
+            calculator.disability_or_health_condition = "yes"
+            assert_not calculator.eligible_for_personal_independence_payment?
+          end
+        end
+
+        should "be false if country is not NI, OVER state pension age, without health condition and with child aged 16 to 19" do
           %w[england wales scotland].each do |country|
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.where_do_you_live = country
+            calculator.over_state_pension_age = "yes"
+            calculator.disability_or_health_condition = "no"
+            calculator.children_living_with_you = "yes"
+            %w[16_to_17 18_to_19].each do |age|
+              calculator.age_of_children = age
+              assert_not calculator.eligible_for_personal_independence_payment?
+            end
+          end
+        end
+
+        should "be false if country is not NI, under state pension age, without health condition and with child aged 16 to 19 without a health condition" do
+          %w[england wales scotland].each do |country|
+            calculator = CheckBenefitsSupportCalculator.new
             calculator.where_do_you_live = country
             calculator.over_state_pension_age = "no"
             calculator.disability_or_health_condition = "no"
             calculator.children_living_with_you = "yes"
             %w[16_to_17 18_to_19].each do |age|
               calculator.age_of_children = age
-              calculator.children_with_disability = "yes"
-              assert calculator.eligible_for_personal_independence_payment?
+              calculator.children_with_disability = "no"
+              assert_not calculator.eligible_for_personal_independence_payment?
             end
           end
         end
 
-        should "return true if eligible for Personal Independence Payment (scenario 2)" do
-          calculator = CheckBenefitsSupportCalculator.new
+        should "be false if country is not NI, under state pension age, without health condition and with child not aged 16 to 19" do
           %w[england wales scotland].each do |country|
+            calculator = CheckBenefitsSupportCalculator.new
             calculator.where_do_you_live = country
             calculator.over_state_pension_age = "no"
-            calculator.disability_or_health_condition = "yes"
-            assert calculator.eligible_for_personal_independence_payment?
-          end
-        end
-
-        should "return false if not eligible for Personal Independence Payment" do
-          calculator = CheckBenefitsSupportCalculator.new
-          calculator.where_do_you_live = "northern-ireland"
-          calculator.over_state_pension_age = "no"
-          calculator.disability_or_health_condition = "yes"
-          assert_not calculator.eligible_for_personal_independence_payment?
-          calculator.disability_or_health_condition = "no"
-          calculator.children_living_with_you = "yes"
-          %w[16_to_17 18_to_19].each do |age|
-            calculator.age_of_children = age
-            calculator.children_with_disability = "no"
+            calculator.disability_or_health_condition = "no"
+            calculator.children_living_with_you = "yes"
+            calculator.age_of_children = "5_to_11"
             assert_not calculator.eligible_for_personal_independence_payment?
           end
         end

--- a/test/unit/calculators/checks_benefits_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_support_calculator_test.rb
@@ -1414,61 +1414,76 @@ module SmartAnswer::Calculators
       end
 
       context "#eligible_for_nhs_low_income_scheme?" do
-        should "return true if eligible for NHS Low Income Scheme" do
-          %w[england wales].each do |country|
-            calculator = CheckBenefitsSupportCalculator.new
-            calculator.where_do_you_live = country
-            calculator.assets_and_savings = "under_16000"
-            assert calculator.eligible_for_nhs_low_income_scheme?
+        context "when eligible" do
+          should "be true if country is England or Wales with under 16000 assets" do
+            %w[england wales].each do |country|
+              calculator = CheckBenefitsSupportCalculator.new
+              calculator.where_do_you_live = country
+              calculator.assets_and_savings = "under_16000"
+              assert calculator.eligible_for_nhs_low_income_scheme?
+            end
           end
         end
 
-        should "return false if not eligible for NHS Low Income Scheme" do
-          calculator = CheckBenefitsSupportCalculator.new
-          %w[england wales].each do |country|
-            calculator.where_do_you_live = country
-            calculator.assets_and_savings = "over_16000"
-            assert_not calculator.eligible_for_nhs_low_income_scheme?
+        context "when ineligible" do
+          should "be false if country is England or Wales with OVER 1600 assets" do
+            %w[england wales].each do |country|
+              calculator = CheckBenefitsSupportCalculator.new
+              calculator.where_do_you_live = country
+              calculator.assets_and_savings = "over_16000"
+              assert_not calculator.eligible_for_nhs_low_income_scheme?
+            end
           end
 
-          %w[scotland northern-ireland].each do |country|
-            calculator.where_do_you_live = country
-            %w[under_16000 over_16000].each do |assets|
-              calculator.assets_and_savings = assets
-              assert_not calculator.eligible_for_nhs_low_income_scheme?
+          should "be false country is not England or Wales with assets above OR below 16000" do
+            %w[scotland northern-ireland].each do |country|
+              calculator = CheckBenefitsSupportCalculator.new
+              calculator.where_do_you_live = country
+              %w[under_16000 over_16000].each do |assets|
+                calculator.assets_and_savings = assets
+                assert_not calculator.eligible_for_nhs_low_income_scheme?
+              end
             end
           end
         end
       end
 
-      context "#eligible_for_help_with_help_costs?" do
-        should "return true if eligible for Help With Health Costs" do
-          calculator = CheckBenefitsSupportCalculator.new
-          calculator.where_do_you_live = "scotland"
-          assert calculator.eligible_for_help_with_health_costs?
+      context "#eligible_for_help_with_health_costs?" do
+        context "when eligible" do
+          should "be true if country is Scotland" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.where_do_you_live = "scotland"
+            assert calculator.eligible_for_help_with_health_costs?
+          end
         end
 
-        should "return false if not eligible for Help With Health Costs" do
-          %w[england wales northern-ireland].each do |country|
-            calculator = CheckBenefitsSupportCalculator.new
-            calculator.where_do_you_live = country
-            assert_not calculator.eligible_for_help_with_health_costs?
+        context "when ineligible" do
+          should "be false if country is not Scotland" do
+            %w[england wales northern-ireland].each do |country|
+              calculator = CheckBenefitsSupportCalculator.new
+              calculator.where_do_you_live = country
+              assert_not calculator.eligible_for_help_with_health_costs?
+            end
           end
         end
       end
 
       context "#eligible_for_nhs_low_income_scheme_northern_ireland?" do
-        should "return true if eligible for NHS Low Income Scheme Northern Ireland" do
-          calculator = CheckBenefitsSupportCalculator.new
-          calculator.where_do_you_live = "northern-ireland"
-          assert calculator.eligible_for_nhs_low_income_scheme_northern_ireland?
+        context "when eligible" do
+          should "be true if country is Northern Ireland" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.where_do_you_live = "northern-ireland"
+            assert calculator.eligible_for_nhs_low_income_scheme_northern_ireland?
+          end
         end
 
-        should "return false if not eligible for NHS Low Income Scheme Northern Ireland" do
-          %w[england wales scotland].each do |country|
-            calculator = CheckBenefitsSupportCalculator.new
-            calculator.where_do_you_live = country
-            assert_not calculator.eligible_for_nhs_low_income_scheme_northern_ireland?
+        context "when ineligible" do
+          should "be false if country is not Northern Ireland" do
+            %w[england wales scotland].each do |country|
+              calculator = CheckBenefitsSupportCalculator.new
+              calculator.where_do_you_live = country
+              assert_not calculator.eligible_for_nhs_low_income_scheme_northern_ireland?
+            end
           end
         end
       end

--- a/test/unit/calculators/checks_benefits_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_support_calculator_test.rb
@@ -898,56 +898,50 @@ module SmartAnswer::Calculators
       end
 
       context "#eligible_for_30hrs_free_childcare_3_4yrs?" do
-        should "return true if eligible for 30 Hours Free Childcare for 3 and 4 Year Olds" do
-          calculator = CheckBenefitsSupportCalculator.new
-          calculator.where_do_you_live = "england"
-          %w[yes_over_16_hours_per_week yes_under_16_hours_per_week].each do |working_hours|
-            calculator.are_you_working = working_hours
-            calculator.children_living_with_you = "yes"
-            calculator.age_of_children = "3_to_4"
-            assert calculator.eligible_for_30hrs_free_childcare_3_4yrs?
-          end
-        end
-
-        should "return false if not eligible for 30 Hours Free Childcare for 3 and 4 Year Olds - not working" do
-          calculator = CheckBenefitsSupportCalculator.new
-          calculator.where_do_you_live = "england"
-          calculator.are_you_working = "no"
-          calculator.children_living_with_you = "yes"
-          calculator.age_of_children = "3_to_4"
-          assert_not calculator.eligible_for_30hrs_free_childcare_3_4yrs?
-        end
-
-        should "return false if not eligible for 30 Hours Free Childcare for 3 and 4 Year Olds - no children" do
-          calculator = CheckBenefitsSupportCalculator.new
-          calculator.where_do_you_live = "england"
-          %w[yes_over_16_hours_per_week yes_under_16_hours_per_week].each do |working_hours|
-            calculator.are_you_working = working_hours
-            calculator.children_living_with_you = "no"
-            assert_not calculator.eligible_for_30hrs_free_childcare_3_4yrs?
-          end
-        end
-
-        should "return false if not eligible for 30 Hours Free Childcare for 3 and 4 Year Olds - older children" do
-          calculator = CheckBenefitsSupportCalculator.new
-          calculator.where_do_you_live = "england"
-          %w[yes_over_16_hours_per_week yes_under_16_hours_per_week].each do |working_hours|
-            calculator.are_you_working = working_hours
-            calculator.children_living_with_you = "yes"
-            calculator.age_of_children = "5 to 11"
-            assert_not calculator.eligible_for_30hrs_free_childcare_3_4yrs?
-          end
-        end
-
-        should "return false if not eligible for 30 Hours Free Childcare for 3 and 4 Year Olds - wrong country" do
-          calculator = CheckBenefitsSupportCalculator.new
-          %w[wales scotland northern-ireland].each do |country|
-            calculator.where_do_you_live = country
+        context "when eligible" do
+          should "be true if country is England, working, with child aged 3 to 4" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.where_do_you_live = "england"
             %w[yes_over_16_hours_per_week yes_under_16_hours_per_week].each do |working_hours|
               calculator.are_you_working = working_hours
               calculator.children_living_with_you = "yes"
               calculator.age_of_children = "3_to_4"
+              assert calculator.eligible_for_30hrs_free_childcare_3_4yrs?
+            end
+          end
+        end
+
+        context "when ineligible" do
+          should "be false if country is England, working, with child not aged 3 to 4" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.where_do_you_live = "england"
+            %w[yes_over_16_hours_per_week yes_under_16_hours_per_week].each do |working_hours|
+              calculator.are_you_working = working_hours
+              calculator.children_living_with_you = "yes"
+              calculator.age_of_children = "1,5_to_11"
               assert_not calculator.eligible_for_30hrs_free_childcare_3_4yrs?
+            end
+          end
+
+          should "be false if country is England, not working, with child aged 3 to 4" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.where_do_you_live = "england"
+            calculator.are_you_working = "no"
+            calculator.children_living_with_you = "yes"
+            calculator.age_of_children = "3_to_4"
+            assert_not calculator.eligible_for_30hrs_free_childcare_3_4yrs?
+          end
+
+          should "be false if country is not England, working, with child aged 3 to 4" do
+            %w[wales northern-ireland scotland].each do |country|
+              calculator = CheckBenefitsSupportCalculator.new
+              calculator.where_do_you_live = country
+              %w[yes_over_16_hours_per_week yes_under_16_hours_per_week].each do |working_hours|
+                calculator.are_you_working = working_hours
+                calculator.children_living_with_you = "yes"
+                calculator.age_of_children = "3_to_4"
+                assert_not calculator.eligible_for_30hrs_free_childcare_3_4yrs?
+              end
             end
           end
         end

--- a/test/unit/calculators/checks_benefits_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_support_calculator_test.rb
@@ -859,27 +859,41 @@ module SmartAnswer::Calculators
       end
 
       context "#eligible_for_15hrs_free_childcare_3_4yr_olds?" do
-        should "return true if eligible for 15 Hours Free Childcare for 3 and 4 Year Olds" do
-          calculator = CheckBenefitsSupportCalculator.new
-          calculator.where_do_you_live = "england"
-          calculator.children_living_with_you = "yes"
-          calculator.age_of_children = "3_to_4"
-          assert calculator.eligible_for_15hrs_free_childcare_3_4yr_olds?
+        context "when eligible" do
+          should "be true if country is England, with child aged 3 to 4" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.where_do_you_live = "england"
+            calculator.children_living_with_you = "yes"
+            calculator.age_of_children = "1,3_to_4"
+            assert calculator.eligible_for_15hrs_free_childcare_3_4yr_olds?
+          end
         end
 
-        should "return false if not eligible for Childcare 3 and 4 Year Olds Wales" do
-          calculator = CheckBenefitsSupportCalculator.new
-          calculator.where_do_you_live = "scotland"
-          assert_not calculator.eligible_for_15hrs_free_childcare_3_4yr_olds?
+        context "when ineligible" do
+          should "be false if country is not England with child aged 3 to 4" do
+            %w[scotland wales northern-ireland].each do |country|
+              calculator = CheckBenefitsSupportCalculator.new
+              calculator.where_do_you_live = country
+              calculator.children_living_with_you = "yes"
+              calculator.age_of_children = "1,3_to_4"
+              assert_not calculator.eligible_for_15hrs_free_childcare_3_4yr_olds?
+            end
+          end
 
-          calculator.where_do_you_live = "england"
-          calculator.children_living_with_you = "no"
-          assert_not calculator.eligible_for_15hrs_free_childcare_3_4yr_olds?
+          should "be false if country is England without children" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.where_do_you_live = "england"
+            calculator.children_living_with_you = "no"
+            assert_not calculator.eligible_for_15hrs_free_childcare_3_4yr_olds?
+          end
 
-          calculator.where_do_you_live = "england"
-          calculator.children_living_with_you = "yes"
-          calculator.age_of_children = "2, 18_to_19"
-          assert_not calculator.eligible_for_15hrs_free_childcare_3_4yr_olds?
+          should "be false if country is England with child not aged 3 to 4" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.where_do_you_live = "england"
+            calculator.children_living_with_you = "yes"
+            calculator.age_of_children = "1,5_to_11"
+            assert_not calculator.eligible_for_15hrs_free_childcare_3_4yr_olds?
+          end
         end
       end
 

--- a/test/unit/calculators/checks_benefits_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_support_calculator_test.rb
@@ -1190,37 +1190,91 @@ module SmartAnswer::Calculators
       end
 
       context "#eligible_for_personal_independence_payment_northern_ireland?" do
-        should "return true if eligible for Personal Independence Payment (NI) (scenario 1)" do
-          calculator = CheckBenefitsSupportCalculator.new
-          calculator.where_do_you_live = "northern-ireland"
-          calculator.over_state_pension_age = "no"
-          calculator.disability_or_health_condition = "no"
-          calculator.children_living_with_you = "yes"
-          %w[16_to_17 18_to_19].each do |age|
-            calculator.age_of_children = age
-            calculator.children_with_disability = "yes"
-            assert calculator.eligible_for_personal_independence_payment_northern_ireland?
-          end
-        end
-
-        should "return true if eligible for Personal Independence Payment (NI) (scenario 2)" do
-          calculator = CheckBenefitsSupportCalculator.new
-          calculator.where_do_you_live = "northern-ireland"
-          calculator.over_state_pension_age = "no"
-          calculator.disability_or_health_condition = "yes"
-          assert calculator.eligible_for_personal_independence_payment_northern_ireland?
-        end
-
-        should "return false if not eligible for Personal Independence Payment (NI)" do
-          calculator = CheckBenefitsSupportCalculator.new
-          %w[england wales scotland].each do |country|
-            calculator.where_do_you_live = country
+        context "when eligible" do
+          should "be true if country is Northern Ireland, under state pension age, no health condition and a child aged 16 to 19 with a health condition" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.where_do_you_live = "northern-ireland"
             calculator.over_state_pension_age = "no"
             calculator.disability_or_health_condition = "no"
             calculator.children_living_with_you = "yes"
             %w[16_to_17 18_to_19].each do |age|
               calculator.age_of_children = age
-              calculator.children_with_disability = "no"
+              calculator.children_with_disability = "yes"
+              assert calculator.eligible_for_personal_independence_payment_northern_ireland?
+            end
+          end
+
+          should "be true if country is Northern Ireland, under state pension age, with a health condition" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.where_do_you_live = "northern-ireland"
+            calculator.over_state_pension_age = "no"
+            calculator.disability_or_health_condition = "yes"
+            assert calculator.eligible_for_personal_independence_payment_northern_ireland?
+          end
+        end
+
+        context "when ineligible" do
+          should "be false if country is Northern Ireland, under state pension age, no health condition and a child not aged 16 to 19" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.where_do_you_live = "northern-ireland"
+            calculator.over_state_pension_age = "no"
+            calculator.disability_or_health_condition = "no"
+            calculator.children_living_with_you = "yes"
+            calculator.age_of_children = "5_to_11"
+            assert_not calculator.eligible_for_personal_independence_payment_northern_ireland?
+          end
+
+          should "be false if country is Northern Ireland, OVER state pension age, no health condition and a child aged 16 to 19 wth a health condition" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.where_do_you_live = "northern-ireland"
+            calculator.over_state_pension_age = "yes"
+            calculator.disability_or_health_condition = "no"
+            calculator.children_living_with_you = "yes"
+            calculator.age_of_children = "5_to_11"
+            %w[16_to_17 18_to_19].each do |age|
+              calculator.age_of_children = age
+              calculator.children_with_disability = "yes"
+              assert_not calculator.eligible_for_personal_independence_payment_northern_ireland?
+            end
+          end
+
+          should "be false if country is Northern Ireland, under state pension age, without a health condition" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.where_do_you_live = "northern-ireland"
+            calculator.over_state_pension_age = "no"
+            calculator.disability_or_health_condition = "no"
+            assert_not calculator.eligible_for_personal_independence_payment_northern_ireland?
+          end
+
+          should "be false if country is Northern Ireland, over state pension age, with a health condition" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.where_do_you_live = "northern-ireland"
+            calculator.over_state_pension_age = "yes"
+            calculator.disability_or_health_condition = "yes"
+            assert_not calculator.eligible_for_personal_independence_payment_northern_ireland?
+          end
+
+          should "be false if country is not NI, under state pension age, no health condition and a child aged 16 to 19 with a health condition" do
+            %w[england wales scotland].each do |country|
+              calculator = CheckBenefitsSupportCalculator.new
+              calculator.where_do_you_live = country
+              calculator.over_state_pension_age = "no"
+              calculator.disability_or_health_condition = "no"
+              calculator.children_living_with_you = "yes"
+              %w[16_to_17 18_to_19].each do |age|
+                calculator.age_of_children = age
+                calculator.children_with_disability = "yes"
+                assert_not calculator.eligible_for_personal_independence_payment_northern_ireland?
+              end
+            end
+          end
+
+          should "be false if country is not NI, under state pension age and with a health condition" do
+            %w[england wales scotland].each do |country|
+              calculator = CheckBenefitsSupportCalculator.new
+              calculator.where_do_you_live = country
+              calculator.over_state_pension_age = "no"
+              calculator.disability_or_health_condition = "yes"
               assert_not calculator.eligible_for_personal_independence_payment_northern_ireland?
             end
           end

--- a/test/unit/calculators/checks_benefits_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_support_calculator_test.rb
@@ -307,42 +307,68 @@ module SmartAnswer::Calculators
       end
 
       context "#eligible_for_jobseekers_allowance_northern_ireland?" do
-        should "return true if eligible for Jobseeker's Allowance (NI)" do
-          calculator = CheckBenefitsSupportCalculator.new
-          calculator.where_do_you_live = "northern-ireland"
-          calculator.over_state_pension_age = "no"
-          %w[no yes_under_16_hours_per_week].each do |working_hours|
-            calculator.are_you_working = working_hours
-            %w[no yes_limits_work].each do |affecting_work|
-              calculator.disability_affecting_work = affecting_work
-              assert calculator.eligible_for_jobseekers_allowance_northern_ireland?
-            end
-          end
-        end
-
-        should "return false if not eligible for Jobseeker's Allowance (NI)" do
-          calculator = CheckBenefitsSupportCalculator.new
-          calculator.where_do_you_live = "northern-ireland"
-          calculator.over_state_pension_age = "yes"
-          assert_not calculator.eligible_for_jobseekers_allowance_northern_ireland?
-
-          calculator.over_state_pension_age = "no"
-          calculator.are_you_working = "yes_over_16_hours_per_week"
-          assert_not calculator.eligible_for_jobseekers_allowance_northern_ireland?
-
-          calculator.over_state_pension_age = "no"
-          calculator.are_you_working = "yes_under_16_hours_per_week"
-          calculator.disability_affecting_work = "yes_unable_to_work"
-          assert_not calculator.eligible_for_jobseekers_allowance_northern_ireland?
-
-          %w[england wales scotland].each do |country|
-            calculator.where_do_you_live = country
+        context "when eligible" do
+          should "be true if country is NI, under state pension age, working under 16 hours, and a health condition that does not prevent work" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.where_do_you_live = "northern-ireland"
             calculator.over_state_pension_age = "no"
             %w[no yes_under_16_hours_per_week].each do |working_hours|
               calculator.are_you_working = working_hours
               %w[no yes_limits_work].each do |affecting_work|
                 calculator.disability_affecting_work = affecting_work
+                assert calculator.eligible_for_jobseekers_allowance_northern_ireland?
+              end
+            end
+          end
+        end
+
+        context "when ineligible" do
+          should "be false if country is NI, OVER state pension age, working under 16 hours, and a health condition that does not prevent work" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.where_do_you_live = "northern-ireland"
+            calculator.over_state_pension_age = "yes"
+            %w[no yes_under_16_hours_per_week].each do |working_hours|
+              calculator.are_you_working = working_hours
+              %w[no yes_limits_work].each do |affecting_work|
+                calculator.disability_affecting_work = affecting_work
                 assert_not calculator.eligible_for_jobseekers_allowance_northern_ireland?
+              end
+            end
+          end
+
+          should "be false if country is NI, under state pension age, working OVER 16 hours, and a health condition that does not prevent work" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.where_do_you_live = "northern-ireland"
+            calculator.over_state_pension_age = "no"
+            calculator.are_you_working = "yes_over_16_hours_per_week"
+            %w[no yes_limits_work].each do |affecting_work|
+              calculator.disability_affecting_work = affecting_work
+              assert_not calculator.eligible_for_jobseekers_allowance_northern_ireland?
+            end
+          end
+
+          should "be false if country is NI, under state pension age, working under 16 hours, and a health condition that prevents work" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.where_do_you_live = "northern-ireland"
+            calculator.over_state_pension_age = "no"
+            %w[no yes_under_16_hours_per_week].each do |working_hours|
+              calculator.are_you_working = working_hours
+              calculator.disability_affecting_work = "yes_unable_to_work"
+              assert_not calculator.eligible_for_jobseekers_allowance_northern_ireland?
+            end
+          end
+
+          should "be false if the country is not NI" do
+            %w[england wales scotland].each do |country|
+              calculator = CheckBenefitsSupportCalculator.new
+              calculator.where_do_you_live = country
+              calculator.over_state_pension_age = "no"
+              %w[no yes_under_16_hours_per_week].each do |working_hours|
+                calculator.are_you_working = working_hours
+                %w[no yes_limits_work].each do |affecting_work|
+                  calculator.disability_affecting_work = affecting_work
+                  assert_not calculator.eligible_for_jobseekers_allowance_northern_ireland?
+                end
               end
             end
           end

--- a/test/unit/calculators/checks_benefits_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_support_calculator_test.rb
@@ -813,35 +813,48 @@ module SmartAnswer::Calculators
       end
 
       context "#eligible_for_childcare_3_4yr_olds_wales??" do
-        should "return true if eligible for Childcare 3 and 4 Year Olds Wales" do
-          calculator = CheckBenefitsSupportCalculator.new
-          calculator.where_do_you_live = "wales"
-          calculator.are_you_working = "yes_over_16_hours_per_week"
-          calculator.children_living_with_you = "yes"
-          calculator.age_of_children = "3_to_4"
-          assert calculator.eligible_for_childcare_3_4yr_olds_wales?
+        context "when eligible" do
+          should "be true if country is Wales, working over 16 hours with child aged 3 to 4" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.where_do_you_live = "wales"
+            calculator.are_you_working = "yes_over_16_hours_per_week"
+            calculator.children_living_with_you = "yes"
+            calculator.age_of_children = "3_to_4"
+            assert calculator.eligible_for_childcare_3_4yr_olds_wales?
+          end
         end
 
-        should "return false if not eligible for Childcare 3 and 4 Year Olds Wales" do
-          calculator = CheckBenefitsSupportCalculator.new
-          calculator.where_do_you_live = "scotland"
-          assert_not calculator.eligible_for_childcare_3_4yr_olds_wales?
+        context "when ineligible" do
+          should "be false if country is not Wales, working over 16 hours with child aged 3 to 4" do
+            %w[england scotland northern-ireland].each do |country|
+              calculator = CheckBenefitsSupportCalculator.new
+              calculator.where_do_you_live = country
+              calculator.are_you_working = "yes_over_16_hours_per_week"
+              calculator.children_living_with_you = "yes"
+              calculator.age_of_children = "3_to_4"
+              assert_not calculator.eligible_for_childcare_3_4yr_olds_wales?
+            end
+          end
 
-          calculator.where_do_you_live = "wales"
-          calculator.are_you_working = "no"
-          assert_not calculator.eligible_for_childcare_3_4yr_olds_wales?
+          should "be false if country is Wales working under 16 hours with child aged 3 to 4" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.where_do_you_live = "wales"
+            %w[no yes_under_16_hours_per_week].each do |working_hours|
+              calculator.are_you_working = working_hours
+              calculator.children_living_with_you = "yes"
+              calculator.age_of_children = "3_to_4"
+              assert_not calculator.eligible_for_childcare_3_4yr_olds_wales?
+            end
+          end
 
-          calculator.where_do_you_live = "wales"
-          calculator.are_you_working = "yes_under_16_hours_per_week"
-          calculator.children_living_with_you = "yes"
-          calculator.age_of_children = "3_to_4"
-          assert_not calculator.eligible_for_childcare_3_4yr_olds_wales?
-
-          calculator.where_do_you_live = "wales"
-          calculator.are_you_working = "yes_over_16_hours_per_week"
-          calculator.children_living_with_you = "yes"
-          calculator.age_of_children = "1_or_under"
-          assert_not calculator.eligible_for_childcare_3_4yr_olds_wales?
+          should "be false if country is Wales working over 16 hours without child aged 3 to 4" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.where_do_you_live = "wales"
+            calculator.are_you_working = "yes_over_16_hours_per_week"
+            calculator.children_living_with_you = "yes"
+            calculator.age_of_children = "1,5_to_11"
+            assert_not calculator.eligible_for_childcare_3_4yr_olds_wales?
+          end
         end
       end
 

--- a/test/unit/calculators/checks_benefits_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_support_calculator_test.rb
@@ -1394,17 +1394,21 @@ module SmartAnswer::Calculators
       end
 
       context "#social_fund_budgeting_loan?" do
-        should "return true if eligible for Social Fund Budgeting Loan" do
-          calculator = CheckBenefitsSupportCalculator.new
-          calculator.where_do_you_live = "northern-ireland"
-          assert calculator.eligible_for_social_fund_budgeting_loan?
+        context "when eligible" do
+          should "be true if country is Northern Ireland" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.where_do_you_live = "northern-ireland"
+            assert calculator.eligible_for_social_fund_budgeting_loan?
+          end
         end
 
-        should "return false if not eligible for Social Fund Budgeting Loan" do
-          calculator = CheckBenefitsSupportCalculator.new
-          %w[england wales scotland].each do |country|
-            calculator.where_do_you_live = country
-            assert_not calculator.eligible_for_social_fund_budgeting_loan?
+        context "when ineligible" do
+          should "be false if country is not Northern Ireland" do
+            calculator = CheckBenefitsSupportCalculator.new
+            %w[england wales scotland].each do |country|
+              calculator.where_do_you_live = country
+              assert_not calculator.eligible_for_social_fund_budgeting_loan?
+            end
           end
         end
       end

--- a/test/unit/calculators/checks_benefits_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_support_calculator_test.rb
@@ -571,34 +571,42 @@ module SmartAnswer::Calculators
       end
 
       context "#eligible_for_universal_credit_ni?" do
-        should "return true if eligible for Universal Credit (NI)" do
-          calculator = CheckBenefitsSupportCalculator.new
-          calculator.where_do_you_live = "northern-ireland"
-          calculator.over_state_pension_age = "no"
-          calculator.assets_and_savings = "under_16000"
-          assert calculator.eligible_for_universal_credit_ni?
+        context "when eligible" do
+          should "be true if country is NI, under state pension and under 16000 assets" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.where_do_you_live = "northern-ireland"
+            calculator.over_state_pension_age = "no"
+            calculator.assets_and_savings = "under_16000"
+            assert calculator.eligible_for_universal_credit_ni?
+          end
         end
 
-        should "return false if not eligible for Universal Credit (NI)" do
-          calculator = CheckBenefitsSupportCalculator.new
-          %w[england wales scotland].each do |country|
-            calculator.where_do_you_live = country
-            calculator.over_state_pension_age = "yes"
-            assert_not calculator.eligible_for_universal_credit_ni?
+        context "when ineligible" do
+          should "be false if country in not NI, under state pension age and under 16000 assets" do
+            %w[england wales scotland].each do |country|
+              calculator = CheckBenefitsSupportCalculator.new
+              calculator.where_do_you_live = country
+              calculator.over_state_pension_age = "no"
+              calculator.assets_and_savings = "over_16000"
+              assert_not calculator.eligible_for_universal_credit_ni?
+            end
+          end
 
+          should "be false if country is NI, over state pension age and under 16000 assets" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.where_do_you_live = "northern-ireland"
+            calculator.over_state_pension_age = "yes"
+            calculator.assets_and_savings = "under_16000"
+            assert_not calculator.eligible_for_universal_credit_ni?
+          end
+
+          should "be false if country is NI, under state pension age and over 16000 assets" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.where_do_you_live = "northern-ireland"
             calculator.over_state_pension_age = "no"
             calculator.assets_and_savings = "over_16000"
             assert_not calculator.eligible_for_universal_credit_ni?
           end
-
-          calculator.where_do_you_live = "northern-ireland"
-          calculator.over_state_pension_age = "yes"
-          assert_not calculator.eligible_for_universal_credit_ni?
-
-          calculator.where_do_you_live = "northern-ireland"
-          calculator.over_state_pension_age = "no"
-          calculator.assets_and_savings = "over_16000"
-          assert_not calculator.eligible_for_universal_credit_ni?
         end
       end
 

--- a/test/unit/calculators/checks_benefits_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_support_calculator_test.rb
@@ -1002,33 +1002,56 @@ module SmartAnswer::Calculators
       end
 
       context "#eligible_for_disability_living_allowance_for_children?" do
-        should "return true if eligible for Disability Living Allowance for Children" do
-          calculator = CheckBenefitsSupportCalculator.new
-          %w[england wales northern-ireland].each do |country|
-            calculator.where_do_you_live = country
-            calculator.children_living_with_you = "yes"
-            calculator.children_with_disability = "yes"
-            %w[1_or_under 2 3_to_4 5_to_11 12_to_15].each do |age|
-              calculator.age_of_children = age
-              assert calculator.eligible_for_disability_living_allowance_for_children?
+        context "when eligible" do
+          should "be true if country is not Scotland, living with child with disability aged under 15" do
+            %w[england wales northern-ireland].each do |country|
+              calculator = CheckBenefitsSupportCalculator.new
+              calculator.where_do_you_live = country
+              calculator.children_living_with_you = "yes"
+              calculator.children_with_disability = "yes"
+              %w[1_or_under 2 3_to_4 5_to_11 12_to_15].each do |age|
+                calculator.age_of_children = age
+                assert calculator.eligible_for_disability_living_allowance_for_children?
+              end
             end
           end
         end
 
-        should "return false if not eligible for Disability Living Allowance for Children" do
-          calculator = CheckBenefitsSupportCalculator.new
-          calculator.where_do_you_live = "scotland"
-          assert_not calculator.eligible_for_disability_living_allowance_for_children?
+        context "when ineligible" do
+          should "be false if country is Scotland, living with child with disability aged under 15" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.where_do_you_live = "scotland"
+            calculator.children_living_with_you = "yes"
+            calculator.children_with_disability = "yes"
+            %w[1_or_under 2 3_to_4 5_to_11 12_to_15].each do |age|
+              calculator.age_of_children = age
+              assert_not calculator.eligible_for_disability_living_allowance_for_children?
+            end
+          end
 
-          calculator.where_do_you_live = "england"
-          calculator.children_living_with_you = "yes"
-          calculator.age_of_children = "1_or_under"
-          calculator.children_with_disability = "no"
-          assert_not calculator.eligible_for_disability_living_allowance_for_children?
+          should "be false if country is not Scotland, living with child with disability aged 18 to 19" do
+            %w[england wales northern-ireland].each do |country|
+              calculator = CheckBenefitsSupportCalculator.new
+              calculator.where_do_you_live = country
+              calculator.children_living_with_you = "yes"
+              calculator.children_with_disability = "yes"
+              calculator.age_of_children = "18_to_19"
+              assert_not calculator.eligible_for_disability_living_allowance_for_children?
+            end
+          end
 
-          calculator.where_do_you_live = "england"
-          calculator.children_living_with_you = "no"
-          assert_not calculator.eligible_for_disability_living_allowance_for_children?
+          should "be false if country is not Scotland, living with child WITHOUT disability aged under 15" do
+            %w[england wales northern-ireland].each do |country|
+              calculator = CheckBenefitsSupportCalculator.new
+              calculator.where_do_you_live = country
+              calculator.children_living_with_you = "yes"
+              calculator.children_with_disability = "no"
+              %w[1_or_under 2 3_to_4 5_to_11 12_to_15].each do |age|
+                calculator.age_of_children = age
+                assert_not calculator.eligible_for_disability_living_allowance_for_children?
+              end
+            end
+          end
         end
       end
 

--- a/test/unit/calculators/checks_benefits_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_support_calculator_test.rb
@@ -376,24 +376,31 @@ module SmartAnswer::Calculators
       end
 
       context "#eligible_for_pension_credit?" do
-        should "return true if eligible for Pension Credit" do
-          calculator = CheckBenefitsSupportCalculator.new
-          %w[england wales scotland].each do |country|
-            calculator.where_do_you_live = country
-            calculator.over_state_pension_age = "yes"
-            assert calculator.eligible_for_pension_credit?
+        context "when eligible" do
+          should "be true if country is not NI and over state pension age" do
+            %w[england wales scotland].each do |country|
+              calculator = CheckBenefitsSupportCalculator.new
+              calculator.where_do_you_live = country
+              calculator.over_state_pension_age = "yes"
+              assert calculator.eligible_for_pension_credit?
+            end
           end
         end
 
-        should "return false if not eligible for Pension Credit" do
-          calculator = CheckBenefitsSupportCalculator.new
-          calculator.where_do_you_live = "northern-ireland"
-          calculator.over_state_pension_age = "yes"
-          assert_not calculator.eligible_for_pension_credit?
+        context "when ineligible" do
+          should "be false if country is not NI and UNDER state pension age" do
+            %w[england wales scotland].each do |country|
+              calculator = CheckBenefitsSupportCalculator.new
+              calculator.where_do_you_live = country
+              calculator.over_state_pension_age = "no"
+              assert_not calculator.eligible_for_pension_credit?
+            end
+          end
 
-          %w[england wales scotland].each do |country|
-            calculator.where_do_you_live = country
-            calculator.over_state_pension_age = "no"
+          should "be false if country is NI " do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.where_do_you_live = "northern-ireland"
+            calculator.over_state_pension_age = "yes"
             assert_not calculator.eligible_for_pension_credit?
           end
         end

--- a/test/unit/calculators/checks_benefits_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_support_calculator_test.rb
@@ -482,37 +482,46 @@ module SmartAnswer::Calculators
         end
       end
 
-      context "#eligible_for_access_to_work_northern_ireland??" do
-        should "return true if eligible for Access to Work (NI)" do
-          calculator = CheckBenefitsSupportCalculator.new
-          calculator.where_do_you_live = "northern-ireland"
-          calculator.disability_or_health_condition = "yes"
-          calculator.disability_affecting_work = "no"
-          assert calculator.eligible_for_access_to_work_northern_ireland?
-
-          calculator.disability_affecting_work = "yes_limits_work"
-          assert calculator.eligible_for_access_to_work_northern_ireland?
+      context "#eligible_for_access_to_work_northern_ireland?" do
+        context "when eligible" do
+          should "be true if country is NI, with healh condition that does not prevent work" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.where_do_you_live = "northern-ireland"
+            calculator.disability_or_health_condition = "yes"
+            %w[no yes_limits_work].each do |affecting_work|
+              calculator.disability_affecting_work = affecting_work
+              assert calculator.eligible_for_access_to_work_northern_ireland?
+            end
+          end
         end
 
-        should "return false if not eligible for Access to Work (NI)" do
-          calculator = CheckBenefitsSupportCalculator.new
-          %w[england wales scotland].each do |country|
-            calculator.where_do_you_live = country
-            calculator.disability_or_health_condition = "yes"
-            calculator.disability_affecting_work = "no"
-            assert_not calculator.eligible_for_access_to_work_northern_ireland?
+        context "when ineligible" do
+          should "be false if the country is not NI, with health condition that does not prevent work" do
+            %w[england wales scotland].each do |country|
+              calculator = CheckBenefitsSupportCalculator.new
+              calculator.where_do_you_live = country
+              calculator.disability_or_health_condition = "yes"
+              %w[no yes_limits_work].each do |affecting_work|
+                calculator.disability_affecting_work = affecting_work
+                assert_not calculator.eligible_for_access_to_work_northern_ireland?
+              end
+            end
+          end
 
-            calculator.disability_affecting_work = "yes_limits_work"
+          should "return false if country is NI, without a health condition" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.where_do_you_live = "northern-ireland"
+            calculator.disability_or_health_condition = "no"
             assert_not calculator.eligible_for_access_to_work_northern_ireland?
           end
 
-          calculator.where_do_you_live = "northern-ireland"
-          calculator.disability_or_health_condition = "no"
-          assert_not calculator.eligible_for_access_to_work_northern_ireland?
-
-          calculator.disability_or_health_condition = "yes"
-          calculator.disability_affecting_work = "yes_unable_to_work"
-          assert_not calculator.eligible_for_access_to_work_northern_ireland?
+          should "return false if country is NI, with a health condition that DOES prevent work" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.where_do_you_live = "northern-ireland"
+            calculator.disability_or_health_condition = "yes"
+            calculator.disability_affecting_work = "yes_unable_to_work"
+            assert_not calculator.eligible_for_access_to_work_northern_ireland?
+          end
         end
       end
 

--- a/test/unit/calculators/checks_benefits_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_support_calculator_test.rb
@@ -1316,18 +1316,22 @@ module SmartAnswer::Calculators
       end
 
       context "#eligible_for_council_tax_reduction?" do
-        should "return true if eligible for Council Tax Reduction" do
-          calculator = CheckBenefitsSupportCalculator.new
-          %w[england wales scotland].each do |country|
-            calculator.where_do_you_live = country
-            assert calculator.eligible_for_council_tax_reduction?
+        context "when eligible" do
+          should "be true if country is not Northern Ireland" do
+            calculator = CheckBenefitsSupportCalculator.new
+            %w[england wales scotland].each do |country|
+              calculator.where_do_you_live = country
+              assert calculator.eligible_for_council_tax_reduction?
+            end
           end
-        end
 
-        should "return false if not eligible for Council Tax Reduction" do
-          calculator = CheckBenefitsSupportCalculator.new
-          calculator.where_do_you_live = "northern-ireland"
-          assert_not calculator.eligible_for_council_tax_reduction?
+          context "ineligible" do
+            should "be false if country is Northern Ireland" do
+              calculator = CheckBenefitsSupportCalculator.new
+              calculator.where_do_you_live = "northern-ireland"
+              assert_not calculator.eligible_for_council_tax_reduction?
+            end
+          end
         end
       end
 

--- a/test/unit/calculators/checks_benefits_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_support_calculator_test.rb
@@ -1336,17 +1336,21 @@ module SmartAnswer::Calculators
       end
 
       context "#eligible_for_rate_relief?" do
-        should "return true if eligible for Rate Relief" do
-          calculator = CheckBenefitsSupportCalculator.new
-          calculator.where_do_you_live = "northern-ireland"
-          assert calculator.eligible_for_rate_relief?
+        context "when eligible" do
+          should "be true if country is Northern Ireland" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.where_do_you_live = "northern-ireland"
+            assert calculator.eligible_for_rate_relief?
+          end
         end
 
-        should "return false if not eligible for Rate Relief" do
-          calculator = CheckBenefitsSupportCalculator.new
-          %w[england wales scotland].each do |country|
-            calculator.where_do_you_live = country
-            assert_not calculator.eligible_for_rate_relief?
+        context "when ineligible" do
+          should "be false if country is not Northern Ireland" do
+            calculator = CheckBenefitsSupportCalculator.new
+            %w[england wales scotland].each do |country|
+              calculator.where_do_you_live = country
+              assert_not calculator.eligible_for_rate_relief?
+            end
           end
         end
       end

--- a/test/unit/calculators/checks_benefits_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_support_calculator_test.rb
@@ -1374,18 +1374,22 @@ module SmartAnswer::Calculators
       end
 
       context "#eligible_for_budgeting_loan?" do
-        should "return true if eligible for Budgeting Loan" do
-          calculator = CheckBenefitsSupportCalculator.new
-          %w[england wales scotland].each do |country|
-            calculator.where_do_you_live = country
-            assert calculator.eligible_for_budgeting_loan?
+        context "when eligible" do
+          should "be true if country is not Northern Ireland" do
+            calculator = CheckBenefitsSupportCalculator.new
+            %w[england wales scotland].each do |country|
+              calculator.where_do_you_live = country
+              assert calculator.eligible_for_budgeting_loan?
+            end
           end
         end
 
-        should "return false if not eligible for Budgeting Loan" do
-          calculator = CheckBenefitsSupportCalculator.new
-          calculator.where_do_you_live = "northern-ireland"
-          assert_not calculator.eligible_for_budgeting_loan?
+        context "when ineligible" do
+          should "be false if country is Northern Ireland" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.where_do_you_live = "northern-ireland"
+            assert_not calculator.eligible_for_budgeting_loan?
+          end
         end
       end
 

--- a/test/unit/calculators/checks_benefits_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_support_calculator_test.rb
@@ -984,16 +984,20 @@ module SmartAnswer::Calculators
       end
 
       context "#eligible_for_child_benefit?" do
-        should "return true if eligible for Child Benefit" do
-          calculator = CheckBenefitsSupportCalculator.new
-          calculator.children_living_with_you = "yes"
-          assert calculator.eligible_for_child_benefit?
+        context "when eligible" do
+          should "be true if living with child" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.children_living_with_you = "yes"
+            assert calculator.eligible_for_child_benefit?
+          end
         end
 
-        should "return false if not eligible for Child Benefit" do
-          calculator = CheckBenefitsSupportCalculator.new
-          calculator.children_living_with_you = "no"
-          assert_not calculator.eligible_for_child_benefit?
+        context "when ineligible" do
+          should "be false if not living with child" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.children_living_with_you = "no"
+            assert_not calculator.eligible_for_child_benefit?
+          end
         end
       end
 

--- a/test/unit/calculators/checks_benefits_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_support_calculator_test.rb
@@ -38,51 +38,89 @@ module SmartAnswer::Calculators
       end
 
       context "#eligible_for_employment_and_support_allowance?" do
-        should "return true if eligible for Employment and Support Allowance" do
-          calculator = CheckBenefitsSupportCalculator.new
-          %w[england wales scotland].each do |country|
-            calculator.where_do_you_live = country
-            calculator.over_state_pension_age = "no"
-            %w[no yes_under_16_hours_per_week].each do |working_hours|
-              calculator.are_you_working = working_hours
-              calculator.disability_or_health_condition = "yes"
-              %w[yes_unable_to_work yes_limits_work].each do |affecting_work|
-                calculator.disability_affecting_work = affecting_work
-                assert calculator.eligible_for_employment_and_support_allowance?
+        context "when eligible" do
+          should "be true if country is not NI, under state pension age, working under 16 hours, with a health issue that affects work" do
+            %w[england wales scotland].each do |country|
+              calculator = CheckBenefitsSupportCalculator.new
+              calculator.where_do_you_live = country
+              calculator.over_state_pension_age = "no"
+              %w[no yes_under_16_hours_per_week].each do |working_hours|
+                calculator.are_you_working = working_hours
+                calculator.disability_or_health_condition = "yes"
+                %w[yes_unable_to_work yes_limits_work].each do |affecting_work|
+                  calculator.disability_affecting_work = affecting_work
+                  assert calculator.eligible_for_employment_and_support_allowance?
+                end
               end
             end
           end
         end
 
-        should "return false if not eligible for Employment and Support Allowance" do
-          calculator = CheckBenefitsSupportCalculator.new
-          calculator.where_do_you_live = "northern-ireland"
-          calculator.over_state_pension_age = "no"
-          calculator.disability_or_health_condition = "yes"
-          %w[yes_unable_to_work yes_limits_work].each do |affecting_work|
-            calculator.disability_affecting_work = affecting_work
-            assert_not calculator.eligible_for_employment_and_support_allowance?
+        context "when ineligible" do
+          should "be false if country is NI" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.where_do_you_live = "northern-ireland"
+            calculator.over_state_pension_age = "no"
+            calculator.disability_or_health_condition = "yes"
+            %w[yes_unable_to_work yes_limits_work].each do |affecting_work|
+              calculator.disability_affecting_work = affecting_work
+              assert_not calculator.eligible_for_employment_and_support_allowance?
+            end
           end
 
-          %w[england wales scotland].each do |country|
-            calculator.where_do_you_live = country
-            calculator.over_state_pension_age = "no"
-            calculator.disability_or_health_condition = "yes"
-            calculator.disability_affecting_work = "no"
-            assert_not calculator.eligible_for_employment_and_support_allowance?
+          should "be false if country is not NI, under state pension age, working under 16 hours, with a health condition that DOES NOT affect work" do
+            %w[england wales scotland].each do |country|
+              calculator = CheckBenefitsSupportCalculator.new
+              calculator.where_do_you_live = country
+              calculator.over_state_pension_age = "no"
+              %w[no yes_under_16_hours_per_week].each do |working_hours|
+                calculator.are_you_working = working_hours
+                calculator.disability_or_health_condition = "yes"
+                calculator.disability_affecting_work = "no"
+                assert_not calculator.eligible_for_employment_and_support_allowance?
+              end
+            end
+          end
 
-            calculator.over_state_pension_age = "yes"
-            calculator.disability_or_health_condition = "yes"
-            calculator.disability_affecting_work = "yes_limits_work"
-            assert_not calculator.eligible_for_employment_and_support_allowance?
+          should "be false if country is not NI, OVER state pension age, working under 16 hours, with a health condition that affects work" do
+            %w[england wales scotland].each do |country|
+              calculator = CheckBenefitsSupportCalculator.new
+              calculator.where_do_you_live = country
+              calculator.over_state_pension_age = "yes"
+              %w[no yes_under_16_hours_per_week].each do |working_hours|
+                calculator.are_you_working = working_hours
+                calculator.disability_or_health_condition = "yes"
+                calculator.disability_affecting_work = "yes_limits_work"
+                assert_not calculator.eligible_for_employment_and_support_allowance?
+              end
+            end
+          end
 
-            calculator.over_state_pension_age = "no"
-            calculator.disability_or_health_condition = "no"
-            assert_not calculator.eligible_for_employment_and_support_allowance?
+          should "be false if country is not NI, under state pension age, working under 16 hours, WITHOUT a health condition" do
+            %w[england wales scotland].each do |country|
+              calculator = CheckBenefitsSupportCalculator.new
+              calculator.where_do_you_live = country
+              calculator.over_state_pension_age = "no"
+              %w[no yes_under_16_hours_per_week].each do |working_hours|
+                calculator.are_you_working = working_hours
+                calculator.disability_or_health_condition = "no"
+                assert_not calculator.eligible_for_employment_and_support_allowance?
+              end
+            end
+          end
 
-            calculator.over_state_pension_age = "no"
-            calculator.are_you_working = "yes_over_16_hours_per_week"
-            assert_not calculator.eligible_for_employment_and_support_allowance_northern_ireland?
+          should "be false if country is not NI, under state pension age, working over 16 hours, with a health issue that affects work" do
+            %w[england wales scotland].each do |country|
+              calculator = CheckBenefitsSupportCalculator.new
+              calculator.where_do_you_live = country
+              calculator.over_state_pension_age = "no"
+              calculator.are_you_working = "yes_over_16_hours_per_week"
+              calculator.disability_or_health_condition = "yes"
+              %w[yes_unable_to_work yes_limits_work].each do |affecting_work|
+                calculator.disability_affecting_work = affecting_work
+                assert_not calculator.eligible_for_employment_and_support_allowance?
+              end
+            end
           end
         end
       end

--- a/test/unit/calculators/checks_benefits_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_support_calculator_test.rb
@@ -526,26 +526,47 @@ module SmartAnswer::Calculators
       end
 
       context "#eligible_for_universal_credit?" do
-        should "return true if eligible for Universal Credit" do
-          calculator = CheckBenefitsSupportCalculator.new
-          %w[england wales scotland].each do |country|
-            calculator.where_do_you_live = country
-            calculator.over_state_pension_age = "no"
-            calculator.assets_and_savings = "under_16000"
+        context "when eligible" do
+          should "be true if country is not NI, under state pension age with under 16000 assets" do
+            %w[england wales scotland].each do |country|
+              calculator = CheckBenefitsSupportCalculator.new
+              calculator.where_do_you_live = country
+              calculator.over_state_pension_age = "no"
+              calculator.assets_and_savings = "under_16000"
 
-            assert calculator.eligible_for_universal_credit?
+              assert calculator.eligible_for_universal_credit?
+            end
           end
         end
 
-        should "return false if not eligible for Universal Credit" do
-          calculator = CheckBenefitsSupportCalculator.new
-          calculator.where_do_you_live = "northern-ireland"
-          calculator.over_state_pension_age = "yes"
-          assert_not calculator.eligible_for_universal_credit?
+        context "when ineligible" do
+          should "be false if country is NI, under state pension age with under 16000 in assets" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.where_do_you_live = "northern-ireland"
+            calculator.over_state_pension_age = "no"
+            calculator.assets_and_savings = "over_16000"
+            assert_not calculator.eligible_for_universal_credit?
+          end
+        end
 
-          calculator.over_state_pension_age = "no"
-          calculator.assets_and_savings = "over_16000"
-          assert_not calculator.eligible_for_universal_credit?
+        should "be false if country is not NI, OVER state pension age with under 16000 in assets" do
+          %w[england wales scotland].each do |country|
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.where_do_you_live = country
+            calculator.over_state_pension_age = "yes"
+            calculator.assets_and_savings = "under_16000"
+            assert_not calculator.eligible_for_universal_credit?
+          end
+        end
+
+        should "be false if country is not NI, under state pension age with OVER 16000 in assets" do
+          %w[england wales scotland].each do |country|
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.where_do_you_live = country
+            calculator.over_state_pension_age = "no"
+            calculator.assets_and_savings = "over_16000"
+            assert_not calculator.eligible_for_universal_credit?
+          end
         end
       end
 

--- a/test/unit/calculators/checks_benefits_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_support_calculator_test.rb
@@ -126,47 +126,82 @@ module SmartAnswer::Calculators
       end
 
       context "#eligible_for_employment_and_support_allowance_northern_ireland?" do
-        should "return true if eligible for Employment and Support Allowance (NI)" do
-          calculator = CheckBenefitsSupportCalculator.new
-          calculator.where_do_you_live = "northern-ireland"
-          calculator.over_state_pension_age = "no"
-          %w[no yes_under_16_hours_per_week].each do |working_hours|
-            calculator.are_you_working = working_hours
-            calculator.disability_or_health_condition = "yes"
-            %w[yes_unable_to_work yes_limits_work].each do |affecting_work|
-              calculator.disability_affecting_work = affecting_work
-              assert calculator.eligible_for_employment_and_support_allowance_northern_ireland?
+        context "when eligible" do
+          should "be true if country is NI, under state pension age, working under 16 hours, with a health issue that affects work" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.where_do_you_live = "northern-ireland"
+            calculator.over_state_pension_age = "no"
+            %w[no yes_under_16_hours_per_week].each do |working_hours|
+              calculator.are_you_working = working_hours
+              calculator.disability_or_health_condition = "yes"
+              %w[yes_unable_to_work yes_limits_work].each do |affecting_work|
+                calculator.disability_affecting_work = affecting_work
+                assert calculator.eligible_for_employment_and_support_allowance_northern_ireland?
+              end
             end
           end
         end
 
-        should "return false if not eligible for Employment and Support Allowance" do
-          calculator = CheckBenefitsSupportCalculator.new
-          calculator.where_do_you_live = "northern-ireland"
-          calculator.over_state_pension_age = "no"
-          calculator.disability_or_health_condition = "yes"
-          calculator.disability_affecting_work = "no"
-          assert_not calculator.eligible_for_employment_and_support_allowance_northern_ireland?
+        context "when ineligible" do
+          should "be false if country is not NI" do
+            %w[england wales scotland].each do |country|
+              calculator = CheckBenefitsSupportCalculator.new
+              calculator.where_do_you_live = country
+              calculator.over_state_pension_age = "no"
+              %w[no yes_under_16_hours_per_week].each do |working_hours|
+                calculator.are_you_working = working_hours
+                calculator.disability_or_health_condition = "yes"
+                %w[yes_unable_to_work yes_limits_work].each do |affecting_work|
+                  calculator.disability_affecting_work = affecting_work
+                  assert_not calculator.eligible_for_employment_and_support_allowance_northern_ireland?
+                end
+              end
+            end
+          end
 
-          calculator.over_state_pension_age = "yes"
-          calculator.disability_or_health_condition = "yes"
-          calculator.disability_affecting_work = "yes_limits_work"
-          assert_not calculator.eligible_for_employment_and_support_allowance_northern_ireland?
-
-          calculator.over_state_pension_age = "no"
-          calculator.disability_or_health_condition = "no"
-          assert_not calculator.eligible_for_employment_and_support_allowance_northern_ireland?
-
-          calculator.over_state_pension_age = "no"
-          calculator.are_you_working = "yes_over_16_hours_per_week"
-          assert_not calculator.eligible_for_employment_and_support_allowance_northern_ireland?
-
-          %w[england wales scotland].each do |country|
-            calculator.where_do_you_live = country
+          should "be false if country is NI, under state pension age, working under 16 hours per week, with a health condition that DOES NOT affect work" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.where_do_you_live = "northern-ireland"
             calculator.over_state_pension_age = "no"
+            %w[no yes_under_16_hours_per_week].each do |working_hours|
+              calculator.are_you_working = working_hours
+              calculator.disability_or_health_condition = "yes"
+              calculator.disability_affecting_work = "no"
+              assert_not calculator.eligible_for_employment_and_support_allowance_northern_ireland?
+            end
+          end
+
+          should "be false if country is NI, under state pension age, working OVER 16 hours per week, with a health condition that affects work" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.where_do_you_live = "northern-ireland"
+            calculator.over_state_pension_age = "no"
+            calculator.are_you_working = "yes_over_16_hours_per_week"
             calculator.disability_or_health_condition = "yes"
             %w[yes_unable_to_work yes_limits_work].each do |affecting_work|
               calculator.disability_affecting_work = affecting_work
+              assert_not calculator.eligible_for_employment_and_support_allowance_northern_ireland?
+            end
+          end
+
+          should "be false if country is NI, OVER state pension age, working under 16 hours, with a health condition that affects work" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.where_do_you_live = "northern-ireland"
+            calculator.over_state_pension_age = "yes"
+            %w[no yes_under_16_hours_per_week].each do |working_hours|
+              calculator.are_you_working = working_hours
+              calculator.disability_or_health_condition = "yes"
+              calculator.disability_affecting_work = "no"
+              assert_not calculator.eligible_for_employment_and_support_allowance_northern_ireland?
+            end
+          end
+
+          should "be false if country is NI, under state pension age, WITHOUT a health condition" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.where_do_you_live = "northern-ireland"
+            calculator.over_state_pension_age = "no"
+            %w[no yes_under_16_hours_per_week].each do |working_hours|
+              calculator.are_you_working = working_hours
+              calculator.disability_or_health_condition = "no"
               assert_not calculator.eligible_for_employment_and_support_allowance_northern_ireland?
             end
           end

--- a/test/unit/calculators/checks_benefits_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_support_calculator_test.rb
@@ -1356,16 +1356,20 @@ module SmartAnswer::Calculators
       end
 
       context "#eligible_for_free_tv_licence?" do
-        should "return true if eligible for Free TV Licence" do
-          calculator = CheckBenefitsSupportCalculator.new
-          calculator.over_state_pension_age = "yes"
-          assert calculator.eligible_for_free_tv_licence?
+        context "when eligible" do
+          should "be true if over state pension age" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.over_state_pension_age = "yes"
+            assert calculator.eligible_for_free_tv_licence?
+          end
         end
 
-        should "return false if not eligible for Free TV Licence" do
-          calculator = CheckBenefitsSupportCalculator.new
-          calculator.over_state_pension_age = "no"
-          assert_not calculator.eligible_for_free_tv_licence?
+        context "when ineligible" do
+          should "be false if under state pension age" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.over_state_pension_age = "no"
+            assert_not calculator.eligible_for_free_tv_licence?
+          end
         end
       end
 

--- a/test/unit/calculators/checks_benefits_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_support_calculator_test.rb
@@ -706,37 +706,73 @@ module SmartAnswer::Calculators
       end
 
       context "#eligible_for_tax_free_childcare?" do
-        should "return true if eligible for Tax Free Childcare without a disabled child" do
-          calculator = CheckBenefitsSupportCalculator.new
-          calculator.are_you_working = "yes_over_16_hours_per_week"
-          calculator.children_living_with_you = "yes"
-          %w[1_or_under 2 3_to_4 5_to_11].each do |age|
-            calculator.age_of_children = age
-            assert calculator.eligible_for_tax_free_childcare?
+        context "when eligible" do
+          should "be true if working, with children between 1 and 11" do
+            calculator = CheckBenefitsSupportCalculator.new
+            %w[yes_over_16_hours_per_week yes_under_16_hours_per_week].each do |working_hours|
+              calculator.are_you_working = working_hours
+              calculator.children_living_with_you = "yes"
+              %w[1_or_under 2 3_to_4 5_to_11].each do |age|
+                calculator.age_of_children = age
+                assert calculator.eligible_for_tax_free_childcare?
+              end
+            end
+          end
+
+          should "be true if working, with a disabled child and children between 1 and 17" do
+            calculator = CheckBenefitsSupportCalculator.new
+            %w[yes_over_16_hours_per_week yes_under_16_hours_per_week].each do |working_hours|
+              calculator.are_you_working = working_hours
+              calculator.children_living_with_you = "yes"
+              calculator.children_with_disability = "yes"
+              %w[1_or_under 2 3_to_4 5_to_11 12_to_15 16_to_17].each do |age|
+                calculator.age_of_children = age
+                assert calculator.eligible_for_tax_free_childcare?
+              end
+            end
           end
         end
 
-        should "return true if eligible for Tax Free Childcare with a disabled child" do
-          calculator = CheckBenefitsSupportCalculator.new
-          calculator.are_you_working = "yes_over_16_hours_per_week"
-          calculator.children_living_with_you = "yes"
-          calculator.children_with_disability = "yes"
-          %w[1_or_under 2 3_to_4 5_to_11 12_to_15 16_to_17].each do |age|
-            calculator.age_of_children = age
-            assert calculator.eligible_for_tax_free_childcare?
+        context "when ineligible" do
+          should "be false if not working with children between 1 and 11" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.are_you_working = "no"
+            %w[1_or_under 2 3_to_4 5_to_11].each do |age|
+              calculator.age_of_children = age
+              assert_not calculator.eligible_for_tax_free_childcare?
+            end
           end
-        end
 
-        should "return false if not eligible for Tax Free Childcare" do
-          calculator = CheckBenefitsSupportCalculator.new
-          calculator.are_you_working = "no"
-          assert_not calculator.eligible_for_tax_free_childcare?
+          should "be false if working with children aged between 12 and 19" do
+            calculator = CheckBenefitsSupportCalculator.new
+            %w[yes_over_16_hours_per_week yes_under_16_hours_per_week].each do |working_hours|
+              calculator.are_you_working = working_hours
+              calculator.children_living_with_you = "yes"
+              %w[12_to_15 16_to_17 18_to_19].each do |age|
+                calculator.age_of_children = age
+                assert_not calculator.eligible_for_tax_free_childcare?
+              end
+            end
+          end
 
-          calculator.are_you_working = "yes"
-          calculator.children_living_with_you = "yes"
-          %w[12_to_15 16_to_17 18_to_19].each do |age|
-            calculator.age_of_children = age
-            assert_not calculator.eligible_for_tax_free_childcare?
+          should "be false if working without children" do
+            calculator = CheckBenefitsSupportCalculator.new
+            %w[yes_over_16_hours_per_week yes_under_16_hours_per_week].each do |working_hours|
+              calculator.are_you_working = working_hours
+              calculator.children_living_with_you = "no"
+              assert_not calculator.eligible_for_tax_free_childcare?
+            end
+          end
+
+          should "be false if working with a disabled child and children aged 18 to 19" do
+            calculator = CheckBenefitsSupportCalculator.new
+            %w[yes_over_16_hours_per_week yes_under_16_hours_per_week].each do |working_hours|
+              calculator.are_you_working = working_hours
+              calculator.children_living_with_you = "yes"
+              calculator.children_with_disability = "yes"
+              calculator.age_of_children = "18_to_19"
+              assert_not calculator.eligible_for_tax_free_childcare?
+            end
           end
         end
       end

--- a/test/unit/calculators/checks_benefits_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_support_calculator_test.rb
@@ -611,37 +611,65 @@ module SmartAnswer::Calculators
       end
 
       context "#eligible_for_housing_benefit?" do
-        should "return true if eligible for Housing Benefit" do
-          calculator = CheckBenefitsSupportCalculator.new
-          %w[england wales].each do |country|
-            calculator.where_do_you_live = country
-            calculator.over_state_pension_age = "yes"
-            assert calculator.eligible_for_housing_benefit?
+        context "when eligible" do
+          should "be true if country is England or Wales and over state pension age" do
+            %w[england wales].each do |country|
+              calculator = CheckBenefitsSupportCalculator.new
+              calculator.where_do_you_live = country
+              calculator.over_state_pension_age = "yes"
+              assert calculator.eligible_for_housing_benefit?
+            end
           end
         end
 
-        should "return false if not eligible for Housing Benefit" do
-          calculator = CheckBenefitsSupportCalculator.new
-          %w[scotland northern-ireland].each do |country|
-            calculator.where_do_you_live = country
-            calculator.over_state_pension_age = "no"
-            assert_not calculator.eligible_for_housing_benefit?
+        context "when ineligible" do
+          should "be false if country is England or Wales and UNDER state pension age" do
+            calculator = CheckBenefitsSupportCalculator.new
+            %w[england wales].each do |country|
+              calculator = CheckBenefitsSupportCalculator.new
+              calculator.where_do_you_live = country
+              calculator.over_state_pension_age = "no"
+              assert_not calculator.eligible_for_housing_benefit?
+            end
+          end
+
+          should "be false if country is not England or Wales" do
+            calculator = CheckBenefitsSupportCalculator.new
+            %w[scotland northern-ireland].each do |country|
+              calculator = CheckBenefitsSupportCalculator.new
+              calculator.where_do_you_live = country
+              %w[yes no].each do |pension_age|
+                calculator.over_state_pension_age = pension_age
+                assert_not calculator.eligible_for_housing_benefit?
+              end
+            end
           end
         end
       end
 
       context "#eligible_for_housing_benefit_scotland?" do
-        should "return true if eligible for Housing Benefit (Scotland)" do
-          calculator = CheckBenefitsSupportCalculator.new
-          calculator.where_do_you_live = "scotland"
-          calculator.over_state_pension_age = "yes"
-          assert calculator.eligible_for_housing_benefit_scotland?
+        context "when eligible" do
+          should "be true if country is Scotland and over state pension age" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.where_do_you_live = "scotland"
+            calculator.over_state_pension_age = "yes"
+            assert calculator.eligible_for_housing_benefit_scotland?
+          end
         end
 
-        should "return false if not eligible for Housing Benefit (Scotland)" do
-          calculator = CheckBenefitsSupportCalculator.new
-          %w[england wales northern-ireland].each do |country|
-            calculator.where_do_you_live = country
+        context "when false" do
+          should "be false if country is not Scotland" do
+            %w[england wales northern-ireland].each do |country|
+              calculator = CheckBenefitsSupportCalculator.new
+              calculator.where_do_you_live = country
+              calculator.over_state_pension_age = "yes"
+              assert_not calculator.eligible_for_housing_benefit_scotland?
+            end
+          end
+
+          should "be false if country is Scotland and under state pension age" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.where_do_you_live = "scotland"
             calculator.over_state_pension_age = "no"
             assert_not calculator.eligible_for_housing_benefit_scotland?
           end
@@ -649,17 +677,28 @@ module SmartAnswer::Calculators
       end
 
       context "#eligible_for_housing_benefit_northern_ireland?" do
-        should "return true if eligible for Housing Benefit (Northern Ireland)" do
-          calculator = CheckBenefitsSupportCalculator.new
-          calculator.where_do_you_live = "northern-ireland"
-          calculator.over_state_pension_age = "yes"
-          assert calculator.eligible_for_housing_benefit_northern_ireland?
+        context "when eligible" do
+          should "be true if country is Northern Ireland and over state pension age" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.where_do_you_live = "northern-ireland"
+            calculator.over_state_pension_age = "yes"
+            assert calculator.eligible_for_housing_benefit_northern_ireland?
+          end
         end
 
-        should "return false if not eligible for Housing Benefit (Northern Ireland)" do
-          calculator = CheckBenefitsSupportCalculator.new
-          %w[england wales scotland].each do |country|
-            calculator.where_do_you_live = country
+        context "when ineligible" do
+          should "be false if country is not Northern Ireland" do
+            %w[england wales scotland].each do |country|
+              calculator = CheckBenefitsSupportCalculator.new
+              calculator.where_do_you_live = country
+              calculator.over_state_pension_age = "yes"
+              assert_not calculator.eligible_for_housing_benefit_northern_ireland?
+            end
+          end
+
+          should "be false if country is Northern Ireland and under state pension age" do
+            calculator = CheckBenefitsSupportCalculator.new
+            calculator.where_do_you_live = "northern-ireland"
             calculator.over_state_pension_age = "no"
             assert_not calculator.eligible_for_housing_benefit_northern_ireland?
           end


### PR DESCRIPTION
This PR enhances the documentation of the check-benefits-support-calculator test file. It ensures that each assertion has its own descriptive "should" block to better document the scenarios under test. It also adds some extra tests for some methods for better coverage.  