### PR TITLE
Update Austria marriage abroad outcomes

### DIFF
--- a/app/flows/marriage_abroad_flow/outcomes/countries/austria/ceremony_country/partner_british/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/austria/ceremony_country/partner_british/_opposite_sex.erb
@@ -37,21 +37,9 @@ If you or your partner have been divorced, widowed or previously in a civil part
 
 ###What happens next
 
-The embassy or notary public will charge a fee for taking the oath.
+The embassy will charge a fee for providing the marital status document.
 
-If you give notice at a notary public, you must post the signed forms and any supporting documents to your nearest British embassy or consulate afterwards.
-
-^The embassy or consulate may charge a fee to return your documents to you.^
-
-The consulate will display your notice of marriage or civil partnership publicly for 7 days.
-
-They’ll then issue your CNI (as long as nobody has registered an objection) and send it to the British embassy or consulate nearest to where you’re getting married or having a civil partnership ceremony in Austria.
-
-There’s an additional fee for this - the embassy or consulate will contact you to arrange payment.
-
-You should check if your CNI needs to be legalised (certified as genuine) by the local authorities in Austria.
-
-^You don't need to stay in the country while your notice is posted.^
+You can show the completed document to Austrian authorities to prove you are allowed to marry or enter a civil partnership.
 
 ## Fees
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/austria/ceremony_country/partner_british/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/austria/ceremony_country/partner_british/_opposite_sex.erb
@@ -8,31 +8,24 @@ Contact the relevant local authorities in Austria to find out about local civil 
 
 ##What you need to do
 
-You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry or enter into a civil partnership or equivalent in Austria.
+You’ll be asked to provide a marital status document (‘Eidesstattliche Versicherung des Familienstandes’) to prove you’re allowed to marry or enter into a civil partnership.
 
-To get a CNI, you must post notice of your intention to get married or enter into a civil partnership in Austria. You can do this at the British embassy or in front of a notary public.
+To get a marital status document, [make an appointment at the British embassy in Vienna](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=38&service=10).
 
-You’ll need to have been living in Austria for at least 3 full days before you can post notice. For example, if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
+At the appointment, you’ll need to bring original versions of your:
 
-[Make an appointment at the embassy in Vienna.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=38&service=10)
++ passport
++ full birth certificate - this will include the names of your parents
++ proof of residence
++ partner’s passport and proof of residence
 
-You’ll need to provide supporting documents, including:
+^If you or your partner are legally resident in Austria, the proof of residence must be an Austrian residence certificate (‘Meldebestätigung’). If you or your partner are resident somewhere else, ask the embassy what proof of residence you need to bring.
 
-- your passport
-- proof of residence, such as a residence certificate - check with the embassy or notary public to find out what you need
-- equivalent documents for your partner
+During the appointment, you’ll need to complete the marital status document and take an oath.
 
-To post notice for marriage you'll need to complete a ['Notice of marriage'](/government/publications/notice-of-marriage-form--2) and an ['Affidavit for marriage’](/government/publications/affirmationaffidavit-of-marital-status-form) form.
+%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage or civil partnership to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example, a marriage certificate or a deed poll).%
 
-To post notice for a civil partnership you'll need to complete both the ['declaration' and 'notice of registered partnership' forms](/government/publications/getting-married-in-austria-civil-partnership-forms).
-
-You can download and fill in (but not sign) the forms in advance.
-
-You must take the forms with you to your appointment.
-
-%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage or civil partnership to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
-
-^Your partner will need to follow the same process and pay the fees to get their own CNI.^
+^Your partner will need to follow the same process and pay the fees to get their own marital status certificate.^
 
 If you or your partner have been divorced, widowed or previously in a civil partnership, you’ll also need whichever of the following documents is appropriate:
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/austria/ceremony_country/partner_british/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/austria/ceremony_country/partner_british/_opposite_sex.erb
@@ -48,8 +48,6 @@ You can show the completed document to Austrian authorities to prove you are all
     as: :service,
     locals: { calculator: calculator } %>
 
-You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Austria](/government/publications/austria-consular-fees).
-
 <%= render partial: 'how_to_pay', locals: {calculator: calculator} %>
 
 *[CNI]:certificate of no impediment

--- a/app/flows/marriage_abroad_flow/outcomes/countries/austria/ceremony_country/partner_british/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/austria/ceremony_country/partner_british/_same_sex.erb
@@ -4,6 +4,8 @@ Same-sex relationships in Austria that are recognised as civil partnerships unde
 
 Contact the relevant local authorities in Austria to find out about local civil partnership and same-sex marriage laws, including what documents you’ll need.
 
+^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
+
 ##What you need to do
 
 You’ll be asked to provide a marital status document (‘Eidesstattliche Versicherung des Familienstandes’) to prove you’re allowed to marry or enter into a civil partnership.

--- a/app/flows/marriage_abroad_flow/outcomes/countries/austria/ceremony_country/partner_british/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/austria/ceremony_country/partner_british/_same_sex.erb
@@ -6,29 +6,24 @@ Contact the relevant local authorities in Austria to find out about local civil 
 
 ##What you need to do
 
-You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry or enter into a civil partnership or equivalent in Austria.
+You’ll be asked to provide a marital status document (‘Eidesstattliche Versicherung des Familienstandes’) to prove you’re allowed to marry or enter into a civil partnership.
 
-To get a CNI, you must post notice of your intended marriage or civil partnership ceremony in Austria. You can do this at the British embassy or in front of a notary public.
+To get a marital status document, [make an appointment at the British embassy in Vienna](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=38&service=10).
 
-You’ll need to have been living in Austria for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
+At the appointment, you’ll need to bring original versions of your:
 
-[Make an appointment at the embassy in Vienna](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=38&service=10).
++ passport
++ full birth certificate - this will include the names of your parents
++ proof of residence
++ partner’s passport and proof of residence
 
-You’ll need to provide supporting documents, including:
+^If you or your partner are legally resident in Austria, the proof of residence must be an Austrian residence certificate (‘Meldebestätigung’). If you or your partner are resident somewhere else, ask the embassy what proof of residence you need to bring.
 
-- your passport
-- proof of residence, such as a residence certificate - check with the embassy or notary public to find out what you need
-- equivalent documents for your partner
+During the appointment, you’ll need to complete the marital status document and take an oath.
 
