### PR TITLE
Remove workaround for bad `mail` gem release.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem "govuk_publishing_components"
 gem "htmlentities"
 gem "httparty"
 gem "json"
-gem "mail", "~> 2.7.1"  # TODO: remove once https://github.com/mikel/mail/issues/1489 is fixed.
+gem "mail"
 gem "method_source"
 gem "parser"
 gem "plek"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -205,8 +205,11 @@ GEM
     loofah (2.19.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.7.1)
+    mail (2.8.0.1)
       mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
@@ -447,7 +450,7 @@ DEPENDENCIES
   json
   launchy
   listen
-  mail (~> 2.7.1)
+  mail
   method_source
   minitest
   minitest-focus


### PR DESCRIPTION
Remove the version constraint that we were using to avoid the bad release of the mail gem, now that https://www.github.com/mikel/mail/issues/1489 is fixed.

Update to 2.8.0.1, which fixes the permissions issue.

Generated with gsed -i '/gem "mail"/d' && bundle update mail.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
