### PR TITLE
Update_civil partnership to marriage

### DIFF
--- a/app/flows/marriage_abroad_flow/outcomes/countries/greece/ceremony_country/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/greece/ceremony_country/_opposite_sex.erb
@@ -41,6 +41,12 @@ If your document is not in English or Greek you’ll need to get it translated b
 
 You might also be asked to get your document [legalised](/get-document-legalised).
 
+### If you want to marry your civil partner
+
+It’s not possible to convert your civil partnership to marriage. You’ll need to end the civil partnership.
+
+You’ll need a document to prove that the civil partnership has ended to get a CNI.
+
 ###After you give notice
 
 The British embassy or vice consulate will display your notice of marriage publicly for 7 full days. This means if you give notice on Monday, it will be displayed until the following Tuesday. 


### PR DESCRIPTION
Trello: https://trello.com/c/XOZhv2Gk/4174-getting-married-abroad-greece-information-on-converting-to-a-marriage

ADD:

##If you want to marry your civil partner

It’s not possible to convert your civil partnership to marriage. You’ll need to end the civil partnership.

You’ll need a document to prove that the civil partnership has ended to get a CNI.

REASON:

People can’t convert their civil partnership to marriage in Greece without dissolving their civil partnership first. I’ve added this to make it clear to the people that this is what they should do to get married in Greece. This is following feedback from the British Embassy in Athens that users aren’t understanding this. 


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
