### PR TITLE
Bump govuk_publishing_components to 34.9.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,7 +160,7 @@ GEM
     govuk_personalisation (0.13.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (34.7.1)
+    govuk_publishing_components (34.9.1)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown


### PR DESCRIPTION
Updates GOV.UK Account to GOV.UK One Login following name change.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
