### PR TITLE
Update print link tracking

### DIFF
--- a/app/views/smart_answers/custom_result.html.erb
+++ b/app/views/smart_answers/custom_result.html.erb
@@ -42,7 +42,7 @@
         module: "ga4-event-tracker",
         ga4: {
           event_name: 'print_page',
-          type: 'Print this page',
+          type: 'print page',
           index: 1,
           index_total: 1,
           section: 'Footer',


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## What / why

Update the GA4 tracking on the print links, minor change to the values passed.

## Visual changes
None.

Trello card: https://trello.com/c/QFQG5IKA/363-change-some-values-on-printpage-events
