### PR TITLE
Update property fire safety payment copy

### DIFF
--- a/app/flows/property_fire_safety_payment_flow.rb
+++ b/app/flows/property_fire_safety_payment_flow.rb
@@ -130,7 +130,7 @@ class PropertyFireSafetyPaymentFlow < SmartAnswer::Flow
       end
 
       next_node do |response|
-        raise SmartAnswer::InvalidResponse unless response.between?(0, 100)
+        raise SmartAnswer::InvalidResponse unless response.between?(10, 100)
 
         outcome :payment_amount
       end

--- a/app/flows/property_fire_safety_payment_flow.rb
+++ b/app/flows/property_fire_safety_payment_flow.rb
@@ -124,14 +124,16 @@ class PropertyFireSafetyPaymentFlow < SmartAnswer::Flow
       end
     end
 
-    value_question :percentage_owned?, parse: :to_f do
+    value_question :percentage_owned?, parse: Float do
       on_response do |response|
         calculator.percentage_owned = response / 100
       end
 
-      next_node do |response|
-        raise SmartAnswer::InvalidResponse unless response.between?(10, 100)
+      validate(:valid_percentage_owned?) do
+        calculator.valid_percentage_owned?
+      end
 
+      next_node do
         outcome :payment_amount
       end
     end

--- a/app/flows/property_fire_safety_payment_flow.rb
+++ b/app/flows/property_fire_safety_payment_flow.rb
@@ -12,7 +12,7 @@ class PropertyFireSafetyPaymentFlow < SmartAnswer::Flow
         if response == "yes"
           question :own_freehold?
         else
-          outcome :unlikely_to_need_fixing
+          outcome :unlikely_to_need_to_pay
         end
       end
     end
@@ -136,7 +136,7 @@ class PropertyFireSafetyPaymentFlow < SmartAnswer::Flow
       end
     end
 
-    outcome :unlikely_to_need_fixing
+    outcome :unlikely_to_need_to_pay
     outcome :have_to_pay
     outcome :payment_amount
   end

--- a/app/flows/property_fire_safety_payment_flow.rb
+++ b/app/flows/property_fire_safety_payment_flow.rb
@@ -38,7 +38,7 @@ class PropertyFireSafetyPaymentFlow < SmartAnswer::Flow
         if response == "yes"
           question :main_home_february_2022?
         else
-          question :year_of_purchase?
+          question :purchased_pre_or_post_february_2022?
         end
       end
     end
@@ -49,16 +49,29 @@ class PropertyFireSafetyPaymentFlow < SmartAnswer::Flow
 
       next_node do |response|
         if response == "yes"
-          question :year_of_purchase?
+          question :purchased_pre_or_post_february_2022?
         else
           outcome :have_to_pay
         end
       end
     end
 
-    value_question :year_of_purchase?, parse: Integer do
+    radio :purchased_pre_or_post_february_2022? do
+      option :pre_feb_2022
+      option :post_feb_2022
+
       on_response do |response|
         self.calculator = SmartAnswer::Calculators::PropertyFireSafetyPaymentCalculator.new
+        calculator.purchased_pre_or_post_february_2022 = response
+      end
+
+      next_node do
+        question :year_of_purchase?
+      end
+    end
+
+    value_question :year_of_purchase?, parse: Integer do
+      on_response do |response|
         calculator.year_of_purchase = response.to_i
       end
 

--- a/app/flows/property_fire_safety_payment_flow/outcomes/payment_amount.erb
+++ b/app/flows/property_fire_safety_payment_flow/outcomes/payment_amount.erb
@@ -6,8 +6,8 @@
   <% if calculator.fully_protected_from_costs?%>
     You are fully protected from costs
   <% else %>
-    Leaseholder costs capped at <%= number_to_currency(calculator.leaseholder_costs, unit: "£") %>
+    Leaseholder costs capped at <%= number_to_currency(calculator.leaseholder_costs, unit: "£", precision: 0) %>
 
-    Annual repayment capped at <%= number_to_currency(calculator.annual_leaseholder_costs, unit: "£") %>
+    Annual repayment capped at <%= number_to_currency(calculator.annual_leaseholder_costs, unit: "£", precision: 0) %>
   <% end%>
 <% end %>

