### PR TITLE
Make 'Minimum wage calculator' use current time

### DIFF
--- a/app/flows/am_i_getting_minimum_wage_flow/questions/what_would_you_like_to_check.erb
+++ b/app/flows/am_i_getting_minimum_wage_flow/questions/what_would_you_like_to_check.erb
@@ -4,5 +4,5 @@
 
 <% options(
   "current_payment": "If you're getting the National Minimum Wage or the National Living Wage",
-  "past_payment": "If an employer owes you payments from last year (April 2022 to March 2023)"
+  "past_payment": "If an employer owes you payments from last year (#{last_year_text('minimum_wage')})"
 ) %>

--- a/app/flows/am_i_getting_minimum_wage_flow/start.erb
+++ b/app/flows/am_i_getting_minimum_wage_flow/start.erb
@@ -15,5 +15,5 @@
 
   ^You must be at least 23 years old to get the National Living Wage.^
 
-  Check [National Minimum Wage and National Living Wage rates](/national-minimum-wage-rates) before March 2023.
+  Check [National Minimum Wage and National Living Wage rates](/national-minimum-wage-rates) before <%= last_year_end_text("minimum_wage") %>.
 <% end %>

--- a/app/flows/minimum_wage_calculator_employers_flow/questions/what_would_you_like_to_check.erb
+++ b/app/flows/minimum_wage_calculator_employers_flow/questions/what_would_you_like_to_check.erb
@@ -4,5 +4,5 @@
 
 <% options(
   "current_payment": "If you’re paying a worker the National Minimum Wage or the National Living Wage",
-  "past_payment": "If you owe a worker payments from last year (April 2022 to March 2023)"
+  "past_payment": "If you owe a worker payments from last year (#{last_year_text('minimum_wage')})"
 ) %>

--- a/app/flows/minimum_wage_calculator_employers_flow/start.erb
+++ b/app/flows/minimum_wage_calculator_employers_flow/start.erb
@@ -15,5 +15,5 @@
 
   ^Your employee must be at least 23 years old to get the National Living Wage.^
 
-Check [National Minimum Wage and National Living Wage rates](/national-minimum-wage-rates) before March 2023.
+Check [National Minimum Wage and National Living Wage rates](/national-minimum-wage-rates) before <%= last_year_end_text("minimum_wage") %>.
 <% end %>

--- a/app/flows/shared/minimum_wage_flow.rb
+++ b/app/flows/shared/minimum_wage_flow.rb
@@ -6,8 +6,8 @@ class MinimumWageFlow < SmartAnswer::Flow
       option "past_payment"
 
       on_response do |response|
-        date = Date.parse("2022-04-01") if response == "past_payment"
-        self.calculator = SmartAnswer::Calculators::MinimumWageCalculator.new(date:)
+        self.calculator = SmartAnswer::Calculators::MinimumWageCalculator.new
+        calculator.date = calculator.previous_period_start_date if response == "past_payment"
         self.accommodation_charge = nil
       end
 

--- a/app/presenters/question_presenter.rb
+++ b/app/presenters/question_presenter.rb
@@ -11,7 +11,7 @@ class QuestionPresenter < NodePresenter
       template_directory: @node.template_directory.join("questions"),
       template_name: @node.template_name,
       locals: @state.to_hash,
-      helpers: [SmartAnswer::FormattingHelper] + helpers,
+      helpers: [SmartAnswer::RateDatesHelper, SmartAnswer::FormattingHelper] + helpers,
     )
   end
 

--- a/app/presenters/start_node_presenter.rb
+++ b/app/presenters/start_node_presenter.rb
@@ -4,6 +4,7 @@ class StartNodePresenter < NodePresenter
     @renderer = options[:renderer] || SmartAnswer::ErbRenderer.new(
       template_directory: @node.template_directory,
       template_name: "start",
+      helpers: [SmartAnswer::RateDatesHelper],
     )
   end
 

--- a/lib/smart_answer/calculators/minimum_wage_calculator.rb
+++ b/lib/smart_answer/calculators/minimum_wage_calculator.rb
@@ -29,7 +29,7 @@ module SmartAnswer::Calculators
     end
 
     def previous_period_start_date
-      data.previous_period(date: date)[:start_date]
+      data.previous_period(date:)[:start_date]
     end
 
     def valid_age?(age)

--- a/lib/smart_answer/calculators/minimum_wage_calculator.rb
+++ b/lib/smart_answer/calculators/minimum_wage_calculator.rb
@@ -28,6 +28,10 @@ module SmartAnswer::Calculators
       @minimum_wage_data = rates_for_date(@date)
     end
 
+    def previous_period_start_date
+      data.previous_period(date: date)[:start_date]
+    end
+
     def valid_age?(age)
       age.positive? && age <= 200
     end

--- a/lib/smart_answer/calculators/rates_query.rb
+++ b/lib/smart_answer/calculators/rates_query.rb
@@ -13,6 +13,17 @@ module SmartAnswer::Calculators
       @data = rates_data
     end
 
+    def previous_period(date: nil)
+      date ||= SmartAnswer::DateHelper.current_day
+      previous_period = nil
+      data.each do |rates_hash|
+        break if rates_hash[:start_date] <= date && rates_hash[:end_date] >= date
+
+        previous_period = rates_hash
+      end
+      previous_period
+    end
+
     def rates(date = nil)
       date ||= SmartAnswer::DateHelper.current_day
       relevant_rates = data.find do |rates_hash|

--- a/lib/smart_answer/rate_dates_helper.rb
+++ b/lib/smart_answer/rate_dates_helper.rb
@@ -1,0 +1,16 @@
+module SmartAnswer
+  module RateDatesHelper
+    def last_year_text(rates_file)
+      "#{last_year(rates_file)[:start_date].strftime('%B %Y')} to #{last_year(rates_file)[:end_date].strftime('%B %Y')}"
+    end
+
+    def last_year_end_text(rates_file)
+      last_year(rates_file)[:end_date].strftime("%B %Y").to_s
+    end
+
+    def last_year(rates_file)
+      data = SmartAnswer::Calculators::RatesQuery.from_file(rates_file)
+      data.previous_period(date: SmartAnswer::DateHelper.current_day)
+    end
+  end
+end

--- a/test/unit/calculators/rates_query_test.rb
+++ b/test/unit/calculators/rates_query_test.rb
@@ -71,5 +71,22 @@ module SmartAnswer::Calculators
         end
       end
     end
+
+    context "#previous_period" do
+      setup do
+        @test_rate = RatesQuery.from_file(
+          "exact_date_rates",
+          load_path: "test/fixtures/rates",
+        )
+      end
+
+      should "be nil for 2013-01-31" do
+        assert_nil @test_rate.previous_period(date: Date.parse("2013-01-31"))
+      end
+
+      should "be 2013-01-31 for 2013-02-01" do
+        assert_equal Date.parse("2012-01-01"), @test_rate.previous_period(date: Date.parse("2013-02-01"))[:start_date]
+      end
+    end
   end
 end


### PR DESCRIPTION
Updates the minimum wage calculator (used by two flows) to dynamically work out the previous period, so that:

1) it requires a little less content maintenance when uprating happens.
2) it can be deployed ahead of time and update when used, rather than needing to be deployed on the uprating day (which in 2023 is on a weekend).

https://trello.com/c/C633ea1Z/1395-ps-15-make-minimum-wage-calculator-use-current-time

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
