### PR TITLE
Update _opposite_sex.erb

### DIFF
--- a/app/flows/marriage_abroad_flow/outcomes/countries/japan/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/japan/_opposite_sex.erb
@@ -18,13 +18,9 @@ If you and your partner are both British, you both need to apply for and swear a
 
 ##Apply for an affirmation or affidavit of marriage
 
-You can apply for an affirmation or affidavit online or with a paper form. It costs £50 per person.
+You can apply for an affirmation or affidavit online. It costs £50 per person.
 
-You need to bring the affirmation or affidavit to your appointment at the British embassy. Do not sign the affirmation or affidavit when you get it - you’ll need to sign it at the embassy appointment.
-
-###Apply for an affirmation or affidavit of marriage online
-
-You can pay the £50 per person fee either:
+You can pay either:
 
 - online as you apply
 - in cash using the [local currency](/government/publications/fco-consular-services-abroad-exchange-rates) when you go for your embassy appointment
@@ -36,21 +32,27 @@ You’ll need:
 - a photo of your proof of address, which can be a utility bill, a bank statement or a Japanese residence card
 - a debit or credit card, if you want to pay online
 
-You’ll be told if you need to provide any other documents. For example, if you’ve been married before you’ll need proof that the marriage is over.
+If it applies to you, you’ll also need: 
+
+- a photo of your certificate of naturalisation or registration
+- a photo of evidence if you've changed your name by deed poll
+- a photo of a death certificate if you’re widowed
+- a photo of your divorce document 
+
+You’ll be told if you need to provide any other documents.
 
 [Apply for the affirmation or affidavit of marriage](https://www.prove-eligibility-foreign-government.service.gov.uk/japan/do-you-have-a-uk-passport).
 
-###Apply for an affirmation or affidavit of marriage with a paper form
-
-This costs £50 per person in the [local currency](/government/publications/fco-consular-services-abroad-exchange-rates). You can pay in person using cash or a Visa or Mastercard credit card.
-
-[Download and fill in an application form using the guidance](/government/publications/affidavitaffirmation-of-marital-status-japan).
+###Help with your affirmation or affidavit application
+If you're having problems applying for an affirmation or affidavit online, call the British Embassy Tokyo on +81 (0)3 5211 1100.
 
 ##Book an appointment at the British embassy in Tokyo
 
 You need to book an appointment to swear your affirmation or affidavit at the British embassy in Tokyo.
 
-You’ll be told how to book the appointment when you apply for the affirmation or affidavit online or by paper form. You’ll also be told what documents you must bring to your appointment, including your affirmation or affidavit.
+You’ll receive the link to book an appointment when you complete your online application. 
+
+You’ll need to bring the original of all your supporting documents. You don’t need to bring your affirmation or affidavit, embassy staff will print this at your appointment.
 
 ##Get married
 


### PR DESCRIPTION
Japan only has 3 outcomes in Marriage abroad, so that's why there’s only one to edit.

Changes made:
- Removing any mention of applying via paper form as this is no longer available to users. 
- Removing references to printing affirmation or affidavit as embassy now do it for you. 
- Updating the documents users need to bring with them to their embassy appointment.
- Adding an option for those who are struggling to complete the form to get help. 
- Restructuring content to help with flow and clarity.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
