### PR TITLE
Amending wording to make the meaning clearer

### DIFF
--- a/app/flows/check_building_safety_costs_flow/outcomes/_remaining_costs.erb
+++ b/app/flows/check_building_safety_costs_flow/outcomes/_remaining_costs.erb
@@ -5,7 +5,7 @@
 <% govspeak_for :body do %>
   If the freeholder or landlord (whoever is responsible for fixing problems with the building) wants to charge you to fix other building safety problems, they must show you a certificate proving that both:
 
-  + they were not responsible for causing the problem - for example because they built the building
+  + they were not responsible for causing the problem - for example because they did not build the building
 
   + they do not make enough money to pass a 'landlord contribution test'
 


### PR DESCRIPTION
Clarifying outcome so it's easier to understand freeholder or landlord are not responsible because they did not build the building.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
