### PR TITLE
Marriage abroad links aug22

### DIFF
--- a/app/flows/marriage_abroad_flow/outcomes/countries/denmark/ceremony_country/partner_british/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/denmark/ceremony_country/partner_british/_opposite_sex.erb
@@ -19,7 +19,7 @@ $C
 Telephone: +44 (0)300 123 1837 (8am to 8pm Monday to Friday and 9am to 4pm Saturday)
 $C
 
-If you are from Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad/what-documents-will-i-need-to-provide).
+If you are from Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad).
 
 If you are from Northern Ireland, you can get a ‘certificate of legal capacity to marry' or a ‘marriage index search’ from [nidirect](https://www.nidirect.gov.uk/articles/marriage-outside-uk).
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/denmark/ceremony_country/partner_british/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/denmark/ceremony_country/partner_british/_same_sex.erb
@@ -21,7 +21,7 @@ $C
 Telephone: +44 (0)300 123 1837 (8am to 8pm Monday to Friday and 9am to 4pm Saturday)
 $C
 
-If you are from Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad/what-documents-will-i-need-to-provide).
+If you are from Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad).
 
 If you are from Northern Ireland, you can get a ‘certificate of legal capacity to marry' or a ‘marriage index search’ from [nidirect](https://www.nidirect.gov.uk/articles/marriage-outside-uk).
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/denmark/ceremony_country/partner_local/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/denmark/ceremony_country/partner_local/_opposite_sex.erb
@@ -19,7 +19,7 @@ $C
 Telephone: +44 (0)300 123 1837 (8am to 8pm Monday to Friday and 9am to 4pm Saturday)
 $C
 
-If you are from Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad/what-documents-will-i-need-to-provide).
+If you are from Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad).
 
 If you are from Northern Ireland, you can get a ‘certificate of legal capacity to marry' or a ‘marriage index search’ from [nidirect](https://www.nidirect.gov.uk/articles/marriage-outside-uk).
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/denmark/ceremony_country/partner_local/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/denmark/ceremony_country/partner_local/_same_sex.erb
@@ -21,7 +21,7 @@ $C
 Telephone: +44 (0)300 123 1837 (8am to 8pm Monday to Friday and 9am to 4pm Saturday)
 $C
 
-If you are from Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad/what-documents-will-i-need-to-provide).
+If you are from Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad).
 
 If you are from Northern Ireland, you can get a ‘certificate of legal capacity to marry' or a ‘marriage index search’ from [nidirect](https://www.nidirect.gov.uk/articles/marriage-outside-uk).
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/denmark/ceremony_country/partner_other/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/denmark/ceremony_country/partner_other/_opposite_sex.erb
@@ -19,7 +19,7 @@ $C
 Telephone: +44 (0)300 123 1837 (8am to 8pm Monday to Friday and 9am to 4pm Saturday)
 $C
 
-If you are from Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad/what-documents-will-i-need-to-provide).
+If you are from Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad).
 
 If you are from Northern Ireland, you can get a ‘certificate of legal capacity to marry' or a ‘marriage index search’ from [nidirect](https://www.nidirect.gov.uk/articles/marriage-outside-uk).
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/denmark/ceremony_country/partner_other/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/denmark/ceremony_country/partner_other/_same_sex.erb
@@ -21,7 +21,7 @@ $C
 Telephone: +44 (0)300 123 1837 (8am to 8pm Monday to Friday and 9am to 4pm Saturday)
 $C
 
-If you are from Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad/what-documents-will-i-need-to-provide).
+If you are from Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad).
 
 If you are from Northern Ireland, you can get a ‘certificate of legal capacity to marry' or a ‘marriage index search’ from [nidirect](https://www.nidirect.gov.uk/articles/marriage-outside-uk).
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/denmark/third_country/partner_british/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/denmark/third_country/partner_british/_opposite_sex.erb
@@ -19,7 +19,7 @@ $C
 Telephone: +44 (0)300 123 1837 (8am to 8pm Monday to Friday and 9am to 4pm Saturday)
 $C
 
-If you are from Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad/what-documents-will-i-need-to-provide).
+If you are from Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad).
 
 If you are from Northern Ireland, you can get a ‘certificate of legal capacity to marry' or a ‘marriage index search’ from [nidirect](https://www.nidirect.gov.uk/articles/marriage-outside-uk).
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/denmark/third_country/partner_british/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/denmark/third_country/partner_british/_same_sex.erb
@@ -21,7 +21,7 @@ $C
 Telephone: +44 (0)300 123 1837 (8am to 8pm Monday to Friday and 9am to 4pm Saturday)
 $C
 
