### PR TITLE
Update start.erb

### DIFF
--- a/app/flows/calculate_statutory_sick_pay_flow/start.erb
+++ b/app/flows/calculate_statutory_sick_pay_flow/start.erb
@@ -19,7 +19,7 @@
 
   ##Sick leave because of coronavirus (COVID-19)
   
-  Do not use the calculator if your employee became sick with COVID-19 on or before 24 March. You'll need to [work out the SSP manually](/guidance/statutory-sick-pay-manually-calculate-your-employees-payments) instead.
+  Do not use the calculator if your employee became sick with COVID-19 after 24 March. You'll need to [work out the SSP manually](/guidance/statutory-sick-pay-manually-calculate-your-employees-payments) instead.
 
   ##Different periods of sick leave
 


### PR DESCRIPTION
Summary:

Updating content below ##Sick leave because of coronavirus to correct inaccuracy. https://govuk.zendesk.com/agent/tickets/4985036 

=========

##Sick leave because of coronavirus (COVID-19)

CHANGE
Do not use the calculator if your employee became sick with COVID-19 on or before 24 March.

TO
Do not use the calculator if your employee became sick with COVID-19 after 24 March 2022.

REASON
Correcting inaccuracy.


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
