### PR TITLE
Replace inset_text component with <p> tags

### DIFF
--- a/app/flows/check_benefits_financial_support_flow/outcomes/results.erb
+++ b/app/flows/check_benefits_financial_support_flow/outcomes/results.erb
@@ -11,9 +11,7 @@
     <% end %>
   </div>
 
-  <%= render "govuk_publishing_components/components/inset_text", {
-    text: "At the moment, not all payments and help you might be able to claim have been included."
-  } %>
+  <p class="govuk-body">At the moment, not all payments and help you might be able to claim have been included.</p>
 
   <div class="govuk-!-margin-bottom-9">
     <%= render "govuk_publishing_components/components/heading", {


### PR DESCRIPTION
Using the inset_text component caused the text to be smaller than the
surrounding body text on the page. This commit swaps out this component
for regular <p> tags which keep the font sizing consistent.

## Previous

<img width="662" alt="Screenshot 2022-07-27 at 11 19 44" src="https://user-images.githubusercontent.com/24479188/181224060-f8d2d63f-a980-4a11-8ac6-14cd37b31812.png">

## New

<img width="677" alt="Screenshot 2022-07-27 at 11 19 34" src="https://user-images.githubusercontent.com/24479188/181224093-20ceae47-699c-4584-976c-61bf61e89caa.png">


Trello:
https://trello.com/c/96VGgATX/1398-smart-answer-new-benefits-to-the-benefits-checker-cost-of-living-checker-v2

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