-If you are from Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad/what-documents-will-i-need-to-provide).
+If you are from Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad).
 
 If you are from Northern Ireland, you can get a ‘certificate of legal capacity to marry' or a ‘marriage index search’ from [nidirect](https://www.nidirect.gov.uk/articles/marriage-outside-uk).
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/denmark/third_country/partner_local/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/denmark/third_country/partner_local/_opposite_sex.erb
@@ -19,7 +19,7 @@ $C
 Telephone: +44 (0)300 123 1837 (8am to 8pm Monday to Friday and 9am to 4pm Saturday)
 $C
 
-If you are from Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad/what-documents-will-i-need-to-provide).
+If you are from Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad).
 
 If you are from Northern Ireland, you can get a ‘certificate of legal capacity to marry' or a ‘marriage index search’ from [nidirect](https://www.nidirect.gov.uk/articles/marriage-outside-uk).
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/denmark/third_country/partner_local/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/denmark/third_country/partner_local/_same_sex.erb
@@ -21,7 +21,7 @@ $C
 Telephone: +44 (0)300 123 1837 (8am to 8pm Monday to Friday and 9am to 4pm Saturday)
 $C
 
-If you are from Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad/what-documents-will-i-need-to-provide).
+If you are from Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad).
 
 If you are from Northern Ireland, you can get a ‘certificate of legal capacity to marry' or a ‘marriage index search’ from [nidirect](https://www.nidirect.gov.uk/articles/marriage-outside-uk).
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/denmark/third_country/partner_other/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/denmark/third_country/partner_other/_opposite_sex.erb
@@ -19,7 +19,7 @@ $C
 Telephone: +44 (0)300 123 1837 (8am to 8pm Monday to Friday and 9am to 4pm Saturday)
 $C
 
-If you are from Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad/what-documents-will-i-need-to-provide).
+If you are from Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad).
 
 If you are from Northern Ireland, you can get a ‘certificate of legal capacity to marry' or a ‘marriage index search’ from [nidirect](https://www.nidirect.gov.uk/articles/marriage-outside-uk).
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/denmark/third_country/partner_other/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/denmark/third_country/partner_other/_same_sex.erb
@@ -21,7 +21,7 @@ $C
 Telephone: +44 (0)300 123 1837 (8am to 8pm Monday to Friday and 9am to 4pm Saturday)
 $C
 
-If you are from Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad/what-documents-will-i-need-to-provide).
+If you are from Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad).
 
 If you are from Northern Ireland, you can get a ‘certificate of legal capacity to marry' or a ‘marriage index search’ from [nidirect](https://www.nidirect.gov.uk/articles/marriage-outside-uk).
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/denmark/uk/partner_british/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/denmark/uk/partner_british/_opposite_sex.erb
@@ -19,7 +19,7 @@ $C
 Telephone: +44 (0)300 123 1837 (8am to 8pm Monday to Friday and 9am to 4pm Saturday)
 $C
 
-If you are in Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad/what-documents-will-i-need-to-provide).
+If you are in Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad).
 
 If you are in Northern Ireland, you can get a ‘certificate of legal capacity to marry' or a ‘marriage index search’ from [nidirect](https://www.nidirect.gov.uk/articles/marriage-outside-uk).
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/denmark/uk/partner_british/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/denmark/uk/partner_british/_same_sex.erb
@@ -21,7 +21,7 @@ $C
 Telephone: +44 (0)300 123 1837 (8am to 8pm Monday to Friday and 9am to 4pm Saturday)
 $C
 
-If you are in Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad/what-documents-will-i-need-to-provide).
+If you are in Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad).
 
 If you are in Northern Ireland, you can get a ‘certificate of legal capacity to marry' or a ‘marriage index search’ from [nidirect](https://www.nidirect.gov.uk/articles/marriage-outside-uk).
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/denmark/uk/partner_local/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/denmark/uk/partner_local/_opposite_sex.erb
@@ -19,7 +19,7 @@ $C
 Telephone: +44 (0)300 123 1837 (8am to 8pm Monday to Friday and 9am to 4pm Saturday)
 $C
 
-If you are in Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad/what-documents-will-i-need-to-provide).
+If you are in Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad).
 
 If you are in Northern Ireland, you can get a ‘certificate of legal capacity to marry' or a ‘marriage index search’ from [nidirect](https://www.nidirect.gov.uk/articles/marriage-outside-uk).
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/denmark/uk/partner_local/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/denmark/uk/partner_local/_same_sex.erb
@@ -21,7 +21,7 @@ $C
 Telephone: +44 (0)300 123 1837 (8am to 8pm Monday to Friday and 9am to 4pm Saturday)
 $C
 
