### PR TITLE
Reinstate supported benefits checker for V2

### DIFF
--- a/app/flows/check_benefits_financial_support_flow.rb
+++ b/app/flows/check_benefits_financial_support_flow.rb
@@ -103,16 +103,18 @@ class CheckBenefitsFinancialSupportFlow < SmartAnswer::Flow
         if calculator.children_living_with_you == "yes"
           question :age_of_children
         else
-          question :assets_and_savings
+          question :on_benefits
         end
       end
     end
 
     checkbox_question :age_of_children do
+      option :pregnant
       option :"1_or_under"
       option :"2"
       option :"3_to_4"
-      option :"5_to_11"
+      option :"5_to_7"
+      option :"8_to_11"
       option :"12_to_15"
       option :"16_to_17"
       option :"18_to_19"
@@ -135,20 +137,61 @@ class CheckBenefitsFinancialSupportFlow < SmartAnswer::Flow
       end
 
       next_node do
-        question :assets_and_savings
+        question :on_benefits
+      end
+    end
+
+    radio_with_intro :on_benefits do
+      option :yes
+      option :no
+      option :dont_know
+
+      on_response do |response|
+        calculator.on_benefits = response
+      end
+
+      next_node do |response|
+        if response == "yes"
+          question :current_benefits
+        else
+          outcome :assets_and_savings
+        end
+      end
+    end
+
+    checkbox_question :current_benefits do
+      option :universal_credit
+      option :jobseekers_allowance
+      option :employment_and_support_allowance
+      option :pension_credit
+      option :tax_credits
+      option :income_support
+      option :housing_benefit
+
+      on_response do |response|
+        calculator.current_benefits = response
+      end
+
+      validate :error_message do
+        calculator.benefits_selected?
+      end
+
+      next_node do
+        outcome :assets_and_savings
       end
     end
 
     radio :assets_and_savings do
       option :over_16000
       option :under_16000
+      option :none_16000
 
       on_response do |response|
         calculator.assets_and_savings = response
       end
 
       next_node do
-        outcome :results
+        question :results
       end
     end
 

--- a/app/flows/check_benefits_financial_support_flow/outcomes/results.erb
+++ b/app/flows/check_benefits_financial_support_flow/outcomes/results.erb
@@ -34,9 +34,8 @@
     <%= render "govuk_publishing_components/components/list", {
     visible_counters: true,
     items: [
-      sanitize("browsing <a class=\"govuk-link\" href=\"/browse/benefits\">information on benefits</a>"),
-      sanitize("reading about <a class=\"govuk-link\" href=\"https://costoflivingsupport.campaign.gov.uk/\">what the government is doing to support people with the cost of living</a>"),
-      sanitize("<a class=\"govuk-link\" href=\"/benefits-calculators\">using a benefits calculator</a>"),
+      sanitize("reading about <a class=\"govuk-link\" href=\"/cost-of-living\">the support available to help with the cost of living</a>"),
+      sanitize("<a class=\"govuk-link\" href=\"/benefits-calculators\">using a benefits calculator</a> - enter information on income, savings and spending to get an estimate of benefits you can get and how much"),
     ]
     } %>
   </div>