--- a/app/flows/property_fire_safety_payment_flow/outcomes/unlikely_to_need_fixing.erb
+++ b/app/flows/property_fire_safety_payment_flow/outcomes/unlikely_to_need_fixing.erb
@@ -1,7 +1,0 @@
-<% text_for :title do %>
-  Thank you
-<% end %>
-
-<% govspeak_for :body do %>
-  Your building is unlikely to need fixing
-<% end %>

--- a/app/flows/property_fire_safety_payment_flow/outcomes/unlikely_to_need_to_pay.erb
+++ b/app/flows/property_fire_safety_payment_flow/outcomes/unlikely_to_need_to_pay.erb
@@ -1,0 +1,9 @@
+<% text_for :title do %>
+  You're unlikely to need to pay for major fire safety work
+<% end %>
+
+<% govspeak_for :body do %>
+  You're unlikely to need to carry out major work (for example replacing cladding) to fix any fire safety issues because your building is under 5 storeys.
+
+  If you're being asked to pay for major fire safety works, [contact correspondence@levellingup.gov.uk](mailto:correspondence@levellingup.gov.uk).
+<% end %>

--- a/app/flows/property_fire_safety_payment_flow/questions/building_over_11_metres.erb
+++ b/app/flows/property_fire_safety_payment_flow/questions/building_over_11_metres.erb
@@ -1,5 +1,9 @@
 <% text_for :title do %>
