### PR TITLE
Turn off font

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,6 +2,11 @@ $govuk-compatibility-govuktemplate: false;
 $govuk-use-legacy-palette: false;
 $govuk-new-link-styles: true;
 
+// This flag stops the font from being included in this application's
+// stylesheet - the font is being served by Static across all of GOV.UK, so is
+// not needed here.
+$govuk-include-default-font-face: false;
+
 @import "govuk_publishing_components/govuk_frontend_support";
 @import "govuk_publishing_components/components/checkboxes";
 @import "govuk_publishing_components/components/contextual-sidebar";


### PR DESCRIPTION
## What

Prevent the font from being included in `smart-answers`'s stylesheet.

## Why

We should be serving the font files from `static` so they're cached across the entirety of GOVUK - so the font shouldn't be included in `smart-answers`'s stylesheet.

With the font being served by each application, users need to re-download it every time they went from a page rendered in one application to a page rendered in another application.

Serving it from `static` means that the same font URI is used in each application, allowing the fonts to be cached and reused.

## Visual changes

None - the same font is being served from `static`, instead of `smart-answers`.

Before (the font paths contains `smart-answers`):
<img width="1904" alt="" src="https://user-images.githubusercontent.com/87758239/181207938-16054314-e907-476d-8041-d1f5f618102d.png">

After (the font path contains `static`):
<img width="1904" alt="" src="https://user-images.githubusercontent.com/87758239/181207968-126a9b1a-9355-41be-9db5-a9a389152e19.png">

---

## Search page examples to sanity check:

- https://smart-answers-pr-6055.herokuapp.com/additional-commodity-code