### PR TITLE
Fix broken logic for unemployed/self-employed mothers.

### DIFF
--- a/app/flows/maternity_paternity_pay_leave_flow.rb
+++ b/app/flows/maternity_paternity_pay_leave_flow.rb
@@ -480,12 +480,12 @@ class MaternityPaternityPayLeaveFlow < SmartAnswer::Flow
                   outcome :outcome_birth_nothing
                 end
               end
-            end
-          elsif %w[unemployed self-employed].include?(calculator.employment_status_of_mother)
-            if calculator.mother_earnings_employment?
-              outcome :outcome_mat_allowance
-            elsif !calculator.mother_earnings_employment?
-              outcome :outcome_birth_nothing
+            else
+              if calculator.mother_earnings_employment?
+                outcome :outcome_mat_allowance
+              else
+                outcome :outcome_birth_nothing
+              end
             end
           elsif !calculator.partner_continuity?
             case calculator.employment_status_of_mother

--- a/app/flows/maternity_paternity_pay_leave_flow/outcomes/_mat_allowance.erb
+++ b/app/flows/maternity_paternity_pay_leave_flow/outcomes/_mat_allowance.erb
@@ -64,7 +64,7 @@ Weekly rate (between <%= calculator.formatted_first_day_in_year(2021) %> and <%=
 
 <% if calculator.paid_leave_is_in_year?(2022) %>
 
-Weekly rate (between <%= calculator.formatted_first_day_in_year(2022) %> and <%= calculator.formatted_last_day_in_year(2022) %>) | £156.66 or 90% of their average weekly earnings (whichever is lower) - or from £27 if they’re [self-employed but have not paid enough Class 2 National Insurance](/maternity-allowance/eligibility)
+Weekly rate (between <%= calculator.formatted_first_day_in_year(2022) %> and <%= calculator.formatted_last_day_in_year(2022) %>) | £156.66 - or £27 if they’re [self-employed but have not paid enough Class 2 National Insurance](/maternity-allowance/eligibility)
 
 <% end %>
 

--- a/test/flows/maternity_paternity_pay_leave_flow_test.rb
+++ b/test/flows/maternity_paternity_pay_leave_flow_test.rb
@@ -3720,7 +3720,7 @@ class MaternityPaternityPayLeaveFlowTest < ActiveSupport::TestCase
 
     should "render _mat_allowance partial weekly rate for 2022" do
       add_responses due_date: "2022-1-1"
-      assert_rendered_outcome text: "£156.66 or 90%"
+      assert_rendered_outcome text: "£156.66"
     end
   end
 


### PR DESCRIPTION
To fix problems like:
https://www.gov.uk/maternity-paternity-pay-leave/y/yes/2022-11-20/unemployed/worker/yes/yes/yes/yes/yes 
crashing the page.

https://trello.com/c/sNwVoHEl/1424-fix-crashes-in-maternity-or-paternity-leave-or-pay-smart-answer

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
