### PR TITLE
Update links on outcome page

### DIFF
--- a/app/flows/help_if_you_are_arrested_abroad_flow/outcomes/answer_one_generic.erb
+++ b/app/flows/help_if_you_are_arrested_abroad_flow/outcomes/answer_one_generic.erb
@@ -46,8 +46,7 @@
     <%= calculator.police %>
     <%= calculator.consul %>
     <%= calculator.lawyer %>
-
-    <%= calculator.region_downloads %>
+    <%= calculator.translator_interpreter %>
   <% end %>
 
   <% if calculator.country_name == "Iran" %>

--- a/app/flows/help_if_you_are_arrested_abroad_flow/outcomes/answer_one_generic.erb
+++ b/app/flows/help_if_you_are_arrested_abroad_flow/outcomes/answer_one_generic.erb
@@ -45,8 +45,10 @@
     <%= calculator.prison %>
     <%= calculator.police %>
     <%= calculator.consul %>
-    <%= calculator.lawyer %>
-    <%= calculator.translator_interpreter %>
+    <% unless calculator.english_speaking? %>
+      <%= calculator.lawyer %>
+      <%= calculator.translator_interpreter %>
+    <% end %>
   <% end %>
 
   <% if calculator.country_name == "Iran" %>

--- a/config/smart_answers/prisoner_packs.yml
+++ b/config/smart_answers/prisoner_packs.yml
@@ -134,20 +134,8 @@
   lawyer: /government/publications/cuba-list-of-lawyers
 - slug: curacao
 - slug: cyprus
-  regions:
-    north:
-      link: /government/publications/cyprus-north-prisoner-pack
-      url_text: Prisoner pack for the north of Cyprus
-    north_lawyer:
-      link: /government/publications/cyprus-north-list-of-lawyers
-      url_text: English speaking lawyers and translators/interpreters in North Cyprus
-    republic:
-      link: /government/publications/cyprus-prisoner-pack
-      url_text: Prisoner pack for people who have been imprisoned at Nicosia Central Prison or held on remand at a police station in the Republic of Cyprus
-    republic_lawyers:
-      link: /government/publications/cyprus-list-of-lawyers
-      url_text: English speaking lawyers and translators/interpreters in the Republic of Cyprus
-
+  pdf: /government/publications/cyprus-prisoner-pack
+  lawyer: /government/publications/cyprus-list-of-lawyers
 - slug: czech-republic
   pdf: /government/publications/czech-republic-prisoner-pack
   lawyer: /government/publications/czech-republic-list-of-lawyers

--- a/lib/smart_answer/calculators/arrested_abroad.rb
+++ b/lib/smart_answer/calculators/arrested_abroad.rb
@@ -4,7 +4,6 @@ module SmartAnswer::Calculators
     attr_reader :country
 
     PRISONER_PACKS = YAML.load_file(Rails.root.join("config/smart_answers/prisoner_packs.yml")).freeze
-    COUNTRIES_WITH_REGIONS = %w[cyprus].freeze
     COUNTRIES_WITHOUT_TRANFSERS_BACK = %w[austria
                                           belgium
                                           croatia
@@ -38,8 +37,10 @@ module SmartAnswer::Calculators
       output.join("\n")
     end
 
-    def get_country_regions
-      country_data["regions"]
+    def generate_url_for_lawyer_translator_interpreter(text, url)
+      return "" unless country_data && country_data["lawyer"]
+
+      "- [#{text}](#{url})"
     end
 
     def location
@@ -86,23 +87,17 @@ module SmartAnswer::Calculators
     end
 
     def lawyer
-      generate_url_for_download("lawyer", "English speaking lawyers and translators/interpreters in #{country_name}")
+      generate_url_for_lawyer_translator_interpreter("Find English speaking lawyers in #{country_name}", "https://find-a-professional-service-abroad.service.csd.fcdo.gov.uk/find?serviceType=lawyers")
+    end
+
+    def translator_interpreter
+      generate_url_for_lawyer_translator_interpreter("Find English speaking translators/interpreters in #{country_name}", "/government/collections/lists-of-translators-and-interpreters")
     end
 
     def has_extra_downloads
       extra_downloads = [police, judicial, consul, prison, lawyer, benefits, doc, pdf]
 
-      extra_downloads.any?(&:present?) || COUNTRIES_WITH_REGIONS.include?(country)
-    end
-
-    def region_downloads
-      return "" unless COUNTRIES_WITH_REGIONS.include?(country)
-
-      links = get_country_regions.values.map do |region|
-        "- [#{region['url_text']}](#{region['link']})"
-      end
-
-      links.join("\n")
+      extra_downloads.any?(&:present?)
     end
 
     def transfer_back

--- a/lib/smart_answer/calculators/arrested_abroad.rb
+++ b/lib/smart_answer/calculators/arrested_abroad.rb
@@ -16,6 +16,41 @@ module SmartAnswer::Calculators
                                           malta
                                           netherlands
                                           slovakia].freeze
