### PR TITLE
Add GA4 analytics to sidebar

### DIFF
--- a/app/views/smart_answers/landing.html.erb
+++ b/app/views/smart_answers/landing.html.erb
@@ -58,9 +58,9 @@
       <% end %>
     </article>
 
-    <%= render 'govuk_publishing_components/components/contextual_footer', content_item: content_item %>
+    <%= render 'govuk_publishing_components/components/contextual_footer', content_item: content_item, ga4_tracking: true %>
   </div>
   <div class="govuk-grid-column-one-third">
-    <%= render 'govuk_publishing_components/components/contextual_sidebar', content_item: content_item %>
+    <%= render 'govuk_publishing_components/components/contextual_sidebar', content_item: content_item, ga4_tracking: true %>
   </div>
 </div>

--- a/app/views/smart_answers/result.html.erb
+++ b/app/views/smart_answers/result.html.erb
@@ -24,7 +24,7 @@
       context_inside: true,
     } %>
 
-    <div 
+    <div
       data-flow-name="<%= @name %>"
       data-module="gem-track-click"
       data-track-category="Internal Link Clicked"
@@ -58,7 +58,7 @@
 
   <% if defined?(@presenter.finished?) and @presenter.finished? %>
     <div class="govuk-grid-column-one-third govuk-!-margin-top-9">
-      <%= render 'govuk_publishing_components/components/contextual_sidebar', content_item: content_item %>
+      <%= render 'govuk_publishing_components/components/contextual_sidebar', content_item: content_item, ga4_tracking: true %>
     </div>
   <% end %>
 </div>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Turn on GA4 tracking in the contextual sidebar component. This will enable tracking for the related navigation component,  present inside the contextual sidebar component.

Example pages:

- [smart answer start page](https://www.gov.uk/am-i-getting-minimum-wage)
- [smart answer result page](https://www.gov.uk/am-i-getting-minimum-wage/y/current_payment/not_an_apprentice/22/1/1.0/1.0/no/no/no)

## Why
Part of implementing analytics using GA4.

## Visual changes
None.

Trello card: https://trello.com/c/IMjw2dHg/382-add-tracking-related-links-contextual-sidebar-and-contextual-footer
