### PR TITLE
Remove references to Imminence, as Smart Answers doesn't use it now.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Smart Answers
 
-A tool for content designers to present complex information as a flow of questions, leading to an outcome. While the app is mostly self-contained, some Smart Answers use [Imminence](https://github.com/alphagov/imminence) for Post Code lookup, and [Whitehall](https://github.com/alphagov/whitehall) to get data on countries and worldwide organisations.
+A tool for content designers to present complex information as a flow of questions, leading to an outcome. While the app is mostly self-contained, some Smart Answers use [Whitehall](https://github.com/alphagov/whitehall) to get data on countries and worldwide organisations.
 
 ## Live examples
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,7 +16,6 @@ WebMock.disable_net_connect!(allow_localhost: true)
 
 require "gds_api/test_helpers/json_client_helper"
 require "gds_api/test_helpers/content_store"
-require "gds_api/test_helpers/imminence"
 require "gds_api/test_helpers/publishing_api"
 require "gds_api/test_helpers/worldwide"
 require_relative "support/fixture_methods"
@@ -24,7 +23,6 @@ require_relative "support/fixture_methods"
 class ActiveSupport::TestCase
   include FixtureMethods
   include GdsApi::TestHelpers::ContentStore
-  include GdsApi::TestHelpers::Imminence
   include GdsApi::TestHelpers::PublishingApi
   include GdsApi::TestHelpers::Worldwide
   include ActionDispatch::Assertions


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
