### PR TITLE
Use `Plek.new` as `current` is deprecated

### DIFF
--- a/lib/link_checker.rb
+++ b/lib/link_checker.rb
@@ -49,7 +49,7 @@ private
 
   def link_checker_api
     @link_checker_api ||= GdsApi::LinkCheckerApi.new(
-      Plek.current.find("link-checker-api"),
+      Plek.new.find("link-checker-api"),
       bearer_token: ENV["LINK_CHECKER_API_BEARER_TOKEN"],
     )
   end


### PR DESCRIPTION
This is causing logging noise.

Trello:
https://trello.com/c/LVVUbd4m/1551-replace-plekcurrent-with-pleknew-in-smartanswer

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
