### PR TITLE
Use a nonce on inline JavaScript

### DIFF
--- a/app/views/smart_answers/visualise.html.erb
+++ b/app/views/smart_answers/visualise.html.erb
@@ -9,9 +9,10 @@
 <%= stylesheet_link_tag 'visualise' %>
 <% end %>
 
-<script defer="false">
+<%# Use of defer is to hoist this JS to head with slimmer, it's totally a hack %>
+<%= javascript_tag(nonce: true, defer: true) do -%>
   var adjacencyList = <%= JSON.pretty_generate(@graph_data).html_safe %>;
-</script>
+<%- end %>
 
 <%= render "govuk_publishing_components/components/title", {
   context: "Flow visualisation for",


### PR DESCRIPTION
This change has been made so that Smart Answers is compatible with upcoming changes to the GOV.UK Content Security Policy [1].

This adds a nonce so this JavaScript will be allowed to execute.

This changes the use of defer="false" to be just a defer attribute. The usage of defer on inline script is unusual as it only applies when src is set [2].

I'm not sure why the `defer="false"` attribute was originally added (the commit [3] doesn't explain it) however it is now needed as part of Slimmer reorganising JavaScripts. Slimmer moves this JS to the head (and strips the `="false"`) so the change to `defer: true` is just to make the code for JS reflect what it actually used. Since it now seems to be used as a hack for Slimmer, I've labelled it as so.

To see an example of things as they are now go to https://www.gov.uk/additional-commodity-code/y/visualise and view source, you'll see the JS in head like: 

```
<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
<script defer>
  var adjacencyList = {
    "labels": {
```

[1]: https://github.com/alphagov/govuk_app_config/pull/279
[2]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-defer
[3]: https://github.com/alphagov/smart-answers/commit/a5c4e14dad70d225bab318c8f8815992fc94e09f

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
