### PR TITLE
Updates to Macao marriage abroad outcomes

### DIFF
--- a/app/flows/marriage_abroad_flow/outcomes/countries/macao/ceremony_country/partner_british/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/macao/ceremony_country/partner_british/_opposite_sex.erb
@@ -7,42 +7,46 @@ Contact the relevant local authorities in Macao to find out about local marriage
 
 You’ll be asked to provide an affirmation or affidavit document to prove you’re allowed to marry.
 
-Make an appointment at the British Consulate General Hong Kong to swear an affirmation/affadavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
+You can book an appointment at the Honorary Consulate in Macao to swear an affirmation or affidavit using the [contact form](https://www.contact-embassy.service.gov.uk/Enquiry/?enquirytext=&country=China&post=British%20Consulate%20General%20Hong%20Kong). You’ll need to:
 
-[Make an appointment at the British Consulate General Hong Kong.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=65&service=13)
+s1. Go to ‘Do the suggested pages answer your enquiry?’ and select ‘No, I would like to submit my enquiry’ to get the ‘Contact us’ form you need to fill in.
+s2. Include ‘MCA’ at the start of the 'What your enquiry is about' field.
+s3. In the ‘Details of your enquiry’ field, explain that you would like to book an appointment in Macao to swear an affirmation or affidavit for marriage.
+
+You’ll get a response asking you to pay a fee, and then your details will be passed over to the Honorary Consul in Macao. They will contact you within three working days to agree a date and time for your appointment.
+
+^Your partner will probably need to get an affirmation or affidavit as well.^
+
+###Prepare for your appointment
 
 You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.
 
-You can download and fill in (but not sign) the forms in advance.
+You can download and fill in the forms in advance, but do not sign them.
 
 $D
 [Download ‘Affidavit for marriage’](/government/publications/affidavit-form-macao)
 [Download ’Affirmation for marriage’](/government/publications/affirmation-form-macao)
 $D
 
-You’ll need to provide supporting documents, including:
+You’ll need to bring supporting documents to your appointment, including:
 
 - your passport
-- your partner’s passport (if they’re not British)
 - your [full birth certificate](/order-copy-birth-death-marriage-certificate) or [naturalisation certificate](/get-replacement-citizenship-certificate)
-- proof of residence, such as a residence certificate - check with the embassy or local notary public to find out what you need
-- equivalent documents for your partner
-
-^Your partner will probably need to get an affirmation or affidavit as well.^
+- proof of residence, such as a residence certificate - check with the consulate or a local notary public to find out what you need
+- your partner’s full birth certificate or naturalisation certificate, and proof of residence for them
 
 ###Legalisation and translation
 
-You’ll need to get your affirmation or affidavit [translated](/government/collections/lists-of-translators-and-interpreters) into the local language and ‘[legalised](/get-document-legalised)’ (certified as genuine) by the local authorities - the embassy or consulate should be able to give you advice.
+You’ll need to get your affirmation or affidavit translated into the local language and [get it ‘legalised’](/get-document-legalised) (certified as genuine) by the local authorities - the consulate should be able to give you advice. [Find a professional translator](/government/collections/lists-of-translators-and-interpreters).
 
-If you’ve been divorced or widowed, you’ll also need:
+##Other documents you might need in order to get married
+
+If you’ve been divorced or widowed, you’ll need to have:
 
 - a [decree absolute or final order](/copy-decree-absolute-final-order) or the [death certificate](/order-copy-birth-death-marriage-certificate/)
-
-- evidence of nationality or residence where your divorce took place if it was outside the UK. You’ll need to get it [translated](/government/collections/lists-of-translators-and-interpreters) if it’s not in English.
+- evidence of nationality or residence where your divorce took place if it was outside the UK. You’ll need to get it [professionally translated](/government/collections/lists-of-translators-and-interpreters) if it’s not in English. [Find a professional translator](/government/collections/lists-of-translators-and-interpreters)
 
 You’ll also need to provide evidence if you’ve changed your name by deed poll.
-
-^Your partner will probably need to get an affirmation or affidavit as well.^
 
 ## Fees
 
@@ -51,6 +55,4 @@ You’ll also need to provide evidence if you’ve changed your name by deed pol
     as: :service,
     locals: { calculator: calculator } %>
 
-You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Macao](/government/publications/macao-consular-fees).
-
-You can pay by cash or credit card, but not by personal cheque.
+You can pay online by debit or credit card. If you’re not able to pay online, ask the consulate if you can pay an equivalent amount in Hong Kong dollars with a bank transfer.

--- a/app/flows/marriage_abroad_flow/outcomes/countries/macao/ceremony_country/partner_local/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/macao/ceremony_country/partner_local/_opposite_sex.erb
@@ -7,42 +7,47 @@ Contact the relevant local authorities in Macao to find out about local marriage
 
 You’ll be asked to provide an affirmation or affidavit document to prove you’re allowed to marry.
 
