### PR TITLE
Resolve dual CSP configurations

### DIFF
--- a/config/initializers/csp.rb
+++ b/config/initializers/csp.rb
@@ -1,1 +1,0 @@
-GovukContentSecurityPolicy.configure


### PR DESCRIPTION
This is to resolve the presence of two content security policy files that both initialise the CSP.

It chooses to use content_security_policy.rb as that is a Rails default.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
