### PR TITLE
Add ga4 tracking to contextual breadcrumb

### DIFF
--- a/app/views/smart_answers/landing.html.erb
+++ b/app/views/smart_answers/landing.html.erb
@@ -16,7 +16,7 @@
 <% end %>
 
 <% content_for :breadcrumbs do %>
-  <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: content_item %>
+  <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: content_item, ga4_tracking: true %>
 <% end %>
 
 <div class="govuk-grid-row">


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Enables GA4 tracking on the contextual breadcrumb by adding a `ga4_tracking: true` attribute.

## Why
Part of the GA4 migration.

## Visual changes
N/A

Trello card: https://trello.com/c/AM5JCKEd/430-add-tracking-to-super-breadcrumbs
