### PR TITLE
Disable source map line comments for css in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -27,6 +27,9 @@ Rails.application.configure do
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass
 
+  # Do not add source map line comments into css files
+  config.sass.line_comments = false
+
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
 


### PR DESCRIPTION
Doing similar to https://github.com/alphagov/email-alert-frontend/pull/1375 for the same reasons

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
