### PR TITLE
Remove 2014-2015 and add 2021-2022 to SA penalty flow.

### DIFF
--- a/app/flows/estimate_self_assessment_penalties_flow.rb
+++ b/app/flows/estimate_self_assessment_penalties_flow.rb
@@ -5,13 +5,13 @@ class EstimateSelfAssessmentPenaltiesFlow < SmartAnswer::Flow
     status :published
 
     radio :which_year? do
-      option :"2014-15"
       option :"2015-16"
       option :"2016-17"
       option :"2017-18"
       option :"2018-19"
       option :"2019-20"
       option :"2020-21"
+      option :"2021-22"
 
       on_response do |response|
         self.calculator = SmartAnswer::Calculators::SelfAssessmentPenalties.new

--- a/app/flows/estimate_self_assessment_penalties_flow/questions/which_year.erb
+++ b/app/flows/estimate_self_assessment_penalties_flow/questions/which_year.erb
@@ -3,11 +3,11 @@
 <% end %>
 
 <% options(
-  "2014-15": "6 April 2014 to 5 April 2015",
   "2015-16": "6 April 2015 to 5 April 2016",
   "2016-17": "6 April 2016 to 5 April 2017",
   "2017-18": "6 April 2017 to 5 April 2018",
   "2018-19": "6 April 2018 to 5 April 2019",
   "2019-20": "6 April 2019 to 5 April 2020",
   "2020-21": "6 April 2020 to 5 April 2021",
+  "2021-22": "6 April 2021 to 5 April 2022",
 ) %>

--- a/lib/smart_answer/calculators/self_assessment_penalties.rb
+++ b/lib/smart_answer/calculators/self_assessment_penalties.rb
@@ -10,7 +10,6 @@ module SmartAnswer::Calculators
 
     DEADLINES = {
       online_filing_deadline: {
-        "2014-15": ONLINE_FILING_DEADLINE_YEAR.starting_in(2016).begins_on,
         "2015-16": ONLINE_FILING_DEADLINE_YEAR.starting_in(2017).begins_on,
         "2016-17": ONLINE_FILING_DEADLINE_YEAR.starting_in(2018).begins_on,
         "2017-18": ONLINE_FILING_DEADLINE_YEAR.starting_in(2019).begins_on,
@@ -19,24 +18,25 @@ module SmartAnswer::Calculators
         "2019-20-covid-easement": ONLINE_FILING_DEADLINE_YEAR_FEB.starting_in(2021).begins_on,
         "2020-21": ONLINE_FILING_DEADLINE_YEAR.starting_in(2022).begins_on,
         "2020-21-covid-easement": ONLINE_FILING_DEADLINE_YEAR_FEB.starting_in(2022).begins_on,
+        "2021-22": ONLINE_FILING_DEADLINE_YEAR.starting_in(2023).begins_on,
       },
       paper_filing_deadline: {
-        "2014-15": OFFLINE_FILING_DEADLINE_YEAR.starting_in(2015).begins_on,
         "2015-16": OFFLINE_FILING_DEADLINE_YEAR.starting_in(2016).begins_on,
         "2016-17": OFFLINE_FILING_DEADLINE_YEAR.starting_in(2017).begins_on,
         "2017-18": OFFLINE_FILING_DEADLINE_YEAR.starting_in(2018).begins_on,
         "2018-19": OFFLINE_FILING_DEADLINE_YEAR.starting_in(2019).begins_on,
         "2019-20": OFFLINE_FILING_DEADLINE_YEAR.starting_in(2020).begins_on,
         "2020-21": OFFLINE_FILING_DEADLINE_YEAR.starting_in(2021).begins_on,
+        "2021-22": OFFLINE_FILING_DEADLINE_YEAR.starting_in(2022).begins_on,
       },
       payment_deadline: {
-        "2014-15": PAYMENT_DEADLINE_YEAR.starting_in(2016).begins_on,
         "2015-16": PAYMENT_DEADLINE_YEAR.starting_in(2017).begins_on,
         "2016-17": PAYMENT_DEADLINE_YEAR.starting_in(2018).begins_on,
         "2017-18": PAYMENT_DEADLINE_YEAR.starting_in(2019).begins_on,
         "2018-19": PAYMENT_DEADLINE_YEAR.starting_in(2020).begins_on,
         "2019-20": PAYMENT_DEADLINE_YEAR.starting_in(2021).begins_on,
         "2020-21": PAYMENT_DEADLINE_YEAR.starting_in(2022).begins_on,
+        "2021-22": PAYMENT_DEADLINE_YEAR.starting_in(2023).begins_on,
       },
     }.freeze
 
@@ -55,8 +55,6 @@ module SmartAnswer::Calculators
 
     def tax_year_range
       case tax_year
-      when "2014-15"
-        SmartAnswer::YearRange.tax_year.starting_in(2014)
       when "2015-16"
         SmartAnswer::YearRange.tax_year.starting_in(2015)
       when "2016-17"
@@ -69,6 +67,8 @@ module SmartAnswer::Calculators
         SmartAnswer::YearRange.tax_year.starting_in(2019)
       when "2020-21"
         SmartAnswer::YearRange.tax_year.starting_in(2020)
