### PR TITLE
Add recruitment banner

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,6 +14,7 @@ $govuk-include-default-font-face: false;
 @import "govuk_publishing_components/components/error-summary";
 @import "govuk_publishing_components/components/fieldset";
 @import "govuk_publishing_components/components/govspeak";
+@import "govuk_publishing_components/components/intervention";
 @import "govuk_publishing_components/components/print-link";
 @import "govuk_publishing_components/components/radio";
 @import "govuk_publishing_components/components/related-navigation";
@@ -26,6 +27,7 @@ $govuk-include-default-font-face: false;
 @import "govuk_publishing_components/components/warning-text";
 
 @import "components/autocomplete";
+@import "components/intervention";
 @import "components/result-card";
 @import "components/result-item";
 @import "components/result-sections";

--- a/app/assets/stylesheets/components/_intervention.scss
+++ b/app/assets/stylesheets/components/_intervention.scss
@@ -1,0 +1,3 @@
+.gem-c-intervention {
+  margin-top: govuk-spacing(4);
+}

--- a/app/presenters/start_node/recruitment_banner.rb
+++ b/app/presenters/start_node/recruitment_banner.rb
@@ -1,0 +1,18 @@
+module StartNode
+  module RecruitmentBanner
+    SURVEY_URLS = {
+      "/state-pension-age" => "https://GDSUserResearch.optimalworkshop.com/treejack/cbd7a696cbf57c683cbb2e95b4a36c8a",
+      "/child-benefit-tax-calculator" => "https://GDSUserResearch.optimalworkshop.com/treejack/cbd7a696cbf57c683cbb2e95b4a36c8a",
+    }.freeze
+
+    def recruitment_survey_url
+      SURVEY_URLS[base_path]
+    end
+
+  private
+
+    def base_path
+      "/#{@flow_presenter.name}"
+    end
+  end
+end

--- a/app/presenters/start_node/recruitment_banner.rb
+++ b/app/presenters/start_node/recruitment_banner.rb
@@ -5,14 +5,18 @@ module StartNode
       "/child-benefit-tax-calculator" => "https://GDSUserResearch.optimalworkshop.com/treejack/cbd7a696cbf57c683cbb2e95b4a36c8a",
     }.freeze
 
-    def recruitment_survey_url
-      SURVEY_URLS[base_path]
+    def recruitment_survey_url(path)
+      landing_page?(path) && SURVEY_URLS[base_path]
     end
 
   private
 
     def base_path
       "/#{@flow_presenter.name}"
+    end
+
+    def landing_page?(current_path)
+      base_path == current_path
     end
   end
 end

--- a/app/presenters/start_node_presenter.rb
+++ b/app/presenters/start_node_presenter.rb
@@ -1,4 +1,6 @@
 class StartNodePresenter < NodePresenter
