### PR TITLE
Add hints for england-and-wales siblings and aunt/uncle questions.

### DIFF
--- a/app/flows/inherits_someone_dies_without_will_flow/questions/aunts_or_uncles.erb
+++ b/app/flows/inherits_someone_dies_without_will_flow/questions/aunts_or_uncles.erb
@@ -6,3 +6,9 @@
   "yes": "Yes",
   "no": "No"
 ) %>
+
+<% if calculator.hint_needed_for_half_relations? %>
+  <% text_for :hint do %>
+    This does not include half-aunts or half-uncles
+  <% end %>
+<% end %>

--- a/app/flows/inherits_someone_dies_without_will_flow/questions/siblings.erb
+++ b/app/flows/inherits_someone_dies_without_will_flow/questions/siblings.erb
@@ -6,3 +6,9 @@
   "yes": "Yes",
   "no": "No"
 ) %>
+
+<% if calculator.hint_needed_for_half_relations? %>
+  <% text_for :hint do %>
+    This does not include half-brothers or half-sisters
+  <% end %>
+<% end %>

--- a/lib/smart_answer/calculators/inherits_someone_dies_without_will_calculator.rb
+++ b/lib/smart_answer/calculators/inherits_someone_dies_without_will_calculator.rb
@@ -55,5 +55,9 @@ module SmartAnswer::Calculators
     def more_than_one_child?
       more_than_one_child == "yes"
     end
+
+    def hint_needed_for_half_relations?
+      region == "england-and-wales"
+    end
   end
 end

--- a/test/flows/inherits_someone_dies_without_will_flow_test.rb
+++ b/test/flows/inherits_someone_dies_without_will_flow_test.rb
@@ -250,6 +250,26 @@ class InheritsSomeoneDiesWithoutWillFlowTest < ActiveSupport::TestCase
       assert_rendered_question
     end
 
+    context "in england-and-wales" do
+      should "render a hint" do
+        assert_rendered_question_hint
+      end
+    end
+
+    context "in scotland" do
+      should "not render a hint" do
+        add_responses region?: "scotland"
+        assert_not_rendered_question_hint
+      end
+    end
+
+    context "in northern-ireland" do
+      should "not render a hint" do
+        add_responses region?: "northern-ireland"
+        assert_not_rendered_question_hint
+      end
+    end
+
     context "next_node" do
       should "have a next node of outcome_4 for a 'yes' response if region is england-and-wales" do
         assert_next_node :outcome_4, for_response: "yes"
@@ -409,6 +429,28 @@ class InheritsSomeoneDiesWithoutWillFlowTest < ActiveSupport::TestCase
 
     should "render the question" do
       assert_rendered_question
+    end
+
+    context "in england-and-wales" do
+      should "render a hint" do
+        add_responses region?: "england-and-wales",
+                      half_siblings?: "no",
+                      grandparents?: "no"
+        assert_rendered_question_hint
+      end
+    end
+
+    context "in scotland" do
+      should "not render a hint" do
+        assert_not_rendered_question_hint
+      end
+    end
+
+    context "in northern-ireland" do
+      should "not render a hint" do
+        add_responses region?: "northern-ireland"
+        assert_not_rendered_question_hint
+      end
     end
 
     context "next_node" do

--- a/test/support/flow_test_helper.rb
+++ b/test/support/flow_test_helper.rb
@@ -68,6 +68,14 @@ module FlowTestHelper
     assert_not_empty test_flow.question_title
   end
 
+  def assert_rendered_question_hint
+    assert_not_empty test_flow.question_hint
+  end
+
+  def assert_not_rendered_question_hint
+    assert_nil test_flow.question_hint
+  end
+
   def assert_rendered_outcome(text: nil)
     ensure_valid_and_correct_node
 
@@ -144,6 +152,12 @@ module FlowTestHelper
       raise "#{state.current_node_name} is not a question" unless current_node_type == :question
 
       QuestionPresenter.new(flow.node(state.current_node_name), nil, state).title
+    end
+
+    def question_hint
+      raise "#{state.current_node_name} is not a question" unless current_node_type == :question
+
+      QuestionPresenter.new(flow.node(state.current_node_name), nil, state).hint
     end
 
     def outcome_body


### PR DESCRIPTION
Adds hint texts to siblings and aunt/uncles questions for england and wales only to not that this does not include half-siblings or half-aunts/half-uncles.

https://trello.com/c/815xfiUt/1445-intestacy-smart-answer-add-hint-text-to-2-questions

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
