### PR TITLE
International Agreement visa (temporary worker) changes

### DIFF
--- a/config/smart_answers/check_uk_visa_data.yml
+++ b/config/smart_answers/check_uk_visa_data.yml
@@ -1075,8 +1075,8 @@
         initial_visa_length:
           answer: Up to 2 years
         can_extend:
-          answer: Depends on initial visa
-          description: Depends on your nationality and the service you're providing
+          answer: Depends on job
+          description: You may be able to extend up to a maximum stay of 2 years (5 years if you work as a private servant in the household of a diplomat). To stay longer, you may be able to switch to another visa
         can_settle:
           answer: "No"
           description: Settling means you can live permanently in the UK. If you successfully apply, you can use this status to apply for citizenship


### PR DESCRIPTION
## What
International Agreement visa (temporary worker) changes

https://trello.com/c/7CSkB15k/1638-check-if-you-need-uk-visa-4-updates
https://govuk.zendesk.com/agent/tickets/5064384

**Review URL**
- https://smart-answers-pr-6186.herokuapp.com/check-uk-visa/y/austria/work/longer_than_six_months/other

## Why
Immigration Rules changes - 9 November

- Need to keep up to a maximum stay of 2 years because they can apply for up to 2 years initially, not all do to start with, but they can extend up to that
- Policy suggested we could simplify things if we drop the or someone employed by a 'recognised international organisation' as these are often diplomats too. This would mean we have 2 clear categories- government employees and private servants.