--- a/app/flows/check_benefits_financial_support_flow/questions/age_of_children.erb
+++ b/app/flows/check_benefits_financial_support_flow/questions/age_of_children.erb
@@ -3,10 +3,12 @@
 <% end %>
 
 <% options(
+    "pregnant": "I'm expecting a child",
     "1_or_under": "1 or under",
     "2": "2",
     "3_to_4": "3 to 4",
-    "5_to_11": "5 to 11",
+    "5_to_7": "5 to 7",
+    "8_to_11": "8 to 11",
     "12_to_15": "12 to 15",
     "16_to_17": "16 to 17",
     "18_to_19": "18 to 19"

--- a/app/flows/check_benefits_financial_support_flow/questions/assets_and_savings.erb
+++ b/app/flows/check_benefits_financial_support_flow/questions/assets_and_savings.erb
@@ -8,6 +8,7 @@
 
 <% options(
     over_16000: "£16,000 or more",
-    under_16000: "Less than £16,000"
+    under_16000: "Less than £16,000",
+    none_16000: "None"
   )
 %>

--- a/app/flows/check_benefits_financial_support_flow/questions/children_living_with_you.erb
+++ b/app/flows/check_benefits_financial_support_flow/questions/children_living_with_you.erb
@@ -1,5 +1,5 @@
 <% text_for :title do %>
-  Do you have children living with you?
+  Do you have children living with you (or are you expecting a child)?
 <% end %>
 
 <% text_for :hint do %>

--- a/app/flows/check_benefits_financial_support_flow/questions/current_benefits.erb
+++ b/app/flows/check_benefits_financial_support_flow/questions/current_benefits.erb
@@ -1,0 +1,21 @@
+<% text_for :title do %>
+  Select everything you are getting at the moment
+<% end %>
+
+<% text_for :hint do %>
+  Income-based JSA and ESA do not include 'new style' JSA and ESA (these are contribution-based benefits).
+<% end %>
+
+<% options(
+  universal_credit: "Universal Credit",
+  jobseekers_allowance: "Income-based Jobseeker's Allowance (JSA)",
+  employment_and_support_allowance: "Income-related Employment and Support Allowance (ESA)",
+  pension_credit: "Pension Credit",
+  tax_credits: "Tax credits",
+  income_support: "Income Support",
+  housing_benefit: "Housing Benefit",
+) %>
+
+<% text_for :error_message do %>
+  Select the benefits you're getting.
+<% end %>

--- a/app/flows/check_benefits_financial_support_flow/questions/on_benefits.erb
+++ b/app/flows/check_benefits_financial_support_flow/questions/on_benefits.erb
@@ -1,0 +1,25 @@
+<% text_for :title do %>
+  What support you're already getting
+<% end %>
+
+<% govspeak_for :body do %>
+  You may be eligible for other payments if you're already getting any of the following:
+
+  * Universal Credit
+  * income-based Jobseeker’s Allowance (JSA) - this does not include new style JSA
+  * income-related Employment and Support Allowance (ESA) - this does not include new style ESA
+  * Pension Credit
+  * Tax credits
+  * Income Support
+  * Housing Benefit
+<% end %>
+
+<% text_for :radio_heading do %>
+  Are you getting any of these?
+<% end %>
+
+<% options(
+  yes: "Yes",
+  no: "No",
+  dont_know: "Don't know"
+) %>

--- a/app/flows/check_benefits_financial_support_flow/start.erb
+++ b/app/flows/check_benefits_financial_support_flow/start.erb
@@ -19,11 +19,7 @@
 <% end %>
 
 <% govspeak_for :post_body do %>
-  At the moment, this tool does not include all the ways you can get help with living costs. It will be updated with more types of support including:
+  At the moment, this tool does not include all the ways you can get help with living costs. It will be updated with more types of support.
 
-  - free school meals
-  - extra help for housing costs
-  - travel costs
-
-  Find out more information about other ways to [get help with the cost of living](https://costoflivingsupport.campaign.gov.uk/).
+  Find out more information about other ways to [get help with the cost of living](https://www.gov.uk/cost-of-living).
 <% end %>

--- a/config/smart_answers/check_benefits_financial_support_data.yml
+++ b/config/smart_answers/check_benefits_financial_support_data.yml
@@ -62,7 +62,10 @@
         - northern-ireland
     - name: housing_benefit
       title: Housing Benefit
-      description: You may be able to get help to pay your rent if you’ve reached State Pension age or are in supported, sheltered or temporary housing. You will not get Housing Benefit if your savings are over £16,000 - unless you get the Guarantee Credit element of Pension Credit.
+      description: |
+        <p>You could get help to pay your rent if you’ve reached State Pension age or are in supported, sheltered or temporary housing.</p>
+
+        <p>You will not get Housing Benefit if your savings are over £16,000 (unless you get the Guarantee Credit element of Pension Credit) or if you live with a partner below State Pension age. You should apply for Universal Credit instead.</p>
       condition: eligible_for_housing_benefit?
       url: /housing-benefit
       url_text: Check if you’re eligible for Housing Benefit
@@ -72,7 +75,10 @@
         - wales
     - name: housing_benefit_scotland
       title: Housing Benefit
-      description: You may be able to get help to pay your rent if you’ve reached State Pension age or are in supported, sheltered or temporary housing. You will not get Housing Benefit if your savings are over £16,000 - unless you get the Guarantee Credit element of Pension Credit.
+      description: |
+        <p>You could get help to pay your rent if you’ve reached State Pension age or are in supported, sheltered or temporary housing.</p>
+
+        <p>You will not get Housing Benefit if your savings are over £16,000 (unless you get the Guarantee Credit element of Pension Credit) or if you live with a partner below State Pension age. You should apply for Universal Credit instead.</p>
       condition: eligible_for_housing_benefit?
       url: https://www.mygov.scot/claim-housing-benefit
       url_text: Check if you’re eligible for Housing Benefit on the mygov.scot website
@@ -133,11 +139,23 @@
       countries:
         - northern-ireland
     - name: tax_free_childcare
-      title: Tax-free childcare
+      title: Tax-Free Childcare
       description: You may be able to get up to £2,000 a year for each of your children to help with the costs of childcare.
       condition: eligible_for_tax_free_childcare?
       url: /tax-free-childcare
-      url_text: Check if you’re eligible for Tax-Free childcare
+      url_text: Check if you’re eligible for Tax-Free Childcare
+      group: Help with childcare costs
+      countries:
+        - england
+        - wales
+        - scotland
+        - northern-ireland
+    - name: tax_free_childcare_with_disability
+      title: Tax-Free Childcare
+      description: You may be able to get up to £2,000 a year for each of your children to help with the costs of childcare, or up to £4000 if a child is disabled.
+      condition: eligible_for_tax_free_childcare_with_disability?
+      url: /tax-free-childcare
+      url_text: Check if you’re eligible for Tax-Free Childcare
       group: Help with childcare costs
       countries:
         - england
@@ -152,11 +170,19 @@
       url_text: Check if you’re eligible for free childcare for 2-year-olds
       group: Help with childcare costs
       countries:
-        - wales
         - england
+    - name: free_childcare_2yr_olds_wales
+      title: Free childcare for 2-year-olds
+      description: You may be able to get free childcare for your 2-year-old if you get certain benefits or if your child is eligible.
+      condition: eligible_for_free_childcare_2yr_olds?
+      url: https://gov.wales/get-help-flying-start
+      url_text: Check if you’re eligible for free childcare for 2-year-olds
+      group: Help with childcare costs
+      countries:
+        - wales
     - name: childcare_3_4yr_olds_wales
-      title: Childcare 3 and 4 year olds
-      description: You may be able to get up to 30 hours a week of free early education and childcare.
+      title: Childcare for 3 and 4-year-olds
+      description: You may be able to get up to 30 hours a week of free early education and childcare if your child has not started school full-time.
       condition: eligible_for_childcare_3_4yr_olds?
       url: https://gov.wales/childcare-3-and-4-year-olds
       url_text: Find out how much free childcare you can get on the GOV.WALES website
@@ -165,7 +191,7 @@
         - wales
     - name: 15hrs_free_childcare_3_4yr_olds_england
       title: 15 hours of free childcare for 3 and 4-year-olds
-      description: You can get 570 hours of free childcare per year with an approved childcare provider if your child is 3 or 4 years old.
+      description: You can get 570 hours of free childcare per year with an approved childcare provider if your child is 3 or 4 years old and has not started school full-time.
       condition: eligible_for_15hrs_free_childcare_3_4yr_olds?
       url: /help-with-childcare-costs/free-childcare-and-education-for-2-to-4-year-olds
       url_text: Find out how to get free childcare for 3 and 4-year-olds
@@ -174,7 +200,7 @@
         - england
     - name: funded_early_learning_and_childcare_scotland
       title: Funded early learning and childcare
-      description: You may be able to get up to 30 hours a week of free early education and childcare during term time if your child is 3 or 4 years old. You may also be able to get funded childcare for your 2-year-old.
+      description: You may be able to get up to 30 hours a week of free early education and childcare during term time if your child is 3 or 4 years old and has not started school full-time. You may also be able to get funded childcare for your 2-year-old.
       condition: eligible_for_funded_early_learning_and_childcare?
       url: https://www.mygov.scot/childcare-costs-help/funded-early-learning-and-childcare
       url_text: Find out how much free childcare you can get on mygov.scot
@@ -183,13 +209,24 @@
         - scotland
     - name: 30hrs_free_childcare_3_4yrs_england
       title: 30 hours of free childcare
-      description: You may be able to get 30 hours of free childcare with an approved childcare provider if you’re working and your child is 3 or 4 years old.
+      description: You may be able to get 30 hours of free childcare with an approved childcare provider if you’re working and your child is 3 or 4 years old and has not started school full-time.
       condition: eligible_for_30hrs_free_childcare_3_4yrs?
       url: /30-hours-free-childcare
       url_text: Check if you’re eligible for 30 hours free childcare
       group: Help with childcare costs
       countries:
         - england
+    - name: winter_fuel_payment
+      title: Winter Fuel Payment
+      description: You'll automatically get a Winter Fuel Payment if you’re getting the State Pension. You may have to apply if you've reached State Pension age but are not getting your State Pension, for example because you deferred it. The amount you’ll get will include a ‘Pensioner Cost of Living Payment’.
+      condition: eligible_for_winter_fuel_payment?
+      url: /winter-fuel-payment
+      url_text: Check if you're eligible and whether you need to apply for a Winter Fuel Payment
+      countries:
+        - england
+        - wales
+        - scotland
+        - northern-ireland
     - name: carers_allowance
       title: Carer’s Allowance
       description: You may be able to get Carer’s Allowance if you care for someone at least 35 hours a week. The person you care for must also be getting certain disability benefits.
@@ -232,6 +269,13 @@
       countries:
         - england
         - wales
+    - name: adult_disability_payment_scotland
+      title: Adult Disability Payment
+      description: You may be able to get help with extra living costs if you have a long-term physical or mental health condition or disability.
+      condition: eligible_for_adult_disability_payment_scotland?
+      url_text: Check if you’re eligible for Adult Disability Payment on the mygov.scot website
+      url: https://www.mygov.scot/adult-disability-payment
+      countries:
         - scotland
     - name: personal_independence_payment_northern_ireland
       title: Personal Independence Payment (PIP)
@@ -288,8 +332,8 @@
         - northern-ireland
     - name: free_tv_licence
       title: Get a free or discounted TV licence
-      description: You may be able to get a free TV licence if you’re 75 or older and get Pension Credit.
-      condition: eligible_for_free_tv_licence?
+      description: You may be able to get a free TV licence if you’re 75 or older and get Pension Credit. You can get a discounted TV licence if you’re registered blind or in residential care.
+      condition: eligible_for_free_tv_license?
       url: /free-discount-tv-licence
       url_text: Check if you’re eligible for a free or discounted TV licence
       group: Help with your bills
@@ -301,6 +345,7 @@
     - name: budgeting_loan
       title: Budgeting Loan
       description: You may be eligible for a Budgeting Loan if you’ve been on certain benefits for 6 months.
+      condition: eligible_for_budgeting_loan?
       url: /budgeting-help-benefits
       url_text: Check if you’re eligible for a Budgeting Loan
       group: Help with your bills
@@ -311,34 +356,227 @@
     - name: social_fund_budgeting_loan_northern_ireland
       title: Social Fund Budgeting Loan
       description: You may be eligible for a Budgeting Loan if you’ve been on certain benefits for 6 months.
+      condition: eligible_for_budgeting_loan?
       url: https://www.nidirect.gov.uk/articles/social-fund-budgeting-loan
       url_text: Check if you’re eligible for a Budgeting Loan on the nidirect website
       group: Help with your bills
       countries:
         - northern-ireland
-    - name: nhs_low_income_scheme
-      title: NHS Low Income Scheme
-      description: If you have a low income, you may be able to get help with prescriptions, dental care and other health costs.
-      condition: eligible_for_nhs_low_income_scheme?
-      url: https://www.nhs.uk/nhs-services/help-with-health-costs/nhs-low-income-scheme-lis/
-      url_text: Check if you’re eligible for the NHS Low Income Scheme on the NHS website
+    - name: nhs_help_with_health_costs
+      title: NHS Help with health costs
+      description: You may be able to get help with prescriptions, dental care, healthcare travel and other health costs, particularly if you’re on a low income or getting certain benefits.
+      url: https://www.nhs.uk/nhs-services/help-with-health-costs
+      url_text: Check if you’re eligible for help with health costs on the NHS website
       group: Healthcare support
       countries:
         - england
         - wales
-    - name: eligible_for_help_with_health_costs_scotland
-      title: Help With Health Costs
-      description: If you have a low income, you may be able to get help with prescriptions, dental care and other health costs.
-      url: https://www.nhsinform.scot/care-support-and-rights/health-rights/access/help-with-health-costs
-      url_text: Check if you’re eligible for help with health costs on the NHS Inform (Scotland) website
+    - name: help_with_health_costs_scotland
+      title: Help with health costs
+      description: You may be able to get help with dental care, healthcare travel and other health costs, particularly if you’re on a low income or getting certain benefits. All prescriptions in Scotland are free.
+      url: https://www.gov.scot/publications/hcs1/
+      url_text: Check if you’re eligible for help with health costs on the Scottish Government website
       group: Healthcare support
       countries:
         - scotland
-    - name: nhs_low_income_scheme_northern_ireland
-      title: NHS Low Income Scheme
-      description: If you have a low income, you may be able to get help with prescriptions, dental care and other health costs.
+    - name: nhs_help_with_health_costs_northern_ireland
+      title: NHS Help with health costs
+      description: You may be able to get help with prescriptions, dental care, healthcare travel and other health costs, particularly if you’re on a low income or getting certain benefits.
       url: https://www.nidirect.gov.uk/articles/help-health-costs
-      url_text: Check if you’re eligible for the NHS Low Income Scheme on the nidirect website
+      url_text: Check if you’re eligible for help with health costs on the nidirect website
       group: Healthcare support
+      countries:
+        - northern-ireland
+    - name: maternity_allowance
+      title: Maternity Allowance
+      description: You may be eligible to get Maternity Allowance for 39 weeks if you’re employed but cannot get Statutory Maternity Pay (SMP), or are registered self-employed. You may still qualify if you’ve recently stopped working.
+      condition: eligible_for_maternity_allowance?
+      url_text: Check if you’re eligible for Maternity Allowance
+      url: https://www.gov.uk/maternity-allowance
+      countries:
+        - england
+        - wales
+        - scotland
+        - northern-ireland
+    - name: sure_start_maternity_grant
+      title: Sure Start Maternity Grant
+      description: If you or your partner get certain benefits you could get a one-off payment of £500 to help towards the costs of having a child. You must usually have no other children under 16.
+      condition: eligible_for_sure_start_maternity_grant?
+      url_text: Check if you’re eligible for a Sure Start Maternity Grant
+      url: https://www.gov.uk/sure-start-maternity-grant
+      countries:
+        - england
+        - wales
+        - northern-ireland
+    - name: pregnancy_and_baby_payment_scotland
+      title: Pregnancy and Baby Payment
+      description: If you or your partner get certain benefits you could get a one-off payment to help with the costs of having a baby. You can apply for this payment during pregnancy or until your baby is 6 months old.
+      condition: eligible_for_pregnancy_and_baby_payment_scotland?
+      url_text: Check if you’re eligible for a Pregnancy and Baby Payment on the mygov.scot website
+      url: https://www.mygov.scot/best-start-grant-best-start-foods
+      countries:
+        - scotland
+    - name: healthy_start
+      title: Healthy Start
+      description: |
+        <p>If you’re getting certain benefits and are more than 10 weeks pregnant or have a child under 4, you may be entitled to get help to buy healthy food and milk.</p>
+
+        <p>If you’re pregnant and under 18 you can get help even if you do not receive any benefits.</p>
+      condition: eligible_for_healthy_start?
+      url_text: Check if you’re eligible for help from Healthy Start
+      url: https://www.healthystart.nhs.uk/
+      countries:
+        - england
+        - wales
+        - northern-ireland
+    - name: best_start_foods_scotland
+      title: Best Start Foods
+      description: If you’re getting certain benefits and are pregnant or have a child under 3, you may be entitled to Best Start Foods payments. These help towards the costs of being pregnant or looking after a child.
+      condition: best_start_foods_scotland?
+      url_text: Check if you’re eligible for help from Best Start on the mygov.scot website
+      url: https://www.mygov.scot/best-start-grant-best-start-foods
+      countries:
+        - scotland
+    - name: free_school_meals_england
+      title: Free school meals
+      description: If you’re on certain benefits your child may be able to get free school meals. You’ll need to apply through your local council. Your child will automatically get free school meals if they’re in a government-funded school and in reception class, year 1 or year 2.
+      condition: eligible_for_free_school_meals?
+      url_text: Check if your child can get free school meals
+      url: https://www.gov.uk/apply-free-school-meals
+      countries:
+        - england
+    - name: free_school_meals_scotland
+      title: Free school meals
+      description: If you’re on certain benefits your child may be able to get free school meals. You’ll need to apply through your local council. Your child will automatically get free school meals if they’re in a government-funded school and in primary years 1 to 5.
+      condition: eligible_for_free_school_meals_scotland?
+      url_text: Check if your child can get free school meals on the mygov.scot website
+      url: https://www.mygov.scot/school-meals
+      countries:
+        - scotland
+    - name: free_school_meals_wales
+      title: Free school meals
+      description: If you’re on certain benefits your child may be able to get free school meals. You’ll need to apply through your local council.
+      condition: eligible_for_free_school_meals?
+      url_text: Check if your child can get free school meals on the GOV.WALES website
+      url: https://gov.wales/find-out-about-free-school-meals
+      countries:
+        - wales
+    - name: free_school_meals_northern_ireland
+      title: Free school meals
+      description: If you’re on certain benefits your child may be able to get free school meals. You’ll need to apply through the Northern Ireland Education Authority.
+      condition: eligible_for_free_school_meals?
+      url_text: Check if your child can get free school meals on the nidirect website
+      url: https://www.nidirect.gov.uk/articles/nutrition-and-school-lunches
+      countries:
+        - northern-ireland
+    - name: school_clothing_grant_scotland
+      title: School Clothing Grant
+      description: If you’re on certain benefits you may be able to get help from your local council with the cost of school uniforms.
+      condition: eligible_for_school_clothing_grant_scotland?
+      url_text: Check if you can get help with school uniform costs on the mygov.scot website
+      url: https://www.mygov.scot/clothing-grants
+      countries:
+        - scotland
+    - name: uniform_grant_northern_ireland
+      title: Uniform Grant
+      description: If you’re on certain benefits you may be able to get help from your local council with the cost of school uniforms.
+      condition: eligible_for_uniform_grant_northern_ireland?
+      url_text: Check if you can get help with school uniform costs on the Education Authority NI website
+      url: https://www.eani.org.uk/financial-help/free-school-meals-uniform-grants
+      countries:
+        - northern-ireland
+    - name: pupil_development_grant_wales
+      title: Pupil Development Grant
+      description: If you’re on certain benefits you may be able to get help from your local council with the cost of school uniforms.
+      condition: eligible_for_pupil_development_grant_wales?
+      url_text: Check if you can get help with school uniform costs on the GOV.WALES website
+      url: https://gov.wales/pupil-development-grant-access
+      countries:
+        - wales
+    - name: home_to_school_transport
+      title: Home to school transport
+      description: You may be able to get help with the cost of home to school transport through your local council. You may be eligible if you’re on a low income, your child has Special Educational Needs (SEN) or because of the distance to the school. There is separate support if your child is 16 or over.
+      condition: eligible_for_school_transport?
+      url_text: Check if your child is eligible for help with the cost of home to school transport
+      url: https://www.gov.uk/free-school-transport
+      countries:
+        - england
+        - wales
+    - name: free_school_transport_scotland
+      title: Free school transport
+      description: You may be able to get help with the cost of home to school transport through your local council. You may be eligible because of the distance to the school, your child has additional support needs or you’re on a low income.
+      condition: eligible_for_school_transport?
+      url_text: Check if your child is eligible for help with the cost of home to school transport on the mygov.scot website
+      url: https://www.mygov.scot/free-school-transport
+      countries:
+        - scotland
+    - name: home_to_school_transport_northern_ireland
+      title: Home to school transport
+      description: You may be able to get help with the cost of home to school transport through the Education Authority. You may be eligible because of distance to the school or if a transport need is specified on your child's Special Educational Needs (SEN) statement.
+      condition: eligible_for_school_transport?
+      url_text: Check if your child is eligible for help with the cost of home to school transport on the Education Authority NI website
+      url: https://www.eani.org.uk/help-available/home-to-school-transport
+      countries:
+        - northern-ireland
+    - name: apply_for_an_older_persons_bus_pass
+      title: Apply for an older person's bus pass
+      description: In England you can get a bus pass for free travel when you reach the State Pension age. In Wales, Scotland and Northern Ireland you can get a pass at 60.
+      condition: eligible_for_an_older_persons_bus_pass?
+      url_text: Find out how to apply for an older person’s bus pass
+      url: https://www.gov.uk/apply-for-elderly-person-bus-pass
+      countries:
+        - england
+        - wales
+        - scotland
+        - northern-ireland
+    - name: apply_for_a_disabled_persons_bus_pass
+      title: Apply for a disabled person's bus pass
+      description: You can get free travel on buses if you’re eligible.
+      condition: eligible_for_a_disabled_persons_bus_pass?
+      url_text: Find out how to apply for a disabled person’s bus pass
+      url: https://www.gov.uk/apply-for-disabled-bus-pass
+      countries:
+        - england
+    - name: apply_for_a_disabled_persons_bus_pass_wales
+      title: Apply for a disabled person's bus pass
+      description: You can get free travel on buses if you’re eligible.
+      condition: eligible_for_a_disabled_persons_bus_pass?
+      url_text: Find out how to apply for a disabled person’s bus pass on the GOV.WALES website
+      url: https://gov.wales/apply-bus-pass
+      countries:
+        - wales
+    - name: apply_for_a_disabled_persons_bus_pass_scotland
+      title: Apply for a disabled person's bus pass
+      description: You can get free travel on buses if you’re eligible.
+      condition: eligible_for_a_disabled_persons_bus_pass?
+      url_text: Find out how to apply for a disabled person’s bus pass on the mygov.scot website
+      url: https://www.mygov.scot/disabled-bus-pass
+      countries:
+        - scotland
+    - name: apply_for_a_disabled_persons_bus_pass_ni
+      title: Apply for a disabled person's bus pass
+      description: You can get free or half-price travel on buses if you’re eligible.
+      condition: eligible_for_a_disabled_persons_bus_pass?
+      url_text: Find out how to apply for a disabled person’s bus pass on the nidirect website
+      url: https://www.nidirect.gov.uk/information-and-services/bus-and-coach-travel/free-bus-travel-and-concessions
+      countries:
+        - northern-ireland
+    - name: support_for_mortgage_interest_(smi)
+      title: Support for Mortgage Interest (SMI)
+      description: If you’re a homeowner, you might be able to get help towards interest payments on your mortgage or certain loans taken out on your home.
+      condition: eligible_for_support_for_mortgage_interest?
+      url_text: Check if you’re eligible for Support for Mortgage Interest
+      url: https://www.gov.uk/support-for-mortgage-interest
+      countries:
+        - england
+        - wales
+        - scotland
+        - northern-ireland
+    - name: education_maintenance_allowance_ni
+      title: Education Maintenance Allowance
+      description: You may be able to get Education Maintenance Allowance (EMA) of £30 a week if you’re aged 16 to 19 and in full-time education at a school or further education college in Northern Ireland.
+      condition: eligible_for_education_maintenance_allowance_ni?
+      url_text: Check if you’re eligible for Education Maintenance Allowance on the nidirect website
+      url: https://www.nidirect.gov.uk/articles/education-maintenance-allowance-explained
       countries:
         - northern-ireland

--- a/lib/smart_answer/calculators/check_benefits_financial_support_calculator.rb
+++ b/lib/smart_answer/calculators/check_benefits_financial_support_calculator.rb
@@ -9,6 +9,8 @@ module SmartAnswer::Calculators
                   :children_living_with_you,
                   :age_of_children,
                   :children_with_disability,
+                  :on_benefits,
+                  :current_benefits,
                   :assets_and_savings
 
     def benefit_data
@@ -27,6 +29,102 @@ module SmartAnswer::Calculators
       benefits_for_outcome.size
     end
 
+    def benefits_selected?
+      @current_benefits != "none"
+    end
+
+    def eligible_for_maternity_allowance?
+      return unless @children_living_with_you == "yes"
+
+      age_groups = %w[pregnant 1_or_under]
+
+      @over_state_pension_age == "no" && eligible_child_ages?(age_groups)
+    end
+
+    def eligible_for_sure_start_maternity_grant?
+      skip_benefit_list = %w[housing_benefit]
+      age_groups = %w[pregnant 1_or_under]
+
+      general_child_benefit_eligibility?(skip_benefit_list, age_groups)
+    end
+
+    def eligible_for_pregnancy_and_baby_payment_scotland?
+      skip_benefit_list = []
+      age_groups = %w[pregnant 1_or_under]
+
+      general_child_benefit_eligibility?(skip_benefit_list, age_groups)
+    end
+
+    def eligible_for_healthy_start?
+      skip_benefit_list = %w[housing_benefit]
+      age_groups = %w[pregnant 1_or_under 2 3_to_4]
+
+      general_child_benefit_eligibility?(skip_benefit_list, age_groups)
+    end
+
+    def best_start_foods_scotland?
+      skip_benefit_list = %w[pension_credit housing_benefit]
+      age_groups = %w[pregnant 1_or_under 2]
+
+      general_child_benefit_eligibility?(skip_benefit_list, age_groups)
+    end
+
+    def eligible_for_free_school_meals?
+      skip_benefit_list = %w[housing_benefit]
+      age_groups = %w[3_to_4 5_to_7 8_to_11 12_to_15 16_to_17]
+
+      general_child_benefit_eligibility?(skip_benefit_list, age_groups)
+    end
+
+    def eligible_for_free_school_meals_scotland?
+      skip_benefit_list = []
+      age_groups = %w[3_to_4 5_to_7 8_to_11 12_to_15 16_to_17]
+
+      general_child_benefit_eligibility?(skip_benefit_list, age_groups)
+    end
+
+    def eligible_for_school_clothing_grant_scotland?
+      skip_benefit_list = []
+      age_groups = %w[3_to_4 5_to_7 8_to_11 12_to_15 16_to_17 18_to_19]
+
+      general_child_benefit_eligibility?(skip_benefit_list, age_groups)
+    end
+
+    def eligible_for_uniform_grant_northern_ireland?
+      skip_benefit_list = %w[housing_benefit]
+      age_groups = %w[3_to_4 5_to_7 8_to_11 12_to_15 16_to_17]
+
+      general_child_benefit_eligibility?(skip_benefit_list, age_groups)
+    end
+
+    def eligible_for_pupil_development_grant_wales?
+      skip_benefit_list = %w[housing_benefit]
+      age_groups = %w[3_to_4 5_to_7 8_to_11 12_to_15 16_to_17]
+
+      general_child_benefit_eligibility?(skip_benefit_list, age_groups)
+    end
+
+    def eligible_for_school_transport?
+      age_groups = %w[3_to_4 5_to_7 8_to_11 12_to_15 16_to_17 18_to_19]
+
+      @children_living_with_you == "yes" && eligible_child_ages?(age_groups)
+    end
+
+    def eligible_for_an_older_persons_bus_pass?
+      @over_state_pension_age == "yes"
+    end
+
+    def eligible_for_free_tv_license?
+      return true if @disability_or_health_condition == "yes"
+      return if @over_state_pension_age == "no"
+
+      @on_benefits == "dont_know" || @current_benefits.include?("pension_credit")
+    end
+
+    def eligible_for_a_disabled_persons_bus_pass?
+      @disability_or_health_condition == "yes"
+    end
+
     def eligible_for_employment_and_support_allowance?
       @over_state_pension_age == "no" &&
         @are_you_working != "yes_over_16_hours_per_week" &&
@@ -41,7 +139,9 @@ module SmartAnswer::Calculators
     end
 
     def eligible_for_pension_credit?
-      @over_state_pension_age == "yes"
+      return if @over_state_pension_age == "no"
+
+      @on_benefits == "no" || permitted_benefits?(%w[pension_credit])
     end
 
     def eligible_for_access_to_work?
@@ -50,52 +150,57 @@ module SmartAnswer::Calculators
     end
 
     def eligible_for_universal_credit?
-      @over_state_pension_age == "no" &&
-        @assets_and_savings == "under_16000"
+      return if @over_state_pension_age == "yes"
+      return if @assets_and_savings == "over_16000"
+
+      @on_benefits == "no" || permitted_benefits?(%w[universal_credit])
     end
 
     def eligible_for_housing_benefit?
-      @over_state_pension_age == "yes"
+      return if @over_state_pension_age == "no"
+
+      @on_benefits == "no" || permitted_benefits?(%w[housing_benefit])
     end
 
     def eligible_for_tax_free_childcare?
-      return unless @are_you_working != "no" && @children_living_with_you == "yes"
+      return false if @are_you_working == "no"
+      return false if @children_living_with_you == "no"
+      return false if @children_with_disability == "yes"
 
-      eligible_child_ages = if @children_with_disability == "yes"
-                              %w[1_or_under 2 3_to_4 5_to_11 12_to_15 16_to_17]
-                            else
-                              %w[1_or_under 2 3_to_4 5_to_11]
-                            end
+      age_groups = %w[1_or_under 2 3_to_4 5_to_7 8_to_11]
+      eligible_child_ages?(age_groups)
+    end
 
-      @age_of_children.split(",").any? { |age| eligible_child_ages.include?(age) }
+    def eligible_for_tax_free_childcare_with_disability?
+      return if @are_you_working == "no"
+      return if @children_living_with_you == "no"
+      return if @children_with_disability == "no"
+
+      age_groups = %w[1_or_under 2 3_to_4 5_to_7 8_to_11 12_to_15 16_to_17]
+      eligible_child_ages?(age_groups)
     end
 
     def eligible_for_free_childcare_2yr_olds?
-      @children_living_with_you == "yes" &&
-        @age_of_children.split(",").any?("2")
+      @children_living_with_you == "yes" && eligible_child_ages?(%w[2])
     end
 
     def eligible_for_childcare_3_4yr_olds?
-      @are_you_working == "yes_over_16_hours_per_week" &&
-        @children_living_with_you == "yes" &&
-        @age_of_children.split(",").any?("3_to_4")
+      @children_living_with_you == "yes" &&
+        eligible_child_ages?(%w[3_to_4])
     end
 
     def eligible_for_15hrs_free_childcare_3_4yr_olds?
-      @children_living_with_you == "yes" &&
-        @age_of_children.split(",").any?("3_to_4")
+      @children_living_with_you == "yes" && eligible_child_ages?(%w[3_to_4])
     end
 
     def eligible_for_30hrs_free_childcare_3_4yrs?
       @are_you_working != "no" &&
         @children_living_with_you == "yes" &&
-        @age_of_children.split(",").any?("3_to_4")
+        eligible_child_ages?(%w[3_to_4])
     end
 
     def eligible_for_funded_early_learning_and_childcare?
-      eligible_child_ages = %w[2 3_to_4]
-      @children_living_with_you == "yes" &&
-        @age_of_children.split(",").any? { |age| eligible_child_ages.include?(age) }
+      @children_living_with_you == "yes" && eligible_child_ages?(%w[2 3_to_4])
     end
 
     def eligible_for_child_benefit?
@@ -103,11 +208,15 @@ module SmartAnswer::Calculators
     end
 
     def eligible_for_child_disability_support?
-      eligible_child_ages = %w[1_or_under 2 3_to_4 5_to_11 12_to_15]
+      age_groups = %w[1_or_under 2 3_to_4 5_to_7 8_to_11 12_to_15]
 
       @children_living_with_you == "yes" &&
-        @age_of_children.split(",").any? { |age| eligible_child_ages.include?(age) } &&
+        eligible_child_ages?(age_groups) &&
         @children_with_disability == "yes"
+    end
+
+    def eligible_for_winter_fuel_payment?
+      @over_state_pension_age == "yes"
     end
 
     def eligible_for_carers_allowance?
@@ -119,22 +228,61 @@ module SmartAnswer::Calculators
 
       return true if @disability_or_health_condition == "yes"
 
-      eligible_child_ages = %w[16_to_17 18_to_19]
+      age_groups = %w[16_to_17 18_to_19]
+
       @children_living_with_you == "yes" &&
-        @age_of_children.split(",").any? { |age| eligible_child_ages.include?(age) } &&
+        eligible_child_ages?(age_groups) &&
         @children_with_disability == "yes"
+    end
+
+    def eligible_for_adult_disability_payment_scotland?
+      @over_state_pension_age == "no" && @disability_or_health_condition == "yes"
     end
 
     def eligible_for_attendance_allowance?
       @over_state_pension_age == "yes" && @disability_or_health_condition == "yes"
     end
 
-    def eligible_for_free_tv_licence?
-      @over_state_pension_age == "yes"
+    def eligible_for_budgeting_loan?
+      return if @on_benefits == "no"
+
+      skip_benefit_list = %w[universal_credit tax_credits housing_benefit]
+
+      permitted_benefits?(skip_benefit_list)
     end
 
-    def eligible_for_nhs_low_income_scheme?
-      @assets_and_savings == "under_16000"
+    def eligible_for_support_for_mortgage_interest?
+      return if @on_benefits == "no"
+
+      skip_benefit_list = %w[tax_credits housing_benefit]
+
+      permitted_benefits?(skip_benefit_list)
+    end
+
+    def eligible_for_education_maintenance_allowance_ni?
+      @children_living_with_you == "yes" && eligible_child_ages?(%w[16_to_17 18_to_19])
+    end
+
+  private
+
+    def eligible_child_ages?(age_groups)
+      @age_of_children.split(",").any? { |age| age_groups.include?(age) }
+    end
+
+    def general_child_benefit_eligibility?(skip_benefit_list, age_groups)
+      return if @children_living_with_you == "no"
+      return unless eligible_child_ages?(age_groups)
+      return if @on_benefits == "no"
+
+      permitted_benefits?(skip_benefit_list)
+    end
+
+    def permitted_benefits?(skip_benefit_list)
+      return true if @on_benefits == "dont_know"
+
+      @current_benefits.split(",").none? do |benefit|
+        skip_benefit_list.include?(benefit)
+      end
     end
   end
 end

--- a/lib/smart_answer/calculators/check_benefits_financial_support_calculator.rb
+++ b/lib/smart_answer/calculators/check_benefits_financial_support_calculator.rb
@@ -117,8 +117,9 @@ module SmartAnswer::Calculators
     def eligible_for_free_tv_license?
       return true if @disability_or_health_condition == "yes"
       return if @over_state_pension_age == "no"
+      return false if @on_benefits == "no"
 
-      @on_benefits == "dont_know" || @current_benefits.include?("pension_credit")
+      @on_benefits == "dont_know" || !permitted_benefits?(%w[pension_credit])
     end
 
     def eligible_for_a_disabled_persons_bus_pass?

--- a/test/flows/check_benefits_financial_support_flow_test.rb
+++ b/test/flows/check_benefits_financial_support_flow_test.rb
@@ -143,8 +143,8 @@ class CheckBenefitsFinancialSupportFlowTest < ActiveSupport::TestCase
         assert_next_node :age_of_children, for_response: "yes"
       end
 
-      should "have a next node of assets_and_savings if there are not children living with you" do
-        assert_next_node :assets_and_savings, for_response: "no"
+      should "have a next node of on_benefits if there are not children living with you" do
+        assert_next_node :on_benefits, for_response: "no"
       end
     end
   end
@@ -166,7 +166,7 @@ class CheckBenefitsFinancialSupportFlowTest < ActiveSupport::TestCase
 
     context "next_node" do
       should "have a next node of children_with_disability" do
-        assert_next_node :children_with_disability, for_response: "5_to_11"
+        assert_next_node :children_with_disability, for_response: "5_to_7"
       end
     end
   end
@@ -180,7 +180,7 @@ class CheckBenefitsFinancialSupportFlowTest < ActiveSupport::TestCase
                     disability_or_health_condition: "no",
                     carer_disability_or_health_condition: "no",
                     children_living_with_you: "yes",
-                    age_of_children: "5_to_11"
+                    age_of_children: "5_to_7"
     end
 
     should "render the question" do
@@ -188,8 +188,65 @@ class CheckBenefitsFinancialSupportFlowTest < ActiveSupport::TestCase
     end
 
     context "next_node" do
-      should "have a next node of assets_and_savings" do
-        assert_next_node :assets_and_savings, for_response: "yes"
+      should "have a next node of on_benefits" do
+        assert_next_node :on_benefits, for_response: "yes"
+      end
+    end
+  end
+
+  context "question: on_benefits" do
+    setup do
+      testing_node :on_benefits
+      add_responses where_do_you_live: "england",
+                    over_state_pension_age: "yes",
+                    are_you_working: "yes_over_16_hours_per_week",
+                    disability_or_health_condition: "no",
+                    carer_disability_or_health_condition: "no",
+                    children_living_with_you: "yes",
+                    age_of_children: "5_to_7",
+                    children_with_disability: "yes"
+    end
+
+    should "render the question" do
+      assert_rendered_question
+    end
+
+    context "next_node" do
+      should "have a next node of current_benefits for yes" do
+        assert_next_node :current_benefits, for_response: "yes"
+      end
+
+      should "have a next node of assets_and_savings for no" do
+        assert_next_node :assets_and_savings, for_response: "no"
+      end
+
+      should "have a next node of assets_and_savings for dont_know" do
+        assert_next_node :assets_and_savings, for_response: "dont_know"
+      end
+    end
+  end
+
+  context "question: current_benefits" do
+    setup do
+      testing_node :current_benefits
+      add_responses where_do_you_live: "england",
+                    over_state_pension_age: "yes",
+                    are_you_working: "yes_over_16_hours_per_week",
+                    disability_or_health_condition: "no",
+                    carer_disability_or_health_condition: "no",
+                    children_living_with_you: "yes",
+                    age_of_children: "5_to_7",
+                    children_with_disability: "yes",
+                    on_benefits: "yes"
+    end
+
+    should "render the question" do
+      assert_rendered_question
+    end
+
+    context "next_node" do
+      should "have a next node of assets_and_savings for universal_credit" do
+        assert_next_node :assets_and_savings, for_response: "universal_credit"
       end
     end
   end
@@ -203,8 +260,10 @@ class CheckBenefitsFinancialSupportFlowTest < ActiveSupport::TestCase
                     disability_or_health_condition: "no",
                     carer_disability_or_health_condition: "no",
                     children_living_with_you: "yes",
-                    age_of_children: "5_to_11",
-                    children_with_disability: "yes"
+                    age_of_children: "5_to_7",
+                    children_with_disability: "yes",
+                    on_benefits: "yes",
+                    current_benefits: "universal_credit"
     end
 
     should "render the question" do
@@ -212,8 +271,12 @@ class CheckBenefitsFinancialSupportFlowTest < ActiveSupport::TestCase
     end
 
     context "next_node" do
-      should "have a next node of results" do
+      should "have a next node of results for under_16000" do
         assert_next_node :results, for_response: "under_16000"
+      end
+
+      should "have a next node of results for none" do
+        assert_next_node :results, for_response: "none_16000"
       end
     end
   end
@@ -227,13 +290,15 @@ class CheckBenefitsFinancialSupportFlowTest < ActiveSupport::TestCase
                     disability_or_health_condition: "no",
                     carer_disability_or_health_condition: "no",
                     children_living_with_you: "yes",
-                    age_of_children: "5_to_11",
+                    age_of_children: "5_to_7",
                     children_with_disability: "yes",
+                    on_benefits: "yes",
+                    current_benefits: "universal_credit",
                     assets_and_savings: "under_16000"
     end
 
     should "render the results outcome with number of eligible benefits" do
-      assert_rendered_outcome text: "Based on your answers, you may be eligible for the following 9 things."
+      assert_rendered_outcome text: "Based on your answers, you may be eligible for the following 12 things."
     end
 
     should "render Employment and Support Allowance when eligible" do
@@ -302,7 +367,7 @@ class CheckBenefitsFinancialSupportFlowTest < ActiveSupport::TestCase
 
     should "render Pension Credit when eligible" do
       %w[england scotland wales].each do |country|
-        add_responses where_do_you_live: country
+        add_responses where_do_you_live: country, over_state_pension_age: "yes"
 
         assert_rendered_outcome text: "Pension Credit"
         assert_rendered_outcome text: "Check if you’re eligible for Pension Credit"
@@ -310,7 +375,7 @@ class CheckBenefitsFinancialSupportFlowTest < ActiveSupport::TestCase
     end
 
     should "render Pension Credit (NI) when eligible" do
-      add_responses where_do_you_live: "northern-ireland"
+      add_responses where_do_you_live: "northern-ireland", over_state_pension_age: "yes"
 
       assert_rendered_outcome text: "Pension Credit"
       assert_rendered_outcome text: "Check if you’re eligible for Pension Credit on the nidirect website"
@@ -318,7 +383,7 @@ class CheckBenefitsFinancialSupportFlowTest < ActiveSupport::TestCase
 
     should "render Housing Benefit when eligible" do
       %w[england wales].each do |country|
-        add_responses where_do_you_live: country
+        add_responses where_do_you_live: country, over_state_pension_age: "yes"
 
         assert_rendered_outcome text: "Housing Benefit"
         assert_rendered_outcome text: "Check if you’re eligible for Housing Benefit"
@@ -326,14 +391,14 @@ class CheckBenefitsFinancialSupportFlowTest < ActiveSupport::TestCase
     end
 
     should "render Housing Benefit (Scotland) when eligible" do
-      add_responses where_do_you_live: "scotland"
+      add_responses where_do_you_live: "scotland", over_state_pension_age: "yes"
 
       assert_rendered_outcome text: "Housing Benefit"
       assert_rendered_outcome text: "Check if you’re eligible for Housing Benefit on the mygov.scot website"
     end
 
     should "render Housing Benefit (Northern Ireland) when eligible" do
-      add_responses where_do_you_live: "northern-ireland"
+      add_responses where_do_you_live: "northern-ireland", over_state_pension_age: "yes"
 
       assert_rendered_outcome text: "Housing Benefit"
       assert_rendered_outcome text: "Check if you’re eligible for Housing Benefit on the NI Housing Executive website"
@@ -367,7 +432,8 @@ class CheckBenefitsFinancialSupportFlowTest < ActiveSupport::TestCase
       %w[england scotland wales].each do |country|
         add_responses where_do_you_live: country,
                       over_state_pension_age: "no",
-                      assets_and_savings: "under_16000"
+                      assets_and_savings: "under_16000",
+                      on_benefits: "no"
 
         assert_rendered_outcome text: "Universal Credit"
         assert_rendered_outcome text: "Check if you’re eligible for Universal Credit"
@@ -377,7 +443,9 @@ class CheckBenefitsFinancialSupportFlowTest < ActiveSupport::TestCase
     should "render Universal Credit (Northern Ireland) when eligible" do
       add_responses where_do_you_live: "northern-ireland",
                     over_state_pension_age: "no",
-                    assets_and_savings: "under_16000"
+                    assets_and_savings: "under_16000",
+                    on_benefits: "yes",
+                    current_benefits: "housing_benefit"
 
       assert_rendered_outcome text: "Universal Credit"
       assert_rendered_outcome text: "Check if you’re eligible for Universal Credit on the nidirect website"
@@ -388,8 +456,8 @@ class CheckBenefitsFinancialSupportFlowTest < ActiveSupport::TestCase
         add_responses where_do_you_live: country,
                       children_with_disability: "no"
 
-        assert_rendered_outcome text: "Tax-free childcare"
-        assert_rendered_outcome text: "Check if you’re eligible for Tax-Free childcare"
+        assert_rendered_outcome text: "Tax-Free Childcare"
+        assert_rendered_outcome text: "Check if you’re eligible for Tax-Free Childcare"
       end
     end
 
@@ -398,29 +466,35 @@ class CheckBenefitsFinancialSupportFlowTest < ActiveSupport::TestCase
         add_responses where_do_you_live: country,
                       age_of_children: "16_to_17"
 
-        assert_rendered_outcome text: "Tax-free childcare"
-        assert_rendered_outcome text: "Check if you’re eligible for Tax-Free childcare"
+        assert_rendered_outcome text: "Tax-Free Childcare"
+        assert_rendered_outcome text: "up to £4000 if a child is disabled."
       end
     end
 
     should "render Free childcare 2 yr olds when eligible" do
-      %w[england wales].each do |country|
-        add_responses where_do_you_live: country,
-                      children_living_with_you: "yes",
-                      age_of_children: "2"
+      add_responses where_do_you_live: "england",
+                    children_living_with_you: "yes",
+                    age_of_children: "2"
 
-        assert_rendered_outcome text: "Free childcare for 2-year-olds"
-        assert_rendered_outcome text: "Check if you’re eligible for free childcare for 2-year-olds"
-      end
+      assert_rendered_outcome text: "Free childcare for 2-year-olds"
+      assert_rendered_outcome text: "Check if you’re eligible for free childcare for 2-year-olds"
+    end
+
+    should "render Free childcare 2 yr olds when eligible [Wales]" do
+      add_responses where_do_you_live: "wales",
+                    children_living_with_you: "yes",
+                    age_of_children: "2"
+
+      assert_rendered_outcome text: "Free childcare for 2-year-olds"
+      assert_rendered_outcome text: "Check if you’re eligible for free childcare for 2-year-olds"
     end
 
     should "render Childcare 3 and 4 year olds Wales when eligible" do
       add_responses where_do_you_live: "wales",
-                    are_you_working: "yes_over_16_hours_per_week",
                     children_living_with_you: "yes",
                     age_of_children: "3_to_4"
 
-      assert_rendered_outcome text: "Childcare 3 and 4 year olds"
+      assert_rendered_outcome text: "Childcare for 3 and 4-year-olds"
       assert_rendered_outcome text: "Find out how much free childcare you can get on the GOV.WALES website"
     end
 
@@ -456,6 +530,15 @@ class CheckBenefitsFinancialSupportFlowTest < ActiveSupport::TestCase
       end
     end
 
+    should "render Winter Fuel Payment" do
+      %w[england wales northern-ireland scotland].each do |country|
+        add_responses where_do_you_live: country, over_state_pension_age: "yes"
+
+        assert_rendered_outcome text: "Winter Fuel Payment"
+        assert_rendered_outcome text: "You'll automatically get a Winter Fuel Payment if you’re getting the State Pension."
+      end
+    end
+
     should "render Carer’s Allowance when eligible" do
       add_responses carer_disability_or_health_condition: "yes"
 
@@ -465,7 +548,7 @@ class CheckBenefitsFinancialSupportFlowTest < ActiveSupport::TestCase
 
     should "render Disability Living Allowance (DLA) for children when eligible" do
       %w[england northern-ireland wales].each do |country|
-        %w[1_or_under 2 3_to_4 5_to_11 12_to_15].each do |age|
+        %w[1_or_under 2 3_to_4 5_to_7 8_to_11 12_to_15].each do |age|
           add_responses where_do_you_live: country,
                         children_living_with_you: "yes",
                         age_of_children: age,
@@ -478,7 +561,7 @@ class CheckBenefitsFinancialSupportFlowTest < ActiveSupport::TestCase
     end
 
     should "render Child Disability Payment when eligible" do
-      %w[1_or_under 2 3_to_4 5_to_11 12_to_15].each do |age|
+      %w[1_or_under 2 3_to_4 5_to_7 8_to_11 12_to_15].each do |age|
         add_responses where_do_you_live: "scotland",
                       children_living_with_you: "yes",
                       age_of_children: age,
@@ -490,7 +573,7 @@ class CheckBenefitsFinancialSupportFlowTest < ActiveSupport::TestCase
     end
 
     should "render Personal Independence Payment (PIP) when eligible with a health condition" do
-      %w[england scotland wales].each do |country|
+      %w[england wales].each do |country|
         %w[no yes_limits_work yes_unable_to_work].each do |affecting_work|
           add_responses where_do_you_live: country,
                         over_state_pension_age: "no",
@@ -504,7 +587,7 @@ class CheckBenefitsFinancialSupportFlowTest < ActiveSupport::TestCase
     end
 
     should "render Personal Independence Payment (PIP) when eligible with a child with a health condition" do
-      %w[england scotland wales].each do |country|
+      %w[england wales].each do |country|
         %w[16_to_17 18_to_19].each do |age|
           add_responses where_do_you_live: country,
                         over_state_pension_age: "no",
@@ -545,6 +628,16 @@ class CheckBenefitsFinancialSupportFlowTest < ActiveSupport::TestCase
       end
     end
 
+    should "render Adult Disability Payment [Scotland]" do
+      add_responses where_do_you_live: "scotland",
+                    over_state_pension_age: "no",
+                    disability_or_health_condition: "yes",
+                    disability_affecting_work: "no"
+
+      assert_rendered_outcome text: "Adult Disability Payment"
+      assert_rendered_outcome text: "You may be able to get help with extra living costs if you have a long-term physical or mental health condition or disability."
+    end
+
     should "render Attendance Allowance when eligible" do
       %w[england scotland wales northern-ireland].each do |country|
         %w[no yes_limits_work yes_unable_to_work].each do |affecting_work|
@@ -583,15 +676,18 @@ class CheckBenefitsFinancialSupportFlowTest < ActiveSupport::TestCase
     end
 
     should "render Free TV Licence when eligible" do
-      add_responses over_state_pension_age: "yes"
+      %w[england scotland wales northern-ireland].each do |_country|
+        add_responses over_state_pension_age: "yes"
+        add_responses on_benefits: "dont_know"
 
-      assert_rendered_outcome text: "Get a free or discounted TV licence"
-      assert_rendered_outcome text: "Check if you’re eligible for a free or discounted TV licence"
+        assert_rendered_outcome text: "Get a free or discounted TV licence"
+        assert_rendered_outcome text: "Check if you’re eligible for a free or discounted TV licence"
+      end
     end
 
     should "render Budgeting Loan when eligible" do
       %w[england scotland wales].each do |country|
-        add_responses where_do_you_live: country
+        add_responses where_do_you_live: country, on_benefits: "dont_know"
 
         assert_rendered_outcome text: "Budgeting Loan"
         assert_rendered_outcome text: "Check if you’re eligible for a Budgeting Loan"
@@ -599,34 +695,264 @@ class CheckBenefitsFinancialSupportFlowTest < ActiveSupport::TestCase
     end
 
     should "render Social Fund Budgeting Loan when eligible" do
-      add_responses where_do_you_live: "northern-ireland"
+      add_responses where_do_you_live: "northern-ireland", on_benefits: "yes", current_benefits: "pension_credit"
 
       assert_rendered_outcome text: "Social Fund Budgeting Loan"
       assert_rendered_outcome text: "Check if you’re eligible for a Budgeting Loan on the nidirect website"
     end
 
-    should "render NHS Low Income Scheme when eligible" do
+    should "render NHS Help with health costs when eligible" do
       %w[england wales].each do |country|
-        add_responses where_do_you_live: country,
-                      assets_and_savings: "under_16000"
+        add_responses where_do_you_live: country
 
-        assert_rendered_outcome text: "NHS Low Income Scheme"
-        assert_rendered_outcome text: "Check if you’re eligible for the NHS Low Income Scheme on the NHS website"
+        assert_rendered_outcome text: "NHS Help with health costs"
+        assert_rendered_outcome text: "You may be able to get help with prescriptions, dental care, healthcare travel and other health costs"
       end
     end
 
     should "render Help With Health Costs Loan when eligible" do
       add_responses where_do_you_live: "scotland"
 
-      assert_rendered_outcome text: "Help With Health Costs"
-      assert_rendered_outcome text: "Check if you’re eligible for help with health costs on the NHS Inform (Scotland) website"
+      assert_rendered_outcome text: "Help with health costs"
+      assert_rendered_outcome text: "Check if you’re eligible for help with health costs"
     end
 
-    should "render NHS Low Income Scheme (Northern Ireland) when eligible" do
+    should "render NHS Help with health costs (Northern Ireland) when eligible" do
       add_responses where_do_you_live: "northern-ireland"
 
-      assert_rendered_outcome text: "NHS Low Income Scheme"
-      assert_rendered_outcome text: "Check if you’re eligible for the NHS Low Income Scheme on the nidirect website"
+      assert_rendered_outcome text: "NHS Help with health costs"
+      assert_rendered_outcome text: "You may be able to get help with prescriptions, dental care, healthcare travel and other health costs"
+    end
+
+    should "render maternity allowance for eligible countries" do
+      %w[england scotland wales northern-ireland].each do |country|
+        add_responses where_do_you_live: country,
+                      children_living_with_you: "yes",
+                      over_state_pension_age: "no",
+                      age_of_children: "1_or_under"
+
+        assert_rendered_outcome text: "Maternity Allowance"
+        assert_rendered_outcome text: "You may be eligible to get Maternity Allowance for 39 weeks if you’re employed"
+      end
+    end
+
+    should "render Sure Start Maternity Grant for eligible countries" do
+      %w[england wales northern-ireland].each do |country|
+        add_responses where_do_you_live: country,
+                      children_living_with_you: "yes",
+                      age_of_children: "1_or_under",
+                      on_benefits: "yes",
+                      current_benefits: "universal_credit"
+
+        assert_rendered_outcome text: "Sure Start Maternity Grant"
+        assert_rendered_outcome text: "If you or your partner get certain benefits you could get a one-off payment of £500"
+      end
+    end
+
+    should "render Pregnancy and Baby Payment [Scotland] for eligible countries" do
+      add_responses where_do_you_live: "scotland",
+                    children_living_with_you: "yes",
+                    age_of_children: "1_or_under",
+                    on_benefits: "yes",
+                    current_benefits: "universal_credit"
+
+      assert_rendered_outcome text: "Pregnancy and Baby Payment"
+      assert_rendered_outcome text: "If you or your partner get certain benefits you could get a one-off payment"
+    end
+
+    should "render Healthy Start for eligible countries" do
+      %w[england wales northern-ireland].each do |country|
+        add_responses where_do_you_live: country,
+                      children_living_with_you: "yes",
+                      age_of_children: "1_or_under",
+                      on_benefits: "dont_know"
+
+        assert_rendered_outcome text: "Healthy Start"
+        assert_rendered_outcome text: "If you’re getting certain benefits and are more than 10 weeks pregnant"
+      end
+    end
+
+    should "render Best Start Food for eligible countries" do
+      add_responses where_do_you_live: "scotland",
+                    children_living_with_you: "yes",
+                    age_of_children: "1_or_under",
+                    on_benefits: "yes",
+                    current_benefits: "universal_credit"
+
+      assert_rendered_outcome text: "Best Start Foods"
+      assert_rendered_outcome text: "If you’re getting certain benefits and are pregnant or have a child under 3"
+    end
+
+    should "render Free school meals [England] for eligible countries" do
+      add_responses where_do_you_live: "england",
+                    children_living_with_you: "yes",
+                    age_of_children: "3_to_4",
+                    on_benefits: "yes",
+                    current_benefits: "universal_credit"
+
+      assert_rendered_outcome text: "Free school meals"
+      assert_rendered_outcome text: "If you’re on certain benefits your child may be able to get free school meals."
+    end
+
+    should "render Free school meals [Scotland]" do
+      add_responses where_do_you_live: "scotland",
+                    children_living_with_you: "yes",
+                    age_of_children: "3_to_4",
+                    on_benefits: "yes",
+                    current_benefits: "universal_credit"
+
+      assert_rendered_outcome text: "Free school meals"
+      assert_rendered_outcome text: "If you’re on certain benefits your child may be able to get free school meals."
+    end
+
+    should "render Free school meals [Wales]" do
+      add_responses where_do_you_live: "wales",
+                    children_living_with_you: "yes",
+                    age_of_children: "3_to_4",
+                    on_benefits: "yes",
+                    current_benefits: "universal_credit"
+
+      assert_rendered_outcome text: "Free school meals"
+      assert_rendered_outcome text: "If you’re on certain benefits your child may be able to get free school meals."
+    end
+
+    should "render Free school meals [NI]" do
+      add_responses where_do_you_live: "northern-ireland",
+                    children_living_with_you: "yes",
+                    age_of_children: "3_to_4",
+                    on_benefits: "yes",
+                    current_benefits: "universal_credit"
+
+      assert_rendered_outcome text: "Free school meals"
+      assert_rendered_outcome text: "If you’re on certain benefits your child may be able to get free school meals."
+    end
+
+    should "render School Clothing Grant [Scotland]" do
+      add_responses where_do_you_live: "scotland",
+                    children_living_with_you: "yes",
+                    age_of_children: "18_to_19",
+                    on_benefits: "yes",
+                    current_benefits: "universal_credit"
+
+      assert_rendered_outcome text: "School Clothing Grant"
+      assert_rendered_outcome text: "If you’re on certain benefits you may be able to get help from your local council with the cost of school uniforms."
+    end
+
+    should "render Uniform Grant [NI]" do
+      add_responses where_do_you_live: "northern-ireland",
+                    children_living_with_you: "yes",
+                    age_of_children: "16_to_17",
+                    on_benefits: "yes",
+                    current_benefits: "universal_credit"
+
+      assert_rendered_outcome text: "Uniform Grant"
+      assert_rendered_outcome text: "If you’re on certain benefits you may be able to get help from your local council with the cost of school uniforms."
+    end
+
+    should "render Pupil Development Grant [Wales]" do
+      add_responses where_do_you_live: "wales",
+                    children_living_with_you: "yes",
+                    age_of_children: "16_to_17",
+                    on_benefits: "yes",
+                    current_benefits: "universal_credit"
+
+      assert_rendered_outcome text: "Pupil Development Grant"
+      assert_rendered_outcome text: "If you’re on certain benefits you may be able to get help from your local council with the cost of school uniforms."
+    end
+
+    should "render Home to school transport for eligible countries" do
+      %w[england wales].each do |country|
+        add_responses where_do_you_live: country,
+                      children_living_with_you: "yes",
+                      age_of_children: "18_to_19",
+                      on_benefits: "dont_know"
+
+        assert_rendered_outcome text: "Home to school transport"
+        assert_rendered_outcome text: "You may be able to get help with the cost of home to school transport through your local council."
+      end
+    end
+
+    should "render Free school transport [Scotland]" do
+      add_responses where_do_you_live: "scotland",
+                    children_living_with_you: "yes",
+                    age_of_children: "18_to_19",
+                    on_benefits: "dont_know"
+
+      assert_rendered_outcome text: "Free school transport"
+      assert_rendered_outcome text: "You may be able to get help with the cost of home to school transport through your local council."
+    end
+
+    should "render Home to school transport [NI]" do
+      add_responses where_do_you_live: "northern-ireland",
+                    children_living_with_you: "yes",
+                    age_of_children: "18_to_19",
+                    on_benefits: "dont_know"
+
+      assert_rendered_outcome text: "Home to school transport"
+      assert_rendered_outcome text: "Check if your child is eligible for help with the cost of home to school transport"
+    end
+
+    should "render Apply for an older person's bus pass" do
+      %w[england wales northern-ireland scotland].each do |country|
+        add_responses where_do_you_live: country, over_state_pension_age: "yes"
+
+        assert_rendered_outcome text: "Apply for an older person's bus pass"
+        assert_rendered_outcome text: "In England you can get a bus pass for free travel when you reach the State Pension age"
+      end
+    end
+
+    should "render Apply for a disabled person's bus pass" do
+      add_responses where_do_you_live: "england",
+                    disability_or_health_condition: "yes",
+                    disability_affecting_work: "no"
+
+      assert_rendered_outcome text: "Apply for a disabled person's bus pass"
+      assert_rendered_outcome text: "You can get free travel on buses if you’re eligible."
+    end
+
+    should "render Apply for a disabled person's bus pass Wales" do
+      add_responses where_do_you_live: "wales",
+                    disability_or_health_condition: "yes",
+                    disability_affecting_work: "yes_limits_work"
+
+      assert_rendered_outcome text: "Apply for a disabled person's bus pass"
+      assert_rendered_outcome text: "Find out how to apply for a disabled person’s bus pass on the GOV.WALES website"
+    end
+
+    should "render Apply for a disabled person's bus pass Scotland" do
+      add_responses where_do_you_live: "scotland",
+                    disability_or_health_condition: "yes",
+                    disability_affecting_work: "yes_unable_to_work"
+
+      assert_rendered_outcome text: "Apply for a disabled person's bus pass"
+      assert_rendered_outcome text: "Find out how to apply for a disabled person’s bus pass on the mygov.scot website"
+    end
+
+    should "render Apply for a disabled person's bus pass NI" do
+      add_responses where_do_you_live: "northern-ireland",
+                    disability_or_health_condition: "yes",
+                    disability_affecting_work: "yes_unable_to_work"
+
+      assert_rendered_outcome text: "Apply for a disabled person's bus pass"
+      assert_rendered_outcome text: "Find out how to apply for a disabled person’s bus pass on the nidirect website"
+    end
+
+    should "render Support for Mortgage Interest (SMI)" do
+      %w[england wales northern-ireland scotland].each do |country|
+        add_responses where_do_you_live: country, on_benefits: "dont_know"
+
+        assert_rendered_outcome text: "Support for Mortgage Interest (SMI)"
+        assert_rendered_outcome text: "If you’re a homeowner, you might be able to get help towards interest payments on your mortgage"
+      end
+    end
+
+    should "render Education Maintenance Allowance NI" do
+      add_responses where_do_you_live: "northern-ireland",
+                    children_living_with_you: "yes",
+                    age_of_children: "16_to_17"
+
+      assert_rendered_outcome text: "Education Maintenance Allowance"
+      assert_rendered_outcome text: "You may be able to get Education Maintenance Allowance (EMA) of £30"
     end
   end
 end

--- a/test/unit/calculators/checks_benefits_financial_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_financial_support_calculator_test.rb
@@ -748,7 +748,7 @@ module SmartAnswer::Calculators
             calculator = CheckBenefitsFinancialSupportCalculator.new
             calculator.over_state_pension_age = "yes"
             calculator.on_benefits = "yes"
-            calculator.current_benefits = "pension_credit"
+            calculator.current_benefits = "pension_credit,tax_credits"
 
             assert calculator.eligible_for_free_tv_license?
           end

--- a/test/unit/calculators/checks_benefits_financial_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_financial_support_calculator_test.rb
@@ -45,6 +45,117 @@ module SmartAnswer::Calculators
         end
       end
 
+      context "#benefits_selected?" do
+        should "return true if benefits are present" do
+          calculator = CheckBenefitsFinancialSupportCalculator.new
+          calculator.current_benefits = "universal_credit"
+          assert calculator.benefits_selected?
+        end
+
+        should "return false if benefits are empty" do
+          calculator = CheckBenefitsFinancialSupportCalculator.new
+          calculator.current_benefits = "none"
+          assert_not calculator.benefits_selected?
+        end
+      end
+
+      context "#eligible_for_maternity_allowance?" do
+        context "when eligible" do
+          should "be true if under state pension age, children living with eligible age" do
+            calculator = CheckBenefitsFinancialSupportCalculator.new
+            calculator.over_state_pension_age = "no"
+            calculator.children_living_with_you = "yes"
+            %w[pregnant 1_or_under].each do |age|
+              calculator.age_of_children = age
+              assert calculator.eligible_for_maternity_allowance?
+            end
+          end
+        end
+
+        context "when ineligible" do
+          should "be false if over state pension age" do
+            calculator = CheckBenefitsFinancialSupportCalculator.new
+            calculator.over_state_pension_age = "yes"
+            assert_not calculator.eligible_for_maternity_allowance?
+          end
+
+          should "be false if child age not eligible" do
+            calculator = CheckBenefitsFinancialSupportCalculator.new
+            calculator.over_state_pension_age = "no"
+            calculator.children_living_with_you = "yes"
+            calculator.age_of_children = "5_to_7"
+            assert_not calculator.eligible_for_maternity_allowance?
+          end
+
+          should "be false if child not living with you" do
+            calculator = CheckBenefitsFinancialSupportCalculator.new
+            calculator.over_state_pension_age = "no"
+            calculator.children_living_with_you = "no"
+            assert_not calculator.eligible_for_maternity_allowance?
+          end
+        end
+      end
+
+      context "#eligible_for_sure_start_maternity_grant?" do
+        context "when eligible" do
+          should "be true if under state pension age, living with eligible age children / claiming permitted benefits" do
+            calculator = CheckBenefitsFinancialSupportCalculator.new
+            calculator.children_living_with_you = "yes"
+            calculator.on_benefits = "yes"
+            calculator.current_benefits = "universal_credit"
+            %w[pregnant 1_or_under].each do |age|
+              calculator.age_of_children = age
+              assert calculator.eligible_for_sure_start_maternity_grant?
+            end
+          end
+
+          should "be true if under state pension age, children living with eligible age / don't know benefits" do
+            calculator = CheckBenefitsFinancialSupportCalculator.new
+            calculator.children_living_with_you = "yes"
+            calculator.on_benefits = "dont_know"
+            %w[pregnant 1_or_under].each do |age|
+              calculator.age_of_children = age
+              assert calculator.eligible_for_sure_start_maternity_grant?
+            end
+          end
+        end
+
+        context "when ineligible" do
+          should "be false if child not living with you" do
+            calculator = CheckBenefitsFinancialSupportCalculator.new
+            calculator.children_living_with_you = "no"
+            assert_not calculator.eligible_for_sure_start_maternity_grant?
+          end
+
+          should "be false if child age not eligible" do
+            calculator = CheckBenefitsFinancialSupportCalculator.new
+            calculator.children_living_with_you = "yes"
+            calculator.on_benefits = "dont_know"
+            %w[2 3_to_4 5_to_7 8_to_11 12_to_15 16_to_17 18_to_19].each do |age|
+              calculator.age_of_children = age
+              assert_not calculator.eligible_for_sure_start_maternity_grant?
+            end
+          end
+
+          should "be false if not claiming benefits" do
+            calculator = CheckBenefitsFinancialSupportCalculator.new
+            calculator.children_living_with_you = "yes"
+            calculator.age_of_children = "pregnant"
+            calculator.on_benefits = "no"
+            assert_not calculator.eligible_for_sure_start_maternity_grant?
+          end
+
+          should "be false if already selected relevant benefit" do
+            calculator = CheckBenefitsFinancialSupportCalculator.new
+            calculator.children_living_with_you = "yes"
+            calculator.age_of_children = "pregnant"
+            calculator.on_benefits = "yes"
+            calculator.current_benefits = "housing_benefit"
+            assert_not calculator.eligible_for_sure_start_maternity_grant?
+          end
+        end
+      end
+
       context "#eligible_for_employment_and_support_allowance?" do
         context "when eligible" do
           should "be true if under state pension age, working under 16 hours, with a health issue that affects work" do
@@ -171,6 +282,15 @@ module SmartAnswer::Calculators
           should "be true if over state pension age" do
             calculator = CheckBenefitsFinancialSupportCalculator.new
             calculator.over_state_pension_age = "yes"
+            calculator.on_benefits = "yes"
+            calculator.current_benefits = "tax_credits"
+            assert calculator.eligible_for_pension_credit?
+          end
+
+          should "be true if over state pension age and not claiming benefits" do
+            calculator = CheckBenefitsFinancialSupportCalculator.new
+            calculator.over_state_pension_age = "yes"
+            calculator.on_benefits = "no"
             assert calculator.eligible_for_pension_credit?
           end
         end
@@ -179,6 +299,15 @@ module SmartAnswer::Calculators
           should "be false if UNDER state pension age" do
             calculator = CheckBenefitsFinancialSupportCalculator.new
             calculator.over_state_pension_age = "no"
+            calculator.on_benefits = "no"
+            assert_not calculator.eligible_for_pension_credit?
+          end
+
+          should "be false if over state pension age but already claiming associated benefit" do
+            calculator = CheckBenefitsFinancialSupportCalculator.new
+            calculator.over_state_pension_age = "yes"
+            calculator.on_benefits = "yes"
+            calculator.current_benefits = "pension_credit"
             assert_not calculator.eligible_for_pension_credit?
           end
         end
@@ -217,8 +346,16 @@ module SmartAnswer::Calculators
           should "be true if under state pension age with under 16000 assets" do
             calculator = CheckBenefitsFinancialSupportCalculator.new
             calculator.over_state_pension_age = "no"
-            calculator.assets_and_savings = "under_16000"
+            calculator.on_benefits = "yes"
+            calculator.current_benefits = "housing_benefit"
+            calculator.assets_and_savings = "none"
+          end
 
+          should "be true if under state pension age with under 16000 assets and not claiming benefits" do
+            calculator = CheckBenefitsFinancialSupportCalculator.new
+            calculator.over_state_pension_age = "no"
+            calculator.on_benefits = "no"
+            calculator.assets_and_savings = "under_1600"
             assert calculator.eligible_for_universal_credit?
           end
         end
@@ -228,6 +365,8 @@ module SmartAnswer::Calculators
             calculator = CheckBenefitsFinancialSupportCalculator.new
             calculator.over_state_pension_age = "no"
             calculator.assets_and_savings = "over_16000"
+            calculator.on_benefits = "yes"
+            calculator.current_benefits = "housing_benefit"
             assert_not calculator.eligible_for_universal_credit?
           end
 
@@ -235,6 +374,17 @@ module SmartAnswer::Calculators
             calculator = CheckBenefitsFinancialSupportCalculator.new
             calculator.over_state_pension_age = "yes"
             calculator.assets_and_savings = "under_16000"
+            calculator.on_benefits = "yes"
+            calculator.current_benefits = "housing_benefit"
+            assert_not calculator.eligible_for_universal_credit?
+          end
+
+          should "be false if over state pension age but already claiming associated benefit" do
+            calculator = CheckBenefitsFinancialSupportCalculator.new
+            calculator.over_state_pension_age = "no"
+            calculator.assets_and_savings = "none"
+            calculator.on_benefits = "yes"
+            calculator.current_benefits = "housing_benefit,universal_credit"
             assert_not calculator.eligible_for_universal_credit?
           end
         end
@@ -245,6 +395,15 @@ module SmartAnswer::Calculators
           should "be true if over state pension age" do
             calculator = CheckBenefitsFinancialSupportCalculator.new
             calculator.over_state_pension_age = "yes"
+            calculator.on_benefits = "yes"
+            calculator.current_benefits = "pension_credit"
+            assert calculator.eligible_for_housing_benefit?
+          end
+
+          should "be true if over state pension age and not claiming benefits" do
+            calculator = CheckBenefitsFinancialSupportCalculator.new
+            calculator.over_state_pension_age = "yes"
+            calculator.on_benefits = "no"
             assert calculator.eligible_for_housing_benefit?
           end
         end
@@ -253,7 +412,52 @@ module SmartAnswer::Calculators
           should "be false if UNDER state pension age" do
             calculator = CheckBenefitsFinancialSupportCalculator.new
             calculator.over_state_pension_age = "no"
+            calculator.on_benefits = "no"
             assert_not calculator.eligible_for_housing_benefit?
+          end
+
+          should "be false if over state pension age but already claiming associated benefit" do
+            calculator = CheckBenefitsFinancialSupportCalculator.new
+            calculator.over_state_pension_age = "yes"
+            calculator.on_benefits = "yes"
+            calculator.current_benefits = "housing_benefit"
+            assert_not calculator.eligible_for_housing_benefit?
+          end
+        end
+      end
+
+      context "#eligible_for_an_older_persons_bus_pass?" do
+        context "when eligible" do
+          should "be true if over state pension age" do
+            calculator = CheckBenefitsFinancialSupportCalculator.new
+            calculator.over_state_pension_age = "yes"
+            assert calculator.eligible_for_an_older_persons_bus_pass?
+          end
+        end
+
+        context "when ineligible" do
+          should "be false if UNDER state pension age" do
+            calculator = CheckBenefitsFinancialSupportCalculator.new
+            calculator.over_state_pension_age = "no"
+            assert_not calculator.eligible_for_an_older_persons_bus_pass?
+          end
+        end
+      end
+
+      context "#eligible_for_a_disabled_persons_bus_pass?" do
+        context "when eligible" do
+          should "be true if with health condition" do
+            calculator = CheckBenefitsFinancialSupportCalculator.new
+            calculator.disability_or_health_condition = "yes"
+            assert calculator.eligible_for_a_disabled_persons_bus_pass?
+          end
+        end
+
+        context "when ineligible" do
+          should "be false if without health condition" do
+            calculator = CheckBenefitsFinancialSupportCalculator.new
+            calculator.disability_or_health_condition = "no"
+            assert_not calculator.eligible_for_a_disabled_persons_bus_pass?
           end
         end
       end
@@ -265,20 +469,7 @@ module SmartAnswer::Calculators
             %w[yes_over_16_hours_per_week yes_under_16_hours_per_week].each do |working_hours|
               calculator.are_you_working = working_hours
               calculator.children_living_with_you = "yes"
-              %w[1_or_under 2 3_to_4 5_to_11].each do |age|
-                calculator.age_of_children = age
-                assert calculator.eligible_for_tax_free_childcare?
-              end
-            end
-          end
-
-          should "be true if working, with a disabled child and children between 1 and 17" do
-            calculator = CheckBenefitsFinancialSupportCalculator.new
-            %w[yes_over_16_hours_per_week yes_under_16_hours_per_week].each do |working_hours|
-              calculator.are_you_working = working_hours
-              calculator.children_living_with_you = "yes"
-              calculator.children_with_disability = "yes"
-              %w[1_or_under 2 3_to_4 5_to_11 12_to_15 16_to_17].each do |age|
+              %w[1_or_under 2 3_to_4 5_to_7 8_to_11].each do |age|
                 calculator.age_of_children = age
                 assert calculator.eligible_for_tax_free_childcare?
               end
@@ -287,16 +478,29 @@ module SmartAnswer::Calculators
         end
 
         context "when ineligible" do
-          should "be false if not working with children between 1 and 11" do
+          should "be false if not working, with children between 1 and 11" do
             calculator = CheckBenefitsFinancialSupportCalculator.new
             calculator.are_you_working = "no"
-            %w[1_or_under 2 3_to_4 5_to_11].each do |age|
+            %w[1_or_under 2 3_to_4 5_to_7 8_to_11].each do |age|
               calculator.age_of_children = age
               assert_not calculator.eligible_for_tax_free_childcare?
             end
           end
 
-          should "be false if working with children aged between 12 and 19" do
+          should "be false if working, with children between 1 and 11, with a disabled child" do
+            calculator = CheckBenefitsFinancialSupportCalculator.new
+            %w[yes_over_16_hours_per_week yes_under_16_hours_per_week].each do |working_hours|
+              calculator.are_you_working = working_hours
+              calculator.children_living_with_you = "yes"
+              calculator.children_with_disability = "yes"
+              %w[1_or_under 2 3_to_4 5_to_7 8_to_11].each do |age|
+                calculator.age_of_children = age
+                assert_not calculator.eligible_for_tax_free_childcare?
+              end
+            end
+          end
+
+          should "be false if working, with children aged between 12 and 19" do
             calculator = CheckBenefitsFinancialSupportCalculator.new
             %w[yes_over_16_hours_per_week yes_under_16_hours_per_week].each do |working_hours|
               calculator.are_you_working = working_hours
@@ -316,16 +520,52 @@ module SmartAnswer::Calculators
               assert_not calculator.eligible_for_tax_free_childcare?
             end
           end
+        end
+      end
 
-          should "be false if working with a disabled child and children aged 18 to 19" do
+      context "#eligible_for_tax_free_childcare_with_disability?" do
+        context "when eligible" do
+          should "be true if working, with a disabled child and child between 1 and 17" do
             calculator = CheckBenefitsFinancialSupportCalculator.new
-            %w[yes_over_16_hours_per_week yes_under_16_hours_per_week].each do |working_hours|
-              calculator.are_you_working = working_hours
-              calculator.children_living_with_you = "yes"
-              calculator.children_with_disability = "yes"
-              calculator.age_of_children = "18_to_19"
-              assert_not calculator.eligible_for_tax_free_childcare?
+            calculator.are_you_working = "yes_over_16_hours_per_week"
+            calculator.children_living_with_you = "yes"
+            calculator.children_with_disability = "yes"
+            %w[1_or_under 2 3_to_4 5_to_7 8_to_11 12_to_15 16_to_17].each do |age|
+              calculator.age_of_children = age
+              assert calculator.eligible_for_tax_free_childcare_with_disability?
             end
+          end
+        end
+
+        context "when ineligible" do
+          should "be false if not working" do
+            calculator = CheckBenefitsFinancialSupportCalculator.new
+            calculator.are_you_working = "no"
+            assert_not calculator.eligible_for_tax_free_childcare_with_disability?
+          end
+
+          should "be false if working, without children" do
+            calculator = CheckBenefitsFinancialSupportCalculator.new
+            calculator.are_you_working = "yes_over_16_hours_per_week"
+            calculator.children_living_with_you = "no"
+            assert_not calculator.eligible_for_tax_free_childcare_with_disability?
+          end
+
+          should "be false if working, without children with a disability" do
+            calculator = CheckBenefitsFinancialSupportCalculator.new
+            calculator.are_you_working = "yes_over_16_hours_per_week"
+            calculator.children_living_with_you = "no"
+            calculator.children_with_disability = "no"
+            assert_not calculator.eligible_for_tax_free_childcare_with_disability?
+          end
+
+          should "be false if working, with children with a disablity between 18 and 19" do
+            calculator = CheckBenefitsFinancialSupportCalculator.new
+            calculator.are_you_working = "yes_over_16_hours_per_week"
+            calculator.children_living_with_you = "yes"
+            calculator.children_with_disability = "yes"
+            calculator.age_of_children = "18_to_19"
+            assert_not calculator.eligible_for_tax_free_childcare_with_disability?
           end
         end
       end
@@ -359,9 +599,8 @@ module SmartAnswer::Calculators
 
       context "#eligible_for_childcare_3_4yr_olds?" do
         context "when eligible" do
-          should "be true if working over 16 hours with child aged 3 to 4" do
+          should "be true if with child aged 3 to 4" do
             calculator = CheckBenefitsFinancialSupportCalculator.new
-            calculator.are_you_working = "yes_over_16_hours_per_week"
             calculator.children_living_with_you = "yes"
             calculator.age_of_children = "3_to_4"
             assert calculator.eligible_for_childcare_3_4yr_olds?
@@ -369,21 +608,16 @@ module SmartAnswer::Calculators
         end
 
         context "when ineligible" do
-          should "be false working under 16 hours with child aged 3 to 4" do
+          should "be false if no children" do
             calculator = CheckBenefitsFinancialSupportCalculator.new
-            %w[no yes_under_16_hours_per_week].each do |working_hours|
-              calculator.are_you_working = working_hours
-              calculator.children_living_with_you = "yes"
-              calculator.age_of_children = "3_to_4"
-              assert_not calculator.eligible_for_childcare_3_4yr_olds?
-            end
+            calculator.children_living_with_you = "no"
+            assert_not calculator.eligible_for_childcare_3_4yr_olds?
           end
 
-          should "be false if working over 16 hours without child aged 3 to 4" do
+          should "be false if child not aged 3 to 4" do
             calculator = CheckBenefitsFinancialSupportCalculator.new
-            calculator.are_you_working = "yes_over_16_hours_per_week"
             calculator.children_living_with_you = "yes"
-            calculator.age_of_children = "1,5_to_11"
+            calculator.age_of_children = "1,5_to_7"
             assert_not calculator.eligible_for_childcare_3_4yr_olds?
           end
         end
@@ -409,7 +643,7 @@ module SmartAnswer::Calculators
           should "be false if child not aged 3 to 4" do
             calculator = CheckBenefitsFinancialSupportCalculator.new
             calculator.children_living_with_you = "yes"
-            calculator.age_of_children = "1,5_to_11"
+            calculator.age_of_children = "1,5_to_7"
             assert_not calculator.eligible_for_15hrs_free_childcare_3_4yr_olds?
           end
         end
@@ -434,7 +668,7 @@ module SmartAnswer::Calculators
             %w[yes_over_16_hours_per_week yes_under_16_hours_per_week].each do |working_hours|
               calculator.are_you_working = working_hours
               calculator.children_living_with_you = "yes"
-              calculator.age_of_children = "1,5_to_11"
+              calculator.age_of_children = "1,5_to_7"
               assert_not calculator.eligible_for_30hrs_free_childcare_3_4yrs?
             end
           end
@@ -465,7 +699,7 @@ module SmartAnswer::Calculators
           should "be false if child not aged 2 or 3 to 4" do
             calculator = CheckBenefitsFinancialSupportCalculator.new
             calculator.children_living_with_you = "yes"
-            calculator.age_of_children = "5_to_11"
+            calculator.age_of_children = "5_to_7"
             assert_not calculator.eligible_for_funded_early_learning_and_childcare?
           end
 
@@ -495,13 +729,64 @@ module SmartAnswer::Calculators
         end
       end
 
+      context "#eligible_for_free_tv_license?" do
+        context "when eligible" do
+          should "be true if with health condition" do
+            calculator = CheckBenefitsFinancialSupportCalculator.new
+            calculator.disability_or_health_condition = "yes"
+            assert calculator.eligible_for_free_tv_license?
+          end
+
+          should "be true if over state pension age and don't know if recieving benefits" do
+            calculator = CheckBenefitsFinancialSupportCalculator.new
+            calculator.over_state_pension_age = "yes"
+            calculator.on_benefits = "dont_know"
+            assert calculator.eligible_for_free_tv_license?
+          end
+
+          should "be true if over state pension age and recieve pension_credit" do
+            calculator = CheckBenefitsFinancialSupportCalculator.new
+            calculator.over_state_pension_age = "yes"
+            calculator.on_benefits = "yes"
+            calculator.current_benefits = "pension_credit"
+
+            assert calculator.eligible_for_free_tv_license?
+          end
+        end
+
+        context "when ineligible" do
+          should "be false if over state pension age but claim benefits other than pension_credit" do
+            calculator = CheckBenefitsFinancialSupportCalculator.new
+            calculator.over_state_pension_age = "yes"
+            calculator.on_benefits = "yes"
+            calculator.current_benefits = "income_support,tax_credits"
+            assert_not calculator.eligible_for_free_tv_license?
+          end
+
+          should "be false if under state pension age without health condition" do
+            calculator = CheckBenefitsFinancialSupportCalculator.new
+            calculator.over_state_pension_age = "no"
+            calculator.disability_or_health_condition = "no"
+            assert_not calculator.eligible_for_free_tv_license?
+          end
+
+          should "be false if under state pension age without health condition and do not claim benefits" do
+            calculator = CheckBenefitsFinancialSupportCalculator.new
+            calculator.over_state_pension_age = "no"
+            calculator.disability_or_health_condition = "no"
+            calculator.on_benefits = "no"
+            assert_not calculator.eligible_for_free_tv_license?
+          end
+        end
+      end
+
       context "#eligible_for_child_disability_support?" do
         context "when eligible" do
           should "be true if living with child with disability aged under 15" do
             calculator = CheckBenefitsFinancialSupportCalculator.new
             calculator.children_living_with_you = "yes"
             calculator.children_with_disability = "yes"
-            %w[1_or_under 2 3_to_4 5_to_11 12_to_15].each do |age|
+            %w[1_or_under 2 3_to_4 5_to_7 8_to_11 12_to_15].each do |age|
               calculator.age_of_children = age
               assert calculator.eligible_for_child_disability_support?
             end
@@ -521,10 +806,28 @@ module SmartAnswer::Calculators
             calculator = CheckBenefitsFinancialSupportCalculator.new
             calculator.children_living_with_you = "yes"
             calculator.children_with_disability = "no"
-            %w[1_or_under 2 3_to_4 5_to_11 12_to_15].each do |age|
+            %w[1_or_under 2 3_to_4 5_to_7 12_to_15].each do |age|
               calculator.age_of_children = age
               assert_not calculator.eligible_for_child_disability_support?
             end
+          end
+        end
+      end
+
+      context "#eligible_for_winter_fuel_payment?" do
+        context "when eligible" do
+          should "be true if eligible for state pension" do
+            calculator = CheckBenefitsFinancialSupportCalculator.new
+            calculator.over_state_pension_age = "yes"
+            assert calculator.eligible_for_winter_fuel_payment?
+          end
+        end
+
+        context "when ineligible" do
+          should "be false if ineligible for state pension" do
+            calculator = CheckBenefitsFinancialSupportCalculator.new
+            calculator.over_state_pension_age = "no"
+            assert_not calculator.eligible_for_winter_fuel_payment?
           end
         end
       end
@@ -581,8 +884,35 @@ module SmartAnswer::Calculators
             calculator.over_state_pension_age = "no"
             calculator.disability_or_health_condition = "no"
             calculator.children_living_with_you = "yes"
-            calculator.age_of_children = "5_to_11"
+            calculator.age_of_children = "5_to_7"
             assert_not calculator.eligible_for_personal_independence_payment?
+          end
+        end
+      end
+
+      context "#eligible_for_adult_disability_payment_scotland?" do
+        context "when eligible" do
+          should "be true if under state pension age, with health condition" do
+            calculator = CheckBenefitsFinancialSupportCalculator.new
+            calculator.over_state_pension_age = "no"
+            calculator.disability_or_health_condition = "yes"
+            assert calculator.eligible_for_adult_disability_payment_scotland?
+          end
+        end
+
+        context "when ineligible" do
+          should "be false if OVER state pension age" do
+            calculator = CheckBenefitsFinancialSupportCalculator.new
+            calculator.over_state_pension_age = "yes"
+            calculator.disability_or_health_condition = "yes"
+            assert_not calculator.eligible_for_adult_disability_payment_scotland?
+          end
+
+          should "be false if under state pension age, without health condition" do
+            calculator = CheckBenefitsFinancialSupportCalculator.new
+            calculator.over_state_pension_age = "no"
+            calculator.disability_or_health_condition = "no"
+            assert_not calculator.eligible_for_adult_disability_payment_scotland?
           end
         end
       end
@@ -621,38 +951,82 @@ module SmartAnswer::Calculators
         end
       end
 
-      context "#eligible_for_free_tv_licence?" do
+      context "#eligible_for_support_for_mortgage_interest?" do
         context "when eligible" do
-          should "be true if over state pension age" do
+          should "be true if not already claiming associated benefit" do
             calculator = CheckBenefitsFinancialSupportCalculator.new
-            calculator.over_state_pension_age = "yes"
-            assert calculator.eligible_for_free_tv_licence?
+            calculator.on_benefits = "yes"
+            calculator.current_benefits = "income_support"
+            assert calculator.eligible_for_support_for_mortgage_interest?
           end
         end
 
         context "when ineligible" do
-          should "be false if under state pension age" do
+          should "be false if already selected associated benefit" do
             calculator = CheckBenefitsFinancialSupportCalculator.new
-            calculator.over_state_pension_age = "no"
-            assert_not calculator.eligible_for_free_tv_licence?
+            calculator.on_benefits = "yes"
+            calculator.current_benefits = "tax_credits"
+            assert_not calculator.eligible_for_support_for_mortgage_interest?
+          end
+
+          should "be false if not claiming benefits benefit" do
+            calculator = CheckBenefitsFinancialSupportCalculator.new
+            calculator.on_benefits = "no"
+            assert_not calculator.eligible_for_support_for_mortgage_interest?
           end
         end
       end
 
-      context "#eligible_for_nhs_low_income_scheme?" do
+      context "#eligible_for_budgeting_loan?" do
         context "when eligible" do
-          should "be true if under 16000 assets" do
+          should "be true if not already claiming associated benefit" do
             calculator = CheckBenefitsFinancialSupportCalculator.new
-            calculator.assets_and_savings = "under_16000"
-            assert calculator.eligible_for_nhs_low_income_scheme?
+            calculator.on_benefits = "yes"
+            calculator.current_benefits = "income_support"
+            assert calculator.eligible_for_budgeting_loan?
+          end
+
+          should "be true if dont know current benefits" do
+            calculator = CheckBenefitsFinancialSupportCalculator.new
+            calculator.on_benefits = "dont_know"
+            assert calculator.eligible_for_budgeting_loan?
           end
         end
 
         context "when ineligible" do
-          should "be false if OVER 1600 assets" do
+          should "be false if already selected associated benefit" do
             calculator = CheckBenefitsFinancialSupportCalculator.new
-            calculator.assets_and_savings = "over_16000"
-            assert_not calculator.eligible_for_nhs_low_income_scheme?
+            calculator.on_benefits = "yes"
+            calculator.current_benefits = "universal_credit"
+            assert_not calculator.eligible_for_budgeting_loan?
+          end
+        end
+      end
+
+      context "#education_maintenance_allowance_ni?" do
+        context "when eligible" do
+          should "be true if living with children and eligible ages" do
+            calculator = CheckBenefitsFinancialSupportCalculator.new
+            calculator.children_living_with_you = "yes"
+            %w[16_to_17 18_to_19].each do |age|
+              calculator.age_of_children = age
+              assert calculator.eligible_for_education_maintenance_allowance_ni?
+            end
+          end
+        end
+
+        context "when ineligible" do
+          should "be false if no children living with you" do
+            calculator = CheckBenefitsFinancialSupportCalculator.new
+            calculator.children_living_with_you = "no"
+            assert_not calculator.eligible_for_education_maintenance_allowance_ni?
+          end
+
+          should "be false if children living but not eligible age" do
+            calculator = CheckBenefitsFinancialSupportCalculator.new
+            calculator.children_living_with_you = "no"
+            calculator.age_of_children = "5_to_7"
+            assert_not calculator.eligible_for_education_maintenance_allowance_ni?
           end
         end
       end


### PR DESCRIPTION
This PR Reverts https://github.com/alphagov/smart-answers/pull/6139, effectively re-instating  https://github.com/alphagov/smart-answers/pull/6128

It also provides a bug-fix for an issue around the `eligible_for_tv_licence` method where users who were over state pension age and claiming no benefits caused the `current_benefits` variable to be nil, uncaught.