### PR TITLE
State pension uprating

### DIFF
--- a/app/flows/state_pension_through_partner_flow/outcomes/age_dependent_pension_outcome.erb
+++ b/app/flows/state_pension_through_partner_flow/outcomes/age_dependent_pension_outcome.erb
@@ -31,11 +31,11 @@
 
   **Example**
 
-  You’ll reach State Pension age on 6 March 2023. This is in the tax year 6 April 2022 to 5 April 2023.
+  You’ll reach State Pension age on 6 March 2024. This is in the tax year 6 April 2023 to 5 April 2024.
 
   You got married in 1975 and chose to pay National Insurance contributions at a reduced rate.
 
-  Your State Pension will be worked out differently if your reduced rate election still applied to you in 1987.
+  Your State Pension will be worked out differently if your reduced rate election still applied to you in 1988.
 
   $E
 

--- a/app/flows/state_pension_through_partner_flow/outcomes/married_woman_and_state_pension_outcome.erb
+++ b/app/flows/state_pension_through_partner_flow/outcomes/married_woman_and_state_pension_outcome.erb
@@ -16,11 +16,11 @@
 
   **Example**
 
-  You’ll reach State Pension age on 6 March 2023. This is in the tax year 6 April 2022 to 5 April 2023.
+  You’ll reach State Pension age on 6 March 2024. This is in the tax year 6 April 2023 to 5 April 2024.
 
   You got married in 1975 and chose to pay National Insurance contributions at a reduced rate.
 
-  Your State Pension will be worked out differently if your reduced rate election still applied to you in 1987.
+  Your State Pension will be worked out differently if your reduced rate election still applied to you in 1988.
 
   $E
 

--- a/app/flows/state_pension_through_partner_flow/outcomes/married_woman_no_state_pension_outcome.erb
+++ b/app/flows/state_pension_through_partner_flow/outcomes/married_woman_no_state_pension_outcome.erb
@@ -15,11 +15,11 @@
   $E
   **Example**
 
-  You’ll reach State Pension age on 6 March 2023. This is in the tax year 6 April 2022 to 5 April 2023.
+  You’ll reach State Pension age on 6 March 2024. This is in the tax year 6 April 2023 to 5 April 2024.
 
   You got married in 1975 and chose to pay National Insurance contributions at a reduced rate.
 
-  Your State Pension will be worked out differently if your reduced rate election still applied to you in 1987.
+  Your State Pension will be worked out differently if your reduced rate election still applied to you in 1988.
 
   $E
 

--- a/config/smart_answers/rates/state_pension.yml
+++ b/config/smart_answers/rates/state_pension.yml
@@ -3,7 +3,7 @@
 # and usually 1. The last item in the file should have an end
 # date of 2999-01-01
 ---
-- start_date: 2022-04-11
+- start_date: 2023-04-11
   end_date: 2999-01-01
-  weekly_rate: 141.85
-  lower_weekly_rate: 85.00
+  weekly_rate: 156.20
+  lower_weekly_rate: 93.60


### PR DESCRIPTION
[TRELLO](https://trello.com/c/VlyDRiUr/162-uprating-national-insurance-and-state-pension-smart-answer-content-requests)

Changes to 3 files: 
[married_woman_and_state_pension_outcome.erb]
[Married_woman_no_state_pension_outcome.erb]
[Age_dependent_pension_outcome.erb]

have updated the content (dates) to:
2023 changes to 2024
2022 changes to 2023
1987 changes to 1988

Needs to be scheduled to be published at 00.01 10th April 2023.
Waiting for the department to confirm if they need a heroku preview.