-Make an appointment at the British Consulate General Hong Kong to swear an affirmation/affadavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
+You can book an appointment at the Honorary Consulate in Macao to swear an affirmation or affidavit using the [contact form](https://www.contact-embassy.service.gov.uk/Enquiry/?enquirytext=&country=China&post=British%20Consulate%20General%20Hong%20Kong). You’ll need to:
 
-[Make an appointment at the British Consulate General Hong Kong.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=65&service=13)
+s1. Go to ‘Do the suggested pages answer your enquiry?’ and select ‘No, I would like to submit my enquiry’ to get the ‘Contact us’ form you need to fill in.
+s2. Include ‘MCA’ at the start of the 'What your enquiry is about' field.
+s3. In the ‘Details of your enquiry’ field, explain that you would like to book an appointment in Macao to swear an affirmation or affidavit for marriage.
+
+You’ll get a response asking you to pay a fee, and then your details will be passed over to the Honorary Consul in Macao. They will contact you within three working days to agree a date and time for your appointment.
+
+^Your partner will probably need to get an affirmation or affidavit from their own national authorities.^
+
+###Prepare for your appointment
 
 You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.
 
-You can download and fill in (but not sign) the forms in advance.
+You can download and fill in the forms in advance, but do not sign them.
 
 $D
 [Download ‘Affidavit for marriage’](/government/publications/affidavit-form-macao)
 [Download ’Affirmation for marriage’](/government/publications/affirmation-form-macao)
 $D
 
-You’ll need to provide supporting documents, including:
+You’ll need to bring supporting documents to your appointment, including:
 
 - your passport
-- your partner’s passport (if they’re not British)
+- your partner’s passport
 - your [full birth certificate](/order-copy-birth-death-marriage-certificate) or [naturalisation certificate](/get-replacement-citizenship-certificate)
-- proof of residence, such as a residence certificate - check with the embassy or local notary public to find out what you need
-- equivalent documents for your partner
-
-^Your partner will probably need to get an affirmation or affidavit as well.^
+- proof of residence, such as a residence certificate - check with the consulate or a local notary public to find out what you need
+- your partner’s full birth certificate or naturalisation certificate, and proof of residence for them
 
 ###Legalisation and translation
 
-You’ll need to get your affirmation or affidavit [translated](/government/collections/lists-of-translators-and-interpreters) into the local language and ‘[legalised](/get-document-legalised)’ (certified as genuine) by the local authorities - the embassy or consulate should be able to give you advice.
+You’ll need to get your affirmation or affidavit translated into the local language and [get it ‘legalised’](/get-document-legalised) (certified as genuine) by the local authorities - the consulate should be able to give you advice. [Find a professional translator](/government/collections/lists-of-translators-and-interpreters).
 
-If you’ve been divorced or widowed, you’ll also need:
+##Other documents you might need in order to get married
+
+If you’ve been divorced or widowed, you’ll need to have:
 
 - a [decree absolute or final order](/copy-decree-absolute-final-order) or the [death certificate](/order-copy-birth-death-marriage-certificate/)
-
-- evidence of nationality or residence where your divorce took place if it was outside the UK. You’ll need to get it [translated](/government/collections/lists-of-translators-and-interpreters) if it’s not in English.
+- evidence of nationality or residence where your divorce took place if it was outside the UK. You’ll need to get it [professionally translated](/government/collections/lists-of-translators-and-interpreters) if it’s not in English. [Find a professional translator](/government/collections/lists-of-translators-and-interpreters)
 
 You’ll also need to provide evidence if you’ve changed your name by deed poll.
-
-^Your partner will probably need to get an equivalent document from their national authorities.^
 
 ##Naturalisation of your partner if they move to the UK
 
@@ -55,6 +60,4 @@ Your partner can apply to [become a British citizen](/becoming-a-british-citizen
     as: :service,
     locals: { calculator: calculator } %>
 
-You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Macao](/government/publications/macao-consular-fees).
-
-You can pay by cash or credit card, but not by personal cheque.
+You can pay online by debit or credit card. If you’re not able to pay online, ask the consulate if you can pay an equivalent amount in Hong Kong dollars with a bank transfer.

--- a/app/flows/marriage_abroad_flow/outcomes/countries/macao/ceremony_country/partner_other/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/macao/ceremony_country/partner_other/_opposite_sex.erb
@@ -7,42 +7,47 @@ Contact the relevant local authorities in Macao to find out about local marriage
 
 You’ll be asked to provide an affirmation or affidavit document to prove you’re allowed to marry.
 
-Make an appointment at the British Consulate General Hong Kong to swear an affirmation/affadavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
+You can book an appointment at the Honorary Consulate in Macao to swear an affirmation or affidavit using the [contact form](https://www.contact-embassy.service.gov.uk/Enquiry/?enquirytext=&country=China&post=British%20Consulate%20General%20Hong%20Kong). You’ll need to:
 
-[Make an appointment at the British Consulate General Hong Kong.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=65&service=13)
+s1. Go to ‘Do the suggested pages answer your enquiry?’ and select ‘No, I would like to submit my enquiry’ to get the ‘Contact us’ form you need to fill in.
+s2. Include ‘MCA’ at the start of the 'What your enquiry is about' field.
+s3. In the ‘Details of your enquiry’ field, explain that you would like to book an appointment in Macao to swear an affirmation or affidavit for marriage.
+
+You’ll get a response asking you to pay a fee, and then your details will be passed over to the Honorary Consul in Macao. They will contact you within three working days to agree a date and time for your appointment.
+
+^Your partner will probably need to get an affirmation or affidavit from their own national authorities.^
+
+###Prepare for your appointment
 
 You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.
 
-You can download and fill in (but not sign) the forms in advance.
+You can download and fill in the forms in advance, but do not sign them.
 
 $D
 [Download ‘Affidavit for marriage’](/government/publications/affidavit-form-macao)
 [Download ’Affirmation for marriage’](/government/publications/affirmation-form-macao)
 $D
 
-You’ll need to provide supporting documents, including:
+You’ll need to bring supporting documents to your appointment, including:
 
 - your passport
-- your partner’s passport (if they’re not British)
+- your partner’s passport
 - your [full birth certificate](/order-copy-birth-death-marriage-certificate) or [naturalisation certificate](/get-replacement-citizenship-certificate)
-- proof of residence, such as a residence certificate - check with the embassy or local notary public to find out what you need
-- equivalent documents for your partner
-
-^Your partner will probably need to get an affirmation or affidavit as well.^
+- proof of residence, such as a residence certificate - check with the consulate or a local notary public to find out what you need
+- your partner’s full birth certificate or naturalisation certificate, and proof of residence for them
 
 ###Legalisation and translation
 
-You’ll need to get your affirmation or affidavit [translated](/government/collections/lists-of-translators-and-interpreters) into the local language and ‘[legalised](/get-document-legalised)’ (certified as genuine) by the local authorities - the embassy or consulate should be able to give you advice.
+You’ll need to get your affirmation or affidavit translated into the local language and [get it ‘legalised’](/get-document-legalised) (certified as genuine) by the local authorities - the consulate should be able to give you advice. [Find a professional translator](/government/collections/lists-of-translators-and-interpreters).
 
-If you’ve been divorced or widowed, you’ll also need:
+##Other documents you might need in order to get married
+
+If you’ve been divorced or widowed, you’ll need to have:
 
 - a [decree absolute or final order](/copy-decree-absolute-final-order) or the [death certificate](/order-copy-birth-death-marriage-certificate/)
-
-- evidence of nationality or residence where your divorce took place if it was outside the UK. You’ll need to get it [translated](/government/collections/lists-of-translators-and-interpreters) if it’s not in English.
+- evidence of nationality or residence where your divorce took place if it was outside the UK. You’ll need to get it [professionally translated](/government/collections/lists-of-translators-and-interpreters) if it’s not in English. [Find a professional translator](/government/collections/lists-of-translators-and-interpreters)
 
 You’ll also need to provide evidence if you’ve changed your name by deed poll.
-
-^Your partner will probably need to get an equivalent document from their national authorities.^
 
 ##Naturalisation of your partner if they move to the UK
 
@@ -55,6 +60,4 @@ Your partner can apply to [become a British citizen](/becoming-a-british-citizen
     as: :service,
     locals: { calculator: calculator } %>
 
-You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Macao](/government/publications/macao-consular-fees).
-
-You can pay by cash or credit card, but not by personal cheque.
+You can pay online by debit or credit card. If you’re not able to pay online, ask the consulate if you can pay an equivalent amount in Hong Kong dollars with a bank transfer.

--- a/app/flows/marriage_abroad_flow/outcomes/countries/macao/third_country/partner_british/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/macao/third_country/partner_british/_opposite_sex.erb
@@ -8,42 +8,46 @@ Contact the relevant local authorities in Macao to find out about local marriage
 
 You’ll be asked to provide an affirmation or affidavit document to prove you’re allowed to marry.
 
-Make an appointment at the British Consulate General Hong Kong to swear an affirmation/affadavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
+You can book an appointment at the Honorary Consulate in Macao to swear an affirmation or affidavit using the [contact form](https://www.contact-embassy.service.gov.uk/Enquiry/?enquirytext=&country=China&post=British%20Consulate%20General%20Hong%20Kong). You’ll need to:
 
-[Make an appointment at the British Consulate General Hong Kong.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=65&service=13)
+s1. Go to ‘Do the suggested pages answer your enquiry?’ and select ‘No, I would like to submit my enquiry’ to get the ‘Contact us’ form you need to fill in.
+s2. Include ‘MCA’ at the start of the 'What your enquiry is about' field.
+s3. In the ‘Details of your enquiry’ field, explain that you would like to book an appointment in Macao to swear an affirmation or affidavit for marriage.
+
+You’ll get a response asking you to pay a fee, and then your details will be passed over to the Honorary Consul in Macao. They will contact you within three working days to agree a date and time for your appointment.
+
+^Your partner will probably need to get an affirmation or affidavit as well.^
+
+###Prepare for your appointment
 
 You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.
 
-You can download and fill in (but not sign) the forms in advance.
+You can download and fill in the forms in advance, but do not sign them.
 
 $D
 [Download ‘Affidavit for marriage’](/government/publications/affidavit-form-macao)
 [Download ’Affirmation for marriage’](/government/publications/affirmation-form-macao)
 $D
 
-You’ll need to provide supporting documents, including:
+You’ll need to bring supporting documents to your appointment, including:
 
 - your passport
-- your partner’s passport (if they’re not British)
 - your [full birth certificate](/order-copy-birth-death-marriage-certificate) or [naturalisation certificate](/get-replacement-citizenship-certificate)
-- proof of residence, such as a residence certificate - check with the embassy or local notary public to find out what you need
-- equivalent documents for your partner
-
-^Your partner will probably need to get an affirmation or affidavit as well.^
+- proof of residence, such as a residence certificate - check with the consulate or a local notary public to find out what you need
+- your partner’s full birth certificate or naturalisation certificate, and proof of residence for them
 
 ###Legalisation and translation
 
-You’ll need to get your affirmation or affidavit [translated](/government/collections/lists-of-translators-and-interpreters) into the local language and ‘[legalised](/get-document-legalised)’ (certified as genuine) by the local authorities - the embassy or consulate should be able to give you advice.
+You’ll need to get your affirmation or affidavit translated into the local language and [get it ‘legalised’](/get-document-legalised) (certified as genuine) by the local authorities - the consulate should be able to give you advice. [Find a professional translator](/government/collections/lists-of-translators-and-interpreters).
 
-If you’ve been divorced or widowed, you’ll also need:
+##Other documents you might need in order to get married
+
+If you’ve been divorced or widowed, you’ll need to have:
 
 - a [decree absolute or final order](/copy-decree-absolute-final-order) or the [death certificate](/order-copy-birth-death-marriage-certificate/)
-
-- evidence of nationality or residence where your divorce took place if it was outside the UK. You’ll need to get it [translated](/government/collections/lists-of-translators-and-interpreters) if it’s not in English.
+- evidence of nationality or residence where your divorce took place if it was outside the UK. You’ll need to get it [professionally translated](/government/collections/lists-of-translators-and-interpreters) if it’s not in English. [Find a professional translator](/government/collections/lists-of-translators-and-interpreters)
 
 You’ll also need to provide evidence if you’ve changed your name by deed poll.
-
-^Your partner will probably need to get an affirmation or affidavit as well.^
 
 ## Fees
 
@@ -52,6 +56,4 @@ You’ll also need to provide evidence if you’ve changed your name by deed pol
     as: :service,
     locals: { calculator: calculator } %>
 
-You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Macao](/government/publications/macao-consular-fees).
-
-You can pay by cash or credit card, but not by personal cheque.
+You can pay online by debit or credit card. If you’re not able to pay online, ask the consulate if you can pay an equivalent amount in Hong Kong dollars with a bank transfer.

--- a/app/flows/marriage_abroad_flow/outcomes/countries/macao/third_country/partner_local/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/macao/third_country/partner_local/_opposite_sex.erb
@@ -8,42 +8,47 @@ Contact the relevant local authorities in Macao to find out about local marriage
 
 You’ll be asked to provide an affirmation or affidavit document to prove you’re allowed to marry.
 
-Make an appointment at the British Consulate General Hong Kong to swear an affirmation/affadavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
+You can book an appointment at the Honorary Consulate in Macao to swear an affirmation or affidavit using the [contact form](https://www.contact-embassy.service.gov.uk/Enquiry/?enquirytext=&country=China&post=British%20Consulate%20General%20Hong%20Kong). You’ll need to:
 
-[Make an appointment at the British Consulate General Hong Kong.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=65&service=13)
+s1. Go to ‘Do the suggested pages answer your enquiry?’ and select ‘No, I would like to submit my enquiry’ to get the ‘Contact us’ form you need to fill in.
+s2. Include ‘MCA’ at the start of the 'What your enquiry is about' field.
+s3. In the ‘Details of your enquiry’ field, explain that you would like to book an appointment in Macao to swear an affirmation or affidavit for marriage.
+
+You’ll get a response asking you to pay a fee, and then your details will be passed over to the Honorary Consul in Macao. They will contact you within three working days to agree a date and time for your appointment.
+
+^Your partner will probably need to get an affirmation or affidavit from their own national authorities.^
+
+###Prepare for your appointment
 
 You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.
 
-You can download and fill in (but not sign) the forms in advance.
+You can download and fill in the forms in advance, but do not sign them.
 
 $D
 [Download ‘Affidavit for marriage’](/government/publications/affidavit-form-macao)
 [Download ’Affirmation for marriage’](/government/publications/affirmation-form-macao)
 $D
 
-You’ll need to provide supporting documents, including:
+You’ll need to bring supporting documents to your appointment, including:
 
 - your passport
-- your partner’s passport (if they’re not British)
+- your partner’s passport
 - your [full birth certificate](/order-copy-birth-death-marriage-certificate) or [naturalisation certificate](/get-replacement-citizenship-certificate)
-- proof of residence, such as a residence certificate - check with the embassy or local notary public to find out what you need
-- equivalent documents for your partner
-
-^Your partner will probably need to get an affirmation or affidavit as well.^
+- proof of residence, such as a residence certificate - check with the consulate or a local notary public to find out what you need
+- your partner’s full birth certificate or naturalisation certificate, and proof of residence for them
 
 ###Legalisation and translation
 
-You’ll need to get your affirmation or affidavit [translated](/government/collections/lists-of-translators-and-interpreters) into the local language and ‘[legalised](/get-document-legalised)’ (certified as genuine) by the local authorities - the embassy or consulate should be able to give you advice.
+You’ll need to get your affirmation or affidavit translated into the local language and [get it ‘legalised’](/get-document-legalised) (certified as genuine) by the local authorities - the consulate should be able to give you advice. [Find a professional translator](/government/collections/lists-of-translators-and-interpreters).
 
-If you’ve been divorced or widowed, you’ll also need:
+##Other documents you might need in order to get married
+
+If you’ve been divorced or widowed, you’ll need to have:
 
 - a [decree absolute or final order](/copy-decree-absolute-final-order) or the [death certificate](/order-copy-birth-death-marriage-certificate/)
-
-- evidence of nationality or residence where your divorce took place if it was outside the UK. You’ll need to get it [translated](/government/collections/lists-of-translators-and-interpreters) if it’s not in English.
+- evidence of nationality or residence where your divorce took place if it was outside the UK. You’ll need to get it [professionally translated](/government/collections/lists-of-translators-and-interpreters) if it’s not in English. [Find a professional translator](/government/collections/lists-of-translators-and-interpreters)
 
 You’ll also need to provide evidence if you’ve changed your name by deed poll.
-
-^Your partner will probably need to get an equivalent document from their national authorities.^
 
 ##Naturalisation of your partner if they move to the UK
 
@@ -56,6 +61,4 @@ Your partner can apply to [become a British citizen](/becoming-a-british-citizen
     as: :service,
     locals: { calculator: calculator } %>
 
-You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Macao](/government/publications/macao-consular-fees).
-
-You can pay by cash or credit card, but not by personal cheque.
+You can pay online by debit or credit card. If you’re not able to pay online, ask the consulate if you can pay an equivalent amount in Hong Kong dollars with a bank transfer.

--- a/app/flows/marriage_abroad_flow/outcomes/countries/macao/third_country/partner_other/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/macao/third_country/partner_other/_opposite_sex.erb
@@ -8,42 +8,47 @@ Contact the relevant local authorities in Macao to find out about local marriage
 
 You’ll be asked to provide an affirmation or affidavit document to prove you’re allowed to marry.
 
-Make an appointment at the British Consulate General Hong Kong to swear an affirmation/affadavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
+You can book an appointment at the Honorary Consulate in Macao to swear an affirmation or affidavit using the [contact form](https://www.contact-embassy.service.gov.uk/Enquiry/?enquirytext=&country=China&post=British%20Consulate%20General%20Hong%20Kong). You’ll need to:
 
-[Make an appointment at the British Consulate General Hong Kong.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=65&service=13)
+s1. Go to ‘Do the suggested pages answer your enquiry?’ and select ‘No, I would like to submit my enquiry’ to get the ‘Contact us’ form you need to fill in.
+s2. Include ‘MCA’ at the start of the 'What your enquiry is about' field.
+s3. In the ‘Details of your enquiry’ field, explain that you would like to book an appointment in Macao to swear an affirmation or affidavit for marriage.
+
+You’ll get a response asking you to pay a fee, and then your details will be passed over to the Honorary Consul in Macao. They will contact you within three working days to agree a date and time for your appointment.
+
+^Your partner will probably need to get an affirmation or affidavit from their own national authorities.^
+
+###Prepare for your appointment
 
 You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.
 
-You can download and fill in (but not sign) the forms in advance.
+You can download and fill in the forms in advance, but do not sign them.
 
 $D
 [Download ‘Affidavit for marriage’](/government/publications/affidavit-form-macao)
 [Download ’Affirmation for marriage’](/government/publications/affirmation-form-macao)
 $D
 
-You’ll need to provide supporting documents, including:
+You’ll need to bring supporting documents to your appointment, including:
 
 - your passport
-- your partner’s passport (if they’re not British)
+- your partner’s passport
 - your [full birth certificate](/order-copy-birth-death-marriage-certificate) or [naturalisation certificate](/get-replacement-citizenship-certificate)
-- proof of residence, such as a residence certificate - check with the embassy or local notary public to find out what you need
-- equivalent documents for your partner
-
-^Your partner will probably need to get an affirmation or affidavit as well.^
+- proof of residence, such as a residence certificate - check with the consulate or a local notary public to find out what you need
+- your partner’s full birth certificate or naturalisation certificate, and proof of residence for them
 
 ###Legalisation and translation
 
-You’ll need to get your affirmation or affidavit [translated](/government/collections/lists-of-translators-and-interpreters) into the local language and ‘[legalised](/get-document-legalised)’ (certified as genuine) by the local authorities - the embassy or consulate should be able to give you advice.
+You’ll need to get your affirmation or affidavit translated into the local language and [get it ‘legalised’](/get-document-legalised) (certified as genuine) by the local authorities - the consulate should be able to give you advice. [Find a professional translator](/government/collections/lists-of-translators-and-interpreters).
 
-If you’ve been divorced or widowed, you’ll also need:
+##Other documents you might need in order to get married
+
+If you’ve been divorced or widowed, you’ll need to have:
 
 - a [decree absolute or final order](/copy-decree-absolute-final-order) or the [death certificate](/order-copy-birth-death-marriage-certificate/)
-
-- evidence of nationality or residence where your divorce took place if it was outside the UK. You’ll need to get it [translated](/government/collections/lists-of-translators-and-interpreters) if it’s not in English.
+- evidence of nationality or residence where your divorce took place if it was outside the UK. You’ll need to get it [professionally translated](/government/collections/lists-of-translators-and-interpreters) if it’s not in English. [Find a professional translator](/government/collections/lists-of-translators-and-interpreters)
 
 You’ll also need to provide evidence if you’ve changed your name by deed poll.
-
-^Your partner will probably need to get an equivalent document from their national authorities.^
 
 ##Naturalisation of your partner if they move to the UK
 
@@ -56,6 +61,4 @@ Your partner can apply to [become a British citizen](/becoming-a-british-citizen
     as: :service,
     locals: { calculator: calculator } %>
 
-You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Macao](/government/publications/macao-consular-fees).
-
-You can pay by cash or credit card, but not by personal cheque.
+You can pay online by debit or credit card. If you’re not able to pay online, ask the consulate if you can pay an equivalent amount in Hong Kong dollars with a bank transfer.

--- a/app/flows/marriage_abroad_flow/outcomes/countries/macao/uk/partner_british/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/macao/uk/partner_british/_opposite_sex.erb
@@ -8,42 +8,46 @@ Contact the [Embassy of Macao](/government/publications/foreign-embassies-in-the
 
 You’ll be asked to provide an affirmation or affidavit document to prove you’re allowed to marry.
 
-Make an appointment at the British Consulate General Hong Kong to swear an affirmation/affadavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
+You can book an appointment at the Honorary Consulate in Macao to swear an affirmation or affidavit using the [contact form](https://www.contact-embassy.service.gov.uk/Enquiry/?enquirytext=&country=China&post=British%20Consulate%20General%20Hong%20Kong). You’ll need to:
 
-[Make an appointment at the British Consulate General Hong Kong.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=65&service=13)
+s1. Go to ‘Do the suggested pages answer your enquiry?’ and select ‘No, I would like to submit my enquiry’ to get the ‘Contact us’ form you need to fill in.
+s2. Include ‘MCA’ at the start of the 'What your enquiry is about' field.
+s3. In the ‘Details of your enquiry’ field, explain that you would like to book an appointment in Macao to swear an affirmation or affidavit for marriage.
+
+You’ll get a response asking you to pay a fee, and then your details will be passed over to the Honorary Consul in Macao. They will contact you within three working days to agree a date and time for your appointment.
+
+^Your partner will probably need to get an affirmation or affidavit as well.^
+
+###Prepare for your appointment
 
 You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.
 
-You can download and fill in (but not sign) the forms in advance.
+You can download and fill in the forms in advance, but do not sign them.
 
 $D
 [Download ‘Affidavit for marriage’](/government/publications/affidavit-form-macao)
 [Download ’Affirmation for marriage’](/government/publications/affirmation-form-macao)
 $D
 
-You’ll need to provide supporting documents, including:
+You’ll need to bring supporting documents to your appointment, including:
 
 - your passport
-- your partner’s passport (if they’re not British)
 - your [full birth certificate](/order-copy-birth-death-marriage-certificate) or [naturalisation certificate](/get-replacement-citizenship-certificate)
-- proof of residence, such as a residence certificate - check with the embassy or local notary public to find out what you need
-- equivalent documents for your partner
-
-^Your partner will probably need to get an affirmation or affidavit as well.^
+- proof of residence, such as a residence certificate - check with the consulate or a local notary public to find out what you need
+- your partner’s full birth certificate or naturalisation certificate, and proof of residence for them
 
 ###Legalisation and translation
 
-You’ll need to get your affirmation or affidavit [translated](/government/collections/lists-of-translators-and-interpreters) into the local language and ‘[legalised](/get-document-legalised)’ (certified as genuine) by the local authorities - the embassy or consulate should be able to give you advice.
+You’ll need to get your affirmation or affidavit translated into the local language and [get it ‘legalised’](/get-document-legalised) (certified as genuine) by the local authorities - the consulate should be able to give you advice. [Find a professional translator](/government/collections/lists-of-translators-and-interpreters).
 
-If you’ve been divorced or widowed, you’ll also need:
+##Other documents you might need in order to get married
+
+If you’ve been divorced or widowed, you’ll need to have:
 
 - a [decree absolute or final order](/copy-decree-absolute-final-order) or the [death certificate](/order-copy-birth-death-marriage-certificate/)
-
-- evidence of nationality or residence where your divorce took place if it was outside the UK. You’ll need to get it [translated](/government/collections/lists-of-translators-and-interpreters) if it’s not in English.
+- evidence of nationality or residence where your divorce took place if it was outside the UK. You’ll need to get it [professionally translated](/government/collections/lists-of-translators-and-interpreters) if it’s not in English. [Find a professional translator](/government/collections/lists-of-translators-and-interpreters)
 
 You’ll also need to provide evidence if you’ve changed your name by deed poll.
-
-^Your partner will probably need to get an affirmation or affidavit as well.^
 
 ## Fees
 
@@ -52,6 +56,4 @@ You’ll also need to provide evidence if you’ve changed your name by deed pol
     as: :service,
     locals: { calculator: calculator } %>
 
-You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Macao](/government/publications/macao-consular-fees).
-
-You can pay by cash or credit card, but not by personal cheque.
+You can pay online by debit or credit card. If you’re not able to pay online, ask the consulate if you can pay an equivalent amount in Hong Kong dollars with a bank transfer.

--- a/app/flows/marriage_abroad_flow/outcomes/countries/macao/uk/partner_local/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/macao/uk/partner_local/_opposite_sex.erb
@@ -8,42 +8,47 @@ Contact the [Embassy of Macao](/government/publications/foreign-embassies-in-the
 
 You’ll be asked to provide an affirmation or affidavit document to prove you’re allowed to marry.
 
-Make an appointment at the British Consulate General Hong Kong to swear an affirmation/affadavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
+You can book an appointment at the Honorary Consulate in Macao to swear an affirmation or affidavit using the [contact form](https://www.contact-embassy.service.gov.uk/Enquiry/?enquirytext=&country=China&post=British%20Consulate%20General%20Hong%20Kong). You’ll need to:
 
-[Make an appointment at the British Consulate General Hong Kong.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=65&service=13)
+s1. Go to ‘Do the suggested pages answer your enquiry?’ and select ‘No, I would like to submit my enquiry’ to get the ‘Contact us’ form you need to fill in.
+s2. Include ‘MCA’ at the start of the 'What your enquiry is about' field.
+s3. In the ‘Details of your enquiry’ field, explain that you would like to book an appointment in Macao to swear an affirmation or affidavit for marriage.
+
+You’ll get a response asking you to pay a fee, and then your details will be passed over to the Honorary Consul in Macao. They will contact you within three working days to agree a date and time for your appointment.
+
+^Your partner will probably need to get an affirmation or affidavit from their own national authorities.^
+
+###Prepare for your appointment
 
 You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.
 
-You can download and fill in (but not sign) the forms in advance.
+You can download and fill in the forms in advance, but do not sign them.
 
 $D
 [Download ‘Affidavit for marriage’](/government/publications/affidavit-form-macao)
 [Download ’Affirmation for marriage’](/government/publications/affirmation-form-macao)
 $D
 
-You’ll need to provide supporting documents, including:
+You’ll need to bring supporting documents to your appointment, including:
 
 - your passport
-- your partner’s passport (if they’re not British)
+- your partner’s passport
 - your [full birth certificate](/order-copy-birth-death-marriage-certificate) or [naturalisation certificate](/get-replacement-citizenship-certificate)
-- proof of residence, such as a residence certificate - check with the embassy or local notary public to find out what you need
-- equivalent documents for your partner
-
-^Your partner will probably need to get an affirmation or affidavit as well.^
+- proof of residence, such as a residence certificate - check with the consulate or a local notary public to find out what you need
+- your partner’s full birth certificate or naturalisation certificate, and proof of residence for them
 
 ###Legalisation and translation
 
-You’ll need to get your affirmation or affidavit [translated](/government/collections/lists-of-translators-and-interpreters) into the local language and ‘[legalised](/get-document-legalised)’ (certified as genuine) by the local authorities - the embassy or consulate should be able to give you advice.
+You’ll need to get your affirmation or affidavit translated into the local language and [get it ‘legalised’](/get-document-legalised) (certified as genuine) by the local authorities - the consulate should be able to give you advice. [Find a professional translator](/government/collections/lists-of-translators-and-interpreters).
 
-If you’ve been divorced or widowed, you’ll also need:
+##Other documents you might need in order to get married
+
+If you’ve been divorced or widowed, you’ll need to have:
 
 - a [decree absolute or final order](/copy-decree-absolute-final-order) or the [death certificate](/order-copy-birth-death-marriage-certificate/)
-
-- evidence of nationality or residence where your divorce took place if it was outside the UK. You’ll need to get it [translated](/government/collections/lists-of-translators-and-interpreters) if it’s not in English.
+- evidence of nationality or residence where your divorce took place if it was outside the UK. You’ll need to get it [professionally translated](/government/collections/lists-of-translators-and-interpreters) if it’s not in English. [Find a professional translator](/government/collections/lists-of-translators-and-interpreters)
 
 You’ll also need to provide evidence if you’ve changed your name by deed poll.
-
-^Your partner will probably need to get an equivalent document from their national authorities.^
 
 ##Naturalisation of your partner if they move to the UK
 
@@ -56,6 +61,4 @@ Your partner can apply to [become a British citizen](/becoming-a-british-citizen
     as: :service,
     locals: { calculator: calculator } %>
 
-You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Macao](/government/publications/macao-consular-fees).
-
-You can pay by cash or credit card, but not by personal cheque.
+You can pay online by debit or credit card. If you’re not able to pay online, ask the consulate if you can pay an equivalent amount in Hong Kong dollars with a bank transfer.

--- a/app/flows/marriage_abroad_flow/outcomes/countries/macao/uk/partner_other/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/macao/uk/partner_other/_opposite_sex.erb
@@ -8,42 +8,47 @@ Contact the [Embassy of Macao](/government/publications/foreign-embassies-in-the
 
 You’ll be asked to provide an affirmation or affidavit document to prove you’re allowed to marry.
 
-Make an appointment at the British Consulate General Hong Kong to swear an affirmation/affadavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
+You can book an appointment at the Honorary Consulate in Macao to swear an affirmation or affidavit using the [contact form](https://www.contact-embassy.service.gov.uk/Enquiry/?enquirytext=&country=China&post=British%20Consulate%20General%20Hong%20Kong). You’ll need to:
 
-[Make an appointment at the British Consulate General Hong Kong.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=65&service=13)
+s1. Go to ‘Do the suggested pages answer your enquiry?’ and select ‘No, I would like to submit my enquiry’ to get the ‘Contact us’ form you need to fill in.
+s2. Include ‘MCA’ at the start of the 'What your enquiry is about' field.
+s3. In the ‘Details of your enquiry’ field, explain that you would like to book an appointment in Macao to swear an affirmation or affidavit for marriage.
+
+You’ll get a response asking you to pay a fee, and then your details will be passed over to the Honorary Consul in Macao. They will contact you within three working days to agree a date and time for your appointment.
+
+^Your partner will probably need to get an affirmation or affidavit from their own national authorities.^
+
+###Prepare for your appointment
 
 You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.
 
-You can download and fill in (but not sign) the forms in advance.
+You can download and fill in the forms in advance, but do not sign them.
 
 $D
 [Download ‘Affidavit for marriage’](/government/publications/affidavit-form-macao)
 [Download ’Affirmation for marriage’](/government/publications/affirmation-form-macao)
 $D
 
-You’ll need to provide supporting documents, including:
+You’ll need to bring supporting documents to your appointment, including:
 
 - your passport
-- your partner’s passport (if they’re not British)
+- your partner’s passport
 - your [full birth certificate](/order-copy-birth-death-marriage-certificate) or [naturalisation certificate](/get-replacement-citizenship-certificate)
-- proof of residence, such as a residence certificate - check with the embassy or local notary public to find out what you need
-- equivalent documents for your partner
-
-^Your partner will probably need to get an affirmation or affidavit as well.^
+- proof of residence, such as a residence certificate - check with the consulate or a local notary public to find out what you need
+- your partner’s full birth certificate or naturalisation certificate, and proof of residence for them
 
 ###Legalisation and translation
 
-You’ll need to get your affirmation or affidavit [translated](/government/collections/lists-of-translators-and-interpreters) into the local language and ‘[legalised](/get-document-legalised)’ (certified as genuine) by the local authorities - the embassy or consulate should be able to give you advice.
+You’ll need to get your affirmation or affidavit translated into the local language and [get it ‘legalised’](/get-document-legalised) (certified as genuine) by the local authorities - the consulate should be able to give you advice. [Find a professional translator](/government/collections/lists-of-translators-and-interpreters).
 
-If you’ve been divorced or widowed, you’ll also need:
+##Other documents you might need in order to get married
+
+If you’ve been divorced or widowed, you’ll need to have:
 
 - a [decree absolute or final order](/copy-decree-absolute-final-order) or the [death certificate](/order-copy-birth-death-marriage-certificate/)
-
-- evidence of nationality or residence where your divorce took place if it was outside the UK. You’ll need to get it [translated](/government/collections/lists-of-translators-and-interpreters) if it’s not in English.
+- evidence of nationality or residence where your divorce took place if it was outside the UK. You’ll need to get it [professionally translated](/government/collections/lists-of-translators-and-interpreters) if it’s not in English. [Find a professional translator](/government/collections/lists-of-translators-and-interpreters)
 
 You’ll also need to provide evidence if you’ve changed your name by deed poll.
-
-^Your partner will probably need to get an equivalent document from their national authorities.^
 
 ##Naturalisation of your partner if they move to the UK
 
@@ -56,6 +61,4 @@ Your partner can apply to [become a British citizen](/becoming-a-british-citizen
     as: :service,
     locals: { calculator: calculator } %>
 
-You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Macao](/government/publications/macao-consular-fees).
-
-You can pay by cash or credit card, but not by personal cheque.
+You can pay online by debit or credit card. If you’re not able to pay online, ask the consulate if you can pay an equivalent amount in Hong Kong dollars with a bank transfer.


### PR DESCRIPTION
https://govuk.zendesk.com/agent/tickets/4988089
https://trello.com/c/Y8yBVlil/3918-marriage-abroad-guide-for-macao

You can now book an appointment in Macao for an affirmation or affidavit, rather than travelling to Hong Kong. These updates explain how you do that.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
