### PR TITLE
Bump govuk_publishing_components to 34.9.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,7 +160,7 @@ GEM
     govuk_personalisation (0.13.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (34.7.1)
+    govuk_publishing_components (34.9.1)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/app/views/smart_answers/landing.html.erb
+++ b/app/views/smart_answers/landing.html.erb
@@ -42,6 +42,16 @@
           href: @presenter.start_page_link(response_store.forwarding_responses),
           rel: "nofollow",
           start: true,
+          data_attributes: {
+            module: 'ga4-link-tracker',
+            ga4_link: {
+              event_name: "form_start",
+              type: "smart answer",
+              section: "start page",
+              action: "start",
+              tool_name: start_node.title,
+            }
+          }
         } %>
       </section>
 

--- a/app/views/smart_answers/question.html.erb
+++ b/app/views/smart_answers/question.html.erb
@@ -7,11 +7,23 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render 'smart_answers/shared/debug' %>
+    <%
+      continue_button_text = "Continue"
+      ga4_attributes = {
+        event_name: "form_response",
+        type: "smart answer",
+        section: question.title,
+        action: continue_button_text,
+        tool_name: @presenter.title,
+      }
+    %>
+
     <%= form_tag(current_question_path(@presenter),
         :method => :get,
         :data => {
-          module: "track-responses",
+          module: "track-responses ga4-form-tracker",
           type: question.partial_template_name,
+          ga4_form: ga4_attributes,
           "question-key": question.node_slug,
         }) do %>
       <div class="govuk-!-margin-bottom-6 govuk-!-margin-top-8" id="current-question">
@@ -44,7 +56,7 @@
 
         <input type="hidden" name="next" value="1" />
         <%= render "govuk_publishing_components/components/button", {
-          text: "Continue",
+          text: continue_button_text,
           margin_bottom: true
         } %>
       </div>

--- a/app/views/smart_answers/shared/_previous_answers.html.erb
+++ b/app/views/smart_answers/shared/_previous_answers.html.erb
@@ -10,10 +10,17 @@
       restart_flow_path(@presenter),
       class: "govuk-link",
       data: {
-        module: "gem-track-click",
+        module: "gem-track-click ga4-link-tracker",
         "track-action": "Start again",
         "track-category": "StartAgain",
-        "track-label": @presenter.current_node.title
+        "track-label": @presenter.current_node.title,
+        ga4_link: {
+          event_name: "form_start_again",
+          type: "smart answer",
+          section: @presenter.current_node.title,
+          action: "start again",
+          tool_name: @presenter.title,
+        }
       } %>
   <% end %>
   <% items = @presenter.answered_questions.map do |question|

--- a/app/views/smart_answers/shared/_previous_answers.html.erb
+++ b/app/views/smart_answers/shared/_previous_answers.html.erb
@@ -40,10 +40,17 @@
       edit: {
         href: @presenter.change_answer_link(question, response_store.forwarding_responses),
         data_attributes: {
-          "module": "gem-track-click",
+          "module": "gem-track-click ga4-link-tracker",
           "track-category": "Smart Answer Change Link",
           "track-action":  "Link clicked",
-          "track-label": question.change_link_track_label(accepted_response)
+          "track-label": question.change_link_track_label(accepted_response),
+          ga4_link: {
+            event_name: "form_change_response",
+            type: "smart answer",
+            section: question.change_link_track_label(accepted_response),
+            action: "change response",
+            tool_name: @presenter.title,
+          }
         }
       }
     }


### PR DESCRIPTION
Updates GOV.UK Account to GOV.UK One Login following name change.


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
