### PR TITLE
Replace govuk-content-schema-test-helpers with govuk_schemas

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,6 @@ gem "gds-api-adapters"
 gem "gds_zendesk"
 gem "govspeak"
 gem "govuk_app_config"
-gem "govuk-content-schema-test-helpers"
 gem "govuk_publishing_components"
 gem "htmlentities"
 gem "httparty"
@@ -36,6 +35,7 @@ end
 
 group :development, :test do
   gem "byebug"
+  gem "govuk_schemas"
   gem "govuk_test"
   gem "pry"
   gem "rubocop-govuk", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,8 +145,6 @@ GEM
       nokogiri (~> 1.12)
       rinku (~> 2.0)
       sanitize (~> 6)
-    govuk-content-schema-test-helpers (1.6.1)
-      json-schema (~> 2.8.0)
     govuk_app_config (4.6.3)
       logstasher (~> 2.1)
       prometheus_exporter (~> 2.0)
@@ -166,6 +164,8 @@ GEM
       rails (>= 6)
       rouge
       sprockets (>= 3)
+    govuk_schemas (4.4.0)
+      json-schema (~> 2.8.0)
     govuk_test (3.0.1)
       brakeman (>= 5.0.2)
       capybara (>= 3.36)
@@ -430,9 +430,9 @@ DEPENDENCIES
   gds-api-adapters
   gds_zendesk
   govspeak
-  govuk-content-schema-test-helpers
   govuk_app_config
   govuk_publishing_components
+  govuk_schemas
   govuk_test
   htmlentities
   httparty

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -38,9 +38,3 @@ class ActiveSupport::TestCase
 end
 
 require "slimmer/test"
-require "govuk-content-schema-test-helpers/test_unit"
-
-GovukContentSchemaTestHelpers.configure do |config|
-  config.schema_type = "publisher_v2"
-  config.project_root = Rails.root
-end

--- a/test/unit/content_item_presenter_test.rb
+++ b/test/unit/content_item_presenter_test.rb
@@ -1,8 +1,9 @@
 require_relative "../test_helper"
+require "govuk_schemas/assert_matchers"
 
 module SmartAnswer
   class ContentItemPresenterPresenterTest < ActiveSupport::TestCase
-    include GovukContentSchemaTestHelpers::TestUnit
+    include GovukSchemas::AssertMatchers
 
     setup do
       setup_fixture_flows
@@ -16,7 +17,7 @@ module SmartAnswer
     test "#payload returns a valid content-item" do
       content_item = ContentItemPresenter.new(@flow)
 
-      assert_valid_against_schema(content_item.payload, "smart_answer")
+      assert_valid_against_publisher_schema(content_item.payload, "smart_answer")
     end
 
     test "#payload includes flow specific data" do


### PR DESCRIPTION
Remove govuk-content-schema-test-helpers and replace with govuk_schemas for tests.

Draft because relies on the minitest branch of govuk_schemas, which is not yet merged.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

https://trello.com/c/b9PRFqgU/231-applications-use-govuk-content-schema-test-helpers-which-is-an-archived-gem
