### PR TITLE
Add tests for the `result-card` component

### DIFF
--- a/app/flows/check_benefits_financial_support_flow/outcomes/results.erb
+++ b/app/flows/check_benefits_financial_support_flow/outcomes/results.erb
@@ -7,7 +7,13 @@
 
   <div class="govuk-!-margin-top-8 govuk-!-margin-bottom-9">
     <% calculator.benefits_for_outcome.each do |benefit| %>
-      <%= render "components/result-card", { title: benefit["title"], description: benefit["description"], url: benefit["url"], url_text: benefit["url_text"] } %>
+      <%= render "components/result-card", {
+        title: benefit["title"],
+        description: benefit["description"],
+        url: benefit["url"],
+        url_text: benefit["url_text"],
+        url_track_action: "Cost of living results"
+      } %>
     <% end %>
   </div>
 

--- a/app/views/components/_result-card.html.erb
+++ b/app/views/components/_result-card.html.erb
@@ -3,6 +3,11 @@
   description ||= nil
   url ||= nil
   url_text ||= nil
+  url_track_action ||= nil
+
+  if !title || !url || !url_text || !url_track_action
+    raise ArgumentError, "The result card component requires a title, url, url_text and url_track_action"
+  end
 %>
 <div class="app-c-result-card">
   <%= render "govuk_publishing_components/components/heading", {
@@ -12,15 +17,17 @@
     font_size: "m"
   } %>
 
-  <div class="govuk-body app-c-result-card__description">
-    <%= sanitize(description) %>
-  </div>
+  <% if description %>
+    <div class="govuk-body app-c-result-card__description">
+      <%= sanitize(description) %>
+    </div>
+  <% end %>
 
   <%= link_to url_text, url,
   class: "govuk-link app-c-result-card__link",
   data: {
     "track-category": "SmartAnswerClicked",
-    "track-action": "Cost of living results",
+    "track-action": url_track_action,
     "track-label": url
   } %>
 </div>

--- a/app/views/components/docs/result-card.yml
+++ b/app/views/components/docs/result-card.yml
@@ -9,3 +9,10 @@ examples:
       description: You may be able to get up to £2,000 a year for each of your children to help with the costs of childcare.
       url: /tax-free-childcare
       url_text: Check if you’re eligible for Tax-Free childcare
+      url_track_action: Cost of living results
+  no_description:
+    data:
+      title: Tax-Free childcare
+      url: /tax-free-childcare
+      url_text: Check if you’re eligible for Tax-Free childcare
+      url_track_action: Cost of living results

--- a/test/components/result_card_test.rb
+++ b/test/components/result_card_test.rb
@@ -1,0 +1,93 @@
+require "component_test_helper"
+
+class ResultCardTest < ComponentTestCase
+  def component_name
+    "result-card"
+  end
+
+  test "fails to render when no data is given" do
+    assert_raises do
+      render_component({})
+    end
+  end
+
+  test "does not render when no title is provided" do
+    assert_raises do
+      render_component({
+        url: "www.gov.uk",
+        url_text: "GOV.UK",
+        url_track_action: "Smart Answer Flow Name",
+      })
+    end
+  end
+
+  test "does not render when no url is provided" do
+    assert_raises do
+      render_component({
+        title: "Result card title",
+        url_text: "GOV.UK",
+        url_track_action: "Smart Answer Flow Name",
+      })
+    end
+  end
+
+  test "does not render when no url_text is provided" do
+    assert_raises do
+      render_component({
+        title: "Result card title",
+        url: "www.gov.uk",
+        url_track_action: "Smart Answer Flow Name",
+      })
+    end
+  end
+
+  test "does not render when no url_track_action is provided" do
+    assert_raises do
+      render_component({
+        title: "Result card title",
+        url: "www.gov.uk",
+        url_text: "GOV.UK",
+      })
+    end
+  end
+
+  test "does not render when only the description is provided" do
+    assert_raises do
+      render_component({ description: "Result card description" })
+    end
+  end
+
+  test "renders a result card with only the title and url with tracking data" do
+    render_component({
+      title: "Result card title",
+      description: nil,
+      url: "www.gov.uk",
+      url_text: "GOV.UK",
+      url_track_action: "Smart Answer Flow Name",
+    })
+
+    assert_select ".app-c-result-card" do
+      assert_select ".gem-c-heading", text: "Result card title"
+      assert_select ".app-c-result-card__link[href='www.gov.uk']", text: "GOV.UK"
+      assert_select ".app-c-result-card__link[data-track-action='Smart Answer Flow Name']", true
+      assert_select ".app-c-result-card__description", false
+    end
+  end
+
+  test "renders a result card with the title, description and url with tracking data" do
+    render_component({
+      title: "Result card title",
+      description: "Result card description",
+      url: "www.gov.uk",
+      url_text: "GOV.UK",
+      url_track_action: "Smart Answer Flow Name",
+    })
+
+    assert_select ".app-c-result-card" do
+      assert_select ".gem-c-heading", text: "Result card title"
+      assert_select ".app-c-result-card__link[href='www.gov.uk']", text: "GOV.UK"
+      assert_select ".app-c-result-card__link[data-track-action='Smart Answer Flow Name']", true
+      assert_select ".app-c-result-card__description", text: "Result card description"
+    end
+  end
+end


### PR DESCRIPTION
## What

Add tests for the `result-card` component and remove the hardcoded value for `track-action`. The "check-benefits-financial-support" outcome template now uses the new url_track_action input.

Also updated the documentation for the `result-card` component to include an example without a description.

## Why

There are currently no tests in place for this component.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
