### PR TITLE
Add error summary component to summarise errors

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -11,6 +11,7 @@ $govuk-include-default-font-face: false;
 @import "govuk_publishing_components/components/checkboxes";
 @import "govuk_publishing_components/components/contextual-sidebar";
 @import "govuk_publishing_components/components/date-input";
+@import "govuk_publishing_components/components/error-summary";
 @import "govuk_publishing_components/components/fieldset";
 @import "govuk_publishing_components/components/govspeak";
 @import "govuk_publishing_components/components/print-link";

--- a/app/presenters/question_presenter.rb
+++ b/app/presenters/question_presenter.rb
@@ -15,6 +15,13 @@ class QuestionPresenter < NodePresenter
     )
   end
 
+  def error_id(template)
+    types = %w[radio_question checkbox_question date_question]
+
+    fragment = types.any? { |type| type == template } ? "response\-0" : "response"
+    "##{fragment}"
+  end
+
   def title
     @renderer.content_for(:title)
   end

--- a/app/views/smart_answers/inputs/_date_question.html.erb
+++ b/app/views/smart_answers/inputs/_date_question.html.erb
@@ -10,18 +10,21 @@
       question.default_day ? nil : {
         label: "Day",
         name: "response[day]",
+        id: "response-0",
         width: 2,
         value: question.parsed_response[:day],
       },
       question.default_month ? nil : {
         label: "Month",
         name: "response[month]",
+        id: "response-1",
         width: 2,
         value: question.parsed_response[:month],
       },
       question.default_year ? nil : {
         label: "Year",
         name: "response[year]",
+        id: "response-2",
         width: 4,
         value: question.parsed_response[:year],
       }

--- a/app/views/smart_answers/inputs/_salary_question.html.erb
+++ b/app/views/smart_answers/inputs/_salary_question.html.erb
@@ -5,7 +5,7 @@
     is_page_heading: true
   },
   name: "response[amount]",
-  id: "response_amount",
+  id: "response",
   heading_size: "l",
   width: 10,
   hint: question.hint,

--- a/app/views/smart_answers/inputs/_year_question.html.erb
+++ b/app/views/smart_answers/inputs/_year_question.html.erb
@@ -10,6 +10,7 @@
        {
         label: "Year",
         name: "response[year]",
+        id: "response",
         width: 4,
         value: question.parsed_response[:year],
       }

--- a/app/views/smart_answers/question.html.erb
+++ b/app/views/smart_answers/question.html.erb
@@ -15,6 +15,18 @@
           "question-key": question.node_slug,
         }) do %>
       <div class="govuk-!-margin-bottom-6 govuk-!-margin-top-8" id="current-question">
+        <% if question.error.present? %>
+          <%= render "govuk_publishing_components/components/error_summary", {
+            id: "error-summary",
+            title: "There is a problem",
+            items: [
+              {
+                text: question.error,
+                href: question.error_id(question.partial_template_name)
+              }
+            ]
+          } %>
+        <% end %>
 
         <%= render partial: "smart_answers/inputs/#{question.partial_template_name}", locals: { question: question } %>
 

--- a/test/functional/smart_answers_controller_country_question_test.rb
+++ b/test/functional/smart_answers_controller_country_question_test.rb
@@ -24,7 +24,8 @@ class SmartAnswersControllerCountryQuestionTest < ActionController::TestCase
     should "show a validation error if invalid input" do
       submit_response "invalid"
       assert_select "h1 .govuk-label.govuk-label--l", /What country\?/
-      assert_select "body", /Please answer this question/
+      assert_select ".govuk-error-summary [href]", /Please answer this question/
+      assert_select ".govuk-error-message", /Please answer this question/
     end
   end
 

--- a/test/functional/smart_answers_controller_money_question_test.rb
+++ b/test/functional/smart_answers_controller_money_question_test.rb
@@ -21,7 +21,8 @@ class SmartAnswersControllerMoneyQuestionTest < ActionController::TestCase
       should "show a validation error if invalid input" do
         submit_response "bad_number"
         assert_select "h1.govuk-label-wrapper .govuk-label.govuk-label--l", /How much\?/
-        assert_select "body", /Please answer this question/
+        assert_select ".govuk-error-summary [href]", /Please answer this question/
+        assert_select ".govuk-error-message", /Please answer this question/
       end
 
       context "suffix_label in erb template" do

--- a/test/functional/smart_answers_controller_postcode_question_test.rb
+++ b/test/functional/smart_answers_controller_postcode_question_test.rb
@@ -20,7 +20,8 @@ class SmartAnswersControllerPostcodeQuestionTest < ActionController::TestCase
     should "show a validation error if invalid input" do
       submit_response "invalid postcode"
       assert_select "h1.govuk-label-wrapper .govuk-label.govuk-label--l", /User input\?/
