### PR TITLE
Add Year question type

### DIFF
--- a/app/flows/all_smart_answer_questions_flow.rb
+++ b/app/flows/all_smart_answer_questions_flow.rb
@@ -21,6 +21,21 @@ class AllSmartAnswerQuestionsFlow < SmartAnswer::Flow
 
     country_select :which_country?, additional_countries: additional_countries do
       next_node do
+        question :which_year?
+      end
+    end
+
+    year_question :which_year? do
+      next_node do
+        question :which_year_in_range?
+      end
+    end
+
+    year_question :which_year_in_range? do
+      from { Time.zone.now.year - 1 }
+      to { Time.zone.now.year + 1 }
+
+      next_node do
         question :which_date?
       end
     end

--- a/app/flows/all_smart_answer_questions_flow/questions/which_year.erb
+++ b/app/flows/all_smart_answer_questions_flow/questions/which_year.erb
@@ -1,0 +1,17 @@
+<% text_for :title do %>
+  Year question: What year is it?
+<% end %>
+
+<% text_for :caption do %>
+  This is a caption
+<% end %>
+
+<% govspeak_for :body do %>
+  Body can contain further explanations.
+
+  - and maybe govspeak
+<% end %>
+
+<% text_for :error_message do %>
+  That's not the year.
+<% end %>

--- a/app/flows/all_smart_answer_questions_flow/questions/which_year_in_range.erb
+++ b/app/flows/all_smart_answer_questions_flow/questions/which_year_in_range.erb
@@ -1,0 +1,17 @@
+<% text_for :title do %>
+  Year question: What year was last year, this year, or next year?
+<% end %>
+
+<% text_for :caption do %>
+  This is a caption
+<% end %>
+
+<% govspeak_for :body do %>
+  Body can contain further explanations.
+
+  - and maybe govspeak
+<% end %>
+
+<% text_for :error_message do %>
+  That's not last year, this year or next year.
+<% end %>

--- a/app/presenters/year_question_presenter.rb
+++ b/app/presenters/year_question_presenter.rb
@@ -1,0 +1,16 @@
+class YearQuestionPresenter < QuestionPresenter
+  def response_label(value)
+    value
+  end
+
+  def parsed_response
+    return {} if current_response.blank?
+
+    year = @node.parse_input(current_response)
+    {
+      year: year,
+    }
+  rescue SmartAnswer::InvalidResponse
+    {}
+  end
+end

--- a/app/views/smart_answers/inputs/_year_question.html.erb
+++ b/app/views/smart_answers/inputs/_year_question.html.erb
@@ -1,0 +1,26 @@
+<% form_contents = capture do %>
+  <% if question.body.present? %>
+    <%= question.body %>
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/date_input", {
+    error_message: question.error,
+    hint: question.hint,
+    items: [
+       {
+        label: "Year",
+        name: "response[year]",
+        width: 4,
+        value: question.parsed_response[:year],
+      }
+    ]
+  } %>
+<% end %>
+
+<%= render "smart_answers/inputs/caption", question: question %>
+<%= render "govuk_publishing_components/components/fieldset", {
+  legend_text: question.title,
+  heading_level: 1,
+  heading_size: "l",
+  text: form_contents
+} %>

--- a/docs/design/question-types.md
+++ b/docs/design/question-types.md
@@ -20,6 +20,11 @@
   * Validation: Must be a valid date.
   * Response: `Date` object.
 
+## `year_question`
+  * User input: Choose a single year.
+  * Validation: Must be a valid date in format YYYY that can be parsed as a valid date.
+  * Response: String of year extracted from `Date` object.
+
 ## `money_question`
   * User input: Enter a money amount.
   * Validation: Must be a number.

--- a/lib/smart_answer/flow.rb
+++ b/lib/smart_answer/flow.rb
@@ -79,6 +79,10 @@ module SmartAnswer
       add_node Question::Date.new(self, name, &block)
     end
 
