### PR TITLE
Fix crash in adoption calculator when pay exactly on threshold

### DIFF
--- a/lib/smart_answer/calculators/maternity_pay_calculator.rb
+++ b/lib/smart_answer/calculators/maternity_pay_calculator.rb
@@ -335,7 +335,7 @@ module SmartAnswer::Calculators
     end
 
     def above_lower_earning_limit
-      average_weekly_earnings > lower_earning_limit
+      average_weekly_earnings >= lower_earning_limit
     end
 
     def pay_dates_and_pay

--- a/test/flows/maternity_paternity_calculator_flow/adoption_calculator_flow_test.rb
+++ b/test/flows/maternity_paternity_calculator_flow/adoption_calculator_flow_test.rb
@@ -402,6 +402,31 @@ class MaternityPaternityCalculatorFlow::AdoptionCalculatorFlowTest < ActiveSuppo
       assert_match(/Total SAP:\s*£10,569.78/, @test_flow.outcome_text)
     end
 
+    should "render when an employee is entitled to statutory adoption pay and exactly on the threshold" do
+      add_responses(
+        what_type_of_leave?: "adoption",
+        taking_paternity_or_maternity_leave_for_adoption?: "maternity",
+        adoption_is_from_overseas?: "no",
+        date_of_adoption_match?: "2022-12-15",
+        date_of_adoption_placement?: "2022-12-15",
+        adoption_did_the_employee_work_for_you?: "yes",
+        adoption_employment_contract?: "yes",
+        adoption_is_the_employee_on_your_payroll?: "yes",
+        adoption_date_leave_starts?: "2022-12-15",
+        last_normal_payday_adoption?: "2022-11-30",
+        payday_eight_weeks_adoption?: "2022-09-30",
+        pay_frequency_adoption?: "monthly",
+        earnings_for_pay_period_adoption?: "1066.0",
+        how_many_payments_monthly?: "2",
+        how_do_you_want_the_sap_calculated?: "weekly_starting",
+      )
+
+      # lower limit for 2021 - 2022 is £123/w, 1066/m
+      assert_rendered_outcome text: "The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP)"
+
+      assert_match(/Total SAP:\s*£4,317.30/, @test_flow.outcome_text)
+    end
+
     should "render when an employee is not entitled to statutory adoption pay due to no payroll" do
       add_responses maternity_adoption_responses.merge(adoption_is_the_employee_on_your_payroll?: "no")
 


### PR DESCRIPTION
Adoption pay calculator crashes when pay is exactly on the threshold (because it passes through tests that the pay isn't under the threshold, and that pay is above the threshold). Since being on the threshold is considered as valid for SAP, update the test for above_lower_earning_limit to be GE rather than GT.

https://trello.com/c/ZGohxjNi/1693-ps37-crash-in-adoption-pay-calculator-if-average-pay-equal-to-threshold

To replicate problem without this patch, go to https://www.integration.publishing.service.gov.uk/maternity-paternity-calculator/y/adoption/maternity/no/2022-12-15/2022-12-15/yes/yes/yes/2022-12-15/2022-11-30/2022-09-30/monthly

then enter 1066.0 / 1 or 2 Payments / Weekly Starting 15th December

If you enter 1067 instead it works, or 1065. But 1066.0 exactly fails. With the patch, 1066.0 works.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
