### PR TITLE
Update print link GA4 tracking

### DIFF
--- a/app/views/smart_answers/custom_result.html.erb
+++ b/app/views/smart_answers/custom_result.html.erb
@@ -61,7 +61,9 @@
         ga4_event: {
           event_name: 'print_page',
           type: 'print page',
-          index: 1,
+          index: {
+            index_link: 1,
+          },
           index_total: 1,
           section: 'Footer',
         },


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Update the `index` parameter on print links in line with a change to the format of the `index` parameter.

## Why
Part of the GA4 migration work.

## Visual changes
None.

Trello card: https://trello.com/c/8tNN5gGX/426-change-the-index-parameter