-To post notice for marriage you’ll need to complete a [‘Notice of marriage’](/government/publications/notice-of-marriage-form--2) and an [‘Affidavit for marriage’](/government/publications/affirmationaffidavit-of-marital-status-form) form.
+%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage or civil partnership to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example, a marriage certificate or a deed poll).%
 
-To post notice for a civil partnership you’ll need to complete both the [‘declaration’ and ‘notice of registered partnership’ forms](/government/publications/getting-married-in-austria-civil-partnership-forms).
-
-You can download and fill in (but not sign) the forms in advance.
-
-You must take the forms with you to your appointment.
-
-%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
+^Your partner will need to follow the same process and pay the fees to get their own marital status certificate.^
 
 If you or your partner have been divorced, widowed or previously in a civil partnership, you’ll also need whichever of the following documents is appropriate:
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/austria/ceremony_country/partner_british/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/austria/ceremony_country/partner_british/_same_sex.erb
@@ -35,17 +35,9 @@ If you or your partner have been divorced, widowed or previously in a civil part
 
 ###What happens next
 
-The embassy or notary public will charge a fee for taking the oath.
+The embassy will charge a fee for providing the marital status document.
 
-If you give notice at a notary public, you must post the signed forms and any supporting documents to your nearest British embassy or consulate afterwards.
-
-^The embassy or consulate may charge a fee to return your documents to you.^
-
-The consulate will display your notice of marriage publicly for 7 days.
-
-They’ll then issue your CNI (as long as nobody has registered an objection). There is an additional fee for this.
-
-^You do not need to stay in the country while your notice is posted.^
+You can show the completed document to Austrian authorities to prove you are allowed to marry or enter a civil partnership.
 
 ## Fees
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/austria/ceremony_country/partner_british/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/austria/ceremony_country/partner_british/_same_sex.erb
@@ -48,8 +48,6 @@ You can show the completed document to Austrian authorities to prove you are all
     as: :service,
     locals: { calculator: calculator } %>
 
-You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Austria](/government/publications/austria-consular-fees).
-
 <%= render partial: 'how_to_pay', locals: { calculator: calculator } %>
 
 *[CNI]: certificate of no impediment

--- a/app/flows/marriage_abroad_flow/outcomes/countries/austria/ceremony_country/partner_local/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/austria/ceremony_country/partner_local/_opposite_sex.erb
@@ -52,8 +52,6 @@ Your partner can apply to become a British citizen once they’ve lived in the U
     as: :service,
     locals: { calculator: calculator } %>
 
-You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Austria](/government/publications/austria-consular-fees).
-
 <%= render partial: 'how_to_pay', locals: {calculator: calculator} %>
 
 *[CNI]:certificate of no impediment

--- a/app/flows/marriage_abroad_flow/outcomes/countries/austria/ceremony_country/partner_local/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/austria/ceremony_country/partner_local/_opposite_sex.erb
@@ -8,29 +8,22 @@ Contact the relevant local authorities in Austria to find out about local civil 
 
 ##What you need to do
 
-You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry or enter into a civil partnership or equivalent in Austria.
+You’ll be asked to provide a marital status document (‘Eidesstattliche Versicherung des Familienstandes’) to prove you’re allowed to marry or enter into a civil partnership.
 
-To get a CNI, you must post notice of your intention to get married or enter into a civil partnership in Austria. You can do this at the British embassy or in front of a notary public.
+To get a marital status document, [make an appointment at the British embassy in Vienna](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=38&service=10).
 
-You’ll need to have been living in Austria for at least 3 full days before you can post notice. For example, if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
+At the appointment, you’ll need to bring original versions of your:
 
-[Make an appointment at the embassy in Vienna.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=38&service=10)
++ passport
++ full birth certificate - this will include the names of your parents
++ proof of residence
++ partner’s passport and proof of residence
 
-You’ll need to provide supporting documents, including:
+^If you or your partner are legally resident in Austria, the proof of residence must be an Austrian residence certificate (‘Meldebestätigung’). If you or your partner are resident somewhere else, ask the embassy what proof of residence you need to bring.
 
-- your passport
-- proof of residence, such as a residence certificate - check with the embassy or notary public to find out what you need
-- equivalent documents for your partner
+During the appointment, you’ll need to complete the marital status document and take an oath.
 
-To post notice for marriage you'll need to complete a ['Notice of marriage'](/government/publications/notice-of-marriage-form--2) and an ['Affidavit for marriage’](/government/publications/affirmationaffidavit-of-marital-status-form) form.
-
-To post notice for a civil partnership you'll need to complete both the ['declaration' and 'notice of registered partnership' forms](/government/publications/getting-married-in-austria-civil-partnership-forms).
-
-You can download and fill in (but not sign) the forms in advance.
-
-You must take the forms with you to your appointment.
-
-%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage or civil partnership to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
+%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage or civil partnership to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example, a marriage certificate or a deed poll).%
 
 If you or your partner have been divorced, widowed or previously in a civil partnership, you’ll also need whichever of the following documents is appropriate:
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/austria/ceremony_country/partner_local/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/austria/ceremony_country/partner_local/_opposite_sex.erb
@@ -35,21 +35,9 @@ If you or your partner have been divorced, widowed or previously in a civil part
 
 ###What happens next
 
-The embassy or notary public will charge a fee for taking the oath.
+The embassy will charge a fee for providing the marital status document.
 
-If you give notice at a notary public, you must post the signed forms and any supporting documents to your nearest British embassy or consulate afterwards.
-
-^The embassy or consulate may charge a fee to return your documents to you.^
-
-The consulate will display your notice of marriage or civil partnership publicly for 7 days.
-
-They’ll then issue your CNI (as long as nobody has registered an objection) and send it to the British embassy or consulate nearest to where you’re getting married or having a civil partnership ceremony in Austria.
-
-There’s an additional fee for this - the embassy or consulate will contact you to arrange payment.
-
-You should check if your CNI needs to be legalised (certified as genuine) by the local authorities in Austria.
-
-^You don't need to stay in the country while your notice is posted.^
+You can show the completed document to Austrian authorities to prove you are allowed to marry or enter a civil partnership.
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/austria/ceremony_country/partner_local/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/austria/ceremony_country/partner_local/_same_sex.erb
@@ -6,29 +6,22 @@ Contact the relevant local authorities in Austria to find out about local civil 
 
 ##What you need to do
 
