### PR TITLE
Fix formatting of text on maternity/paternity leave flow

### DIFF
--- a/app/flows/maternity_paternity_calculator_flow/questions/earnings_for_pay_period.erb
+++ b/app/flows/maternity_paternity_calculator_flow/questions/earnings_for_pay_period.erb
@@ -8,6 +8,6 @@
 
 <%= render partial: 'earnings_question_error_message' %>
 
-<% content_for :post_body do %>
+<% govspeak_for :post_body do %>
   For leave starting after 25 April 2020: if your employee earned less than usual because they were 'on furlough' under the Coronavirus Job Retention Scheme, enter what they would have earned normally. 
 <% end %>

--- a/app/flows/maternity_paternity_calculator_flow/questions/earnings_for_pay_period_adoption.erb
+++ b/app/flows/maternity_paternity_calculator_flow/questions/earnings_for_pay_period_adoption.erb
@@ -8,6 +8,6 @@
 
 <%= render partial: 'earnings_question_error_message' %>
 
-<% content_for :post_body do %>
+<% govspeak_for :post_body do %>
   For leave starting after 25 April 2020: if your employee earned less than usual because they were 'on furlough' under the Coronavirus Job Retention Scheme, enter what they would have earned normally. 
 <% end %>

--- a/app/flows/maternity_paternity_calculator_flow/questions/earnings_for_pay_period_paternity.erb
+++ b/app/flows/maternity_paternity_calculator_flow/questions/earnings_for_pay_period_paternity.erb
@@ -8,6 +8,6 @@
 
 <%= render partial: 'earnings_question_error_message' %>
 
-<% content_for :post_body do %>
+<% govspeak_for :post_body do %>
   For leave starting after 25 April 2020: if your employee earned less than usual because they were 'on furlough' under the Coronavirus Job Retention Scheme, enter what they would have earned normally.
 <% end %>

--- a/app/flows/maternity_paternity_pay_leave_flow/questions/mother_earned_more_than_lower_earnings_limit.erb
+++ b/app/flows/maternity_paternity_pay_leave_flow/questions/mother_earned_more_than_lower_earnings_limit.erb
@@ -7,6 +7,6 @@
   "no": "No"
 ) %>
 
-<% content_for :post_body do %>
-  For leave starting after 25 April 2020: if they earned less than usual in any weeks because they were 'on furlough' under the Coronavirus Job Retention Scheme, you can use what they would have earned normally. 
+<% govspeak_for :post_body do %>
+  For leave starting after 25 April 2020: if they earned less than usual in any weeks because they were 'on furlough' under the Coronavirus Job Retention Scheme, you can use what they would have earned normally.
 <% end %>

--- a/app/flows/maternity_paternity_pay_leave_flow/questions/partner_earned_more_than_lower_earnings_limit.erb
+++ b/app/flows/maternity_paternity_pay_leave_flow/questions/partner_earned_more_than_lower_earnings_limit.erb
@@ -7,6 +7,6 @@
   "no": "No"
 ) %>
 
-<% content_for :post_body do %>
+<% govspeak_for :post_body do %>
   For leave starting after 25 April 2020: if they earned less than usual in any weeks because they were 'on furlough' under the Coronavirus Job Retention Scheme, you can use what they would have earned normally. 
 <% end %>


### PR DESCRIPTION
## What

The formatting on some question pages isn't right.

- [Check if you can get Maternity or Paternity Leave 1](https://www.gov.uk/maternity-paternity-pay-leave/y/yes/2023-01-01/employee/employee/no/no/yes/no/no/yes) and
- [Check if you can get Maternity or Paternity Leave 2](https://www.integration.publishing.service.gov.uk/maternity-paternity-pay-leave/y/yes/2023-01-01/employee/employee/no/no).

Content is added with post_body which, where used, appears below input questions. The [docs](https://github.com/alphagov/smart-answers/blob/main/docs/design/erb-templates/question-templates.md#post_body) says it can be Govspeak or HTML but in the examples above content_for is used e.g.

<% content_for :post_body do %>
  For leave starting after 25 April 2020: if they earned less than usual in any weeks because they were 'on furlough' under the Coronavirus Job Retention Scheme, you can use what they would have earned normally.
<% end %>

The text should be formatted similar to how it looks [here](https://www.integration.publishing.service.gov.uk/maternity-paternity-pay-leave/y/yes/2023-01-01/employee/employee/no/no/yes) which is handled as Govspeak.

## Why

The small text size could confuse users as to why it has been formatted differently. It should be consistent with other text on the page.

https://trello.com/c/pIbZZIZ8/1820-ps7-smart-answers-formatting-issue-on-some-question-pages

Also noticed the same method content_for being used in the maternity/paternity calculator flow and changed to govspeak_for which fixed the formatting issue there.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
