### PR TITLE
Add ga4 tracking attributes to cost of living results page

### DIFF
--- a/app/flows/check_benefits_financial_support_flow/outcomes/results.erb
+++ b/app/flows/check_benefits_financial_support_flow/outcomes/results.erb
@@ -1,6 +1,6 @@
 <% text_for :body do %>
   <% if calculator.number_of_benefits > 0 %>
-    <p class="govuk-body">Based on your answers, you may be eligible for the following <span style="font-weight: bold"><%= calculator.number_of_benefits %> things</span>.</p>
+    <p class="govuk-body">Based on your answers, you may be eligible for the following <span id="ga4-ecommerce-result-count" style="font-weight: bold"><%= calculator.number_of_benefits %> things</span>.</p>
   <% else %>
     <p class="govuk-body">Based on your answers, you may not be eligible for any benefits.</p>
   <% end %>

--- a/app/views/components/_result-card.html.erb
+++ b/app/views/components/_result-card.html.erb
@@ -28,6 +28,7 @@
   data: {
     "track-category": "SmartAnswerClicked",
     "track-action": url_track_action,
-    "track-label": url
+    "track-label": url,
+    "ga4-ecommerce-path": url
   } %>
 </div>

--- a/app/views/smart_answers/result.html.erb
+++ b/app/views/smart_answers/result.html.erb
@@ -11,7 +11,7 @@
   <div
     id="result-info"
     class="govuk-grid-column-two-thirds outcome"
-    data-module="auto-track-event ga4-auto-tracker"
+    data-module="auto-track-event ga4-auto-tracker ga4-smart-answer-results-tracker"
     data-track-category="Smart Answer"
     data-track-action="Completed"
     data-track-label="<%= @name %>"
@@ -23,6 +23,8 @@
       "action": "complete",
       "tool_name": "<%= @presenter.title %>"
     }'
+    data-ecommerce-start-index="1"
+    data-list-title="<%= @presenter.title %>"
   >
     <%= render 'smart_answers/shared/debug' %>
     <%= render "govuk_publishing_components/components/title", {


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Adds data attributes to the Cost of Living smart answers results to enable GA4 tracking. An `id` has also been added to the element containing the number of results so they can be targeted and extracted.

## Why
Part of the GA4 migration.

## Visual changes
N/A

Trello card: https://trello.com/c/x08gMmOU/386-add-tracking-ecommerce-smart-answer-results-cost-of-living 