+  include StartNode::RecruitmentBanner
+
   def initialize(node, flow_presenter, state = nil, options = {})
     super(node, flow_presenter, state)
     @renderer = options[:renderer] || SmartAnswer::ErbRenderer.new(

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -33,6 +33,16 @@
   <body class="govuk-template__body">
     <div id="wrapper">
       <div class="smart_answer">
+        <% if @presenter && @presenter.start_node.recruitment_survey_url(request.path) %>
+          <div class="banner-container">
+              <%= render "govuk_publishing_components/components/intervention", {
+                suggestion_text: "Help improve GOV.UK",
+                suggestion_link_text: "Take part in user research",
+                suggestion_link_url: @presenter.start_node.recruitment_survey_url(request.path),
+                new_tab: true,
+              } %>
+          </div>
+        <% end %>
         <%= yield :breadcrumbs %>
         <main id="content" role="main">
           <%= yield %>

--- a/app/views/smart_answers/landing.html.erb
+++ b/app/views/smart_answers/landing.html.erb
@@ -19,6 +19,17 @@
   <link title="Search" rel="search" type="application/opensearchdescription+xml" href="/search/opensearch.xml"/>
 <% end %>
 
+<% if start_node && start_node.recruitment_survey_url %>
+  <div class="banner-container">
+      <%= render "govuk_publishing_components/components/intervention", {
+        suggestion_text: "Help improve GOV.UK",
+        suggestion_link_text: "Take part in user research",
+        suggestion_link_url: start_node.recruitment_survey_url,
+        new_tab: true,
+      } %>
+  </div>
+<% end %>
+
 <% content_for :breadcrumbs do %>
   <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: content_item %>
 <% end %>

--- a/app/views/smart_answers/landing.html.erb
+++ b/app/views/smart_answers/landing.html.erb
@@ -19,17 +19,6 @@
   <link title="Search" rel="search" type="application/opensearchdescription+xml" href="/search/opensearch.xml"/>
 <% end %>
 
-<% if start_node && start_node.recruitment_survey_url %>
-  <div class="banner-container">
-      <%= render "govuk_publishing_components/components/intervention", {
-        suggestion_text: "Help improve GOV.UK",
-        suggestion_link_text: "Take part in user research",
-        suggestion_link_url: start_node.recruitment_survey_url,
-        new_tab: true,
-      } %>
-  </div>
-<% end %>
-
 <% content_for :breadcrumbs do %>
   <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: content_item %>
 <% end %>

--- a/test/integration/recruitment_banner_test.rb
+++ b/test/integration/recruitment_banner_test.rb
@@ -1,0 +1,50 @@
+require_relative "../integration_test_helper"
+
+class RecruitmentBannerTest < ActionDispatch::IntegrationTest
+  context "cost of living recruitment banner" do
+    context "child benefit tax calculator" do
+      setup do
+        stub_content_store_has_item("/child-benefit-tax-calculator")
+      end
+
+      should "display Recruitment Banner on the landing page" do
+        visit "/child-benefit-tax-calculator"
+        assert page.has_css?(".gem-c-intervention")
+        assert page.has_link?("Take part in user research (opens in a new tab)", href: "https://GDSUserResearch.optimalworkshop.com/treejack/cbd7a696cbf57c683cbb2e95b4a36c8a")
+      end
+
+      should "not display Recruitment Banner on non-landing pages of the specific smart answer" do
+        visit "/child-benefit-tax-calculator/y"
+
+        assert_not page.has_css?(".gem-c-intervention")
+        assert_not page.has_link?("Take part in user research (opens in a new tab)", href: "https://GDSUserResearch.optimalworkshop.com/treejack/cbd7a696cbf57c683cbb2e95b4a36c8a")
+      end
+
+      should "not display Recruitment Banner unless survey URL is specified for the base path" do
+        visit "/bridge-of-death"
+
+        assert_not page.has_css?(".gem-c-intervention")
+        assert_not page.has_link?("Take part in user research (opens in a new tab)", href: "https://GDSUserResearch.optimalworkshop.com/treejack/cbd7a696cbf57c683cbb2e95b4a36c8a")
+      end
+    end
+
+    context "state pension age smart answer" do
+      setup do
+        stub_content_store_has_item("/state-pension-age")
+      end
+
+      should "display Recruitment Banner on the landing page" do
+        visit "/state-pension-age"
+        assert page.has_css?(".gem-c-intervention")
+        assert page.has_link?("Take part in user research (opens in a new tab)", href: "https://GDSUserResearch.optimalworkshop.com/treejack/cbd7a696cbf57c683cbb2e95b4a36c8a")
+      end
+
+      should "not display Recruitment Banner on non-landing pages of the specific smart answer" do
+        visit "/state-pension-age/y"
+
+        assert_not page.has_css?(".gem-c-intervention")
+        assert_not page.has_link?("Take part in user research (opens in a new tab)", href: "https://GDSUserResearch.optimalworkshop.com/treejack/cbd7a696cbf57c683cbb2e95b4a36c8a")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add recruitment banner to:

- /state-pension-age
- /child-benefit-tax-calculator

Original implementation by @AgaDufrat: https://github.com/alphagov/smart-answers/pull/6100

Trello: https://trello.com/c/woeqmUsz/1521-banner-request-for-cost-of-living-tree-test-m

Screenshots:
<img width="1058" alt="Screenshot 2022-12-15 at 12 13 17" src="https://user-images.githubusercontent.com/17908089/207856574-d440c1eb-1a32-4cca-bae1-966217a5c2f6.png">

<img width="1029" alt="Screenshot 2022-12-15 at 12 13 54" src="https://user-images.githubusercontent.com/17908089/207856653-4d18c3fb-11a0-4a72-9758-65ba72bbcfb0.png">



Review apps: 
- https://smart-answers-pr-6228.herokuapp.com/state-pension-age
- https://smart-answers-pr-6228.herokuapp.com/child-benefit-tax-calculator
