### PR TITLE
Uprate Married Couple's Allowance for 2023

### DIFF
--- a/config/smart_answers/rates/married_couples_allowance.yml
+++ b/config/smart_answers/rates/married_couples_allowance.yml
@@ -4,6 +4,11 @@
 # date of 2999-01-01
 ---
 - start_date: 2022-04-06
-  end_date: 2999-01-01
+  end_date: 2023-04-05
   maximum_married_couple_allowance: 9415
   minimum_married_couple_allowance: 3640
+
+- start_date: 2023-04-06
+  end_date: 2999-01-01
+  maximum_married_couple_allowance: 10375
+  minimum_married_couple_allowance: 4010

--- a/config/smart_answers/rates/personal_allowance.yml
+++ b/config/smart_answers/rates/personal_allowance.yml
@@ -4,6 +4,11 @@
 # date of 2999-01-01
 ---
 - start_date: 2022-04-06
-  end_date: 2999-01-01
+  end_date: 2023-04-05
   personal_allowance: 12570
   income_limit_for_personal_allowances: 31400.0
+
+- start_date: 2023-04-06
+  end_date: 2999-01-01
+  personal_allowance: 12570
+  income_limit_for_personal_allowances: 34600.0

--- a/test/unit/calculators/married_couple_allowance_calculator_test.rb
+++ b/test/unit/calculators/married_couple_allowance_calculator_test.rb
@@ -118,5 +118,16 @@ module SmartAnswer::Calculators
         assert_equal 3640, calculator.minimum_mca
       end
     end
+
+    test "rate values for 2023/24" do
+      travel_to("2023-06-01") do
+        calculator = MarriedCouplesAllowanceCalculator.new
+
+        assert_equal 12_570, calculator.personal_allowance
+        assert_equal 34_600.0, calculator.income_limit_for_personal_allowances
+        assert_equal 10_375, calculator.maximum_mca
+        assert_equal 4010, calculator.minimum_mca
+      end
+    end
   end
 end


### PR DESCRIPTION
Uprating changes for 2023

Married couple's allowance will be increased:

Minimum from £3,640 to £4,010
Maximum from £9,415 to £10,375

Change £364 to £401
Change £941.50 to £1,037.50

The income limit will increase from £31,400 to £34,600.

[Zendesk ticket](https://govuk.zendesk.com/agent/tickets/5225962)