-If you are in Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad/what-documents-will-i-need-to-provide).
+If you are in Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad).
 
 If you are in Northern Ireland, you can get a ‘certificate of legal capacity to marry' or a ‘marriage index search’ from [nidirect](https://www.nidirect.gov.uk/articles/marriage-outside-uk).
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/denmark/uk/partner_other/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/denmark/uk/partner_other/_opposite_sex.erb
@@ -19,7 +19,7 @@ $C
 Telephone: +44 (0)300 123 1837 (8am to 8pm Monday to Friday and 9am to 4pm Saturday)
 $C
 
-If you are in Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad/what-documents-will-i-need-to-provide).
+If you are in Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad).
 
 If you are in Northern Ireland, you can get a ‘certificate of legal capacity to marry' or a ‘marriage index search’ from [nidirect](https://www.nidirect.gov.uk/articles/marriage-outside-uk).
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/denmark/uk/partner_other/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/denmark/uk/partner_other/_same_sex.erb
@@ -21,7 +21,7 @@ $C
 Telephone: +44 (0)300 123 1837 (8am to 8pm Monday to Friday and 9am to 4pm Saturday)
 $C
 
-If you are in Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad/what-documents-will-i-need-to-provide).
+If you are in Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad).
 
 If you are in Northern Ireland, you can get a ‘certificate of legal capacity to marry' or a ‘marriage index search’ from [nidirect](https://www.nidirect.gov.uk/articles/marriage-outside-uk).
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/iceland/_ceremony_country.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/iceland/_ceremony_country.erb
@@ -37,7 +37,7 @@ General Register Office\\
 Telephone: +44 (0)300 123 1837 (8am to 8pm Monday to Friday and 9am to 4pm Saturday)
 $C
 