+    def year_question(name, &block)
+      add_node Question::Year.new(self, name, &block)
+    end
+
     def value_question(name, options = {}, &block)
       add_node Question::Value.new(self, name, options, &block)
     end

--- a/lib/smart_answer/question/year.rb
+++ b/lib/smart_answer/question/year.rb
@@ -13,6 +13,14 @@ module SmartAnswer
         end
       end
 
+      def to(&block)
+        if block_given?
+          @to_func = block
+        else
+          @to_func && @to_func.call
+        end
+      end
+
       def parse_input(raw_input)
         date = case raw_input
                when Hash, ActiveSupport::HashWithIndifferentAccess
@@ -42,7 +50,7 @@ module SmartAnswer
     private
 
       def validate_input(date)
-        if from && date.year < from
+        if (from && date.year < from) || (to && date.year > to)
           raise InvalidResponse, "Provided year is out of range: #{date}", caller
         end
       end

--- a/lib/smart_answer/question/year.rb
+++ b/lib/smart_answer/question/year.rb
@@ -50,6 +50,8 @@ module SmartAnswer
     private
 
       def validate_input(date)
+        raise "from year must not be after the to year" if from && to && from >= to
+
         if (from && date.year < from) || (to && date.year > to)
           raise InvalidResponse, "Provided year is out of range: #{date}", caller
         end

--- a/lib/smart_answer/question/year.rb
+++ b/lib/smart_answer/question/year.rb
@@ -5,6 +5,14 @@ module SmartAnswer
     class Year < Base
       PRESENTER_CLASS = YearQuestionPresenter
 
+      def from(&block)
+        if block_given?
+          @from_func = block
+        else
+          @from_func && @from_func.call
+        end
+      end
+
       def parse_input(raw_input)
         date = case raw_input
                when Hash, ActiveSupport::HashWithIndifferentAccess
@@ -21,12 +29,21 @@ module SmartAnswer
                else
                  raise InvalidResponse, "Bad date", caller
                end
+        validate_input(date)
         date.year
       rescue ArgumentError => e
         if e.message =~ /invalid date/
           raise InvalidResponse, "Bad date: #{input.inspect}", caller
         else
           raise
+        end
+      end
+
+    private
+
+      def validate_input(date)
+        if from && date.year < from
+          raise InvalidResponse, "Provided year is out of range: #{date}", caller
         end
       end
     end

--- a/lib/smart_answer/question/year.rb
+++ b/lib/smart_answer/question/year.rb
@@ -1,0 +1,34 @@
+require "date"
+
+module SmartAnswer
+  module Question
+    class Year < Base
+      PRESENTER_CLASS = YearQuestionPresenter
+
+      def parse_input(raw_input)
+        date = case raw_input
+               when Hash, ActiveSupport::HashWithIndifferentAccess
+                 input = raw_input.symbolize_keys
+
+                 begin
+                   input = Integer(raw_input[:year])
+                   ::Date.new(input, 1, 1)
+                 rescue TypeError, ArgumentError
+                   raise InvalidResponse
+                 end
+               when String
+                 ::Date.parse("#{raw_input}-1-1")
+               else
+                 raise InvalidResponse, "Bad date", caller
+               end
+        date.year
+      rescue ArgumentError => e
+        if e.message =~ /invalid date/
+          raise InvalidResponse, "Bad date: #{input.inspect}", caller
+        else
+          raise
+        end
+      end
+    end
+  end
+end

--- a/test/fixtures/flows/year_sample_flow.rb
+++ b/test/fixtures/flows/year_sample_flow.rb
@@ -1,0 +1,12 @@
+class YearSampleFlow < SmartAnswer::Flow
+  def define
+    name "year-sample"
+
+    year_question :what_year? do
+      next_node do
+        outcome :done
+      end
+    end
+    outcome :done
+  end
+end

