### PR TITLE
Bump interest rates for self assessment penalties

### DIFF
--- a/lib/smart_answer/calculators/self_assessment_penalties.rb
+++ b/lib/smart_answer/calculators/self_assessment_penalties.rb
@@ -47,7 +47,8 @@ module SmartAnswer::Calculators
       { start_date: "2022-04-05", end_date: "2022-05-23", value: 0.0325 },
       { start_date: "2022-05-24", end_date: "2022-07-04", value: 0.035 },
       { start_date: "2022-07-05", end_date: "2022-08-22", value: 0.0375 },
-      { start_date: "2022-08-23", end_date: "2100-04-04", value: 0.0425 },
+      { start_date: "2022-08-23", end_date: "2022-10-10", value: 0.0425 },
+      { start_date: "2022-10-11", end_date: "2100-04-04", value: 0.0475 },
     ].freeze
 
     def tax_year_range


### PR DESCRIPTION
Trello:
https://trello.com/c/FwdCCkDi/1568-estimate-your-penalty-for-late-self-assessment-tax-returns-and-payments-change-of-interest-rate-from-425-to-475

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