+      when "2021-22"
+        SmartAnswer::YearRange.tax_year.starting_in(2021)
       end
     end
 
@@ -78,8 +78,6 @@ module SmartAnswer::Calculators
 
     def one_year_after_start_date_for_penalties
       case tax_year
-      when "2014-15"
-        PENALTY_YEAR.starting_in(2017).begins_on
       when "2015-16"
         PENALTY_YEAR.starting_in(2018).begins_on
       when "2016-17"
@@ -92,6 +90,8 @@ module SmartAnswer::Calculators
         PENALTY_YEAR.starting_in(2022).begins_on
       when "2020-21"
         PENALTY_YEAR.starting_in(2023).begins_on
+      when "2021-22"
+        PENALTY_YEAR.starting_in(2024).begins_on
       end
     end
 

--- a/test/unit/calculators/self_assessment_penalties_test.rb
+++ b/test/unit/calculators/self_assessment_penalties_test.rb
@@ -5,19 +5,14 @@ module SmartAnswer::Calculators
     def setup
       @calculator = SmartAnswer::Calculators::SelfAssessmentPenalties.new(
         submission_method: "online",
-        filing_date: Date.parse("2016-01-10"),
-        payment_date: Date.parse("2016-03-10"),
+        filing_date: Date.parse("2023-01-10"),
+        payment_date: Date.parse("2023-03-10"),
         estimated_bill: SmartAnswer::Money.new(5000),
-        tax_year: "2014-15",
+        tax_year: "2021-22",
       )
     end
 
     context "#start_of_next_year" do
-      should "return 2015-04-06 if tax-year is 2014-15" do
-        @calculator.tax_year = "2014-15"
-
-        assert_equal Date.new(2015, 4, 6), @calculator.start_of_next_tax_year
-      end
       should "return 2016-04-06 if tax-year is 2016-15" do
         @calculator.tax_year = "2015-16"
 
@@ -48,14 +43,14 @@ module SmartAnswer::Calculators
 
         assert_equal Date.new(2021, 4, 6), @calculator.start_of_next_tax_year
       end
+      should "return 2022-04-06 if tax-year is 2021-22" do
+        @calculator.tax_year = "2021-22"
+
+        assert_equal Date.new(2022, 4, 6), @calculator.start_of_next_tax_year
+      end
     end
 
     context "one_year_after_start_date_for_penalties" do
-      should "return 2017-02-01 if tax-year is 2014-15" do
-        @calculator.tax_year = "2014-15"
-
-        assert_equal Date.new(2017, 2, 1), @calculator.one_year_after_start_date_for_penalties
-      end
       should "return 2018-02-01 if tax-year is 2015-16" do
         @calculator.tax_year = "2015-16"
 
@@ -85,6 +80,11 @@ module SmartAnswer::Calculators
         @calculator.tax_year = "2020-21"
 
         assert_equal Date.new(2023, 2, 1), @calculator.one_year_after_start_date_for_penalties
+      end
+      should "return 2024-02-01 if tax-year is 2021-22" do
+        @calculator.tax_year = "2021-22"
+
+        assert_equal Date.new(2024, 2, 1), @calculator.one_year_after_start_date_for_penalties
       end
     end
 
@@ -121,8 +121,8 @@ module SmartAnswer::Calculators
     context "online submission" do
       context "filed and paid on time" do
         should "confirm payment was made on time" do
-          @calculator.filing_date = Date.parse("2015-01-10")
-          @calculator.payment_date = Date.parse("2015-01-10")
+          @calculator.filing_date = Date.parse("2022-01-10")
+          @calculator.payment_date = Date.parse("2022-01-10")
 
           assert @calculator.paid_on_time?
         end
@@ -247,73 +247,73 @@ module SmartAnswer::Calculators
 
         should "calculate late filing penalty" do
           # band 0: No penalty by 31 January for previous tax year
-          @calculator.filing_date = Date.parse("2016-01-31")
+          @calculator.filing_date = Date.parse("2023-01-31")
           assert_equal 0, @calculator.late_filing_penalty
 
           # band one: 01 Feb - 29 April: incurs £100 penalty (<= 89 days)
-          @calculator.filing_date = Date.parse("2016-02-01")
+          @calculator.filing_date = Date.parse("2023-02-01")
           assert_equal 1, @calculator.overdue_filing_days
           assert_equal 100, @calculator.late_filing_penalty
-          @calculator.filing_date = Date.parse("2016-04-29")
+          @calculator.filing_date = Date.parse("2023-04-30")
           assert_equal 89, @calculator.overdue_filing_days
           assert_equal 100, @calculator.late_filing_penalty
 
-          # band two: 30 April - 30 July: band one + £10/day (up to 90 days)
+          # band two: 1 May - 30 July: band one + £10/day (up to 90 days)
           # 1 day late incurs £10 penalty
-          @calculator.filing_date = Date.parse("2016-04-30")
+          @calculator.filing_date = Date.parse("2023-05-01")
           assert_equal 90, @calculator.overdue_filing_days
           assert_equal 110, @calculator.late_filing_penalty
           # 3 days late incurs £30 penalty