-You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry or enter into a civil partnership or equivalent in Austria.
+You’ll be asked to provide a marital status document (‘Eidesstattliche Versicherung des Familienstandes’) to prove you’re allowed to marry or enter into a civil partnership.
 
-To get a CNI, you must post notice of your intended marriage or civil partnership ceremony in Austria. You can do this at the British embassy or in front of a notary public.
+To get a marital status document, [make an appointment at the British embassy in Vienna](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=38&service=10).
 
-You’ll need to have been living in Austria for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
+At the appointment, you’ll need to bring original versions of your:
 
-[Make an appointment at the embassy in Vienna](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=38&service=10).
++ passport
++ full birth certificate - this will include the names of your parents
++ proof of residence
++ partner’s passport and proof of residence
 
-You’ll need to provide supporting documents, including:
+^If you or your partner are legally resident in Austria, the proof of residence must be an Austrian residence certificate (‘Meldebestätigung’). If you or your partner are resident somewhere else, ask the embassy what proof of residence you need to bring.
 
-- your passport
-- proof of residence, such as a residence certificate - check with the embassy or notary public to find out what you need
-- equivalent documents for your partner
+During the appointment, you’ll need to complete the marital status document and take an oath.
 
-To post notice for marriage you’ll need to complete a [‘Notice of marriage’](/government/publications/notice-of-marriage-form--2) and an [‘Affidavit for marriage’](/government/publications/affirmationaffidavit-of-marital-status-form) form.
-
-To post notice for a civil partnership you’ll need to complete both the [‘declaration’ and ‘notice of registered partnership’ forms](/government/publications/getting-married-in-austria-civil-partnership-forms).
-
-You can download and fill in (but not sign) the forms in advance.
-
-You must take the forms with you to your appointment.
-
-%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
+%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage or civil partnership to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example, a marriage certificate or a deed poll).%
 
 If you or your partner have been divorced, widowed or previously in a civil partnership, you’ll also need whichever of the following documents is appropriate:
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/austria/ceremony_country/partner_local/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/austria/ceremony_country/partner_local/_same_sex.erb
@@ -4,6 +4,8 @@ Same-sex relationships in Austria that are recognised as civil partnerships unde
 
 Contact the relevant local authorities in Austria to find out about local civil partnership and same-sex marriage laws, including what documents you’ll need.
 
+^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
+
 ##What you need to do
 
 You’ll be asked to provide a marital status document (‘Eidesstattliche Versicherung des Familienstandes’) to prove you’re allowed to marry or enter into a civil partnership.

--- a/app/flows/marriage_abroad_flow/outcomes/countries/austria/ceremony_country/partner_local/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/austria/ceremony_country/partner_local/_same_sex.erb
@@ -33,17 +33,9 @@ If you or your partner have been divorced, widowed or previously in a civil part
 
 ###What happens next
 
-The embassy or notary public will charge a fee for taking the oath.
+The embassy will charge a fee for providing the marital status document.
 
-If you give notice at a notary public, you must post the signed forms and any supporting documents to your nearest British embassy or consulate afterwards.
-
-^The embassy or consulate may charge a fee to return your documents to you.^
-
-The consulate will display your notice of marriage publicly for 7 days.
-
-They’ll then issue your CNI (as long as nobody has registered an objection). There is an additional fee for this.
-
-^You do not need to stay in the country while your notice is posted.^
+You can show the completed document to Austrian authorities to prove you are allowed to marry or enter a civil partnership.
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/austria/ceremony_country/partner_local/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/austria/ceremony_country/partner_local/_same_sex.erb
@@ -50,8 +50,6 @@ Your partner can apply to [become a British citizen](/becoming-a-british-citizen
     as: :service,
     locals: { calculator: calculator } %>
 
-You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Austria](/government/publications/austria-consular-fees).
-
 <%= render partial: 'how_to_pay', locals: { calculator: calculator } %>
 
 *[CNI]: certificate of no impediment

--- a/app/flows/marriage_abroad_flow/outcomes/countries/austria/ceremony_country/partner_other/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/austria/ceremony_country/partner_other/_opposite_sex.erb
@@ -52,8 +52,6 @@ Your partner can apply to become a British citizen once they’ve lived in the U
     as: :service,
     locals: { calculator: calculator } %>
 
-You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Austria](/government/publications/austria-consular-fees).
-
 <%= render partial: 'how_to_pay', locals: {calculator: calculator} %>
 
 *[CNI]:certificate of no impediment

--- a/app/flows/marriage_abroad_flow/outcomes/countries/austria/ceremony_country/partner_other/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/austria/ceremony_country/partner_other/_opposite_sex.erb
@@ -8,29 +8,22 @@ Contact the relevant local authorities in Austria to find out about local civil 
 
 ##What you need to do
 
-You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry or enter into a civil partnership or equivalent in Austria.
+You’ll be asked to provide a marital status document (‘Eidesstattliche Versicherung des Familienstandes’) to prove you’re allowed to marry or enter into a civil partnership.
 
-To get a CNI, you must post notice of your intention to get married or enter into a civil partnership in Austria. You can do this at the British embassy or in front of a notary public.
+To get a marital status document, [make an appointment at the British embassy in Vienna](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=38&service=10).
 
-You’ll need to have been living in Austria for at least 3 full days before you can post notice. For example, if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
+At the appointment, you’ll need to bring original versions of your:
 
-[Make an appointment at the embassy in Vienna.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=38&service=10)
++ passport
++ full birth certificate - this will include the names of your parents
++ proof of residence
++ partner’s passport and proof of residence
 
-You’ll need to provide supporting documents, including:
+^If you or your partner are legally resident in Austria, the proof of residence must be an Austrian residence certificate (‘Meldebestätigung’). If you or your partner are resident somewhere else, ask the embassy what proof of residence you need to bring.
 
-- your passport
-- proof of residence, such as a residence certificate - check with the embassy or notary public to find out what you need
-- equivalent documents for your partner
+During the appointment, you’ll need to complete the marital status document and take an oath.
 
