### PR TITLE
Add radio with intro question

### DIFF
--- a/app/presenters/radio_with_intro_question_presenter.rb
+++ b/app/presenters/radio_with_intro_question_presenter.rb
@@ -1,0 +1,5 @@
+class RadioWithIntroQuestionPresenter < RadioQuestionPresenter
+  def radio_heading
+    @renderer.content_for(:radio_heading).presence
+  end
+end

--- a/app/views/smart_answers/inputs/_radio_with_intro_question.html.erb
+++ b/app/views/smart_answers/inputs/_radio_with_intro_question.html.erb
@@ -1,0 +1,16 @@
+<%= render "smart_answers/inputs/caption", question: question %>
+<h1 class="govuk-heading-l">
+  <%= question.title %>
+</h1>
+
+<%= question.body %>
+
+<%= render "govuk_publishing_components/components/radio", {
+  name: "response",
+  heading: question.radio_heading,
+  heading_size: "m",
+  heading_level: 2,
+  id_prefix: "response",
+  error_message: question.error,
+  items: question.radio_buttons
+} %>

--- a/docs/design/question-types.md
+++ b/docs/design/question-types.md
@@ -36,6 +36,12 @@
   * Response: String containing the chosen option.
   * Can remove options.
 
+## `radio_with_intro`
+  * User input: Choose a single option from a list of options.
+  * Validation: Must be in the list of options.
+  * Response: String containing the chosen option.
+  * Can remove options.
+
 ## `postcode_question`
   * User input: Enter a postcode.
   * Validation: Must be a valid postcode.

--- a/lib/smart_answer/flow.rb
+++ b/lib/smart_answer/flow.rb
@@ -71,6 +71,10 @@ module SmartAnswer
       add_node Question::Radio.new(self, name, &block)
     end
 
+    def radio_with_intro(name, &block)
+      add_node Question::RadioWithIntro.new(self, name, &block)
+    end
+
     def country_select(name, options = {}, &block)
       add_node Question::CountrySelect.new(self, name, options, &block)
     end

--- a/lib/smart_answer/question/radio_with_intro.rb
+++ b/lib/smart_answer/question/radio_with_intro.rb
@@ -1,0 +1,7 @@
+module SmartAnswer
+  module Question
+    class RadioWithIntro < Radio
+      PRESENTER_CLASS = RadioWithIntroQuestionPresenter
+    end
+  end
+end

--- a/test/fixtures/flows/bridge_of_death_flow.rb
+++ b/test/fixtures/flows/bridge_of_death_flow.rb
@@ -22,7 +22,7 @@ class BridgeOfDeathFlow < SmartAnswer::Flow
         if your_name =~ /robin/i && response == "to_seek_the_holy_grail"
           question :what_is_the_capital_of_assyria?
         else
-          question :what_is_your_favorite_colour?
+          question :colour_options?
         end
       end
     end
@@ -34,6 +34,20 @@ class BridgeOfDeathFlow < SmartAnswer::Flow
 
       next_node do
         outcome :auuuuuuuugh
+      end
+    end
+
+    radio_with_intro :colour_options? do
+      option :yes
+      option :no
+
+      next_node do |response|
+        case response
+        when "yes"
+          question :what_is_your_favorite_colour?
+        when "no"
+          outcome :done
+        end
       end
     end
 

--- a/test/fixtures/flows/bridge_of_death_flow/questions/colour_options.erb
+++ b/test/fixtures/flows/bridge_of_death_flow/questions/colour_options.erb
@@ -1,0 +1,25 @@
+<% text_for :title do %>
+  Colour options
+<% end %>
+
+<% govspeak_for :body do %>
+  Colours include:
+
+  * red
+  * yellow
+  * blue
+  * green
+
+  Teal is classed as blue, not green.
+
+  Purple and pink are not currently supported but will be soon.
+<% end %>
+
+<% text_for :radio_heading do %>
+  Do you want to select any of these?
+<% end %>
+
+<% options(
+  "yes": "Yes",
+  "no": "No",
+) %>

