### PR TITLE
Add cost of living survey banner to Check benefits and financial support you can get page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,6 +14,7 @@ $govuk-include-default-font-face: false;
 @import "govuk_publishing_components/components/error-summary";
 @import "govuk_publishing_components/components/fieldset";
 @import "govuk_publishing_components/components/govspeak";
+@import "govuk_publishing_components/components/intervention";
 @import "govuk_publishing_components/components/print-link";
 @import "govuk_publishing_components/components/radio";
 @import "govuk_publishing_components/components/related-navigation";
@@ -25,6 +26,7 @@ $govuk-include-default-font-face: false;
 @import "govuk_publishing_components/components/table";
 @import "govuk_publishing_components/components/warning-text";
 
+@import "components/intervention";
 @import "components/result-card";
 @import "components/result-item";
 @import "components/result-sections";

--- a/app/assets/stylesheets/components/_intervention.scss
+++ b/app/assets/stylesheets/components/_intervention.scss
@@ -1,0 +1,3 @@
+.gem-c-intervention {
+  margin-top: govuk-spacing(4);
+}

--- a/app/presenters/start_node/cost_of_living_banner.rb
+++ b/app/presenters/start_node/cost_of_living_banner.rb
@@ -1,0 +1,19 @@
+module StartNode
+  module CostOfLivingBanner
+    COST_OF_LIVING_SURVEY_URL = "https://surveys.publishing.service.gov.uk/s/XS2YWV/".freeze
+
+    SURVEY_URL_MAPPINGS = {
+      "/check-benefits-financial-support" => COST_OF_LIVING_SURVEY_URL,
+    }.freeze
+
+    def survey_url
+      SURVEY_URL_MAPPINGS[base_path]
+    end
+
+  private
+
+    def base_path
+      "/#{@flow_presenter.name}"
+    end
+  end
+end

--- a/app/presenters/start_node_presenter.rb
+++ b/app/presenters/start_node_presenter.rb
@@ -1,4 +1,6 @@
 class StartNodePresenter < NodePresenter
+  include StartNode::CostOfLivingBanner
+
   def initialize(node, flow_presenter, state = nil, options = {})
     super(node, flow_presenter, state)
     @renderer = options[:renderer] || SmartAnswer::ErbRenderer.new(

--- a/app/views/smart_answers/landing.html.erb
+++ b/app/views/smart_answers/landing.html.erb
@@ -19,6 +19,15 @@
   <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: content_item %>
 <% end %>
 
+<% if start_node&.survey_url %>
+  <%= render "govuk_publishing_components/components/intervention", {
+    suggestion_text: "Help make GOV.UK better",
+    suggestion_link_text: "Take part in user research",
+    suggestion_link_url: start_node.survey_url,
+    new_tab: true,
+  } %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/title", {

--- a/test/integration/cost_of_living_banner_test.rb
+++ b/test/integration/cost_of_living_banner_test.rb
@@ -1,0 +1,29 @@
+require_relative "../integration_test_helper"
+
+class CostOfLivingBannerTest < ActionDispatch::IntegrationTest
+  context "cost of living survey banner" do
+    setup do
+      stub_content_store_has_item("/check-benefits-financial-support")
+    end
+
+    should "display cost of living survey banner on the landing page" do
+      visit "/check-benefits-financial-support"
+
+      assert page.has_css?(".gem-c-intervention")
+      assert page.has_link?("Take part in user research (opens in a new tab)", href: "https://surveys.publishing.service.gov.uk/s/XS2YWV/")
+    end
+
+    should "not display cost of living survey banner on non-landing pages of the specific smart answer" do
+      visit "/check-benefits-financial-support/y"
+
+      assert_not page.has_css?(".gem-c-intervention")
+      assert_not page.has_link?("Take part in user research (opens in a new tab)", href: "https://surveys.publishing.service.gov.uk/s/XS2YWV/")
+    end
+
+    should "not display cost of living survey banner unless survey URL is specified for the base path" do
+      visit "/bridge-of-death"
+
+      assert_not page.has_css?(".gem-c-intervention")
+    end
+  end
+end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / Why

Add an intervention banner that links to the Cost of living survey banner.

[Trello](https://trello.com/c/XozIyJgB/1670-cost-of-living-col-1-of-2-surveys-user-research-banner-request-m)

## Screenshots

### Before

![www gov uk_check-benefits-financial-support](https://user-images.githubusercontent.com/424772/222149538-5c9d63c5-4a41-40d6-a0dc-9b122cbae362.png)

### After

![localhost_3010_check-benefits-financial-support](https://user-images.githubusercontent.com/424772/222149555-bffcfff9-90ec-4695-a156-79b5c1305c56.png)