--- a/test/fixtures/flows/year_sample_flow/questions/what_year.erb
+++ b/test/fixtures/flows/year_sample_flow/questions/what_year.erb
@@ -1,0 +1,3 @@
+<% text_for :title do %>
+  What year?
+<% end %>

--- a/test/fixtures/flows/year_sample_flow/start.erb
+++ b/test/fixtures/flows/year_sample_flow/start.erb
@@ -1,0 +1,3 @@
+<% text_for :title do %>
+  Sample year question
+<% end %>

--- a/test/functional/smart_answers_controller_year_question_test.rb
+++ b/test/functional/smart_answers_controller_year_question_test.rb
@@ -1,0 +1,59 @@
+require_relative "../test_helper"
+require_relative "smart_answers_controller_test_helper"
+
+class SmartAnswersControllerYearQuestionTest < ActionController::TestCase
+  tests SmartAnswersController
+
+  include SmartAnswersControllerTestHelper
+
+  setup { setup_fixture_flows }
+  teardown { teardown_fixture_flows }
+
+  context "GET /<slug>" do
+    context "year question" do
+      should "display question" do
+        get :show, params: { id: "year-sample", started: "y" }
+        assert_select ".govuk-caption-l", "Sample year question"
+        assert_select ".govuk-fieldset__legend.govuk-fieldset__legend--l h1.govuk-fieldset__heading", /What year\?/
+        assert_select "input[name='response[year]']"
+      end
+
+      should "accept question input and redirect to canonical url" do
+        submit_response year: "2011"
+        assert_redirected_to "/year-sample/y/2011"
+      end
+
+      should "not error if passed blank response" do
+        submit_response ""
+        assert_response :success
+      end
+
+      should "not error if passed string response" do
+        submit_response "bob"
+        assert_response :success
+      end
+
+      context "no response given" do
+        should "redisplay question" do
+          submit_response(year: "")
+          assert_select ".govuk-fieldset__legend.govuk-fieldset__legend--l h1.govuk-fieldset__heading", /What year\?/
+        end
+
+        should "show an error message" do
+          submit_response(year: "")
+          assert_select ".govuk-error-message"
+          assert_contains css_select("title").first.content, /Error/
+        end
+      end
+
+      should "display answered question, and format number" do
+        get :show, params: { id: "year-sample", started: "y", responses: "2011" }
+        assert_select ".govuk-summary-list", /What year\?\s+2011/
+      end
+    end
+  end
+
+  def submit_response(response = nil, other_params = {})
+    super(response, other_params.merge(id: "year-sample"))
+  end
+end

--- a/test/unit/flow_presenter_test.rb
+++ b/test/unit/flow_presenter_test.rb
@@ -21,6 +21,12 @@ class FlowPresenterTest < ActiveSupport::TestCase
     @flow_presenter = FlowPresenter.new(@flow, state)
   end
 
+  test "#presenter_for returns presenter for Year question" do
+    question = @flow.year_question(:question_key).last
+    node_presenter = @flow_presenter.presenter_for(question)
+    assert_instance_of YearQuestionPresenter, node_presenter
+  end
+
   test "#presenter_for returns presenter for Date question" do
     question = @flow.date_question(:question_key).last
     node_presenter = @flow_presenter.presenter_for(question)

--- a/test/unit/flow_test.rb
+++ b/test/unit/flow_test.rb
@@ -115,6 +115,20 @@ class FlowTest < ActiveSupport::TestCase
     assert_equal Date.parse("2014-01-01"), s.questions.first.to
   end
 
+  test "Can build year question nodes" do
+    s = SmartAnswer::Flow.build do
+      year_question :what_year_were_you_born? do
+        on_response do |response|
+          self.year_of_birth = response
+        end
+      end
+    end
+
+    assert_equal 1, s.nodes.size
+    assert_equal 1, s.questions.size
+    assert_equal :what_year_were_you_born?, s.questions.first.name
+  end
+
   test "Can build value question nodes" do
     s = SmartAnswer::Flow.build do
       value_question :what_colour_are_the_bottles? do