--- a/test/fixtures/flows/radio_with_intro_sample_flow.rb
+++ b/test/fixtures/flows/radio_with_intro_sample_flow.rb
@@ -1,0 +1,23 @@
+class RadioWithIntroSampleFlow < SmartAnswer::Flow
+  def define
+    name "radio-with-intro-sample"
+    content_id "f26e566e-2557-4921-b944-9373c32255f1"
+
+    radio_with_intro :colour_options? do
+      option :yes
+      option :no
+
+      next_node do |response|
+        case response
+        when "yes"
+          outcome :supported_colour
+        when "no"
+          outcome :no_colour_matches
+        end
+      end
+    end
+
+    outcome :supported_colour
+    outcome :no_colour_matches
+  end
+end

--- a/test/fixtures/flows/radio_with_intro_sample_flow/outcomes/no_colour_matches.erb
+++ b/test/fixtures/flows/radio_with_intro_sample_flow/outcomes/no_colour_matches.erb
@@ -1,0 +1,7 @@
+<% text_for :title do %>
+  Not matched
+<% end %>
+
+<% govspeak_for :body do %>
+  Boo
+<% end %>

--- a/test/fixtures/flows/radio_with_intro_sample_flow/outcomes/supported_colour.erb
+++ b/test/fixtures/flows/radio_with_intro_sample_flow/outcomes/supported_colour.erb
@@ -1,0 +1,7 @@
+<% text_for :title do %>
+  Colour matched
+<% end %>
+
+<% govspeak_for :body do %>
+  Awesome
+<% end %>

--- a/test/fixtures/flows/radio_with_intro_sample_flow/questions/colour_options.erb
+++ b/test/fixtures/flows/radio_with_intro_sample_flow/questions/colour_options.erb
@@ -1,0 +1,25 @@
+<% text_for :title do %>
+  Colour options
+<% end %>
+
+<% govspeak_for :body do %>
+  Colours include:
+
+  * red
+  * yellow
+  * blue
+  * green
+
+  Teal is classed as blue, not green.
+
+  Purple and pink are not currently supported but will be soon.
+<% end %>
+
+<% text_for :radio_heading do %>
+  Do you want to select any of these?
+<% end %>
+
+<% options(
+  "yes": "Yes",
+  "no": "No",
+) %>

--- a/test/fixtures/flows/radio_with_intro_sample_flow/start.erb
+++ b/test/fixtures/flows/radio_with_intro_sample_flow/start.erb
@@ -1,0 +1,7 @@
+<% text_for :title do %>
+  Sample radio with intro question
+<% end %>
+
+<% text_for :meta_description do %>
+  This is a test description
+<% end %>

--- a/test/functional/smart_answers_controller_radio_with_intro_question_test.rb
+++ b/test/functional/smart_answers_controller_radio_with_intro_question_test.rb
@@ -1,0 +1,34 @@
+require_relative "../test_helper"
+require_relative "smart_answers_controller_test_helper"
+
+class SmartAnswersControllerRadioWithIntroQuestionTest < ActionController::TestCase
+  tests SmartAnswersController
+
+  include SmartAnswersControllerTestHelper
+
+  setup { setup_fixture_flows }
+  teardown { teardown_fixture_flows }
+
+  context "radio with intro question" do
+    should "display question" do
+      get :show, params: { id: "radio-with-intro-sample", started: "y" }
+      assert_select "span.govuk-caption-l", "Sample radio with intro question"
+      assert_select "h1.govuk-heading-l", "Colour options"
+      assert_contains css_select("div.gem-c-govspeak.govuk-govspeak").first.content, /Colours include:/
+      assert_select ".govuk-fieldset__legend.govuk-fieldset__legend--m h2.govuk-fieldset__heading", /Do you want to select any of these\?/
+      assert_select "input[type=radio][name=response]"
+    end
+
+    context "no response given" do
+      should "show an error message" do
+        submit_response(nil)
+        assert_select ".govuk-error-message"
+        assert_contains css_select("title").first.content, /Error/
+      end
+    end
+  end
+
+  def submit_response(response = nil, other_params = {})
+    super(response, other_params.merge(id: "radio-sample"))
+  end
+end

