### PR TITLE
Update FCDO email addresses

### DIFF
--- a/app/flows/register_a_birth_flow/outcomes/homeoffice_result.erb
+++ b/app/flows/register_a_birth_flow/outcomes/homeoffice_result.erb
@@ -10,5 +10,5 @@
   - you’ve married the other parent since the child was born (depending on the father's [legal country of domicile](/government/publications/legitimation-and-domicile) at the time of the birth)
   - the country where the father was [legally domiciled](/government/publications/legitimation-and-domicile) at the time of the birth did not distinguish between married and unmarried parents
 
-  Contact the Overseas Registration Unit for advice at <birthregistrationenquiries@fcdo.gov.uk>.
+  Contact the Overseas Registration Unit for advice at <Overseas.RegistrationUnit@fcdo.gov.uk>.
 <% end %>

--- a/app/flows/register_a_birth_flow/outcomes/no_birth_certificate_result.erb
+++ b/app/flows/register_a_birth_flow/outcomes/no_birth_certificate_result.erb
@@ -4,7 +4,7 @@
     <% when 'afghanistan' %>
       ^It’s illegal in Afghanistan to have a child outside of marriage. You can’t get a local birth certificate.^
 
-      A local birth certificate is normally needed to register an overseas birth. Contact the FCDO at <birthregistrationenquiries@fcdo.gov.uk> for advice.
+      A local birth certificate is normally needed to register an overseas birth. Contact the FCDO at <Overseas.RegistrationUnit@fcdo.gov.uk> for advice.
     <% when 'iran' %>
       ^It’s illegal in Iran to register the birth of a child if the parents aren't married. You can’t get a local birth certificate.^
 
@@ -16,35 +16,35 @@
     <% when 'jordan' %>
       ^It’s illegal in Jordan to have a child outside of marriage. You can’t get a local birth certificate.^
 
-      A local birth certificate is normally needed to register an overseas birth. Contact the FCDO at <birthregistrationenquiries@fcdo.gov.uk> for advice.
+      A local birth certificate is normally needed to register an overseas birth. Contact the FCDO at <Overseas.RegistrationUnit@fcdo.gov.uk> for advice.
     <% when 'kuwait' %>
       ^It’s illegal in Kuwait to have a child outside of marriage or within the first 6 months of marriage. You can’t get a local birth certificate.^
 
-      A local birth certificate is normally needed to register an overseas birth. Contact the FCDO at <birthregistrationenquiries@fcdo.gov.uk> for advice.
+      A local birth certificate is normally needed to register an overseas birth. Contact the FCDO at <Overseas.RegistrationUnit@fcdo.gov.uk> for advice.
     <% when 'oman' %>
       ^It’s illegal in Oman to have a child outside of marriage. You can’t get a local birth certificate.^
 
-      A local birth certificate is normally needed to register an overseas birth. Contact the FCDO at <birthregistrationenquiries@fcdo.gov.uk> for advice.
+      A local birth certificate is normally needed to register an overseas birth. Contact the FCDO at <Overseas.RegistrationUnit@fcdo.gov.uk> for advice.
     <% when 'pakistan' %>
       ^It’s illegal in Pakistan to have a child outside of marriage. You can’t get a local birth certificate.^
 
-      A local birth certificate is normally needed to register an overseas birth. Contact the FCDO at <birthregistrationenquiries@fcdo.gov.uk> for advice.
+      A local birth certificate is normally needed to register an overseas birth. Contact the FCDO at <Overseas.RegistrationUnit@fcdo.gov.uk> for advice.
     <% when 'qatar' %>
       ^It’s illegal in Qatar to have a child outside of marriage. You can’t get a local birth certificate.^
 
-      A local birth certificate is normally needed to register an overseas birth. Contact the FCDO at <birthregistrationenquiries@fcdo.gov.uk> for advice.
+      A local birth certificate is normally needed to register an overseas birth. Contact the FCDO at <Overseas.RegistrationUnit@fcdo.gov.uk> for advice.
     <% when 'saudi-arabia' %>
       ^It’s illegal in Saudi Arabia to have a child outside of marriage. You can’t get a local birth certificate.^
 
-      A local birth certificate is normally needed to register an overseas birth. Contact the FCDO at <birthregistrationenquiries@fcdo.gov.uk> for advice.
+      A local birth certificate is normally needed to register an overseas birth. Contact the FCDO at <Overseas.RegistrationUnit@fcdo.gov.uk> for advice.
     <% when 'united-arab-emirates' %>
       ^It’s illegal in the United Arab Emirates to have a child outside of marriage. You can’t get a local birth certificate.^
 
-      A local birth certificate is normally needed to register an overseas birth. Contact the FCDO at <birthregistrationenquiries@fcdo.gov.uk> for advice.
+      A local birth certificate is normally needed to register an overseas birth. Contact the FCDO at <Overseas.RegistrationUnit@fcdo.gov.uk> for advice.
     <% end %>
   <% else %>
     You can’t get a local birth certificate if you weren’t married when you had your child.
 
-    A local birth certificate is normally needed to register an overseas birth. Contact the FCDO at <birthregistrationenquiries@fcdo.gov.uk> to find out what other proof can be accepted.
+    A local birth certificate is normally needed to register an overseas birth. Contact the FCDO at <Overseas.RegistrationUnit@fcdo.gov.uk> to find out what other proof can be accepted.
   <% end %>
 <% end %>

--- a/app/flows/register_a_birth_flow/outcomes/oru_result.erb
+++ b/app/flows/register_a_birth_flow/outcomes/oru_result.erb
@@ -184,10 +184,9 @@ Depending on the document, you'll be asked to provide an original version or a p
 
   Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
 
+ ##3. Pay
 
   <% if !calculator.in_the_uk? && calculator.registration_country == 'algeria' %>
-
-  ##3. Pay
     Pay by credit or debit card - fill in the [credit card authorisation slip](/government/publications/credit-card-authorisation-form-algeria) and post it with your registration form.
   <% elsif calculator.country_of_birth == 'sudan' ||
     calculator.current_country == 'sudan' %>
@@ -204,7 +203,6 @@ Depending on the document, you'll be asked to provide an original version or a p
              locals: { calculator: calculator } %>
 
   <%= render partial: 'shared/births_and_deaths_registration/document_return_fees', locals: { document_return_fees: calculator.document_return_fees } %>
-      
   <%= render partial: 'shared/births_and_deaths_registration/button', locals: { button_data: { text: "Pay now", url: "https://pay-register-birth-abroad.service.gov.uk" } } %>
 
   The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register. 

--- a/app/flows/register_a_birth_flow/outcomes/oru_result.erb
+++ b/app/flows/register_a_birth_flow/outcomes/oru_result.erb
@@ -204,10 +204,10 @@ Depending on the document, you'll be asked to provide an original version or a p
              locals: { calculator: calculator } %>
 
   <%= render partial: 'shared/births_and_deaths_registration/document_return_fees', locals: { document_return_fees: calculator.document_return_fees } %>
-
-  The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the 
+      
   <%= render partial: 'shared/births_and_deaths_registration/button', locals: { button_data: { text: "Pay now", url: "https://pay-register-birth-abroad.service.gov.uk" } } %>
-General Register Office or the National Records Office of Scotland, but only from November the year after you register. 
+
+  The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register. 
         
   If you need a copy sooner, email the name of the registered person, the registration date and reference number to <Overseas.RegistrationUnit@fcdo.gov.uk>. You’ll get a reply telling you how to get your copy and the cost - usually £50 plus courier fees.
        

--- a/app/flows/register_a_birth_flow/outcomes/oru_result.erb
+++ b/app/flows/register_a_birth_flow/outcomes/oru_result.erb
@@ -185,9 +185,9 @@ Depending on the document, you'll be asked to provide an original version or a p
   Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
 
 
-  ##3. Pay
-
   <% if !calculator.in_the_uk? && calculator.registration_country == 'algeria' %>
+
+  ##3. Pay
     Pay by credit or debit card - fill in the [credit card authorisation slip](/government/publications/credit-card-authorisation-form-algeria) and post it with your registration form.
   <% elsif calculator.country_of_birth == 'sudan' ||
     calculator.current_country == 'sudan' %>
@@ -195,7 +195,7 @@ Depending on the document, you'll be asked to provide an original version or a p
 
     If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
   <% else %>
-    You should pay online for the registration. Email <birthregistrationenquiries@fcdo.gov.uk> if you’re unable to pay online.
+    You should pay online for the registration. Email <Overseas.RegistrationUnit@fcdo.gov.uk> if you’re unable to pay online.
   <% end %>
 
   Once you’ve paid you will be given a reference number to use on your birth registration form.
@@ -205,11 +205,11 @@ Depending on the document, you'll be asked to provide an original version or a p
 
   <%= render partial: 'shared/births_and_deaths_registration/document_return_fees', locals: { document_return_fees: calculator.document_return_fees } %>
 
+  The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the 
   <%= render partial: 'shared/births_and_deaths_registration/button', locals: { button_data: { text: "Pay now", url: "https://pay-register-birth-abroad.service.gov.uk" } } %>
-
-  The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register. 
+General Register Office or the National Records Office of Scotland, but only from November the year after you register. 
         
-  If you need a copy sooner, email the name of the registered person, the registration date and reference number to <birthregistrationapplications@fcdo.gov.uk>. You’ll get a reply telling you how to get your copy and the cost - usually £50 plus courier fees.
+  If you need a copy sooner, email the name of the registered person, the registration date and reference number to <Overseas.RegistrationUnit@fcdo.gov.uk>. You’ll get a reply telling you how to get your copy and the cost - usually £50 plus courier fees.
        
         
   ##4. Send your registration

--- a/app/flows/register_a_death_flow/outcomes/oru_result.erb
+++ b/app/flows/register_a_death_flow/outcomes/oru_result.erb
@@ -53,7 +53,7 @@
   <% if !calculator.in_the_uk? && calculator.registration_country == 'algeria' %>
     Pay by credit or debit card - fill in the [credit card authorisation slip](/government/publications/credit-card-authorisation-form-algeria) and post it with your registration form.
   <% else %>
-    Pay online for the registration. Email <deathregistrationenquiries@fcdo.gov.uk> if you are unable to pay online.
+    Pay online for the registration. Email <Overseas.RegistrationUnit@fcdo.gov.uk> if you are unable to pay online.
   <% end %>
 
   <%= render partial: 'fees',
@@ -64,7 +64,7 @@
 
   The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
-  If you need a copy sooner, email the name of the registered person, the registration date and reference number to <deathregistrationapplications@fcdo.gov.uk>. You’ll get a reply telling you how to get your copy and the cost - usually £50 plus courier fees.
+  If you need a copy sooner, email the name of the registered person, the registration date and reference number to <Overseas.RegistrationUnit@fcdo.gov.uk>. You’ll get a reply telling you how to get your copy and the cost - usually £50 plus courier fees.
 
   ###4. Send your registration
 


### PR DESCRIPTION
https://govuk.zendesk.com/agent/tickets/5147399
https://trello.com/c/riFeJiTo/4309-email-address-change-on-registering-a-birth-or-death-abroad-pages

These email addresses are getting replaced by Overseas.RegistrationUnit@fcdo.gov.uk:
 
- birthregistrationenquiries@fcdo.gov.uk
- birthregistrationapplications@fcdo.gov.uk
- deathregistrationenquiries@fcdo.gov.uk
- deathregistrationapplications@fcdo.gov.uk