--- a/test/unit/year_question_presenter_test.rb
+++ b/test/unit/year_question_presenter_test.rb
@@ -1,0 +1,37 @@
+require_relative "../test_helper"
+
+module SmartAnswer
+  class YearQuestionPresenterTest < ActiveSupport::TestCase
+    setup do
+      @question = Question::Year.new(nil, :question_name?)
+      @renderer = stub("renderer")
+
+      @presenter = YearQuestionPresenter.new(@question, nil, nil, renderer: @renderer)
+    end
+
+    test "#parsed_response returns current_response when it is a hash" do
+      hash = { year: 2021 }
+      @presenter.stubs(:current_response).returns(hash)
+
+      assert_equal hash, @presenter.parsed_response
+    end
+
+    test "#parsed_response returns year details as a hash when current_response is a parsable string" do
+      @presenter.stubs(:current_response).returns("2021")
+      hash = { year: 2021 }
+      assert_equal hash, @presenter.parsed_response
+    end
+
+    test "#parsed_response returns an empty hash when current_response is an invalid input" do
+      @presenter.stubs(:current_response).returns("blah-blah")
+
+      assert_empty @presenter.parsed_response
+    end
+
+    test "#parsed_response returns an empty hash when current_response is blank" do
+      @presenter.stubs(:current_response).returns("")
+
+      assert_empty @presenter.parsed_response
+    end
+  end
+end

--- a/test/unit/year_question_test.rb
+++ b/test/unit/year_question_test.rb
@@ -1,0 +1,83 @@
+require_relative "../test_helper"
+require "ostruct"
+
+module SmartAnswer
+  class YearQuestionTest < ActiveSupport::TestCase
+    def setup
+      @initial_state = State.new(:example)
+    end
+
+    context "#parse_input" do
+      setup do
+        @question = Question::Year.new(nil, :example)
+      end
+
+      context "when supplied with a hash" do
+        should "return a year representing the hash" do
+          year = @question.parse_input(year: 2015)
+          assert_equal 2015, year
+        end
+
+        should "raise an InvalidResponse exception when the hash value cannot be parsed an an Integer" do
+          assert_raises(InvalidResponse) do
+            @question.parse_input(year: "abc")
+          end
+        end
+      end
+
+      context "when supplied with a string" do
+        should "return a year representing the string" do
+          year = @question.parse_input("2015")
+          assert_equal 2015, year
+        end
+
+        should "raise an InvalidResponse exception when the string represents an invalid year" do
+          assert_raises(InvalidResponse) do
+            @question.parse_input("!")
+          end
+        end
+
+        should "raise an InvalidResponse exception when the string is empty" do
+          assert_raises(InvalidResponse) do
+            @question.parse_input("")
+          end
+        end
+      end
+
+      context "when supplied with another object" do
+        should "raise an InvalidResponse exception" do
+          assert_raises(InvalidResponse) do
+            @question.parse_input(Object.new)
+          end
+        end
+      end
+    end
+
+    test "years are parsed from Hash into Date before being saved" do
+      q = Question::Year.new(nil, :example) do
+        on_response do |response|
+          self.date = response
+        end
+
+        next_node { outcome :done }
+      end
+
+      new_state = q.transition(@initial_state, year: 2015)
+      assert_equal Date.parse("2015-01-01").year, new_state.date
+    end
+
+    test "invalid years raise an error" do
+      q = Question::Year.new(nil, :example) do
+        on_response do |response|
+          self.date = response
+        end
+
+        next_node { outcome :done }
+      end
+
+      assert_raise SmartAnswer::InvalidResponse do
+        q.transition(@initial_state, year: "!")
+      end
+    end
+  end
+end

--- a/test/unit/year_question_test.rb
+++ b/test/unit/year_question_test.rb
@@ -79,5 +79,36 @@ module SmartAnswer
         q.transition(@initial_state, year: "!")
       end
     end
