### PR TITLE
Fix raising InvalidNode errors based on user input

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ class ApplicationController < ActionController::Base
   rescue_from GdsApi::TimedOutException, with: :error_503
   rescue_from GdsApi::HTTPForbidden, with: :error_403
   rescue_from ActionController::UnknownFormat, with: :error_404
+  rescue_from SmartAnswer::FlowRegistry::NotFound, SmartAnswer::InvalidTransition, with: :error_404
 
   if ENV["BASIC_AUTH_USERNAME"] && ENV["BASIC_AUTH_PASSWORD"]
     http_basic_authenticate_with(

--- a/app/controllers/flow_controller.rb
+++ b/app/controllers/flow_controller.rb
@@ -4,8 +4,6 @@ class FlowController < ApplicationController
   before_action :set_cache_headers
   before_action :redirect_path_based_flows, except: :landing
 
-  rescue_from SmartAnswer::FlowRegistry::NotFound, with: :error_404
-
   def landing
     @presenter = FlowPresenter.new(flow, nil)
     @title = @presenter.title

--- a/app/controllers/smart_answers_controller.rb
+++ b/app/controllers/smart_answers_controller.rb
@@ -5,8 +5,6 @@ class SmartAnswersController < ApplicationController
   before_action :redirect_response_to_canonical_path, only: %w[show]
   before_action :content_item, except: %w[index]
 
-  rescue_from SmartAnswer::FlowRegistry::NotFound, with: :error_404
-
   content_security_policy only: :visualise do |p|
     # The script used to render the visualise tool requires eval execution
     # unfortunately

--- a/lib/smart_answer/invalid_transition.rb
+++ b/lib/smart_answer/invalid_transition.rb
@@ -1,0 +1,3 @@
+module SmartAnswer
+  class InvalidTransition < RuntimeError; end
+end

--- a/lib/smart_answer/outcome.rb
+++ b/lib/smart_answer/outcome.rb
@@ -7,7 +7,7 @@ module SmartAnswer
     end
 
     def transition(*_args)
-      raise InvalidNode
+      raise InvalidTransition, "can't transition once an outcome has been reached"
     end
   end
 end

--- a/test/functional/smart_answers_controller_test.rb
+++ b/test/functional/smart_answers_controller_test.rb
@@ -136,6 +136,11 @@ class SmartAnswersControllerTest < ActionController::TestCase
       assert_select ".outcome"
     end
 
+    should "return a 404 when providing more responses than accepted" do
+      get :show, params: { id: "radio-sample", started: "y", responses: "colder/no/extra-response" }
+      assert_response :missing
+    end
+
     should "have meta robots noindex on question pages" do
       get :show, params: { id: "radio-sample", started: "y" }
       assert_select "head meta[name=robots][content=noindex]"

--- a/test/unit/outcome_test.rb
+++ b/test/unit/outcome_test.rb
@@ -7,8 +7,8 @@ module SmartAnswer
     end
 
     context "#transition" do
-      should "raise InvalidNode exception so app responds with 404 Not Found" do
-        assert_raises(InvalidNode) do
+      should "raise InvalidTransition exception so app responds with 404 Not Found" do
+        assert_raises(InvalidTransition) do
           @outcome.transition
         end
       end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This resolves a regression introduced by https://github.com/alphagov/smart-answers/commit/152f74a3e6a3739fc45f45734b5e145e83bfb6f1 which led to 500 errors in Smart Answers when a user provided incorrect input. The situation was when a user was requesting a Smart Answer and had a path that had responses beyond what produces an outcome the application raises an error. (the example situation is: given a request of `/state-pension-age/y/age/2022-01-11/male` we only need `age/2022-01-11` to produce an outcome and `/male` is superfluous - when the application tries to process the `male` argument the application errors).

To resolve this I've created a new type of exception to cover this event that can be converted into a 404, so that this can be distinct from the configuration issues that InvalidNode exposes.

More info in the commits.