### PR TITLE
Fix missing and incorrect 404s

### DIFF
--- a/app/controllers/flow_controller.rb
+++ b/app/controllers/flow_controller.rb
@@ -4,6 +4,8 @@ class FlowController < ApplicationController
   before_action :set_cache_headers
   before_action :redirect_path_based_flows, except: :landing
 
+  rescue_from SmartAnswer::FlowRegistry::NotFound, with: :error_404
+
   def landing
     @presenter = FlowPresenter.new(flow, nil)
     @title = @presenter.title

--- a/app/controllers/smart_answers_controller.rb
+++ b/app/controllers/smart_answers_controller.rb
@@ -6,7 +6,6 @@ class SmartAnswersController < ApplicationController
   before_action :content_item, except: %w[index]
 
   rescue_from SmartAnswer::FlowRegistry::NotFound, with: :error_404
-  rescue_from SmartAnswer::InvalidNode, with: :error_404
 
   content_security_policy only: :visualise do |p|
     # The script used to render the visualise tool requires eval execution

--- a/test/functional/flow_controller_test.rb
+++ b/test/functional/flow_controller_test.rb
@@ -35,6 +35,11 @@ class FlowControllerTest < ActionController::TestCase
         end
       end
     end
+
+    should "respond 404 if flow isn't found" do
+      get :landing, params: { id: "non-existent-flow" }
+      assert_response :missing
+    end
   end
 
   context "GET /<id>/start" do


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Off the back of issues discovered in https://github.com/alphagov/smart-answers/pull/5988 this implements two changes:

- it fixes an issue where Smart Answers will raise a 500 when a non-existent Smart Answer is requested.
- it fixes an issue where Smart Answers raises a 404 when a programmer has made a configuration error. This should be a 500 error as a 404 is misleading.