### PR TITLE
[DO NOT MERGE] Uprating maternity and paternity leave or pay and maternity allowance

### DIFF
--- a/app/flows/maternity_paternity_pay_leave_flow/outcomes/_mat_allowance.erb
+++ b/app/flows/maternity_paternity_pay_leave_flow/outcomes/_mat_allowance.erb
@@ -74,4 +74,16 @@ Weekly rate (between <%= calculator.formatted_first_day_in_year(2022) %> and <%=
   <% end %>
 <% end %>
 
+<% if calculator.paid_leave_is_in_year?(2023)%>
+  <% if calculator.employment_status_of_mother == "self-employed" %>
+
+Weekly rate (between <%= calculator.formatted_first_day_in_year(2023) %> and <%= calculator.formatted_last_day_in_year(2023) %>) | £172.48 - or £27 if they’re [self-employed but have not paid enough Class 2 National Insurance](/maternity-allowance/eligibility)
+
+  <% else %>
+
+Weekly rate (between <%= calculator.formatted_first_day_in_year(2023) %> and <%= calculator.formatted_last_day_in_year(2023) %>) | £172.48 or 90% of their average weekly earnings (whichever is lower)
+
+  <% end %> 
+<% end%>
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.

--- a/app/flows/maternity_paternity_pay_leave_flow/outcomes/_mat_pay.erb
+++ b/app/flows/maternity_paternity_pay_leave_flow/outcomes/_mat_pay.erb
@@ -66,6 +66,14 @@ Remaining weeks (between <%= calculator.formatted_first_day_in_year(2022) %> and
 
 <% end %>
 
+<% if calculator.paid_leave_is_in_year?(2023) %>
+
+Remaining weeks (between <%= calculator.formatted_first_day_in_year(2023) %> and <%= calculator.formatted_last_day_in_year(2023) %>) | £172.48 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+<% end %>
+
+
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/app/flows/maternity_paternity_pay_leave_flow/outcomes/_pat_pay.erb
+++ b/app/flows/maternity_paternity_pay_leave_flow/outcomes/_pat_pay.erb
@@ -64,6 +64,12 @@ Weekly rate (between <%= calculator.formatted_first_day_in_year(2022) %> and <%=
 
 <% end %>
 
+<% if calculator.paid_leave_is_in_year?(2023) %>
+
+Weekly rate (between <%= calculator.formatted_first_day_in_year(2023) %> and <%= calculator.formatted_last_day_in_year(2023) %>) | £172.48 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+<% end %>
+
 <% if calculator.paid_leave_is_in_year?(2013) %>
 
 Tell the partner’s employer | 28 days before they want to start paternity pay

--- a/lib/smart_answer/calculators/maternity_pay_calculator.rb
+++ b/lib/smart_answer/calculators/maternity_pay_calculator.rb
@@ -315,7 +315,8 @@ module SmartAnswer::Calculators
         { min: uprating_date(2019), max: uprating_date(2020), amount: 148.68 },
         { min: uprating_date(2020), max: uprating_date(2021), amount: 151.20 },
         { min: uprating_date(2021), max: uprating_date(2022), amount: 151.97 },
-        { min: uprating_date(2022), max: uprating_date(2200), amount: 156.66 },
+        { min: uprating_date(2022), max: uprating_date(2023), amount: 156.66 },
+        { min: uprating_date(2023), max: uprating_date(2200), amount: 172.48 },
         ### Change year in future
       ]
       rate = rates.find { |r| r[:min] <= date && date < r[:max] } || rates.last

--- a/test/flows/maternity_paternity_calculator_flow/adoption_calculator_flow_test.rb
+++ b/test/flows/maternity_paternity_calculator_flow/adoption_calculator_flow_test.rb
@@ -393,13 +393,13 @@ class MaternityPaternityCalculatorFlow::AdoptionCalculatorFlowTest < ActiveSuppo
     end
 
     should "render when an employee is entitled to statutory adoption pay" do
-      add_responses maternity_adoption_responses(pay_frequency: "weekly", pay_per_frequency: 1_000, placement_date: "2022-05-01")
+      add_responses maternity_adoption_responses(pay_frequency: "weekly", pay_per_frequency: 1_000, placement_date: "2023-05-01")
 
       assert_rendered_outcome text: "The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP)"
 
-      # 90% of 1000 a week for 6 weeks + (39 - 6) * 156.66 statutory (rate for 2022)
-      # = 900 * 6 + 33 * 156.66
-      assert_match(/Total SAP:\s*£10,569.78/, @test_flow.outcome_text)
+      # 90% of 1000 a week for 6 weeks + (39 - 6) * 172.48 statutory (rate for 2023)
+      # = 900 * 6 + 33 * 172.48
+      assert_match(/Total SAP:\s*£11,091.84/, @test_flow.outcome_text)
     end
 
     should "render when an employee is entitled to statutory adoption pay and exactly on the threshold" do

--- a/test/flows/maternity_paternity_calculator_flow/maternity_calculator_flow_test.rb
+++ b/test/flows/maternity_paternity_calculator_flow/maternity_calculator_flow_test.rb
@@ -389,13 +389,13 @@ class MaternityPaternityCalculatorFlow::MaternityCalculatorFlowTest < ActiveSupp
     end
 
     should "render when an employee is entitled to statutory maternity pay" do
-      add_responses maternity_responses(pay_frequency: "weekly", pay_per_frequency: 1_000, due_date: "2022-05-01")
+      add_responses maternity_responses(pay_frequency: "weekly", pay_per_frequency: 1_000, due_date: "2023-05-01")
 
       assert_rendered_outcome text: "The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP)"
 
-      # 90% of 1000 a week for 6 weeks + (39 - 6) * 156.66 statutory (rate for 2022)
-      # = 900 * 6 + 33 * 156.66
-      assert_match(/Total SMP:\s*£10,569.78/, @test_flow.outcome_text)
+      # 90% of 1000 a week for 6 weeks + (39 - 6) * 172.48 statutory (rate for 2023)
+      # = 900 * 6 + 33 * 172.48
+      assert_match(/Total SMP:\s*£11,091.84/, @test_flow.outcome_text)
     end
 
     should "render when an employee is not entitled to statutory maternity pay and have average earnings" do

--- a/test/unit/calculators/maternity_pay_calculator_test.rb
+++ b/test/unit/calculators/maternity_pay_calculator_test.rb
@@ -359,6 +359,7 @@ module SmartAnswer::Calculators
 
       context "statutory pay rate for given year" do
         {
+          2023 => 172.48,
           2022 => 156.66,
           2021 => 151.97,
           2020 => 151.20,


### PR DESCRIPTION
[Trello Card](https://trello.com/c/Pf8HfhyA/405-uprating-check-if-you-can-get-maternity-or-paternity-leave-or-pay-or-maternity-allowance)

The rate for the following are being uprated:
- Maternity allowance
- Maternity pay
- Shared parental pay
- Paternity pay

The rate increases from £156.66 to £172.48 from 2nd April 2023 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