-If you’re from Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad/what-documents-will-i-need-to-provide).
+If you’re from Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad).
 
 If you’re from Northern Ireland, you can get a ‘certificate of legal capacity to marry’ or a ‘marriage index search’ from the [nidirect website](https://www.nidirect.gov.uk/articles/marriage-outside-uk).
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/iceland/_third_country.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/iceland/_third_country.erb
@@ -31,7 +31,7 @@ General Register Office\\
 Telephone: +44 (0)300 123 1837 (8am to 8pm Monday to Friday and 9am to 4pm Saturday)
 $C
 
-If you’re from Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad/what-documents-will-i-need-to-provide).
+If you’re from Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad).
 
 If you’re from Northern Ireland, you can get a ‘certificate of legal capacity to marry’ or a ‘marriage index search’ from the [nidirect website](https://www.nidirect.gov.uk/articles/marriage-outside-uk).
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/iceland/_uk.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/iceland/_uk.erb
@@ -38,7 +38,7 @@ General Register Office\\
 Telephone: +44 (0)300 123 1837 (8am to 8pm Monday to Friday and 9am to 4pm Saturday)
 $C
 
-If you’re in Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad/what-documents-will-i-need-to-provide).
+If you’re in Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad).
 
 If you’re in Northern Ireland, you can get a ‘certificate of legal capacity to marry’ or a ‘marriage index search’ from the [nidirect website](https://www.nidirect.gov.uk/articles/marriage-outside-uk).
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/uganda/ceremony_country/partner_british/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/uganda/ceremony_country/partner_british/_opposite_sex.erb
@@ -15,7 +15,7 @@ $C
 Telephone: +44 (0)300 123 1837 (8am to 8pm Monday to Friday and 9am to 4pm Saturday)
 $C
 
-If you are from Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad/what-documents-will-i-need-to-provide).
+If you are from Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad).
 
 If you are from Northern Ireland, you can get a ‘marriage index search’ from [nidirect](https://www.nidirect.gov.uk/articles/marriage-outside-uk).
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/uganda/ceremony_country/partner_local/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/uganda/ceremony_country/partner_local/_opposite_sex.erb
@@ -15,7 +15,7 @@ $C
 Telephone: +44 (0)300 123 1837 (8am to 8pm Monday to Friday and 9am to 4pm Saturday)
 $C
 
-If you are from Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad/what-documents-will-i-need-to-provide).
+If you are from Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad).
 
 If you are from Northern Ireland, you can get a ‘marriage index search’ from [nidirect](https://www.nidirect.gov.uk/articles/marriage-outside-uk).
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/uganda/ceremony_country/partner_other/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/uganda/ceremony_country/partner_other/_opposite_sex.erb
@@ -15,7 +15,7 @@ $C
 Telephone: +44 (0)300 123 1837 (8am to 8pm Monday to Friday and 9am to 4pm Saturday)
 $C
 
-If you are from Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad/what-documents-will-i-need-to-provide).
+If you are from Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad).
 
 If you are from Northern Ireland, you can get a ‘marriage index search’ from [nidirect](https://www.nidirect.gov.uk/articles/marriage-outside-uk).
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/uganda/third_country/partner_british/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/uganda/third_country/partner_british/_opposite_sex.erb
@@ -15,7 +15,7 @@ $C
 Telephone: +44 (0)300 123 1837 (8am to 8pm Monday to Friday and 9am to 4pm Saturday)
 $C
 
-If you are from Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad/what-documents-will-i-need-to-provide).
+If you are from Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad).
 
 If you are from Northern Ireland, you can get a ‘marriage index search’ from [nidirect](https://www.nidirect.gov.uk/articles/marriage-outside-uk).
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/uganda/third_country/partner_local/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/uganda/third_country/partner_local/_opposite_sex.erb
@@ -15,7 +15,7 @@ $C
 Telephone: +44 (0)300 123 1837 (8am to 8pm Monday to Friday and 9am to 4pm Saturday)
 $C
 
-If you are from Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad/what-documents-will-i-need-to-provide).
+If you are from Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad).
 
 If you are from Northern Ireland, you can get a ‘marriage index search’ from [nidirect](https://www.nidirect.gov.uk/articles/marriage-outside-uk).
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/uganda/third_country/partner_other/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/uganda/third_country/partner_other/_opposite_sex.erb
@@ -15,7 +15,7 @@ $C
 Telephone: +44 (0)300 123 1837 (8am to 8pm Monday to Friday and 9am to 4pm Saturday)
 $C
 
-If you are from Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad/what-documents-will-i-need-to-provide).
+If you are from Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad).
 
 If you are from Northern Ireland, you can get a ‘marriage index search’ from [nidirect](https://www.nidirect.gov.uk/articles/marriage-outside-uk).
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/uganda/uk/partner_british/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/uganda/uk/partner_british/_opposite_sex.erb
@@ -15,7 +15,7 @@ $C
 Telephone: +44 (0)300 123 1837 (8am to 8pm Monday to Friday and 9am to 4pm Saturday)
 $C
 
-If you are in Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad/what-documents-will-i-need-to-provide).
+If you are in Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad).
 
 If you are in Northern Ireland, you can get a ‘marriage index search’ from [nidirect](https://www.nidirect.gov.uk/articles/marriage-outside-uk).
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/uganda/uk/partner_local/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/uganda/uk/partner_local/_opposite_sex.erb
@@ -15,7 +15,7 @@ $C
 Telephone: +44 (0)300 123 1837 (8am to 8pm Monday to Friday and 9am to 4pm Saturday)
 $C
 
-If you are in Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad/what-documents-will-i-need-to-provide).
+If you are in Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad).
 
 If you are in Northern Ireland, you can get a ‘marriage index search’ from [nidirect](https://www.nidirect.gov.uk/articles/marriage-outside-uk).
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/uganda/uk/partner_other/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/uganda/uk/partner_other/_opposite_sex.erb
@@ -15,7 +15,7 @@ $C
 Telephone: +44 (0)300 123 1837 (8am to 8pm Monday to Friday and 9am to 4pm Saturday)
 $C
 
-If you are in Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad/what-documents-will-i-need-to-provide).
+If you are in Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad).
 
 If you are in Northern Ireland, you can get a ‘marriage index search’ from [nidirect](https://www.nidirect.gov.uk/articles/marriage-outside-uk).
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/zimbabwe/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/zimbabwe/_opposite_sex.erb
@@ -15,7 +15,7 @@ $C
 Telephone: +44 (0)300 123 1837 (8am to 8pm Monday to Friday and 9am to 4pm Saturday)
 $C
 
-If you are from Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad/what-documents-will-i-need-to-provide).
+If you are from Scotland, you can get a ’to whom it may concern’ letter from the [National Records of Scotland](https://www.nrscotland.gov.uk/registration/getting-married-abroad).
 
 If you are from Northern Ireland, you can get a ‘certificate of legal capacity to marry’ or a ‘marriage index search’ from [nidirect](https://www.nidirect.gov.uk/articles/marriage-outside-uk).
 


### PR DESCRIPTION
Trello: https://trello.com/c/B94Xbmt4/4148-smart-answers-broken-link-report-1-august-2022

Changing National Records of Scotland link for a ’to whom it may concern’ letter for:

Denmark
Iceland
Uganda (opposite sex)
Zimbabwe (opposite sex)

Current link brings up an access denied message. Moving the link up one level to be https://www.nrscotland.gov.uk/registration/getting-married-abroad resolves the problem.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