-      assert_select "body", /Please answer this question/
+      assert_select ".govuk-error-summary [href]", /Please answer this question/
+      assert_select ".govuk-error-message", /Please answer this question/
     end
   end
 

--- a/test/functional/smart_answers_controller_salary_question_test.rb
+++ b/test/functional/smart_answers_controller_salary_question_test.rb
@@ -35,6 +35,7 @@ class SmartAnswersControllerSalaryQuestionTest < ActionController::TestCase
         should "show a generic message" do
           submit_response amount: "bad_number"
           assert_select "h1.govuk-label-wrapper .govuk-label.govuk-label--l", /How much\?/
+          assert_select ".govuk-error-summary [href]", /Please answer this question/
           assert_select ".govuk-error-message", /Please answer this question/
         end
 
@@ -47,6 +48,7 @@ class SmartAnswersControllerSalaryQuestionTest < ActionController::TestCase
       should "show a validation error if invalid period" do
         submit_response amount: "1", period: "bad_period"
         assert_select "h1.govuk-label-wrapper .govuk-label.govuk-label--l", /How much\?/
+        assert_select ".govuk-error-summary [href]", /Please answer this question/
         assert_select ".govuk-error-message", /Please answer this question/
       end
 

--- a/test/integration/engine/checkbox_questions_test.rb
+++ b/test/integration/engine/checkbox_questions_test.rb
@@ -81,6 +81,10 @@ class CheckboxQuestionsTest < EngineIntegrationTest
 
       assert_equal current_path, "/checkbox-sample/y/none"
 
+      within(".govuk-error-summary [href]") do
+        assert_page_has_content "Please answer this question"
+      end
+
       within(".govuk-error-message") do
         assert_page_has_content "Please answer this question"
       end

--- a/test/integration/engine/input_validation_test.rb
+++ b/test/integration/engine/input_validation_test.rb
@@ -12,6 +12,7 @@ class InputValidationTest < EngineIntegrationTest
 
       within "#current-question" do
         assert_page_has_content "How much do you earn?"
+        within(".govuk-error-summary [href]") { assert_page_has_content "Please answer this question" }
         within(".govuk-error-message") { assert_page_has_content "Please answer this question" }
         assert page.has_field?("response[amount]", type: "text", with: "-123")
       end

--- a/test/integration/engine/money_and_salary_questions_test.rb
+++ b/test/integration/engine/money_and_salary_questions_test.rb
@@ -10,7 +10,7 @@ class MoneyAndSalaryQuestionsTest < EngineIntegrationTest
       visit "/annual-bonus/y"
 
       within "#current-question" do
-        within '.govuk-label[for="response_amount"]' do
+        within '.govuk-label[for="response"]' do
           assert_page_has_content "How much do you earn?"
         end
 


### PR DESCRIPTION
## What

https://trello.com/c/ccqRr6tz/1541-an-error-summary-component-is-not-presented-at-the-top-of-the-main-content-to-summarise-validation-errors-when-they-occur-3

Add error summary component to summarise validation errors

### Review link

https://smart-answers-pr-6159.herokuapp.com/check-uk-visa/y/new-zealand/study?next=1#

## Why

Some users may struggle to identify where validation errors have occurred or how to fix them.

## Visual changes
<table role="table">
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td valign="top"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/201337305-a469342e-f37d-44b4-b7ec-f8a941aae607.png"><img src="https://user-images.githubusercontent.com/87758239/201337305-a469342e-f37d-44b4-b7ec-f8a941aae607.png" width="360" style="max-width: 100%;"></a></td>
<td valign="top"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/201337286-99813688-c529-453b-83a3-dc83438f5606.png"><img src="https://user-images.githubusercontent.com/87758239/201337286-99813688-c529-453b-83a3-dc83438f5606.png" width="360" style="max-width: 100%;"></a></td>
</tr>
<tr>
<td valign="top"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/201337319-09ce8b56-9ddb-4abe-87fa-c63672c79978.png"><img src="https://user-images.githubusercontent.com/87758239/201337319-09ce8b56-9ddb-4abe-87fa-c63672c79978.png" width="360" style="max-width: 100%;"></a></td>
<td valign="top"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/201337296-842632b8-6803-4b3a-a09b-b8b370d4714b.png"><img src="https://user-images.githubusercontent.com/87758239/201337296-842632b8-6803-4b3a-a09b-b8b370d4714b.png" width="360" style="max-width: 100%;"></a></td>
</tr>
</tbody>
</table>