### PR TITLE
Add information click tracking to smart answer result links

### DIFF
--- a/app/views/smart_answers/custom_result_full_width.erb
+++ b/app/views/smart_answers/custom_result_full_width.erb
@@ -35,9 +35,18 @@
 
   <div
     data-flow-name="<%= @name %>"
-    data-module="gem-track-click"
+    data-module="gem-track-click ga4-link-tracker"
     data-track-category="Internal Link Clicked"
     data-track-action="<%= @name %> results"
+    data-ga4-link='{
+      "event_name": "information_click", 
+      "type": "smart answer",
+      "section": "<%= title %>", 
+      "action": "information_click",
+      "tool_name": "<%= @presenter.title %>" 
+    }'
+    data-ga4-track-links-only
+    data-ga4-set-indexes
     data-track-links-only
   >
     <div class="govuk-!-margin-bottom-6">

--- a/app/views/smart_answers/result.html.erb
+++ b/app/views/smart_answers/result.html.erb
@@ -35,9 +35,18 @@
 
     <div
       data-flow-name="<%= @name %>"
-      data-module="gem-track-click"
+      data-module="gem-track-click ga4-link-tracker"
       data-track-category="Internal Link Clicked"
       data-track-action="<%= @name %> results"
+      data-ga4-link='{
+      "event_name": "information_click", 
+      "type": "smart answer",
+      "section": "<%= title %>", 
+      "action": "information_click",
+      "tool_name": "<%= @presenter.title %>" 
+    }'
+    data-ga4-track-links-only
+    data-ga4-set-indexes
       data-track-links-only
     >
       <div class="govuk-!-margin-bottom-6">


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Adds link tracking to smart answer results pages for tracking links within the body of the page. Due to the nature of how these links are generated (from govspeak), some attributes such as `index` and `index_total` are not retrievable from the `erb` template. Therefore, a `data-g4-set-indexes` attribute has been added to "switch on" the addition of indexes using JS from the components gem.

## Why
Part of the GA4 migration.

## Visual changes
N/A

Trello card: https://trello.com/c/4hvUQKAf/415-add-tracking-smart-answers-information-click
