### PR TITLE
Update GA4 event tracking

### DIFF
--- a/app/views/smart_answers/custom_result.html.erb
+++ b/app/views/smart_answers/custom_result.html.erb
@@ -40,7 +40,7 @@
     <%= render 'govuk_publishing_components/components/print_link', {
       data_attributes: {
         module: "ga4-event-tracker",
-        ga4: {
+        ga4_event: {
           event_name: 'print_page',
           type: 'print page',
           index: 1,


### PR DESCRIPTION
**NOT TO BE MERGED unless also including the [new version of the components gem](https://github.com/alphagov/govuk_publishing_components/pull/3091) that includes the changes detailed below**

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why
Update references to GA4 event tracker to cope with breaking changes introduced in https://github.com/alphagov/govuk_publishing_components/pull/3057

- GA4 event tracker has been rewritten to use a `data-ga-event` attribute in place of `data-ga4`
- updating for tracking on custom result page for print link

## Visual changes
None.

Trello cards: https://trello.com/c/uMgCIdtY/289-update-link-tracking