-To post notice for marriage you'll need to complete a ['Notice of marriage'](/government/publications/notice-of-marriage-form--2) and an ['Affidavit for marriage’](/government/publications/affirmationaffidavit-of-marital-status-form) form.
-
-To post notice for a civil partnership you'll need to complete both the ['declaration' and 'notice of registered partnership' forms](/government/publications/getting-married-in-austria-civil-partnership-forms).
-
-You can download and fill in (but not sign) the forms in advance.
-
-You must take the forms with you to your appointment.
-
-%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage or civil partnership to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
+%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage or civil partnership to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example, a marriage certificate or a deed poll).%
 
 If you or your partner have been divorced, widowed or previously in a civil partnership, you’ll also need whichever of the following documents is appropriate:
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/austria/ceremony_country/partner_other/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/austria/ceremony_country/partner_other/_opposite_sex.erb
@@ -35,21 +35,9 @@ If you or your partner have been divorced, widowed or previously in a civil part
 
 ###What happens next
 
-The embassy or notary public will charge a fee for taking the oath.
+The embassy will charge a fee for providing the marital status document.
 
-If you give notice at a notary public, you must post the signed forms and any supporting documents to your nearest British embassy or consulate afterwards.
-
-^The embassy or consulate may charge a fee to return your documents to you.^
-
-The consulate will display your notice of marriage or civil partnership publicly for 7 days.
-
-They’ll then issue your CNI (as long as nobody has registered an objection) and send it to the British embassy or consulate nearest to where you’re getting married or having a civil partnership ceremony in Austria.
-
-There’s an additional fee for this - the embassy or consulate will contact you to arrange payment.
-
-You should check if your CNI needs to be legalised (certified as genuine) by the local authorities in Austria.
-
-^You don't need to stay in the country while your notice is posted.^
+You can show the completed document to Austrian authorities to prove you are allowed to marry or enter a civil partnership.
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/austria/ceremony_country/partner_other/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/austria/ceremony_country/partner_other/_same_sex.erb
@@ -6,29 +6,22 @@ Contact the relevant local authorities in Austria to find out about local civil 
 
 ##What you need to do
 
-You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry or enter into a civil partnership or equivalent in Austria.
+You’ll be asked to provide a marital status document (‘Eidesstattliche Versicherung des Familienstandes’) to prove you’re allowed to marry or enter into a civil partnership.
 
-To get a CNI, you must post notice of your intended marriage or civil partnership ceremony in Austria. You can do this at the British embassy or in front of a notary public.
+To get a marital status document, [make an appointment at the British embassy in Vienna](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=38&service=10).
 
-You’ll need to have been living in Austria for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
+At the appointment, you’ll need to bring original versions of your:
 
-[Make an appointment at the embassy in Vienna](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=38&service=10).
++ passport
++ full birth certificate - this will include the names of your parents
++ proof of residence
++ partner’s passport and proof of residence
 
-You’ll need to provide supporting documents, including:
+^If you or your partner are legally resident in Austria, the proof of residence must be an Austrian residence certificate (‘Meldebestätigung’). If you or your partner are resident somewhere else, ask the embassy what proof of residence you need to bring.
 
-- your passport
-- proof of residence, such as a residence certificate - check with the embassy or notary public to find out what you need
-- equivalent documents for your partner
+During the appointment, you’ll need to complete the marital status document and take an oath.
 
-To post notice for marriage you’ll need to complete a [‘Notice of marriage’](/government/publications/notice-of-marriage-form--2) and an [‘Affidavit for marriage’](/government/publications/affirmationaffidavit-of-marital-status-form) form.
-
-To post notice for a civil partnership you’ll need to complete both the [‘declaration’ and ‘notice of registered partnership’ forms](/government/publications/getting-married-in-austria-civil-partnership-forms).
-
-You can download and fill in (but not sign) the forms in advance.
-
-You must take the forms with you to your appointment.
-
-%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
+%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage or civil partnership to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example, a marriage certificate or a deed poll).%
 
 If you or your partner have been divorced, widowed or previously in a civil partnership, you’ll also need whichever of the following documents is appropriate:
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/austria/ceremony_country/partner_other/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/austria/ceremony_country/partner_other/_same_sex.erb
@@ -4,6 +4,8 @@ Same-sex relationships in Austria that are recognised as civil partnerships unde
 
 Contact the relevant local authorities in Austria to find out about local civil partnership and same-sex marriage laws, including what documents you’ll need.
 
+^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
+
 ##What you need to do
 
 You’ll be asked to provide a marital status document (‘Eidesstattliche Versicherung des Familienstandes’) to prove you’re allowed to marry or enter into a civil partnership.

--- a/app/flows/marriage_abroad_flow/outcomes/countries/austria/ceremony_country/partner_other/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/austria/ceremony_country/partner_other/_same_sex.erb
@@ -33,17 +33,9 @@ If you or your partner have been divorced, widowed or previously in a civil part
 
 ###What happens next
 
-The embassy or notary public will charge a fee for taking the oath.
+The embassy will charge a fee for providing the marital status document.
 
-If you give notice at a notary public, you must post the signed forms and any supporting documents to your nearest British embassy or consulate afterwards.
-
-^The embassy or consulate may charge a fee to return your documents to you.^
-
-The consulate will display your notice of marriage publicly for 7 days.
-
-They’ll then issue your CNI (as long as nobody has registered an objection). There is an additional fee for this.
-
-^You do not need to stay in the country while your notice is posted.^
+You can show the completed document to Austrian authorities to prove you are allowed to marry or enter a civil partnership.
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/austria/ceremony_country/partner_other/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/austria/ceremony_country/partner_other/_same_sex.erb
@@ -50,8 +50,6 @@ Your partner can apply to [become a British citizen](/becoming-a-british-citizen
     as: :service,
     locals: { calculator: calculator } %>
 
-You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Austria](/government/publications/austria-consular-fees).
-
 <%= render partial: 'how_to_pay', locals: { calculator: calculator } %>
 
 *[CNI]: certificate of no impediment

