### PR TITLE
Add GA4 analytics to print link

### DIFF
--- a/app/views/smart_answers/custom_result.html.erb
+++ b/app/views/smart_answers/custom_result.html.erb
@@ -37,7 +37,19 @@
         } %>
     <% end %>
 
-    <%= render "govuk_publishing_components/components/print_link" %>
+    <%= render 'govuk_publishing_components/components/print_link', {
+      data_attributes: {
+        module: "ga4-event-tracker",
+        ga4: {
+          event_name: 'print_page',
+          type: 'Print this page',
+          index: 1,
+          index_total: 1,
+          section: 'Footer',
+        },
+      },
+    } %>
+
     <%= render 'smart_answers/shared/debug' %>
   </div>
 </div>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
- adds GA4 tracking attributes to the print link component
- print link only occurs in one place, at the end of the '[Check the next steps for your limited company](https://www.gov.uk/next-steps-for-your-business)' smart answer, as it uses a custom finish page

Note that this tracking is only active on integration.

## Why

## Visual changes
None.

Trello card: https://trello.com/c/GlsJk20k/350-print-this-page
