### PR TITLE
Update start.erb

### DIFF
--- a/app/flows/calculate_statutory_sick_pay_flow/questions/how_often_pay_employee_pay_patterns.erb
+++ b/app/flows/calculate_statutory_sick_pay_flow/questions/how_often_pay_employee_pay_patterns.erb
@@ -6,6 +6,6 @@
   "weekly": "Weekly",
   "fortnightly": "Every 2 weeks",
   "every_4_weeks": "Every 4 weeks",
-  "monthly": "Monthly - eg last day or Friday of a month",
+  "monthly": "Monthly - for example, the last Friday of the month",
   "irregularly": "Irregularly"
 ) %>

--- a/app/flows/calculate_statutory_sick_pay_flow/start.erb
+++ b/app/flows/calculate_statutory_sick_pay_flow/start.erb
@@ -19,7 +19,7 @@
 
   ##Sick leave because of coronavirus (COVID-19)
   
-  Do not use the calculator if your employee became sick with COVID-19 after 24 March 2022. You'll need to [work out the SSP manually](/guidance/statutory-sick-pay-manually-calculate-your-employees-payments) instead.
+  Do not use the calculator if your employee became sick with COVID-19 before 25 March 2022. You’ll need to [work out the SSP manually](https://www.gov.uk/guidance/statutory-sick-pay-manually-calculate-your-employees-payments) instead.
 
   ##Different periods of sick leave
 


### PR DESCRIPTION
Updated line 22 to say:

Do not use the calculator if your employee became sick with COVID-19 before 25 March 2022. You’ll need to [work out the SSP manually](https://www.gov.uk/guidance/statutory-sick-pay-manually-calculate-your-employees-payments) instead.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
