### PR TITLE
Remove answer from section parameter

### DIFF
--- a/app/views/smart_answers/shared/_previous_answers.html.erb
+++ b/app/views/smart_answers/shared/_previous_answers.html.erb
@@ -47,7 +47,7 @@
           ga4_link: {
             event_name: "form_change_response",
             type: "smart answer",
-            section: question.change_link_track_label(accepted_response),
+            section: question.title,
             action: "change response",
             tool_name: @presenter.title,
           }


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

This PR removes the answer from the `section` parameter for the `change_form_response` event. I checked with the PA's and the answer does not need removing from `data-track-label` (which is the data attribute that UA uses for tracking the same data)

## Why

Requested by PA's.

## Visual Changes
N/A

Trello card: https://trello.com/c/dWFDOLAV/433-smart-answer-bugs-formchangeresponse