+
+    test "rejects years before a specified from year" do
+      question = Question::Year.new(nil, :example) do
+        from { 2015 }
+        next_node { outcome :done }
+      end
+
+      assert_raises(InvalidResponse) do
+        question.transition(@initial_state, "2014")
+      end
+    end
+
+    test "accepts years equal to the specified from date" do
+      question = Question::Year.new(nil, :example) do
+        from { 2015 }
+        next_node { outcome :done }
+      end
+
+      new_state = question.transition(@initial_state, "2015")
+      assert @initial_state != new_state
+    end
+
+    test "accepts year greater than the specified from date" do
+      question = Question::Year.new(nil, :example) do
+        from { 2015 }
+        next_node { outcome :done }
+      end
+
+      new_state = question.transition(@initial_state, "2016")
+      assert @initial_state != new_state
+    end
   end
 end

--- a/test/unit/year_question_test.rb
+++ b/test/unit/year_question_test.rb
@@ -141,5 +141,19 @@ module SmartAnswer
       new_state = question.transition(@initial_state, "2014")
       assert @initial_state != new_state
     end
+
+    test "raises an error when year validation is misconfigured to block flow progression" do
+      question = Question::Year.new(nil, :example) do
+        to { 2015 }
+        from { 2015 }
+        next_node { outcome :done }
+      end
+
+      exception = assert_raise RuntimeError do
+        question.transition(@initial_state, "2015")
+      end
+
+      assert "from date must not be after the to date", exception.message
+    end
   end
 end

--- a/test/unit/year_question_test.rb
+++ b/test/unit/year_question_test.rb
@@ -110,5 +110,36 @@ module SmartAnswer
       new_state = question.transition(@initial_state, "2016")
       assert @initial_state != new_state
     end
+
+    test "rejects years after a specified to date" do
+      question = Question::Year.new(nil, :example) do
+        to { 2015 }
+        next_node { outcome :done }
+      end
+
+      assert_raises(InvalidResponse) do
+        question.transition(@initial_state, "2016")
+      end
+    end
+
+    test "accepts years equal to the specified to date" do
+      question = Question::Year.new(nil, :example) do
+        to { 2015 }
+        next_node { outcome :done }
+      end
+
+      new_state = question.transition(@initial_state, "2015")
+      assert @initial_state != new_state
+    end
+
+    test "accepts years less than the specified to date" do
+      question = Question::Year.new(nil, :example) do
+        to { 2015 }
+        next_node { outcome :done }
+      end
+
+      new_state = question.transition(@initial_state, "2014")
+      assert @initial_state != new_state
+    end
   end
 end


### PR DESCRIPTION
This PR adds a new question type, Year, which allows a user to answer questions requiring just a Year rather than a full day-month-year date.

A use-case has arisen for just the year to be entered. Current questions that could handle this are `value`, which allows free text, or `date`, which can apply a default day or month. These are both problematic.

- `value` will parse it as an integer and display the response in the playback as e.g `2,022`
- date will parse it as a Date and display the response in the playback and the url with default month or day e.g `01-01-2022` which may be misleading and confusing for the user

Extending the [Date question](https://github.com/alphagov/smart-answers/blob/3cbf1fa502a4dacfacd1aae06840252fd63abe53/lib/smart_answer/question/date.rb#L48)  to be able to handle a `year_only` option adds some complexity to an already complex class. It would need to be adapted to return different object types in different circumstances.

The new Year question will take user input and parse this into a Date object, before returning just the given year as a string. This resolves the presentation issues and keeps the class open for future Date-related operations to be added if needed.

[Preview app showing the new year_question type. The following question is a year_question with a stipulated range i.e given year must be between two dates.](https://smart-answers-pr-6016.herokuapp.com/all-smart-answer-questions/y/mithrandir,olorin/afghanistan)