--- a/app/flows/marriage_abroad_flow/outcomes/countries/austria/third_country/partner_british/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/austria/third_country/partner_british/_opposite_sex.erb
@@ -1,4 +1,4 @@
-You can get married or enter into a civil partnership in Austria. 
+You can get married or enter into a civil partnership in Austria.
 
 Opposite-sex relationships in Austria that are recognised as civil partnerships under British law are known as ‘eingetragene Partnerschaft’, or ‘registered partnership’.
 
@@ -8,18 +8,13 @@ Contact the relevant local authorities in Austria to find out about local civil 
 
 ##What you need to do
 
-You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry or enter into a civil partnership.
+You need to get a document to prove you’re allowed to marry or enter into a civil partnership.
 
-There are 2 ways you can get a CNI for marriage in Austria:
+You can either:
 
-+ [go to the UK and post notice with a UK registrar](/marriage-abroad/y/austria/uk/partner_british/opposite_sex)
-+ [go to Austria and post notice at the embassy or consulate there](/marriage-abroad/y/austria/ceremony_country/partner_british/opposite_sex)  
++ [go to the UK and get a certificate of no impediment (CNI)](/marriage-abroad/y/austria/uk/partner_british/opposite_sex)
++ [go to Austria and get a marital status document (‘Eidesstattliche Versicherung des Familienstandes’)](/marriage-abroad/y/austria/ceremony_country/partner_british/opposite_sex)
 
