### PR TITLE
Remove and replace styles with Design System styles in app component

### DIFF
--- a/app/assets/stylesheets/components/_result-item.scss
+++ b/app/assets/stylesheets/components/_result-item.scss
@@ -1,18 +1,6 @@
 .app-c-result-item {
   @include govuk-font($size: 19);
   padding-top: govuk-spacing(6);
-
-  &:first-child {
-    padding-top: 0;
-  }
-
-  .govuk-heading-s {
-    margin-bottom: govuk-spacing(2);
-  }
-
-  .govuk-body {
-    margin-bottom: govuk-spacing(6);
-  }
 }
 
 .app-c-result-item--highlighted {
@@ -20,12 +8,4 @@
   background-color: govuk-colour("light-grey");
   border-left: 5px solid govuk-colour("blue");
   padding: govuk-spacing(3);
-
-  &:first-child {
-    padding-top: govuk-spacing(3);
-  }
-
-  .govuk-body:last-child {
-    margin-bottom: govuk-spacing(1);
-  }
 }

--- a/app/views/components/_result-item.html.erb
+++ b/app/views/components/_result-item.html.erb
@@ -9,19 +9,19 @@
   css_classes << "app-c-result-item--highlighted" if highlighted
 %>
 <%= tag.div class: css_classes do %>
-  <h4 class="govuk-heading-s">
+  <h4 class="govuk-heading-s govuk-!-margin-bottom-2">
     <%= link_to (title + " (opens in new tab)" if title.present?), url,
-    class: "govuk-link",
-    target: "_blank",
-    rel: "noreferrer noopener",
-    data: {
-      module: "gem-track-click",
-      "track-action": "#{group_index}.#{result_index}",
-      "track-category": "SmartAnswerClicked",
-      "track-label": url
+      class: "govuk-link",
+      target: "_blank",
+      rel: "noreferrer noopener",
+      data: {
+        module: "gem-track-click",
+        "track-action": "#{group_index}.#{result_index}",
+        "track-category": "SmartAnswerClicked",
+        "track-label": url
     } %>
   </h4>
-  <p class="govuk-body">
+  <p class="govuk-body govuk-!-margin-bottom-1">
     <%= description %>
   </p>
 <% end %>


### PR DESCRIPTION
## What
https://trello.com/c/h0UwZnV3/1352-update-govuk-classes-in-result-itemscss

Replace the `.govuk-` classes in the `result-item` component with Design System utility classes.

Review link: [Next steps for your limited company - Check the next steps for your limited company](https://smart-answers-pr-6022.herokuapp.com/next-steps-for-your-business/results?activities%5B%5D=export_goods_or_services&activities%5B%5D=import_goods&annual_turnover_over_85k=yes&business_premises%5B%5D=owned&employ_someone=in_future&financial_support=yes)

## Why

To:
- adhere to the Single Responsibility Principle in the [CSS Style guide](
https://github.com/alphagov/govuk-frontend/blob/main/docs/contributing/coding-standards/css.md#single-responsibility-principle)
- replace custom styles with Design System styles.

## Anything else

I have removed the following style blocks which are unused.

- `govuk-body`

https://github.com/alphagov/smart-answers/blob/6c33e3c345e37f36e425b1fad2615e0fe0054259/app/assets/stylesheets/components/_result-item.scss#L13-L15

https://github.com/alphagov/smart-answers/blob/6c33e3c345e37f36e425b1fad2615e0fe0054259/app/assets/stylesheets/components/_result-item.scss#L28-L30

Because only one `p` element is rendered (for which I have settled on one DS utility class of `govuk-!-margin-bottom-1`).

https://github.com/alphagov/smart-answers/blob/cf7cc07776af34e0dc98ef5f26aa7af439aa7ef3/app/views/components/_result-item.html.erb#L24-L26

-  `&:first-child { padding-top: 0; }`

Which is an invalid selector and cannot identify the second element, in `app-c-result-sections__section`, as the first child https://www.w3.org/TR/selectors-3/#first-child-pseudo

```
<section class="app-c-result-sections__section">
  <h3 class="govuk-heading-m">Financial help</h3>
  <div class="app-c-result-item app-c-result-item--highlighted">
    <h4 class="govuk-heading-s">
    ..
  </div>
  <div class="app-c-result-item app-c-result-item--highlighted">
    <h4 class="govuk-heading-s">
    ..
  </div>
</section>

```