--- a/test/integration/engine/changing_answer_test.rb
+++ b/test/integration/engine/changing_answer_test.rb
@@ -104,6 +104,10 @@ class ChangingAnswerTest < EngineIntegrationTest
       choose("To seek the Holy Grail", visible: false)
       click_on "Continue"
 
+      within("#current-question") { assert_page_has_content "Do you want to select any of these?" }
+      choose("Yes", visible: false)
+      click_on "Continue"
+
       within("#current-question") { assert_page_has_content "What...is your favorite colour?" }
       choose("Blue", visible: false)
       click_on "Continue"
@@ -120,6 +124,10 @@ class ChangingAnswerTest < EngineIntegrationTest
 
       within("#current-question") { assert_page_has_content "What...is your quest?" }
       choose("To seek the Holy Grail", visible: false)
+      click_on "Continue"
+
+      within("#current-question") { assert_page_has_content "Do you want to select any of these?" }
+      choose("Yes", visible: false)
       click_on "Continue"
 
       within("#current-question") { assert_page_has_content "What...is your favorite colour?" }
@@ -140,11 +148,14 @@ class ChangingAnswerTest < EngineIntegrationTest
 
       assert_current_url "/bridge-of-death/y/Bors/to_rescue_the_princess"
 
+      choose("Yes", visible: false)
+      click_on "Continue"
+
       choose("Blue", visible: false)
       click_on "Continue"
 
       within("#result-info") { assert_page_has_content "Right, off you go." }
-      within(".govuk-summary-list__row:nth-child(3)") { click_on "Change" }
+      within(".govuk-summary-list__row:nth-child(4)") { click_on "Change" }
 
       within "#current-question" do
         assert page.has_checked_field?("Blue", visible: false)
@@ -155,7 +166,7 @@ class ChangingAnswerTest < EngineIntegrationTest
       choose("Red", visible: false)
       click_on "Continue"
 
-      assert_current_url "/bridge-of-death/y/Bors/to_rescue_the_princess/red"
+      assert_current_url "/bridge-of-death/y/Bors/to_rescue_the_princess/yes/red"
     end
 
     should "be able to change checkbox answers" do

--- a/test/integration/engine/radio_and_value_questions_test.rb
+++ b/test/integration/engine/radio_and_value_questions_test.rb
@@ -94,6 +94,24 @@ class RadioAndValueQuestionsTest < EngineIntegrationTest
       end
 
       within "#current-question" do
+        within("h1.govuk-heading-l") { assert_page_has_content "Colour options" }
+        assert_page_has_content "Colours include"
+
+        within ".govuk-fieldset__legend" do
+          assert_page_has_content "Do you want to select any of these?"
+        end
+
+        assert page.has_field?("Yes", type: "radio", with: "yes", visible: false)
+        assert page.has_field?("No", type: "radio", with: "no", visible: false)
+        # Assert they're in the correct order
+        options = page.all(:xpath, ".//label").map(&:text).map(&:strip)
+        assert_equal %w[Yes No], options
+      end
+
+      choose("Yes", visible: false)
+      click_on "Continue"
+
+      within "#current-question" do
         within ".govuk-fieldset__legend" do
           assert_page_has_content "What...is your favorite colour?"
         end
@@ -109,7 +127,7 @@ class RadioAndValueQuestionsTest < EngineIntegrationTest
       choose("Blue", visible: false)
       click_on "Continue"
 
-      assert_current_url "/bridge-of-death/y/Lancelot/to_seek_the_holy_grail/blue"
+      assert_current_url "/bridge-of-death/y/Lancelot/to_seek_the_holy_grail/yes/blue"
 
       assert page.has_link?("Start again", href: "/bridge-of-death")
       within ".govuk-summary-list__row:nth-child(1)" do
