### PR TITLE
Try reinstating config removed by Rails 7 update

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -24,6 +24,8 @@ Rails.application.configure do
   # Apache or NGINX already handles this.
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
+  # Compress JavaScripts.
+  config.assets.js_compressor = :uglifier
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass
 
@@ -35,6 +37,10 @@ Rails.application.configure do
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"
+
+  # Rather than use a CSS compressor, use the SASS style to perform compression.
+  config.sass.style = :compressed
+  config.sass.line_comments = false
 
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for Apache


### PR DESCRIPTION
https://trello.com/c/q2OSP8iz/1705-smart-answers-css-and-js-not-optimized

Some compression/minifying config was removed by accident during the Rails 7 update, resulting in Smart Answers CSS and JS not being compressed. This fix reinstates the config.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
