### PR TITLE
Update Personal Independence Payment method

### DIFF
--- a/lib/smart_answer/calculators/check_benefits_support_calculator.rb
+++ b/lib/smart_answer/calculators/check_benefits_support_calculator.rb
@@ -182,7 +182,8 @@ module SmartAnswer::Calculators
 
       eligible_child_ages = %w[16_to_17 18_to_19]
       @children_living_with_you == "yes" &&
-        @age_of_children.split(",").any? { |age| eligible_child_ages.include?(age) }
+        @age_of_children.split(",").any? { |age| eligible_child_ages.include?(age) } &&
+        @children_with_disability == "yes"
     end
 
     def eligible_for_personal_independence_payment_northern_ireland?

--- a/lib/smart_answer/calculators/check_benefits_support_calculator.rb
+++ b/lib/smart_answer/calculators/check_benefits_support_calculator.rb
@@ -193,7 +193,8 @@ module SmartAnswer::Calculators
 
       eligible_child_ages = %w[16_to_17 18_to_19]
       @children_living_with_you == "yes" &&
-        @age_of_children.split(",").any? { |age| eligible_child_ages.include?(age) }
+        @age_of_children.split(",").any? { |age| eligible_child_ages.include?(age) } &&
+        @children_with_disability == "yes"
     end
 
     def eligible_for_attendance_allowance?

--- a/test/unit/calculators/checks_benefits_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_support_calculator_test.rb
@@ -790,6 +790,7 @@ module SmartAnswer::Calculators
           calculator.children_living_with_you = "yes"
           %w[16_to_17 18_to_19].each do |age|
             calculator.age_of_children = age
+            calculator.children_with_disability = "yes"
             assert calculator.eligible_for_personal_independence_payment_northern_ireland?
           end
         end
@@ -811,6 +812,7 @@ module SmartAnswer::Calculators
             calculator.children_living_with_you = "yes"
             %w[16_to_17 18_to_19].each do |age|
               calculator.age_of_children = age
+              calculator.children_with_disability = "no"
               assert_not calculator.eligible_for_personal_independence_payment_northern_ireland?
             end
           end

--- a/test/unit/calculators/checks_benefits_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_support_calculator_test.rb
@@ -749,6 +749,7 @@ module SmartAnswer::Calculators
             calculator.children_living_with_you = "yes"
             %w[16_to_17 18_to_19].each do |age|
               calculator.age_of_children = age
+              calculator.children_with_disability = "yes"
               assert calculator.eligible_for_personal_independence_payment?
             end
           end
@@ -774,6 +775,7 @@ module SmartAnswer::Calculators
           calculator.children_living_with_you = "yes"
           %w[16_to_17 18_to_19].each do |age|
             calculator.age_of_children = age
+            calculator.children_with_disability = "no"
             assert_not calculator.eligible_for_personal_independence_payment?
           end
         end


### PR DESCRIPTION
Updates the Personal Independence Payment  and Personal Independence Payment Northern Ireland methods to display for children aged 16 to 19 who have a health condition or disability.