@@ -128,10 +146,17 @@ class RadioAndValueQuestionsTest < EngineIntegrationTest
       end
       within ".govuk-summary-list__row:nth-child(3)" do
         within ".govuk-summary-list__key" do
+          assert_page_has_content "Colour options"
+        end
+        within(".govuk-summary-list__value") { assert_page_has_content "Yes" }
+        within(".govuk-summary-list__actions") { assert page.has_link?("Change", href: "/bridge-of-death/y/Lancelot/to_seek_the_holy_grail?previous_response=yes") }
+      end
+      within ".govuk-summary-list__row:nth-child(4)" do
+        within ".govuk-summary-list__key" do
           assert_page_has_content "What...is your favorite colour?"
         end
         within(".govuk-summary-list__value") { assert_page_has_content "Blue" }
-        within(".govuk-summary-list__actions") { assert page.has_link?("Change", href: "/bridge-of-death/y/Lancelot/to_seek_the_holy_grail?previous_response=blue") }
+        within(".govuk-summary-list__actions") { assert page.has_link?("Change", href: "/bridge-of-death/y/Lancelot/to_seek_the_holy_grail/yes?previous_response=blue") }
       end
 
       within "#result-info" do

--- a/test/unit/flow_test.rb
+++ b/test/unit/flow_test.rb
@@ -89,6 +89,28 @@ class FlowTest < ActiveSupport::TestCase
     assert_equal 1, s.questions.size
   end
 
+  test "Can build radio with intro question nodes" do
+    s = SmartAnswer::Flow.build do
+      radio_with_intro :do_you_like_chocolate? do
+        option :yes
+        option :no
+        next_node do |response|
+          case response
+          when "yes" then outcome :sweet_tooth
+          when "no" then outcome :savoury_tooth
+          end
+        end
+      end
+
+      outcome :sweet_tooth
+      outcome :savoury_tooth
+    end
+
+    assert_equal 3, s.nodes.size
+    assert_equal 2, s.outcomes.size
+    assert_equal 1, s.questions.size
+  end
+
   test "Can build country select question nodes" do
     stub_worldwide_api_has_locations(%w[afghanistan])
 

--- a/test/unit/radio_with_intro_question_presenter_test.rb
+++ b/test/unit/radio_with_intro_question_presenter_test.rb
@@ -1,0 +1,18 @@
+require_relative "../test_helper"
+
+module SmartAnswer
+  class RadioWithIntroQuestionPresenterTest < ActiveSupport::TestCase
+    setup do
+      @question = Question::RadioWithIntro.new(nil, :question_name?)
+      @renderer = stub("renderer")
+      @presenter = RadioWithIntroQuestionPresenter.new(@question, nil, nil, renderer: @renderer)
+      @presenter.stubs(:current_response).returns(nil)
+    end
+
+    test "#radio_heading returns single line of content rendered for radio_heading block" do
+      @renderer.stubs(:content_for).with(:radio_heading).returns("A good heading")
+
+      assert_equal "A good heading", @presenter.radio_heading
+    end
+  end
+end


### PR DESCRIPTION
This pattern is supported by the design system [1] and has been requested for the Cost of Living checker V2 Smart Answer.

The radio component [2] does not support this format and so we need to update Smart Answers. My original thinking was to update the existing radio question. However, Smart Answer questions are not really designed to support variances in format and so a new question seemed the cleanest solution.

Trello:
https://trello.com/c/96VGgATX/1398-smart-answer-new-benefits-to-the-benefits-checker-cost-of-living-checker-v2

[1]: https://design-system.service.gov.uk/patterns/question-pages/#asking-complex-questions-without-using-hint-text
[2]: https://github.com/alphagov/govuk_publishing_components/blob/main/app/views/govuk_publishing_components/components/_radio.html.erb

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
