### PR TITLE
Set up individual component CSS loading

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,4 +1,10 @@
 //= link application.css
+
+//= link components/_intervention.css
+//= link components/_result-card.css
+//= link components/_result-item.css
+//= link components/_result-sections.css
+
 //= link visualise.css
 //= link joint.css
 //= link application.js

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -9,10 +9,6 @@ $govuk-include-default-font-face: false;
 
 @import "govuk_publishing_components/govuk_frontend_support";
 
-@import "components/intervention";
-@import "components/result-card";
-@import "components/result-item";
-@import "components/result-sections";
 @import "smart_answers";
 
 .desktop-min-height {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,23 +8,6 @@ $govuk-new-link-styles: true;
 $govuk-include-default-font-face: false;
 
 @import "govuk_publishing_components/govuk_frontend_support";
-@import "govuk_publishing_components/components/checkboxes";
-@import "govuk_publishing_components/components/contextual-sidebar";
-@import "govuk_publishing_components/components/date-input";
-@import "govuk_publishing_components/components/error-summary";
-@import "govuk_publishing_components/components/fieldset";
-@import "govuk_publishing_components/components/govspeak";
-@import "govuk_publishing_components/components/intervention";
-@import "govuk_publishing_components/components/print-link";
-@import "govuk_publishing_components/components/radio";
-@import "govuk_publishing_components/components/related-navigation";
-@import "govuk_publishing_components/components/select";
-@import "govuk_publishing_components/components/step-by-step-nav";
-@import "govuk_publishing_components/components/step-by-step-nav-header";
-@import "govuk_publishing_components/components/step-by-step-nav-related";
-@import "govuk_publishing_components/components/summary-list";
-@import "govuk_publishing_components/components/table";
-@import "govuk_publishing_components/components/warning-text";
 
 @import "components/intervention";
 @import "components/result-card";

--- a/app/assets/stylesheets/components/_intervention.scss
+++ b/app/assets/stylesheets/components/_intervention.scss
@@ -1,3 +1,5 @@
+@import "govuk_publishing_components/individual_component_support";
+
 .gem-c-intervention {
   margin-top: govuk-spacing(4);
 }

--- a/app/assets/stylesheets/components/_result-card.scss
+++ b/app/assets/stylesheets/components/_result-card.scss
@@ -1,3 +1,5 @@
+@import "govuk_publishing_components/individual_component_support";
+
 .app-c-result-card {
   position: relative;
   padding: govuk-spacing(5) govuk-spacing(4);

--- a/app/assets/stylesheets/components/_result-item.scss
+++ b/app/assets/stylesheets/components/_result-item.scss
@@ -1,3 +1,5 @@
+@import "govuk_publishing_components/individual_component_support";
+
 .app-c-result-item {
   @include govuk-font($size: 19);
   padding-top: govuk-spacing(6);

--- a/app/assets/stylesheets/components/_result-sections.scss
+++ b/app/assets/stylesheets/components/_result-sections.scss
@@ -1,3 +1,5 @@
+@import "govuk_publishing_components/individual_component_support";
+
 .app-c-result-sections {
   margin-bottom: govuk-spacing(7) * 2;
 }

--- a/app/assets/stylesheets/smart_answers.scss
+++ b/app/assets/stylesheets/smart_answers.scss
@@ -1,3 +1,5 @@
+@import "govuk_publishing_components/components/hint";
+
 .smart_answer {
   .app-c-callout-title {
     @include govuk-font($size: 19, $weight: bold);

--- a/app/assets/stylesheets/visualise.scss
+++ b/app/assets/stylesheets/visualise.scss
@@ -3,8 +3,6 @@ $govuk-use-legacy-palette: false;
 
 @import "govuk_publishing_components/govuk_frontend_support";
 @import "govuk_publishing_components/component_support";
-@import "govuk_publishing_components/components/table";
-@import "govuk_publishing_components/components/warning-text";
 
 .visualisation {
   overflow-x: scroll;

--- a/app/presenters/outcome_presenter.rb
+++ b/app/presenters/outcome_presenter.rb
@@ -37,4 +37,16 @@ class OutcomePresenter < NodePresenter
   def view_template_path
     @node.view_template_path || "smart_answers/result"
   end
+
+  def add_app_component_stylesheets?
+    base_path == "/check-uk-visa" && @node.slug == "outcome-work-y" ||
+      base_path == "/check-benefits-financial-support" && @node.slug == "results" ||
+      base_path == "/next-steps-for-your-business" && @node.slug == "results"
+  end
+
+private
+
+  def base_path
+    "/#{@flow_presenter.name}"
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,14 +1,23 @@
+<% content_for :body do %>
+  <div class="smart_answer">
+    <%= yield :breadcrumbs %>
+    <main id="content" role="main">
+      <%= yield %>
+    </main>
+  </div>
+<% end %>
+
 <%
-    answer_title = @title
-    question_title = yield :question_title
-    outcome_title = yield :outcome_title
-    if question_title.present?
-      title = "#{question_title} - #{answer_title}"
-    elsif outcome_title.present?
-      title = "#{outcome_title} - #{answer_title}"
-    else
-      title = answer_title
-    end
+  answer_title = @title
+  question_title = yield :question_title
+  outcome_title = yield :outcome_title
+  if question_title.present?
+    title = "#{question_title} - #{answer_title}"
+  elsif outcome_title.present?
+    title = "#{outcome_title} - #{answer_title}"
+  else
+    title = answer_title
+  end
 %>
 <!DOCTYPE html>
 <html>
@@ -29,15 +38,14 @@
     <% if @meta_section %>
       <meta name="govuk:section" content="<%= @meta_section %>">
     <% end %>
+
+    <%=
+      render_component_stylesheets
+    %>
   </head>
   <body class="govuk-template__body">
     <div id="wrapper">
-      <div class="smart_answer">
-        <%= yield :breadcrumbs %>
-        <main id="content" role="main">
-          <%= yield %>
-        </main>
-      </div>
+      <%= yield :body %>
     </div>
   </body>
 </html>

--- a/app/views/smart_answers/custom_result.html.erb
+++ b/app/views/smart_answers/custom_result.html.erb
@@ -1,5 +1,13 @@
 <% # this custom result template is currently tested on the next-steps-for-your-business flow %>
 <% outcome = @presenter.current_node %>
+
+<% add_gem_component_stylesheet("govspeak") %>
+
+<% if outcome.add_app_component_stylesheets? %>
+  <% add_app_component_stylesheet("result-sections") %>
+  <% add_app_component_stylesheet("result-item") %>
+<% end %>
+
 <% content_for :outcome_title do %>
   <% if outcome.title.present? %><%= outcome.title %><% else %>Outcome<% end %>
 <% end %>

--- a/app/views/smart_answers/custom_result_full_width.erb
+++ b/app/views/smart_answers/custom_result_full_width.erb
@@ -1,5 +1,13 @@
 <% outcome = @presenter.current_node %>
 
+<% add_gem_component_stylesheet("govspeak") %>
+
+<% if outcome.add_app_component_stylesheets? %>
+  <% add_app_component_stylesheet("result-card") %>
+  <% add_app_component_stylesheet("result-sections") %>
+  <% add_app_component_stylesheet("result-item") %>
+<% end %>
+
 <%= outcome.banner %>
 
 <% content_for :outcome_title do %>

--- a/app/views/smart_answers/inputs/_radio_question.html.erb
+++ b/app/views/smart_answers/inputs/_radio_question.html.erb
@@ -1,3 +1,5 @@
+<% add_gem_component_stylesheet("govspeak") if question.body %>
+
 <%= render "smart_answers/inputs/caption", question: question %>
 <%= render "govuk_publishing_components/components/radio", {
   name: "response",

--- a/app/views/smart_answers/inputs/_radio_with_intro_question.html.erb
+++ b/app/views/smart_answers/inputs/_radio_with_intro_question.html.erb
@@ -1,3 +1,5 @@
+<% add_gem_component_stylesheet("govspeak") %>
+
 <%= render "smart_answers/inputs/caption", question: question %>
 <h1 class="govuk-heading-l">
   <%= question.title %>

--- a/app/views/smart_answers/landing.html.erb
+++ b/app/views/smart_answers/landing.html.erb
@@ -1,3 +1,4 @@
+<% add_app_component_stylesheet("intervention") %>
 <% add_gem_component_stylesheet("govspeak") %>
 
 <% start_node = @presenter.start_node %>

--- a/app/views/smart_answers/landing.html.erb
+++ b/app/views/smart_answers/landing.html.erb
@@ -1,3 +1,5 @@
+<% add_gem_component_stylesheet("govspeak") %>
+
 <% start_node = @presenter.start_node %>
 
 <% content_for :head do %>

--- a/app/views/smart_answers/result.html.erb
+++ b/app/views/smart_answers/result.html.erb
@@ -1,6 +1,12 @@
+<% outcome = @presenter.current_node %>
+
 <% add_gem_component_stylesheet("govspeak") %>
 
-<% outcome = @presenter.current_node %>
+<% if outcome.add_app_component_stylesheets? %>
+  <% add_app_component_stylesheet("result-card") %>
+  <% add_app_component_stylesheet("result-sections") %>
+<% end %>
+
 <% content_for :outcome_title do %>
   <% if outcome.title.present? %><%= outcome.title %><% else %>Outcome<% end %>
 <% end %>

--- a/app/views/smart_answers/result.html.erb
+++ b/app/views/smart_answers/result.html.erb
@@ -1,3 +1,5 @@
+<% add_gem_component_stylesheet("govspeak") %>
+
 <% outcome = @presenter.current_node %>
 <% content_for :outcome_title do %>
   <% if outcome.title.present? %><%= outcome.title %><% else %>Outcome<% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,6 +12,8 @@ Bundler.require(*Rails.groups)
 
 module SmartAnswers
   class Application < Rails::Application
+    include GovukPublishingComponents::AppHelpers::AssetHelper
+
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.0
     config.time_zone = "London"
@@ -67,5 +69,7 @@ module SmartAnswers
 
     # Allow requests for all domains e.g. <app>.dev.gov.uk
     config.hosts.clear
+
+    config.assets.precompile << get_component_css_paths
   end
 end


### PR DESCRIPTION
## What

Changes to load component and view style sheets only required by the page being viewed. For example, CSS for the radio buttons only loads on the radio button question page.

## Why

This reduces the amount of CSS required for each page and increases the ability of a browser to cache the stylesheets - this should mean a faster load time for both first time and repeat visitors.

See [RFC #149](https://github.com/alphagov/govuk-rfcs/pull/152) for more details.

## Visual changes

None

## Anything else

- https://github.com/alphagov/govuk_publishing_components/pull/3014
- https://github.com/alphagov/frontend/pull/3342
- [RFC #149](https://github.com/alphagov/govuk-rfcs/pull/152)