### PR TITLE
Fix run-name for deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -30,17 +30,17 @@ jobs:
     name: Build and publish image
     uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-image.yaml@main
     with:
-      gitRef: ${{ github.event.inputs.gitRef || github.ref }}
+      gitRef: ${{ inputs.gitRef || github.ref }}
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_GOVUK_ECR_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_GOVUK_ECR_SECRET_ACCESS_KEY }}
   trigger-deploy:
-    name: Trigger deploy to ${{ github.event.inputs.environment || 'integration' }}
+    name: Trigger deploy to ${{ inputs.environment || 'integration' }}
     needs: build-and-publish-image
     uses: alphagov/govuk-infrastructure/.github/workflows/deploy.yaml@main
     with:
       imageTag: ${{ needs.build-and-publish-image.outputs.imageTag }}
-      environment: ${{ github.event.inputs.environment || 'integration' }}
+      environment: ${{ inputs.environment || 'integration' }}
     secrets:
       WEBHOOK_TOKEN: ${{ secrets.GOVUK_ARGO_EVENTS_WEBHOOK_TOKEN }}
       WEBHOOK_URL: ${{ secrets.GOVUK_ARGO_EVENTS_WEBHOOK_URL }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,6 +1,6 @@
 name: Deploy
 
-run-name: Deploy ${{ inputs.gitRef || github.ref  }} to ${{ inputs.environment || 'integration' }}
+run-name: Deploy ${{ inputs.gitRef || github.ref_name  }} to ${{ inputs.environment || 'integration' }}
 
 on:
   workflow_dispatch:
@@ -30,17 +30,17 @@ jobs:
     name: Build and publish image
     uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-image.yaml@main
     with:
-      gitRef: ${{ inputs.gitRef || github.ref }}
+      gitRef: ${{ github.event.inputs.gitRef || github.ref }}
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_GOVUK_ECR_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_GOVUK_ECR_SECRET_ACCESS_KEY }}
   trigger-deploy:
-    name: Trigger deploy to ${{ inputs.environment }}
+    name: Trigger deploy to ${{ github.event.inputs.environment || 'integration' }}
     needs: build-and-publish-image
     uses: alphagov/govuk-infrastructure/.github/workflows/deploy.yaml@main
     with:
       imageTag: ${{ needs.build-and-publish-image.outputs.imageTag }}
-      environment: ${{ inputs.environment }}
+      environment: ${{ github.event.inputs.environment || 'integration' }}
     secrets:
       WEBHOOK_TOKEN: ${{ secrets.GOVUK_ARGO_EVENTS_WEBHOOK_TOKEN }}
       WEBHOOK_URL: ${{ secrets.GOVUK_ARGO_EVENTS_WEBHOOK_URL }}


### PR DESCRIPTION
This updates the variable references to account for when the workflow is triggered by a CI workflow run. In that scenario the "inputs" context is blank and leads to empty strings.

This also switches other input references to use the `inputs` instead of `github.event.inputs` context. This is a  more concise way to access input variables. The `inputs` and `github.event.inputs` context are exactly the same, except booleans are preserved in the `inputs` context.