-To get a CNI for a civil partnership you must:
-
-+ [go to Austria and post notice at the embassy or consulate there](/marriage-abroad/y/austria/ceremony_country/partner_british/opposite_sex)
-
-%If you choose to post notice, you’ll normally have to wait at least 13 days for your CNI. It can take longer depending on the local authorities’ processes and the time of year.%
 
 *[CNI]:Certificate of no impediment
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/austria/third_country/partner_british/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/austria/third_country/partner_british/_same_sex.erb
@@ -8,16 +8,14 @@ Contact the [Embassy of Austria](/government/publications/foreign-embassies-in-t
 
 ##What you need to do
 
-You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry.
+You need to get a document to prove you’re allowed to marry or enter into a civil partnership.
 
-There are 2 ways you can get a CNI:
+You can either:
 
-- [go to the UK and post notice with a UK registrar](/marriage-abroad/y/austria/uk/partner_local/same_sex)
-- [go to Austria and post notice at the embassy or consulate there](/marriage-abroad/y/austria/ceremony_country/partner_local/same_sex)
++ [go to the UK and get a certificate of no impediment (CNI)](/marriage-abroad/y/austria/uk/partner_british/same_sex)
++ [go to Austria and get a marital status document (’Eidesstattliche Versicherung des Familienstandes’)](/marriage-abroad/y/austria/ceremony_country/partner_british/same_sex)
 
-%If you choose to post notice, you’ll normally have to wait at least 13 days for your CNI. It can take longer depending on the local authorities’ processes and the time of year.%
 
-*[CNI]:Certificate of no impediment
 
 
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/austria/third_country/partner_local/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/austria/third_country/partner_local/_opposite_sex.erb
@@ -1,4 +1,4 @@
-You can get married or enter into a civil partnership in Austria. 
+You can get married or enter into a civil partnership in Austria.
 
 Opposite-sex relationships in Austria that are recognised as civil partnerships under British law are known as ‘eingetragene Partnerschaft’, or ‘registered partnership’.
 
@@ -8,24 +8,18 @@ Contact the relevant local authorities in Austria to find out about local civil 
 
 ##What you need to do
 
-You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry or enter into a civil partnership.
+You need to get a document to prove you’re allowed to marry or enter into a civil partnership.
 
-There are 2 ways you can get a CNI for marriage in Austria:
+You can either:
 
-+ [go to the UK and post notice with a UK registrar](/marriage-abroad/y/austria/uk/partner_british/opposite_sex)
-+ [go to Austria and post notice at the embassy or consulate there](/marriage-abroad/y/austria/ceremony_country/partner_british/opposite_sex)  
-
-To get a CNI for a civil partnership you must:
-
-+ [go to Austria and post notice at the embassy or consulate there](/marriage-abroad/y/austria/ceremony_country/partner_british/opposite_sex)
-
-%If you choose to post notice, you’ll normally have to wait at least 13 days for your CNI. It can take longer depending on the local authorities’ processes and the time of year.%
++ [go to the UK and get a certificate of no impediment (CNI)](/marriage-abroad/y/austria/uk/partner_british/opposite_sex)
++ [go to Austria and get a marital status document (‘Eidesstattliche Versicherung des Familienstandes’)](/marriage-abroad/y/austria/ceremony_country/partner_british/opposite_sex)
 
 ##Naturalisation of your partner if they move to the UK
 
 Your partner can apply to become a British citizen once they’ve lived in the UK for 3 years after getting married.
 
-[Check if you can become a British citizen](/british-citizenship). 
+[Check if you can become a British citizen](/british-citizenship).
 
 *[CNI]:Certificate of no impediment
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/austria/third_country/partner_local/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/austria/third_country/partner_local/_same_sex.erb
@@ -8,20 +8,13 @@ Contact the [Embassy of Austria](/government/publications/foreign-embassies-in-t
 
 ##What you need to do
 
-You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry.
+You need to get a document to prove you’re allowed to marry or enter into a civil partnership.
 
-There are 2 ways you can get a CNI:
+You can either:
 
-- [go to the UK and post notice with a UK registrar](/marriage-abroad/y/austria/uk/partner_local/same_sex)
-- [go to Austria and post notice at the embassy or consulate there](/marriage-abroad/y/austria/ceremony_country/partner_local/same_sex)
-
-%If you choose to post notice, you’ll normally have to wait at least 13 days for your CNI. It can take longer depending on the local authorities’ processes and the time of year.%
++ [go to the UK and get a certificate of no impediment (CNI)](/marriage-abroad/y/austria/uk/partner_local/same_sex)
++ [go to Austria and get a marital status document (‘Eidesstattliche Versicherung des Familienstandes’)](/marriage-abroad/y/austria/ceremony_country/partner_local/same_sex)
 
 ##Naturalisation of your partner if they move to the UK
 
 Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.
-
-*[CNI]:Certificate of no impediment
-
-
-

--- a/app/flows/marriage_abroad_flow/outcomes/countries/austria/third_country/partner_other/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/austria/third_country/partner_other/_opposite_sex.erb
@@ -1,4 +1,4 @@
-You can get married or enter into a civil partnership in Austria. 
+You can get married or enter into a civil partnership in Austria.
 
 Opposite-sex relationships in Austria that are recognised as civil partnerships under British law are known as ‘eingetragene Partnerschaft’, or ‘registered partnership’.
 
@@ -8,24 +8,18 @@ Contact the relevant local authorities in Austria to find out about local civil 
 
 ##What you need to do
 
-You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry or enter into a civil partnership.
+You need to get a document to prove you’re allowed to marry or enter into a civil partnership.
 
-There are 2 ways you can get a CNI for marriage in Austria:
+You can either:
 
-+ [go to the UK and post notice with a UK registrar](/marriage-abroad/y/austria/uk/partner_british/opposite_sex)
-+ [go to Austria and post notice at the embassy or consulate there](/marriage-abroad/y/austria/ceremony_country/partner_british/opposite_sex)  
-
-To get a CNI for a civil partnership you must:
-
-+ [go to Austria and post notice at the embassy or consulate there](/marriage-abroad/y/austria/ceremony_country/partner_british/opposite_sex)
-
-%If you choose to post notice, you’ll normally have to wait at least 13 days for your CNI. It can take longer depending on the local authorities’ processes and the time of year.%
++ [go to the UK and get a certificate of no impediment (CNI)](/marriage-abroad/y/austria/uk/partner_other/opposite_sex)
++ [go to Austria and get a marital status document (‘Eidesstattliche Versicherung des Familienstandes’)](/marriage-abroad/y/austria/ceremony_country/partner_other/opposite_sex)
 
 ##Naturalisation of your partner if they move to the UK
 
 Your partner can apply to become a British citizen once they’ve lived in the UK for 3 years after getting married.
 
-[Check if you can become a British citizen](/british-citizenship). 
+[Check if you can become a British citizen](/british-citizenship).
 
 *[CNI]:Certificate of no impediment
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/austria/third_country/partner_other/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/austria/third_country/partner_other/_same_sex.erb
@@ -8,14 +8,12 @@ Contact the [Embassy of Austria](/government/publications/foreign-embassies-in-t
 
 ##What you need to do
 
-You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry.
+You need to get a document to prove you’re allowed to marry or enter into a civil partnership.
 
-There are 2 ways you can get a CNI:
+You can either:
 
-- [go to the UK and post notice with a UK registrar](/marriage-abroad/y/austria/uk/partner_local/same_sex)
-- [go to Austria and post notice at the embassy or consulate there](/marriage-abroad/y/austria/ceremony_country/partner_local/same_sex)
-
-%If you choose to post notice, you’ll normally have to wait at least 13 days for your CNI. It can take longer depending on the local authorities’ processes and the time of year.%
++ [go to the UK and get a certificate of no impediment (CNI)](/marriage-abroad/y/austria/uk/partner_other/same_sex)
++ [go to Austria and get a marital status document (‘Eidesstattliche Versicherung des Familienstandes’)](/marriage-abroad/y/austria/ceremony_country/partner_other/same_sex)
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/austria/uk/partner_british/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/austria/uk/partner_british/_opposite_sex.erb
@@ -22,14 +22,6 @@ Ask the local authorities in Austria if you need to get your CNI translated. You
 
 %The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example, a marriage certificate or a deed poll).%
 
-##Getting a civil partnership
-
-###What you need to do
-
-To get a CNI for a civil partnership you must [go to Austria and post notice at the embassy or consulate there](/marriage-abroad/y/austria/ceremony_country/partner_british/opposite_sex).
-
-%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
-
 *[CNI]:certificate of no impediment
 
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/austria/uk/partner_british/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/austria/uk/partner_british/_opposite_sex.erb
@@ -1,8 +1,8 @@
-You can get married or enter into a civil partnership in Austria. 
+You can get married or enter into a civil partnership in Austria.
 
 Opposite-sex relationships in Austria that are recognised as civil partnerships under British law are known as ‘eingetragene Partnerschaft’, or ‘registered partnership’.
 
-Contact the [Embassy of Austria](/government/publications/foreign-embassies-in-the-uk) before making plans to find out about local marriage and civil partnership laws, including what documents you’ll need. 
+Contact the [Embassy of Austria](/government/publications/foreign-embassies-in-the-uk) before making plans to find out about local marriage and civil partnership laws, including what documents you’ll need.
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Austria](/foreign-travel-advice/austria) before making any plans.
 
@@ -18,14 +18,11 @@ You can normally get a CNI by giving a notice of marriage at your local register
 
 ###Legalisation and translation
 
-You might need to exchange your UK-issued CNI for one that’s valid in Austria at the nearest embassy or consulate to where you’re getting married.
+You need to get your CNI [‘legalised’ (certified as genuine)](/get-document-legalised).
 
-You should also check if it needs to be:
+Ask the local authorities in Austria if you need to get your CNI translated. You can [find a translator abroad](https://find-a-professional-service-abroad.service.csd.fcdo.gov.uk/find?serviceType=translators-interpreters), or in the UK through the [Institute of Linguists](https://www.ciol.org.uk/).
 
-- ‘[legalised](/get-document-legalised)’ (certified as genuine)
-- translated - [find a translator abroad](/government/collections/list-of-lawyers), or in the UK through the [Institute of Linguists](http://www.ciol.org.uk)
-
-You should also check with the local authorities in Austria to find out if you need to provide legalised and translated copies of any other documents.
+%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example, a marriage certificate or a deed poll).%
 
 ##Getting a civil partnership
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/austria/uk/partner_british/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/austria/uk/partner_british/_opposite_sex.erb
@@ -6,9 +6,7 @@ Contact the [Embassy of Austria](/government/publications/foreign-embassies-in-t
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Austria](/foreign-travel-advice/austria) before making any plans.
 
-##Getting married
-
-###What you need to do
+##What you need to do
 
 You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry.
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/austria/uk/partner_british/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/austria/uk/partner_british/_same_sex.erb
@@ -16,16 +16,11 @@ You can normally get a CNI by giving a notice of marriage at your local register
 
 ###Legalisation and translation
 
-You might need to exchange your UK-issued CNI for one that’s valid in Austria at the nearest embassy or consulate to where you’re getting married.
+You need to get your CNI [‘legalised’ (certified as genuine)](/get-document-legalised).
 
-You should also check if it needs to be:
+Ask the local authorities in Austria if you need to get your CNI translated. You can [find a translator abroad](https://find-a-professional-service-abroad.service.csd.fcdo.gov.uk/find?serviceType=translators-interpreters), or in the UK through the [Institute of Linguists](https://www.ciol.org.uk/).
 
-- [‘legalised’](/get-document-legalised) (certified as genuine)
-- translated - [find a translator abroad](/government/collections/list-of-lawyers), or in the UK through the [Institute of Linguists](https://www.ciol.org.uk/)     
-
-You should also check with the local authorities in Austria to find out if you need to provide legalised and translated copies of any other documents.
-
-%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
+%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example, a marriage certificate or a deed poll).%
 
 *[CNI]: certificate of no impediment
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/austria/uk/partner_local/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/austria/uk/partner_local/_opposite_sex.erb
@@ -22,14 +22,6 @@ Ask the local authorities in Austria if you need to get your CNI translated. You
 
 %The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example, a marriage certificate or a deed poll).%
 
-##Getting a civil partnership
-
-###What you need to do
-
-To get a CNI for a civil partnership you must [go to Austria and post notice at the embassy or consulate there](/marriage-abroad/y/austria/ceremony_country/partner_british/opposite_sex).
-
-%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
-
 ##Naturalisation of your partner if they move to the UK
 
 Your partner can apply to become a British citizen once they’ve lived in the UK for 3 years after getting married.

--- a/app/flows/marriage_abroad_flow/outcomes/countries/austria/uk/partner_local/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/austria/uk/partner_local/_opposite_sex.erb
@@ -1,8 +1,8 @@
-You can get married or enter into a civil partnership in Austria. 
+You can get married or enter into a civil partnership in Austria.
 
 Opposite-sex relationships in Austria that are recognised as civil partnerships under British law are known as ‘eingetragene Partnerschaft’, or ‘registered partnership’.
 
-Contact the [Embassy of Austria](/government/publications/foreign-embassies-in-the-uk) before making plans to find out about local marriage and civil partnership laws, including what documents you’ll need. 
+Contact the [Embassy of Austria](/government/publications/foreign-embassies-in-the-uk) before making plans to find out about local marriage and civil partnership laws, including what documents you’ll need.
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Austria](/foreign-travel-advice/austria) before making any plans.
 
@@ -18,14 +18,11 @@ You can normally get a CNI by giving a notice of marriage at your local register
 
 ###Legalisation and translation
 
-You might need to exchange your UK-issued CNI for one that’s valid in Austria at the nearest embassy or consulate to where you’re getting married.
+You need to get your CNI [‘legalised’ (certified as genuine)](/get-document-legalised).
 
-You should also check if it needs to be:
+Ask the local authorities in Austria if you need to get your CNI translated. You can [find a translator abroad](https://find-a-professional-service-abroad.service.csd.fcdo.gov.uk/find?serviceType=translators-interpreters), or in the UK through the [Institute of Linguists](https://www.ciol.org.uk/).
 
-- ‘[legalised](/get-document-legalised)’ (certified as genuine)
-- translated - [find a translator abroad](/government/collections/list-of-lawyers), or in the UK through the [Institute of Linguists](http://www.ciol.org.uk)
-
-You should also check with the local authorities in Austria to find out if you need to provide legalised and translated copies of any other documents.
+%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example, a marriage certificate or a deed poll).%
 
 ##Getting a civil partnership
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/austria/uk/partner_local/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/austria/uk/partner_local/_opposite_sex.erb
@@ -6,9 +6,7 @@ Contact the [Embassy of Austria](/government/publications/foreign-embassies-in-t
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Austria](/foreign-travel-advice/austria) before making any plans.
 
-##Getting married
-
-###What you need to do
+##What you need to do
 
 You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry.
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/austria/uk/partner_local/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/austria/uk/partner_local/_same_sex.erb
@@ -16,16 +16,11 @@ You can normally get a CNI by giving a notice of marriage at your local register
 
 ###Legalisation and translation
 
-You might need to exchange your UK-issued CNI for one that’s valid in Austria at the nearest embassy or consulate to where you’re getting married.
+You need to get your CNI [‘legalised’ (certified as genuine)](/get-document-legalised).
 
-You should also check if it needs to be:
+Ask the local authorities in Austria if you need to get your CNI translated. You can [find a translator abroad](https://find-a-professional-service-abroad.service.csd.fcdo.gov.uk/find?serviceType=translators-interpreters), or in the UK through the [Institute of Linguists](https://www.ciol.org.uk/).
 
-- [‘legalised’](/get-document-legalised) (certified as genuine)
-- translated - [find a translator abroad](/government/collections/list-of-lawyers), or in the UK through the [Institute of Linguists](https://www.ciol.org.uk/)     
-
-You should also check with the local authorities in Austria to find out if you need to provide legalised and translated copies of any other documents.
-
-%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
+%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example, a marriage certificate or a deed poll).%
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/austria/uk/partner_other/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/austria/uk/partner_other/_opposite_sex.erb
@@ -1,8 +1,8 @@
-You can get married or enter into a civil partnership in Austria. 
+You can get married or enter into a civil partnership in Austria.
 
 Opposite-sex relationships in Austria that are recognised as civil partnerships under British law are known as ‘eingetragene Partnerschaft’, or ‘registered partnership’.
 
-Contact the [Embassy of Austria](/government/publications/foreign-embassies-in-the-uk) before making plans to find out about local marriage and civil partnership laws, including what documents you’ll need. 
+Contact the [Embassy of Austria](/government/publications/foreign-embassies-in-the-uk) before making plans to find out about local marriage and civil partnership laws, including what documents you’ll need.
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Austria](/foreign-travel-advice/austria) before making any plans.
 
@@ -18,16 +18,11 @@ You can normally get a CNI by giving a notice of marriage at your local register
 
 ###Legalisation and translation
 
-You might need to exchange your UK-issued CNI for one that’s valid in Austria at the nearest embassy or consulate to where you’re getting married.
+You need to get your CNI [‘legalised’ (certified as genuine)](/get-document-legalised).
 
-You should also check if it needs to be:
+Ask the local authorities in Austria if you need to get your CNI translated. You can [find a translator abroad](https://find-a-professional-service-abroad.service.csd.fcdo.gov.uk/find?serviceType=translators-interpreters), or in the UK through the [Institute of Linguists](https://www.ciol.org.uk/).
 
-- ‘[legalised](/get-document-legalised)’ (certified as genuine)
-- translated - [find a translator abroad](/government/collections/list-of-lawyers), or in the UK through the [Institute of Linguists](http://www.ciol.org.uk)
-
-You should also check with the local authorities in Austria to find out if you need to provide legalised and translated copies of any other documents.
-
-%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
+%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example, a marriage certificate or a deed poll).%
 
 ##Getting a civil partnership
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/austria/uk/partner_other/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/austria/uk/partner_other/_opposite_sex.erb
@@ -22,12 +22,6 @@ Ask the local authorities in Austria if you need to get your CNI translated. You
 
 %The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example, a marriage certificate or a deed poll).%
 
-##Getting a civil partnership
-
-###What you need to do
-
-To get a CNI for a civil partnership you must [go to Austria and post notice at the embassy or consulate there](/marriage-abroad/y/austria/ceremony_country/partner_british/opposite_sex).
-
 ##Naturalisation of your partner if they move to the UK
 
 Your partner can apply to become a British citizen once they’ve lived in the UK for 3 years after getting married.

--- a/app/flows/marriage_abroad_flow/outcomes/countries/austria/uk/partner_other/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/austria/uk/partner_other/_opposite_sex.erb
@@ -6,9 +6,7 @@ Contact the [Embassy of Austria](/government/publications/foreign-embassies-in-t
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Austria](/foreign-travel-advice/austria) before making any plans.
 
-##Getting married
-
-###What you need to do
+##What you need to do
 
 You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry.
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/austria/uk/partner_other/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/austria/uk/partner_other/_same_sex.erb
@@ -16,16 +16,11 @@ You can normally get a CNI by giving a notice of marriage at your local register
 
 ###Legalisation and translation
 
-You might need to exchange your UK-issued CNI for one that’s valid in Austria at the nearest embassy or consulate to where you’re getting married.
+You need to get your CNI [‘legalised’ (certified as genuine)](/get-document-legalised).
 
-You should also check if it needs to be:
+Ask the local authorities in Austria if you need to get your CNI translated. You can [find a translator abroad](https://find-a-professional-service-abroad.service.csd.fcdo.gov.uk/find?serviceType=translators-interpreters), or in the UK through the [Institute of Linguists](https://www.ciol.org.uk/).
 
-- [‘legalised’](/get-document-legalised) (certified as genuine)
-- translated - [find a translator abroad](/government/collections/list-of-lawyers), or in the UK through the [Institute of Linguists](https://www.ciol.org.uk/)     
-
-You should also check with the local authorities in Austria to find out if you need to provide legalised and translated copies of any other documents.
-
-%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
+%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example, a marriage certificate or a deed poll).%
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/app/flows/marriage_abroad_flow/outcomes/payment_information_partials/_pay_by_mastercard_and_visa_credit_debit.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/payment_information_partials/_pay_by_mastercard_and_visa_credit_debit.erb
@@ -1,0 +1,1 @@
+You can only pay by MasterCard and Visa debit or credit cards.

--- a/app/flows/marriage_abroad_flow/outcomes/payment_information_partials/_pay_by_visa_masterdcard_sometimes_cash_or_friends_card.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/payment_information_partials/_pay_by_visa_masterdcard_sometimes_cash_or_friends_card.erb
@@ -1,7 +1,0 @@
-You can pay by Mastercard or Visa credit cards.
-
-If you do not have a credit card of your own, the embassy will accept a credit
-card payment from a friend or relative. They should fill in and sign the
-[credit card authorisation form](/government/publications/passport-credit-debit-card-payment-authorisation-slip-austria)
-and attach a copy of their passport or ID card. You should then bring this with
-you to your appointment.

--- a/config/smart_answers/marriage_abroad_services.yml
+++ b/config/smart_answers/marriage_abroad_services.yml
@@ -265,14 +265,12 @@ austria:
   opposite_sex:
     ceremony_country:
       default:
-      - :receiving_notice_of_marriage_or_civil_partnership
-      - :issuing_cni_or_nulla_osta
+      - :affidavit_or_affirmation_for_marriage
     payment_partial_name: pay_by_mastercard_and_visa_only
   same_sex:
     default:
       default:
-      - :receiving_notice_of_marriage_or_civil_partnership
-      - :issuing_cni_or_nulla_osta
+      - :affidavit_or_affirmation_for_marriage
     payment_partial_name: pay_by_visa_masterdcard_sometimes_cash_or_friends_card
 azerbaijan:
   opposite_sex:

--- a/config/smart_answers/marriage_abroad_services.yml
+++ b/config/smart_answers/marriage_abroad_services.yml
@@ -266,12 +266,12 @@ austria:
     ceremony_country:
       default:
       - :affidavit_or_affirmation_for_marriage
-    payment_partial_name: pay_by_mastercard_and_visa_only
+    payment_partial_name: pay_by_mastercard_and_visa_credit_debit
   same_sex:
     default:
       default:
       - :affidavit_or_affirmation_for_marriage
-    payment_partial_name: pay_by_visa_masterdcard_sometimes_cash_or_friends_card
+    payment_partial_name: pay_by_mastercard_and_visa_credit_debit
 azerbaijan:
   opposite_sex:
     ceremony_country:


### PR DESCRIPTION
[Trello](https://trello.com/c/xFsuSHc8/353-3-march-update-austria-outcomes-in-getting-married-abroad-tool)

Update Austria marriage abroad outcomes to reflect that:

For users in the UK: you can only get a CNI issued in the UK, as the embassy in Austria won’t be offering these anymore. There’s also now no difference in the process between getting an opposite sex marriage and an opposite sex civil partnership.

For users in Austria: the embassy issued CNI is being replaced by a marital status document.


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
