### PR TITLE
Reinstate conditional for TV licence

### DIFF
--- a/config/smart_answers/check_benefits_financial_support_data.yml
+++ b/config/smart_answers/check_benefits_financial_support_data.yml
@@ -289,6 +289,7 @@
     - name: free_tv_licence
       title: Get a free or discounted TV licence
       description: You may be able to get a free TV licence if you’re 75 or older and get Pension Credit.
+      condition: eligible_for_free_tv_licence?
       url: /free-discount-tv-licence
       url_text: Check if you’re eligible for a free or discounted TV licence
       group: Help with your bills

--- a/lib/smart_answer/calculators/check_benefits_financial_support_calculator.rb
+++ b/lib/smart_answer/calculators/check_benefits_financial_support_calculator.rb
@@ -129,6 +129,10 @@ module SmartAnswer::Calculators
       @over_state_pension_age == "yes" && @disability_or_health_condition == "yes"
     end
 
+    def eligible_for_free_tv_licence?
+      @over_state_pension_age == "yes"
+    end
+
     def eligible_for_nhs_low_income_scheme?
       @assets_and_savings == "under_16000"
     end

--- a/test/unit/calculators/checks_benefits_financial_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_financial_support_calculator_test.rb
@@ -621,6 +621,24 @@ module SmartAnswer::Calculators
         end
       end
 
+      context "#eligible_for_free_tv_licence?" do
+        context "when eligible" do
+          should "be true if over state pension age" do
+            calculator = CheckBenefitsFinancialSupportCalculator.new
+            calculator.over_state_pension_age = "yes"
+            assert calculator.eligible_for_free_tv_licence?
+          end
+        end
+
+        context "when ineligible" do
+          should "be false if under state pension age" do
+            calculator = CheckBenefitsFinancialSupportCalculator.new
+            calculator.over_state_pension_age = "no"
+            assert_not calculator.eligible_for_free_tv_licence?
+          end
+        end
+      end
+
       context "#eligible_for_nhs_low_income_scheme?" do
         context "when eligible" do
           should "be true if under 16000 assets" do


### PR DESCRIPTION
The conditional was accidentally removed in [1].

[1]: https://github.com/alphagov/smart-answers/pull/6064/files

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
