### PR TITLE
Remove duplication of metatags

### DIFF
--- a/app/views/smart_answers/landing.html.erb
+++ b/app/views/smart_answers/landing.html.erb
@@ -5,10 +5,6 @@
     <meta name="description" content="<%= start_node.meta_description %>">
   <% end %>
   <% if content_item.present? %>
-    <%= render "govuk_publishing_components/components/meta_tags",
-      content_item: content_item,
-      strip_dates_pii: true,
-      strip_postcode_pii: true %>
     <%= render 'govuk_publishing_components/components/machine_readable_metadata',
       schema: :article,
       content_item: content_item %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Removes duplicate metatags from the markup of the smart answers landing page ([example](https://www.gov.uk/check-uk-visa)). Currently there is a whole chunk of duplicated tags.

## Why
We shouldn't be duplicating these things.

## Visual changes
None, but here's a screenshot of the metatags in question.

![Screenshot 2023-02-27 at 15 16 10](https://user-images.githubusercontent.com/861310/221602868-8f304092-4c2d-4e5f-8c5d-bf0076dd6b2d.png)
