### PR TITLE
Move question caption from legend

### DIFF
--- a/app/views/smart_answers/inputs/_checkbox_question.html.erb
+++ b/app/views/smart_answers/inputs/_checkbox_question.html.erb
@@ -1,8 +1,8 @@
+<%= render "smart_answers/inputs/caption", question: question %>
 <%= render "govuk_publishing_components/components/checkboxes", {
   name: "response[]",
   heading: question.title,
   heading_size: "l",
-  heading_caption: question.caption,
   is_page_heading: true,
   description: question.body,
   id: "response",

--- a/app/views/smart_answers/inputs/_radio_question.html.erb
+++ b/app/views/smart_answers/inputs/_radio_question.html.erb
@@ -1,8 +1,8 @@
+<%= render "smart_answers/inputs/caption", question: question %>
 <%= render "govuk_publishing_components/components/radio", {
   name: "response",
   heading: question.title,
   heading_size: "l",
-  heading_caption: question.caption,
   heading_level: 1,
   hint: question.hint,
   id_prefix: "response",

--- a/test/functional/smart_answers_controller_checkbox_question_test.rb
+++ b/test/functional/smart_answers_controller_checkbox_question_test.rb
@@ -12,7 +12,7 @@ class SmartAnswersControllerCheckboxQuestionTest < ActionController::TestCase
   context "checkbox question" do
     should "display question" do
       get :show, params: { id: "checkbox-sample", started: "y" }
-      assert_select ".govuk-fieldset__legend.govuk-fieldset__legend--l .govuk-caption-l", "Sample checkbox question"
+      assert_select ".govuk-caption-l", "Sample checkbox question"
       assert_select ".govuk-fieldset__legend.govuk-fieldset__legend--l h1.govuk-fieldset__heading", /What do you want on your pizza\?/
       assert_select "input[type=checkbox][name=\"response[]\"]"
     end

--- a/test/functional/smart_answers_controller_radio_question_test.rb
+++ b/test/functional/smart_answers_controller_radio_question_test.rb
@@ -12,7 +12,7 @@ class SmartAnswersControllerRadioQuestionTest < ActionController::TestCase
   context "radio question" do
     should "display question" do
       get :show, params: { id: "radio-sample", started: "y" }
-      assert_select ".govuk-fieldset__legend.govuk-fieldset__legend--l .govuk-caption-l", "Sample radio question"
+      assert_select ".govuk-caption-l", "Sample radio question"
       assert_select ".govuk-fieldset__legend.govuk-fieldset__legend--l h1.govuk-fieldset__heading", /Hotter or colder\?/
       assert_select "input[type=radio][name=response]"
     end


### PR DESCRIPTION
## What

Move question caption from legend for the following question types:

- `_checkbox_question`
- `_radio_question`

https://trello.com/c/csSdzo6I/1765-overly-long-legends-with-caption-in-smart-answers-3

## Why

Legends are read out to screen reader users whenever they encounter a form control within that fieldset. When a legend is overly long, it gets more time-consuming to understand it. When the question isn't front-loaded, it gets more difficult to understand it.