### PR TITLE
Update link to provide a warning before automatically opening a new tab

### DIFF
--- a/app/views/components/_result-item.html.erb
+++ b/app/views/components/_result-item.html.erb
@@ -10,10 +10,10 @@
 %>
 <%= tag.div class: css_classes do %>
   <h4 class="govuk-heading-s">
-    <%= link_to title, url,
+    <%= link_to (title + " (opens in new tab)" if title.present?), url,
     class: "govuk-link",
     target: "_blank",
-    rel: "noopener noreferrer",
+    rel: "noreferrer noopener",
     data: {
       module: "gem-track-click",
       "track-action": "#{group_index}.#{result_index}",


### PR DESCRIPTION
## What
https://trello.com/c/UFUUlRnQ/1354-accessibility-issue-on-next-steps-for-your-business-results-page

Update the links on the `next-steps-for-your-business` smart answer results page to follow the [Design System](https://design-system.service.gov.uk/styles/typography/#opening-links-in-a-new-tab) guidance to provide a warning that the links will open in a new tab.

Review link: [Next steps for your limited company - Check the next steps for your limited company](https://smart-answers-pr-6011.herokuapp.com/next-steps-for-your-business/results?activities%5B%5D=none&annual_turnover_over_85k=not_sure&business_premises%5B%5D=none&employ_someone=not_sure&financial_support=no)

## Why

To avoid confusion that may be caused by the appearance of new windows that were not requested by the user. Suddenly opening new windows can disorient users or be missed completely by some.