### PR TITLE
Add UR recruitment banner

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -17,6 +17,7 @@ $govuk-new-link-styles: true;
 @import "govuk_publishing_components/components/hint";
 @import "govuk_publishing_components/components/input";
 @import "govuk_publishing_components/components/inset-text";
+@import "govuk_publishing_components/components/intervention";
 @import "govuk_publishing_components/components/label";
 @import "govuk_publishing_components/components/phase-banner";
 @import "govuk_publishing_components/components/print-link";

--- a/app/presenters/start_node/recruitment_banner.rb
+++ b/app/presenters/start_node/recruitment_banner.rb
@@ -1,0 +1,17 @@
+module StartNode
+  module RecruitmentBanner
+    SURVEY_URLS = {
+      "/maternity-paternity-pay-leave" => "https://GDSUserResearch.optimalworkshop.com/treejack/3z828uy6",
+    }.freeze
+
+    def recruitment_survey_url
+      SURVEY_URLS[base_path]
+    end
+
+  private
+
+    def base_path
+      "/#{@flow_presenter.name}"
+    end
+  end
+end

--- a/app/presenters/start_node_presenter.rb
+++ b/app/presenters/start_node_presenter.rb
@@ -1,4 +1,6 @@
 class StartNodePresenter < NodePresenter
+  include StartNode::RecruitmentBanner
+
   def initialize(node, flow_presenter, state = nil, options = {})
     super(node, flow_presenter, state)
     @renderer = options[:renderer] || SmartAnswer::ErbRenderer.new(

--- a/app/views/smart_answers/landing.html.erb
+++ b/app/views/smart_answers/landing.html.erb
@@ -19,6 +19,17 @@
   <link title="Search" rel="search" type="application/opensearchdescription+xml" href="/search/opensearch.xml"/>
 <% end %>
 
+<% if start_node && start_node.recruitment_survey_url %>
+  <div class="banner-container">
+      <%= render "govuk_publishing_components/components/intervention", {
+        suggestion_text: "Help improve GOV.UK",
+        suggestion_link_text: "Take part in user research",
+        suggestion_link_url: start_node.recruitment_survey_url,
+        new_tab: true,
+      } %>
+  </div>
+<% end %>
+
 <% content_for :breadcrumbs do %>
   <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: content_item %>
 <% end %>

--- a/test/fixtures/flows/banner_testing_flow.rb
+++ b/test/fixtures/flows/banner_testing_flow.rb
@@ -1,0 +1,17 @@
+class BannerTestingFlow < SmartAnswer::Flow
+  def define
+    name "maternity-paternity-pay-leave"
+    status :published
+
+    radio :two_carers do
+      option "yes"
+      option "no"
+
+      next_node do
+        outcome :done
+      end
+    end
+
+    outcome :done
+  end
+end

--- a/test/fixtures/flows/banner_testing_flow/questions/two_carers.erb
+++ b/test/fixtures/flows/banner_testing_flow/questions/two_carers.erb
@@ -1,0 +1,8 @@
+<% text_for :title do %>
+  Will the mother care for the child with a partner?
+<% end %>
+
+<% options(
+  "yes": "Yes",
+  "no": "No"
+) %>

--- a/test/fixtures/flows/banner_testing_flow/start.erb
+++ b/test/fixtures/flows/banner_testing_flow/start.erb
@@ -1,0 +1,3 @@
+<% text_for :title do %>
+  Check if you can get Maternity or Paternity Leave or Pay, or Maternity Allowance
+<% end %>

--- a/test/integration/recruitment_banner_test.rb
+++ b/test/integration/recruitment_banner_test.rb
@@ -1,0 +1,32 @@
+require_relative "../integration_test_helper"
+
+class RecruitmentBannerTest < ActionDispatch::IntegrationTest
+  setup do
+    stub_content_store_has_item("/maternity-paternity-pay-leave")
+    stub_content_store_has_item("/bridge-of-death")
+    setup_fixture_flows
+  end
+
+  teardown { teardown_fixture_flows }
+
+  should "display Recruitment Banner on the landing page of the specific smart answer" do
+    visit "/maternity-paternity-pay-leave"
+
+    assert page.has_css?(".gem-c-intervention")
+    assert page.has_link?("Take part in user research (opens in a new tab)", href: "https://GDSUserResearch.optimalworkshop.com/treejack/3z828uy6")
+  end
+
+  should "not display Recruitment Banner on non-landing pages of the specific smart answer" do
+    visit "/maternity-paternity-pay-leave/y"
+
+    assert_not page.has_css?(".gem-c-intervention")
+    assert_not page.has_link?("Take part in user research (opens in a new tab)", href: "https://GDSUserResearch.optimalworkshop.com/treejack/3z828uy6")
+  end
+
+  should "not display Recruitment Banner unless survey URL is specified for the base path" do
+    visit "/bridge-of-death"
+
+    assert_not page.has_css?(".gem-c-intervention")
+    assert_not page.has_link?("Take part in user research (opens in a new tab)", href: "https://GDSUserResearch.optimalworkshop.com/treejack/3z828uy6")
+  end
+end


### PR DESCRIPTION
Adds UR recruitment banner on the maternity-paternity-pay-leave smart answer landing page.

[Trello](https://trello.com/c/1Mo3VmGB/1106-launch-and-monitor-the-tree-test-using-the-intervention-banner-baseline)
[Sheet to show what URLs and study links to use](https://docs.google.com/spreadsheets/d/104ird2xevvcA77Lrhtrelkz4DpkoLJ30jdnDaq6bhpg/edit#gid=0)

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