-  Is your building over 11 metres or 5 storeys tall?
+  Is your building over 4 storeys or 11 metres tall?
+<% end %>
+
+<% text_for :hint do %>
+  The ground floor is storey 1. Do not count any underground floors, for example a basement or car park.
 <% end %>
 
 <% options(

--- a/app/flows/property_fire_safety_payment_flow/questions/live_in_london.erb
+++ b/app/flows/property_fire_safety_payment_flow/questions/live_in_london.erb
@@ -1,5 +1,9 @@
 <% text_for :title do %>
-  Do you live in London?
+  Is your property in Greater London?
+<% end %>
+
+<% text_for :hint do %>
+  Answer yes if it's in a London borough or the City of London.
 <% end %>
 
 <% options(

--- a/app/flows/property_fire_safety_payment_flow/questions/own_freehold.erb
+++ b/app/flows/property_fire_safety_payment_flow/questions/own_freehold.erb
@@ -1,5 +1,5 @@
 <% text_for :title do %>
-  Do you own part or all of the freehold?
+  Is your building owned by some or all of the leaseholders?
 <% end %>
 
 <% options(

--- a/app/flows/property_fire_safety_payment_flow/questions/own_more_than_3_properties.erb
+++ b/app/flows/property_fire_safety_payment_flow/questions/own_more_than_3_properties.erb
@@ -1,5 +1,5 @@
 <% text_for :title do %>
-  Do you own more than 3 properties?
+  Do you own more than 3 residential properties in the UK?
 <% end %>
 
 <% options(

--- a/app/flows/property_fire_safety_payment_flow/questions/percentage_owned.erb
+++ b/app/flows/property_fire_safety_payment_flow/questions/percentage_owned.erb
@@ -1,5 +1,5 @@
 <% text_for :title do %>
-  What percentage of the property do you own?
+  What percentage of the property did you own on 14 February 2022?
 <% end %>
 
 <% text_for :error_message do %>

--- a/app/flows/property_fire_safety_payment_flow/questions/percentage_owned.erb
+++ b/app/flows/property_fire_safety_payment_flow/questions/percentage_owned.erb
@@ -2,6 +2,10 @@
   What percentage of the property did you own on 14 February 2022?
 <% end %>
 
+<% text_for :hint do %>
+  Check your shared ownership lease if you're not sure. If you bought the property after 14 February 2022, check the leaseholder certificate you got with the property.
+<% end%>
+
 <% text_for :error_message do %>
-  Please enter a figure between 0 and 100
+  Enter a number between 10 and 100
 <% end %>

--- a/app/flows/property_fire_safety_payment_flow/questions/purchased_pre_or_post_february_2022.erb
+++ b/app/flows/property_fire_safety_payment_flow/questions/purchased_pre_or_post_february_2022.erb
@@ -1,0 +1,8 @@
+<% text_for :title do %>
+  When did you buy your property?
+<% end %>
+
+<% options(
+  "pre_feb_2022": "Before or on 14 February 2022",
+  "post_feb_2022": "After 14 February 2022"
+) %>

--- a/app/flows/property_fire_safety_payment_flow/questions/value_of_property.erb
+++ b/app/flows/property_fire_safety_payment_flow/questions/value_of_property.erb
@@ -1,3 +1,17 @@
-<% text_for :title do %>
-  How much did you pay for your property?
-<% end %>
+<% if calculator.purchased_before_feb_2022? %>
+  <% text_for :title do %>
+   How much did you pay for your property?
+  <% end %>
+
+  <% text_for :hint do %>
+    You'll get a more accurate answer if you enter the exact value.
+  <% end %>
+<% else %>
+  <% text_for :title do %>
+    What was the value of your property the last time it was sold before 14 February 2022?
+  <% end %>
+
+  <% text_for :hint do %>
+    Check the leaseholder certificate you got when you bought the property. You'll get a more accurate answer if you enter the exact value.
+  <% end %>
+<% end%>

--- a/app/flows/property_fire_safety_payment_flow/questions/year_of_purchase.erb
+++ b/app/flows/property_fire_safety_payment_flow/questions/year_of_purchase.erb
@@ -1,8 +1,17 @@
-<% text_for :title do %>
-  What year did you buy your property?
-<% end %>
+<% if calculator.purchased_before_feb_2022? %>
+  <% text_for :title do %>
+    In what year did you buy your property?
+  <% end %>
+<% else %>
+  <% text_for :title do %>
+    In what year was your property last sold before 14 February 2022?
+  <% end %>
 
+ <% text_for :hint do %>
+    Check the leaseholder certificate you got when you bought the property.
+  <% end %>
+<% end%>
 
 <% text_for :error_message do %>
-  Please enter a year between <%= SmartAnswer::Calculators::PropertyFireSafetyPaymentCalculator::FIRST_VALID_YEAR %> and <%= SmartAnswer::Calculators::PropertyFireSafetyPaymentCalculator::LAST_VALID_YEAR %>
+  Enter a year between <%= SmartAnswer::Calculators::PropertyFireSafetyPaymentCalculator::FIRST_VALID_YEAR %> and <%= SmartAnswer::Calculators::PropertyFireSafetyPaymentCalculator::LAST_VALID_YEAR %>
 <% end %>

--- a/app/flows/property_fire_safety_payment_flow/start.erb
+++ b/app/flows/property_fire_safety_payment_flow/start.erb
@@ -1,8 +1,13 @@
-
 <% text_for :title do %>
-  Property fire safety payment
+  Check if you have to pay to fix fire safety problems with your property
 <% end %>
 
 <% govspeak_for :body do %>
-  Check if you have to pay to fix a fire safety issue with your property
+  If you're a leaseholder, check whether you'll have to pay to replace cladding or to fix other fire safety problems with your property.
+
+  If you have more than one property, answer for one property at a time.
+
+  You'll need to know the value of the property the last time it was sold before 14 February 2022. Check your leaseholder certificate if you bought your property after this date.
+
+  ^You do not have to pay costs if your property was built by a [developer who's agreed to pay for fire safety works](/guidance/list-of-developers-who-have-signed-building-safety-repairs-pledge).
 <% end %>

--- a/lib/smart_answer/calculators/property_fire_safety_payment_calculator.rb
+++ b/lib/smart_answer/calculators/property_fire_safety_payment_calculator.rb
@@ -1,6 +1,7 @@
 module SmartAnswer::Calculators
   class PropertyFireSafetyPaymentCalculator
-    attr_accessor :year_of_purchase,
+    attr_accessor :purchased_pre_or_post_february_2022,
+                  :year_of_purchase,
                   :value_of_property,
                   :live_in_london,
                   :shared_ownership,
@@ -16,6 +17,10 @@ module SmartAnswer::Calculators
     FIFTEEN_THOUSAND = 15_000
     FIFTY_THOUSAND = 50_000
     ONE_HUNDRED_THOUSAND = 100_000
+
+    def purchased_before_feb_2022?
+      @purchased_pre_or_post_february_2022 == "pre_feb_2022"
+    end
 
     def valid_year_of_purchase?
       @year_of_purchase.between?(FIRST_VALID_YEAR, LAST_VALID_YEAR)

--- a/lib/smart_answer/calculators/property_fire_safety_payment_calculator.rb
+++ b/lib/smart_answer/calculators/property_fire_safety_payment_calculator.rb
@@ -9,6 +9,8 @@ module SmartAnswer::Calculators
 
     FIRST_VALID_YEAR = 1900
     LAST_VALID_YEAR = 2022
+    MIN_PERCENTAGE_LIMIT = 0.1
+    MAX_PERCENTAGE_LIMIT = 1
     OUTSIDE_LONDON_VALUATION_LIMIT = 175_000
     INSIDE_LONDON_VALUATION_LIMIT = 325_000
     ONE_MILLION = 1_000_000
@@ -24,6 +26,10 @@ module SmartAnswer::Calculators
 
     def valid_year_of_purchase?
       @year_of_purchase.between?(FIRST_VALID_YEAR, LAST_VALID_YEAR)
+    end
+
+    def valid_percentage_owned?
+      @percentage_owned.between?(MIN_PERCENTAGE_LIMIT, MAX_PERCENTAGE_LIMIT)
     end
 
     def property_uprating_values

--- a/lib/smart_answer/calculators/property_fire_safety_payment_calculator.rb
+++ b/lib/smart_answer/calculators/property_fire_safety_payment_calculator.rb
@@ -19,6 +19,7 @@ module SmartAnswer::Calculators
     FIFTEEN_THOUSAND = 15_000
     FIFTY_THOUSAND = 50_000
     ONE_HUNDRED_THOUSAND = 100_000
+    ANNUAL_COST_OFFSET = 10
 
     def purchased_before_feb_2022?
       @purchased_pre_or_post_february_2022 == "pre_feb_2022"
@@ -57,7 +58,7 @@ module SmartAnswer::Calculators
     end
 
     def annual_leaseholder_costs
-      leaseholder_costs / 10
+      leaseholder_costs / ANNUAL_COST_OFFSET
     end
 
   private

--- a/lib/smart_answer/calculators/property_fire_safety_payment_calculator.rb
+++ b/lib/smart_answer/calculators/property_fire_safety_payment_calculator.rb
@@ -7,7 +7,7 @@ module SmartAnswer::Calculators
                   :shared_ownership,
                   :percentage_owned
 
-    FIRST_VALID_YEAR = 1945
+    FIRST_VALID_YEAR = 1900
     LAST_VALID_YEAR = 2022
     OUTSIDE_LONDON_VALUATION_LIMIT = 175_000
     INSIDE_LONDON_VALUATION_LIMIT = 325_000

--- a/test/flows/property_fire_safety_payment_flow_test.rb
+++ b/test/flows/property_fire_safety_payment_flow_test.rb
@@ -131,11 +131,11 @@ class PropertyFireSafetyPaymentFlowTest < ActiveSupport::TestCase
     end
 
     context "next_node" do
-      should "have a next node of value_of_property if year between 1945 and 2022 given" do
+      should "have a next node of value_of_property if year between 1900 and 2022 given" do
         assert_next_node :value_of_property?, for_response: "2019"
       end
 
-      should "have an invalid response if year outside 1945 - 2022 given" do
+      should "have an invalid response if year outside 1900 - 2022 given" do
         assert_invalid_response("2023")
       end
     end

--- a/test/flows/property_fire_safety_payment_flow_test.rb
+++ b/test/flows/property_fire_safety_payment_flow_test.rb
@@ -24,8 +24,8 @@ class PropertyFireSafetyPaymentFlowTest < ActiveSupport::TestCase
         assert_next_node :own_freehold?, for_response: "yes"
       end
 
-      should "have an outcome of unlikely_to_need_fixing if no" do
-        assert_next_node :unlikely_to_need_fixing, for_response: "no"
+      should "have an outcome of unlikely_to_need_to_pay if no" do
+        assert_next_node :unlikely_to_need_to_pay, for_response: "no"
       end
     end
   end
@@ -250,12 +250,12 @@ class PropertyFireSafetyPaymentFlowTest < ActiveSupport::TestCase
   context "outcomes" do
     context "when building is under 11 metres" do
       setup do
-        testing_node :unlikely_to_need_fixing
+        testing_node :unlikely_to_need_to_pay
         add_responses building_over_11_metres?: "no"
       end
 
       should "render outcome text" do
-        assert_rendered_outcome text: "Your building is unlikely to need fixing"
+        assert_rendered_outcome text: "You're unlikely to need to pay for major fire safety work"
       end
     end
 

--- a/test/flows/property_fire_safety_payment_flow_test.rb
+++ b/test/flows/property_fire_safety_payment_flow_test.rb
@@ -241,8 +241,8 @@ class PropertyFireSafetyPaymentFlowTest < ActiveSupport::TestCase
         assert_invalid_response("101")
       end
 
-      should "have an invalid response if percentage is under 0" do
-        assert_invalid_response("-1")
+      should "have an invalid response if percentage is under 10" do
+        assert_invalid_response("9")
       end
     end
   end
@@ -297,7 +297,7 @@ class PropertyFireSafetyPaymentFlowTest < ActiveSupport::TestCase
                       value_of_property?: "100000",
                       live_in_london?: "yes",
                       shared_ownership?: "yes",
-                      percentage_owned?: "5"
+                      percentage_owned?: "15"
       end
 
       should "render outcome text" do

--- a/test/flows/property_fire_safety_payment_flow_test.rb
+++ b/test/flows/property_fire_safety_payment_flow_test.rb
@@ -67,8 +67,8 @@ class PropertyFireSafetyPaymentFlowTest < ActiveSupport::TestCase
         assert_next_node :main_home_february_2022?, for_response: "yes"
       end
 
-      should "have a next node of year_of_purchase? if no" do
-        assert_next_node :year_of_purchase?, for_response: "no"
+      should "have a next node of purchased_pre_or_post_february_2022? if no" do
+        assert_next_node :purchased_pre_or_post_february_2022?, for_response: "no"
       end
     end
   end
@@ -86,12 +86,32 @@ class PropertyFireSafetyPaymentFlowTest < ActiveSupport::TestCase
     end
 
     context "next_node" do
-      should "have a next node of year_of_purchase? if yes" do
-        assert_next_node :year_of_purchase?, for_response: "yes"
+      should "have a next node of purchased_pre_or_post_february_2022? if yes" do
+        assert_next_node :purchased_pre_or_post_february_2022?, for_response: "yes"
       end
 
       should "have an outcome of have_to_pay if no" do
         assert_next_node :have_to_pay, for_response: "no"
+      end
+    end
+  end
+
+  context "question: purchased_pre_or_post_february_2022?" do
+    setup do
+      testing_node :purchased_pre_or_post_february_2022?
+      add_responses building_over_11_metres?: "yes",
+                    own_freehold?: "no",
+                    own_more_than_3_properties?: "yes",
+                    main_home_february_2022?: "yes"
+    end
+
+    should "render the question" do
+      assert_rendered_question
+    end
+
+    context "next_node" do
+      should "have a next node of year_of_purchase?" do
+        assert_next_node :year_of_purchase?, for_response: "post_feb_2022"
       end
     end
   end
@@ -102,7 +122,8 @@ class PropertyFireSafetyPaymentFlowTest < ActiveSupport::TestCase
       add_responses building_over_11_metres?: "yes",
                     own_freehold?: "no",
                     own_more_than_3_properties?: "yes",
-                    main_home_february_2022?: "yes"
+                    main_home_february_2022?: "yes",
+                    purchased_pre_or_post_february_2022?: "pre_feb_2022"
     end
 
     should "render the question" do
@@ -127,6 +148,7 @@ class PropertyFireSafetyPaymentFlowTest < ActiveSupport::TestCase
                     own_freehold?: "no",
                     own_more_than_3_properties?: "yes",
                     main_home_february_2022?: "yes",
+                    purchased_pre_or_post_february_2022?: "pre_feb_2022",
                     year_of_purchase?: "2019"
     end
 
@@ -148,6 +170,7 @@ class PropertyFireSafetyPaymentFlowTest < ActiveSupport::TestCase
                     own_freehold?: "no",
                     own_more_than_3_properties?: "yes",
                     main_home_february_2022?: "yes",
+                    purchased_pre_or_post_february_2022?: "pre_feb_2022",
                     year_of_purchase?: "2019",
                     value_of_property?: "100000"
     end
@@ -170,6 +193,7 @@ class PropertyFireSafetyPaymentFlowTest < ActiveSupport::TestCase
                     own_freehold?: "no",
                     own_more_than_3_properties?: "yes",
                     main_home_february_2022?: "yes",
+                    purchased_pre_or_post_february_2022?: "pre_feb_2022",
                     year_of_purchase?: "2019",
                     value_of_property?: "100000",
                     live_in_london?: "yes"
@@ -197,6 +221,7 @@ class PropertyFireSafetyPaymentFlowTest < ActiveSupport::TestCase
                     own_freehold?: "no",
                     own_more_than_3_properties?: "yes",
                     main_home_february_2022?: "yes",
+                    purchased_pre_or_post_february_2022?: "pre_feb_2022",
                     year_of_purchase?: "2019",
                     value_of_property?: "100000",
                     live_in_london?: "yes",
@@ -267,6 +292,7 @@ class PropertyFireSafetyPaymentFlowTest < ActiveSupport::TestCase
                       own_freehold?: "no",
                       own_more_than_3_properties?: "no",
                       main_home_february_2022?: "yes",
+                      purchased_pre_or_post_february_2022?: "pre_feb_2022",
                       year_of_purchase?: "2019",
                       value_of_property?: "100000",
                       live_in_london?: "yes",
@@ -286,6 +312,7 @@ class PropertyFireSafetyPaymentFlowTest < ActiveSupport::TestCase
                       own_freehold?: "no",
                       own_more_than_3_properties?: "no",
                       main_home_february_2022?: "yes",
+                      purchased_pre_or_post_february_2022?: "pre_feb_2022",
                       year_of_purchase?: "2019",
                       value_of_property?: "2000000",
                       live_in_london?: "yes",

--- a/test/unit/calculators/property_fire_safety_payment_calculator_test.rb
+++ b/test/unit/calculators/property_fire_safety_payment_calculator_test.rb
@@ -23,6 +23,23 @@ module SmartAnswer::Calculators
       end
     end
 
+    context "#valid_percentage_owned?" do
+      should "be valid if percentage owned is between minimum and maximum percentage limit" do
+        @calculator.percentage_owned = PropertyFireSafetyPaymentCalculator::MIN_PERCENTAGE_LIMIT
+        assert @calculator.valid_percentage_owned?
+      end
+
+      should "be invalid if percentage owned is over max percentage limit " do
+        @calculator.percentage_owned = PropertyFireSafetyPaymentCalculator::MAX_PERCENTAGE_LIMIT + 1
+        assert_not @calculator.valid_percentage_owned?
+      end
+
+      should "be invalid if year of purchase isless than minimum percentage" do
+        @calculator.percentage_owned = PropertyFireSafetyPaymentCalculator::MIN_PERCENTAGE_LIMIT - 1
+        assert_not @calculator.valid_percentage_owned?
+      end
+    end
+
     context "#uprated_value_of_property" do
       setup do
         stubbed_uprating_data = {


### PR DESCRIPTION
This PR introduces multiple changes in copy to questions and views.
It also makes a small number of technical changes
- changes a date validation from 1945 to 1900
- updates a percentage validation to check between 0.1 and 1 rather than 0 and 100
- moves a percentage validation from the flow to the calculator, following smart-answer ADR guidance
- some refactoring to move a magic number to a constant