### PR TITLE
Update interest rate for self assessment penalties

### DIFF
--- a/lib/smart_answer/calculators/self_assessment_penalties.rb
+++ b/lib/smart_answer/calculators/self_assessment_penalties.rb
@@ -46,7 +46,8 @@ module SmartAnswer::Calculators
       { start_date: "2022-02-21", end_date: "2022-04-04", value: 0.03 },
       { start_date: "2022-04-05", end_date: "2022-05-23", value: 0.0325 },
       { start_date: "2022-05-24", end_date: "2022-07-04", value: 0.035 },
-      { start_date: "2022-07-05", end_date: "2100-04-04", value: 0.0375 },
+      { start_date: "2022-07-05", end_date: "2022-08-22", value: 0.0375 },
+      { start_date: "2022-08-23", end_date: "2100-04-04", value: 0.0425 },
     ].freeze
 
     def tax_year_range


### PR DESCRIPTION
Updates interest rate from 3.75% to 4.25% from the 23 August 2022.

Trello:
https://trello.com/c/bGAvqMJ8/1433-estimate-your-penalty-for-late-self-assessment-tax-returns-and-payments

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