-          @calculator.filing_date = Date.parse("2016-05-02")
+          @calculator.filing_date = Date.parse("2023-05-03")
           assert_equal 92, @calculator.overdue_filing_days
           assert_equal 130, @calculator.late_filing_penalty
           # 90 days late incurs £900 penalty + band one
-          @calculator.filing_date = Date.parse("2016-07-30")
+          @calculator.filing_date = Date.parse("2023-07-31")
           assert_equal 181, @calculator.overdue_filing_days
           assert_equal 1000, @calculator.late_filing_penalty
 
-          # band three: 31 July - 31 Jan 2017: bands one + two + greater of £300 or 5% tax
+          # band three: 1 Aug - 31 Jan 2017: bands one + two + greater of £300 or 5% tax
           # > 181 days late incurs band two + £300
-          @calculator.filing_date = Date.parse("2016-07-31")
+          @calculator.filing_date = Date.parse("2023-08-01")
           assert_equal 182, @calculator.overdue_filing_days
           assert_equal 1300, @calculator.late_filing_penalty
           # < 366 days late incurs band two + £300
-          @calculator.filing_date = Date.parse("2017-01-30")
+          @calculator.filing_date = Date.parse("2024-01-31")
           assert_equal 365, @calculator.overdue_filing_days
           assert_equal 1300, @calculator.late_filing_penalty
           # > 181 days late incurs band two + 5% tax
           @calculator.estimated_bill = SmartAnswer::Money.new(10_000)
-          @calculator.filing_date = Date.parse("2016-07-31")
+          @calculator.filing_date = Date.parse("2023-08-01")
           assert_equal 182, @calculator.overdue_filing_days
           assert_equal 1500, @calculator.late_filing_penalty
           # < 366 days late incurs band two + 5% tax
-          @calculator.filing_date = Date.parse("2017-01-30")
+          @calculator.filing_date = Date.parse("2024-01-31")
           assert_equal 365, @calculator.overdue_filing_days
           assert_equal 1500, @calculator.late_filing_penalty
 
           # band four: After 31 Jan 2017: band one + two + three + greater of £300 or 5% tax
           # > 365 days late incurs band three + £300
           @calculator.estimated_bill = SmartAnswer::Money.new(5_000)
-          @calculator.filing_date = Date.parse("2017-01-31")
+          @calculator.filing_date = Date.parse("2024-02-01")
           assert_equal 366, @calculator.overdue_filing_days
           assert_equal 1600, @calculator.late_filing_penalty
           # > 365 days late incurs band three + 5% tax
           @calculator.estimated_bill = SmartAnswer::Money.new(10_000)
-          @calculator.filing_date = Date.parse("2017-01-31")
+          @calculator.filing_date = Date.parse("2024-02-01")
           assert_equal 366, @calculator.overdue_filing_days
           assert_equal 2000, @calculator.late_filing_penalty
         end
 
         should "calculate total owed (excludes filing penalty)" do
-          @calculator.payment_date = Date.parse("2016-02-02")
+          @calculator.payment_date = Date.parse("2023-02-02")
           assert_equal 5000, @calculator.total_owed
-          @calculator.payment_date = Date.parse("2016-02-04")
+          @calculator.payment_date = Date.parse("2023-02-03")
           assert_equal 5001, @calculator.total_owed
-          @calculator.payment_date = Date.parse("2016-08-03")
-          assert_equal 5581, @calculator.total_owed
-          @calculator.payment_date = Date.parse("2017-02-03")
+          @calculator.payment_date = Date.parse("2023-08-03")
+          assert_equal 5650, @calculator.total_owed
+          @calculator.payment_date = Date.parse("2024-02-03")
           assert_equal 750, @calculator.late_payment_penalty
-          assert_equal 5913, @calculator.total_owed
+          assert_equal 6051, @calculator.total_owed
         end
 
         context "HMRC Covid-19 Extension to 1 April for 2019-20" do
@@ -419,8 +419,8 @@ module SmartAnswer::Calculators
 
       context "filed and paid on time" do
         setup do
-          @calculator.filing_date = Date.parse("2014-10-30")
-          @calculator.payment_date = Date.parse("2015-01-30")
+          @calculator.filing_date = Date.parse("2021-10-30")
+          @calculator.payment_date = Date.parse("2022-01-30")
         end
 
         should "confirm payment was made on time" do
@@ -430,8 +430,8 @@ module SmartAnswer::Calculators
 
       context "filed or paid late" do
         setup do
-          @calculator.filing_date = Date.parse("2015-01-10")
-          @calculator.payment_date = Date.parse("2016-02-01")
+          @calculator.filing_date = Date.parse("2022-01-10")
+          @calculator.payment_date = Date.parse("2023-02-01")
         end
         should "confirm payment was made late" do
           assert_not @calculator.paid_on_time?


### PR DESCRIPTION

https://trello.com/c/rEAR33Pw/1740-change-to-estimate-your-penalty-for-late-sa-tax-returns-and-payments-addition-of-2021-22

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance]
(https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
