### PR TITLE
Use year_question type for year_of_purchase

### DIFF
--- a/app/flows/check_fire_safety_costs_flow.rb
+++ b/app/flows/check_fire_safety_costs_flow.rb
@@ -70,13 +70,12 @@ class CheckFireSafetyCostsFlow < SmartAnswer::Flow
       end
     end
 
-    value_question :year_of_purchase?, parse: Integer do
+    year_question :year_of_purchase? do
+      from { SmartAnswer::Calculators::CheckFireSafetyCostsCalculator::FIRST_VALID_YEAR }
+      to { SmartAnswer::Calculators::CheckFireSafetyCostsCalculator::LAST_VALID_YEAR }
+
       on_response do |response|
         calculator.year_of_purchase = response.to_i
-      end
-
-      validate(:valid_year_of_purchase?) do
-        calculator.valid_year_of_purchase?
       end
 
       next_node do

--- a/lib/smart_answer/calculators/check_fire_safety_costs_calculator.rb
+++ b/lib/smart_answer/calculators/check_fire_safety_costs_calculator.rb
@@ -27,10 +27,6 @@ module SmartAnswer::Calculators
       @purchased_pre_or_post_february_2022 == "pre_feb_2022"
     end
 
-    def valid_year_of_purchase?
-      @year_of_purchase.between?(FIRST_VALID_YEAR, LAST_VALID_YEAR)
-    end
-
     def valid_percentage_owned?
       @percentage_owned.between?(MIN_PERCENTAGE_LIMIT, MAX_PERCENTAGE_LIMIT)
     end

--- a/test/flows/check_fire_safety_costs_flow_test.rb
+++ b/test/flows/check_fire_safety_costs_flow_test.rb
@@ -135,7 +135,11 @@ class CheckFireSafetyCostsFlowTest < ActiveSupport::TestCase
         assert_next_node :value_of_property?, for_response: "2019"
       end
 
-      should "have an invalid response if year outside 1900 - 2022 given" do
+      should "have an invalid response if year before 1900 given" do
+        assert_invalid_response("1899")
+      end
+
+      should "have an invalid response if year after 2022 given" do
         assert_invalid_response("2023")
       end
     end

--- a/test/unit/calculators/check_fire_safety_costs_calculator_test.rb
+++ b/test/unit/calculators/check_fire_safety_costs_calculator_test.rb
@@ -6,23 +6,6 @@ module SmartAnswer::Calculators
       @calculator = CheckFireSafetyCostsCalculator.new
     end
 
-    context "#valid_year_of_purchase?" do
-      should "be valid if year of purchase is between first valid year and last valid year" do
-        @calculator.year_of_purchase = CheckFireSafetyCostsCalculator::LAST_VALID_YEAR - 1
-        assert @calculator.valid_year_of_purchase?
-      end
-
-      should "be invalid if year of purchase is later than last valid " do
-        @calculator.year_of_purchase = CheckFireSafetyCostsCalculator::LAST_VALID_YEAR + 1
-        assert_not @calculator.valid_year_of_purchase?
-      end
-
-      should "be invalid if year of purchase is earlier than first valid year " do
-        @calculator.year_of_purchase = CheckFireSafetyCostsCalculator::FIRST_VALID_YEAR - 1
-        assert_not @calculator.valid_year_of_purchase?
-      end
-    end
-
     context "#valid_percentage_owned?" do
       should "be valid if percentage owned is between minimum and maximum percentage limit" do
         @calculator.percentage_owned = CheckFireSafetyCostsCalculator::MIN_PERCENTAGE_LIMIT


### PR DESCRIPTION
This PR changes the check-fire-safety-costs year_of_purchase question from a value_question to a year_question type.
This fixes a bug where the date was displayed as an integer in answer playback e.g `2,022`.

It also removes the validation of the date range from the calculator, as we can make use of the validation present in the question type instead.