+    ENGLISH_SPEAKING_COUNTRIES = %w[antigua-and-barbuda
+                                    australia
+                                    bahamas
+                                    barbados
+                                    belize
+                                    botswana
+                                    brunei
+                                    canada
+                                    dominica
+                                    fiji
+                                    the-gambia
+                                    ghana
+                                    grenada
+                                    ireland
+                                    jamaica
+                                    kenya
+                                    malawi
+                                    maldives
+                                    malta
+                                    mauritius
+                                    new-zealand
+                                    nigeria
+                                    papua-new-guinea
+                                    seychelles
+                                    sierra-leone
+                                    solomon-islands
+                                    sri-lanka
+                                    st-kitts-and-nevis
+                                    st-vincent-and-the-grenadines
+                                    trinidad-and-tobago
+                                    uganda
+                                    usa
+                                    zambia
+                                    zimbabwe].freeze
+
 
     def initialize(country)
       @country = country
@@ -56,6 +91,10 @@ module SmartAnswer::Calculators
 
     def country_name
       location.name
+    end
+
+    def english_speaking?
+      ENGLISH_SPEAKING_COUNTRIES.include?(country)
     end
 
     def pdf

--- a/test/flows/help_if_you_are_arrested_abroad_flow_test.rb
+++ b/test/flows/help_if_you_are_arrested_abroad_flow_test.rb
@@ -53,7 +53,7 @@ class HelpIfYouAreArrestedAbroadFlowTest < ActiveSupport::TestCase
     end
 
     should "render the extra dowloads if there are any for that country" do
-      assert_rendered_outcome text: "English speaking lawyers and translators/interpreters in France"
+      assert_rendered_outcome text: "Find English speaking lawyers in France"
     end
 
     should "render the transfer back option if it is a country with transfers back" do

--- a/test/unit/calculators/arrested_abroad_calculator_test.rb
+++ b/test/unit/calculators/arrested_abroad_calculator_test.rb
@@ -43,43 +43,6 @@ module SmartAnswer::Calculators
           assert calc.has_extra_downloads
         end
       end
-
-      context "region downloads" do
-        should "return list of region links for countries with regions" do
-          calc = ArrestedAbroad.new("cyprus")
-          calc.stubs(:get_country_regions).returns({
-            "a": { "url_text" => "Text 1", "link" => "link1" },
-            "b": { "url_text" => "Text 2", "link" => "link2" },
-          })
-          assert_equal calc.region_downloads, "- [Text 1](link1)\n- [Text 2](link2)"
-        end
-
-        should "return empty for countries without regions" do
-          calc = ArrestedAbroad.new("bermuda")
-          assert_equal calc.region_downloads, ""
-        end
-      end
-
-      context "countries with regions" do
-        should "pull out regions of the YML for Cyprus" do
-          calc = ArrestedAbroad.new("cyprus")
-          resp = calc.get_country_regions
-          assert resp["north"]
-          assert resp["north_lawyer"]
-          assert resp["republic"]
-          assert resp["republic_lawyers"]
-        end
-
-        should "pull the regions out of the YML for Cyprus" do
-          calc = ArrestedAbroad.new("cyprus")
-          resp = calc.get_country_regions["north"]
-          expected = {
-            "link" => "/government/publications/cyprus-north-prisoner-pack",
-            "url_text" => "Prisoner pack for the north of Cyprus",
-          }
-          assert_equal expected, resp
-        end
-      end
     end
   end
 end

--- a/test/unit/calculators/arrested_abroad_calculator_test.rb
+++ b/test/unit/calculators/arrested_abroad_calculator_test.rb
@@ -3,6 +3,18 @@ require_relative "../../test_helper"
 module SmartAnswer::Calculators
   class ArrestedAbroadCalculatorTest < ActiveSupport::TestCase
     context ArrestedAbroad do
+      context "#english_speaking?" do
+        should "return true for english speaking countries" do
+          calculator = ArrestedAbroad.new("usa")
+          assert calculator.english_speaking?
+        end
+
+        should "return false for non-english speaking countries" do
+          calculator = ArrestedAbroad.new("italy")
+          assert_not calculator.english_speaking?
+        end
+      end
+
       context "generating a URL" do
         should "not error if the country doesn't exist" do
           assert_nothing_raised do


### PR DESCRIPTION
We currently say 'lawyers and translators/interpreters' but only provide a link for lawyers. Including a separate link for translators will be helpful for users.

Replacing the individual country links with generic ones for all countries will make this smart answer easier to maintain.

Also hides the links for English speaking countries.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
