### PR TITLE
Add GA4 tracking to errors and results pages

### DIFF
--- a/app/views/smart_answers/custom_result.html.erb
+++ b/app/views/smart_answers/custom_result.html.erb
@@ -8,7 +8,17 @@
 <% end %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div
+    class="govuk-grid-column-two-thirds"
+    data-module="ga4-auto-tracker"
+    data-ga4-auto='{
+      "event_name": "form_complete",
+      "type": "smart answer",
+      "section": "<%= outcome.title %>",
+      "action": "complete",
+      "tool_name": "<%= @presenter.title %>"
+    }'
+  >
     <%= render "govuk_publishing_components/components/title", {
       title: outcome.title,
       margin_bottom: 6

--- a/app/views/smart_answers/custom_result_full_width.erb
+++ b/app/views/smart_answers/custom_result_full_width.erb
@@ -9,23 +9,31 @@
   <meta name="robots" content="noindex">
 <% end %>
 
+<% title = "Information based on your answers" %>
 <div
   id="result-info"
   class="outcome"
-  data-module="auto-track-event"
+  data-module="auto-track-event ga4-auto-tracker"
   data-track-category="Smart Answer"
   data-track-action="Completed"
   data-track-label="<%= @name %>"
   data-track-options='{"nonInteraction": true}'
+  data-ga4-auto='{
+    "event_name": "form_complete",
+    "type": "smart answer",
+    "section": "<%= title %>",
+    "action": "complete",
+    "tool_name": "<%= @presenter.title %>"
+  }'
 >
   <%= render 'smart_answers/shared/debug' %>
   <%= render "govuk_publishing_components/components/title", {
-    title: "Information based on your answers",
+    title: title,
     context: @presenter.title + ":",
     context_inside: true,
   } %>
 
-  <div 
+  <div
     data-flow-name="<%= @name %>"
     data-module="gem-track-click"
     data-track-category="Internal Link Clicked"

--- a/app/views/smart_answers/question.html.erb
+++ b/app/views/smart_answers/question.html.erb
@@ -31,6 +31,17 @@
           <%= render "govuk_publishing_components/components/error_summary", {
             id: "error-summary",
             title: "There is a problem",
+            data_attributes: {
+              module: 'ga4-auto-tracker',
+              ga4_auto: {
+                event_name: 'form_error',
+                type: 'smart answer',
+                text: question.error,
+                section: question.title,
+                action: 'error',
+                tool_name: @presenter.title,
+              },
+            },
             items: [
               {
                 text: question.error,

--- a/app/views/smart_answers/result.html.erb
+++ b/app/views/smart_answers/result.html.erb
@@ -7,19 +7,26 @@
 <% end %>
 
 <div class="govuk-grid-row">
-
+  <% title = "Information based on your answers" %>
   <div
     id="result-info"
     class="govuk-grid-column-two-thirds outcome"
-    data-module="auto-track-event"
+    data-module="auto-track-event ga4-auto-tracker"
     data-track-category="Smart Answer"
     data-track-action="Completed"
     data-track-label="<%= @name %>"
     data-track-options='{"nonInteraction": true}'
+    data-ga4-auto='{
+      "event_name": "form_complete",
+      "type": "smart answer",
+      "section": "<%= title %>",
+      "action": "complete",
+      "tool_name": "<%= @presenter.title %>"
+    }'
   >
     <%= render 'smart_answers/shared/debug' %>
     <%= render "govuk_publishing_components/components/title", {
-      title: "Information based on your answers",
+      title: title,
       context: @presenter.title + ":",
       context_inside: true,
     } %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Adds GA4 tracking to the error pages and results pages of smart answers, using the GA4 auto tracker, which sends an event on page load.

Error pages are easy to test with this - go to the 'all smart answer questions' smart answer and click through without filling anything in until you see an error.

The custom result template is currently only used by the 'next steps for your business' smart answer. The custom result full width template doesn't appear to be used by anything right now, but can be tested locally by modifying `/Users/andysellick/workspace/govuk/smart-answers/app/flows/next_steps_for_your_business_flow.rb` to use it in the 'outcome' section.

Results page URL: `/next-steps-for-your-business/results?activities%5B%5D=none&annual_turnover_over_85k=no&business_premises%5B%5D=none&employ_someone=no&financial_support=no`

Depends upon https://github.com/alphagov/govuk_publishing_components/pull/3240 being released before it can work.

## Why
Part of the GA4 implementation.

## Visual changes
None.

Trello cards:

- https://trello.com/c/xf2dDOBN/407-add-tracking-smart-answers-formerror
- https://trello.com/c/dAu6HYuw/412-add-tracking-smart-answers-formcomplete
