### PR TITLE
Update Redundancy Pay NI for 2022-23

### DIFF
--- a/config/smart_answers/rates/redundancy_pay_northern_ireland.yml
+++ b/config/smart_answers/rates/redundancy_pay_northern_ireland.yml
@@ -39,3 +39,7 @@
   end_date: 2022-04-05
   max: "16,980"
   rate: 566
+- start_date: 2022-04-06
+  end_date: 2023-04-05
+  max: "17,820"
+  rate: 594

--- a/test/unit/calculators/redundancy_calculator_test.rb
+++ b/test/unit/calculators/redundancy_calculator_test.rb
@@ -61,12 +61,13 @@ module SmartAnswer::Calculators
       should "vary the rate per year" do
         assert_equal 547, RedundancyCalculator.northern_ireland_redundancy_rates(Date.new(2019, 4, 6)).rate
         assert_equal 560, RedundancyCalculator.northern_ireland_redundancy_rates(Date.new(2020, 4, 6)).rate
+        assert_equal 594, RedundancyCalculator.northern_ireland_redundancy_rates(Date.new(2022, 4, 6)).rate
       end
 
       should "vary the max amount per year" do
         assert_equal "16,410", RedundancyCalculator.northern_ireland_redundancy_rates(Date.new(2019, 4, 6)).max
         assert_equal "16,800", RedundancyCalculator.northern_ireland_redundancy_rates(Date.new(2020, 4, 6)).max
-        assert_equal "16,980", RedundancyCalculator.northern_ireland_redundancy_rates(Date.new(Time.zone.today.year, 12, 31)).max
+        assert_equal "17,820", RedundancyCalculator.northern_ireland_redundancy_rates(Date.new(Time.zone.today.year, 12, 31)).max
       end
     end
 


### PR DESCRIPTION
Updates Northern Ireland redundancy pay rate for 2022-23

[trello](https://trello.com/c/vwxZpdhX/1425-pay-cap-redundancy-calculator)