### PR TITLE
Update interest rates for self assessment penalties

### DIFF
--- a/lib/smart_answer/calculators/self_assessment_penalties.rb
+++ b/lib/smart_answer/calculators/self_assessment_penalties.rb
@@ -49,7 +49,8 @@ module SmartAnswer::Calculators
       { start_date: "2022-07-05", end_date: "2022-08-22", value: 0.0375 },
       { start_date: "2022-08-23", end_date: "2022-10-10", value: 0.0425 },
       { start_date: "2022-10-11", end_date: "2022-11-21", value: 0.0475 },
-      { start_date: "2022-11-22", end_date: "2100-04-04", value: 0.055 },
+      { start_date: "2022-11-22", end_date: "2023-01-05", value: 0.055 },
+      { start_date: "2023-01-06", end_date: "2100-04-04", value: 0.06 },
     ].freeze
 
     def tax_year_range


### PR DESCRIPTION
## What
Update interest rate from 5.5% to 6% from the 6 January 2023.

**Review URL**

https://smart-answers-pr-6246.herokuapp.com/estimate-self-assessment-penalties

https://trello.com/c/HdCi0ifU/4245-smart-answer-change-of-interest-rate-in-estimate-your-penalty-for-late-sa-tax-returns-and-payments