### PR TITLE
Uprating national minimum wage 2023/24

### DIFF
--- a/app/flows/am_i_getting_minimum_wage_flow/questions/what_would_you_like_to_check.erb
+++ b/app/flows/am_i_getting_minimum_wage_flow/questions/what_would_you_like_to_check.erb
@@ -4,5 +4,5 @@
 
 <% options(
   "current_payment": "If you're getting the National Minimum Wage or the National Living Wage",
-  "past_payment": "If an employer owes you payments from last year (April 2021 to March 2022)"
+  "past_payment": "If an employer owes you payments from last year (April 2022 to March 2023)"
 ) %>

--- a/app/flows/am_i_getting_minimum_wage_flow/start.erb
+++ b/app/flows/am_i_getting_minimum_wage_flow/start.erb
@@ -15,5 +15,5 @@
 
   ^You must be at least 23 years old to get the National Living Wage.^
 
-  Check [National Minimum Wage and National Living Wage rates](/national-minimum-wage-rates) before March 2022.
+  Check [National Minimum Wage and National Living Wage rates](/national-minimum-wage-rates) before March 2023.
 <% end %>

--- a/app/flows/minimum_wage_calculator_employers_flow/questions/what_would_you_like_to_check.erb
+++ b/app/flows/minimum_wage_calculator_employers_flow/questions/what_would_you_like_to_check.erb
@@ -4,5 +4,5 @@
 
 <% options(
   "current_payment": "If you’re paying a worker the National Minimum Wage or the National Living Wage",
-  "past_payment": "If you owe a worker payments from last year (April 2021 to March 2022)"
+  "past_payment": "If you owe a worker payments from last year (April 2022 to March 2023)"
 ) %>

--- a/app/flows/minimum_wage_calculator_employers_flow/start.erb
+++ b/app/flows/minimum_wage_calculator_employers_flow/start.erb
@@ -15,5 +15,5 @@
 
   ^Your employee must be at least 23 years old to get the National Living Wage.^
 
-Check [National Minimum Wage and National Living Wage rates](/national-minimum-wage-rates) before March 2022.
+Check [National Minimum Wage and National Living Wage rates](/national-minimum-wage-rates) before March 2023.
 <% end %>

--- a/app/flows/shared/minimum_wage_flow.rb
+++ b/app/flows/shared/minimum_wage_flow.rb
@@ -6,7 +6,7 @@ class MinimumWageFlow < SmartAnswer::Flow
       option "past_payment"
 
       on_response do |response|
-        date = Date.parse("2021-04-01") if response == "past_payment"
+        date = Date.parse("2022-04-01") if response == "past_payment"
         self.calculator = SmartAnswer::Calculators::MinimumWageCalculator.new(date:)
         self.accommodation_charge = nil
       end

--- a/config/smart_answers/rates/minimum_wage.yml
+++ b/config/smart_answers/rates/minimum_wage.yml
@@ -2,25 +2,8 @@
 # make sure we have that at least. If adding a new set of data at
 # the end, you may have to update dates/values in the test file.
 ---
-- :start_date: 2021-04-01
-  :end_date: 2022-03-31
-  :minimum_rates:
-  - :min_age: 0
-    :max_age: 18
-    :rate: 4.62
-  - :min_age: 18
-    :max_age: 21
-    :rate: 6.56
-  - :min_age: 21
-    :max_age: 23
-    :rate: 8.36
-  - :min_age: 23
-    :max_age: 1000
-    :rate: 8.91
-  :apprentice_rate: 4.30
-  :accommodation_rate: 8.36
 - :start_date: 2022-04-01
-  :end_date: 3000-01-01
+  :end_date: 2023-03-31
   :minimum_rates:
   - :min_age: 0
     :max_age: 18
@@ -36,3 +19,21 @@
     :rate: 9.50
   :apprentice_rate: 4.81
   :accommodation_rate: 8.70
+
+- :start_date: 2023-04-01
+  :end_date: 3000-01-01
+  :minimum_rates:
+  - :min_age: 0
+    :max_age: 18
+    :rate: 5.28
+  - :min_age: 18
+    :max_age: 21
+    :rate: 7.49
+  - :min_age: 21
+    :max_age: 23
+    :rate: 10.18
+  - :min_age: 23
+    :max_age: 1000
+    :rate: 10.42
+  :apprentice_rate: 5.28
+  :accommodation_rate: 9.10

--- a/test/unit/calculators/minimum_wage_calculator_test.rb
+++ b/test/unit/calculators/minimum_wage_calculator_test.rb
@@ -126,9 +126,9 @@ module SmartAnswer::Calculators
         end
       end
 
-      should "return true if the age is 23 or over, and the date is on or after 2021-04-01" do
+      should "return true if the age is 23 or over, and the date is on or after 2022-04-01" do
         %w[23 24].each do |age|
-          @calculator.date = Date.parse("2021-04-01")
+          @calculator.date = Date.parse("2022-04-01")
           @calculator.age = age
           assert @calculator.eligible_for_living_wage?
         end
@@ -172,7 +172,7 @@ module SmartAnswer::Calculators
         @basic_hours = 39
         @calculator = MinimumWageCalculator.new(
           age: @age,
-          date: Date.parse("2022-04-01"),
+          date: Date.parse("2023-04-01"),
           basic_pay: @basic_pay,
           basic_hours: @basic_hours,
         )
@@ -186,7 +186,7 @@ module SmartAnswer::Calculators
 
       context "minimum hourly rate" do
         should "be the minimum wage per hour for the age and year" do
-          assert_equal 6.83, @calculator.minimum_hourly_rate
+          assert_equal 7.49, @calculator.minimum_hourly_rate
         end
         context "when eligible for living wage?" do
           should "return the national living wage rate" do
@@ -227,17 +227,17 @@ module SmartAnswer::Calculators
         end
 
         should "calculate the accommodation cost" do
-          assert_equal(-13.2, @calculator.accommodation_cost)
+          assert_equal(-11.6, @calculator.accommodation_cost)
         end
 
         should "be included the total pay calculation" do
-          assert_equal 174.26, @calculator.total_pay
+          assert_equal 175.86, @calculator.total_pay
         end
       end
 
       context "historical entitlement" do
         setup do
-          @historical_entitlement = 266.37
+          @historical_entitlement = 292.11
         end
         should "be minimum wage for the year multiplied by total hours" do
           assert_equal @historical_entitlement, @calculator.historical_entitlement
@@ -262,7 +262,7 @@ module SmartAnswer::Calculators
         end
 
         should "have a total hourly rate of 4.20" do
-          assert_equal 9.5, @calculator.minimum_hourly_rate
+          assert_equal 10.42, @calculator.minimum_hourly_rate
         end
       end
 
@@ -296,19 +296,19 @@ module SmartAnswer::Calculators
         end
 
         should "calculate total hourly rate" do
-          assert_equal 9.5, @calculator.minimum_hourly_rate
+          assert_equal 10.42, @calculator.minimum_hourly_rate
           assert_not @calculator.minimum_wage_or_above?, "should be below the minimum wage"
         end
 
         should "adjust for free accommodation" do
           @calculator.accommodation_adjustment(0, 5)
-          assert_equal 43.5, @calculator.accommodation_cost
+          assert_equal 45.5, @calculator.accommodation_cost
           assert_not @calculator.minimum_wage_or_above?, "should be below the minimum wage"
         end
 
         should "adjust for accommodation charged above the threshold" do
           @calculator.accommodation_adjustment(12, 5)
-          assert_equal(-16.5, @calculator.accommodation_cost)
+          assert_equal(-14.5, @calculator.accommodation_cost)
           assert_not @calculator.minimum_wage_or_above?, "should be below the minimum wage"
         end
 
@@ -321,45 +321,45 @@ module SmartAnswer::Calculators
     end
 
     context "per hour minimum wage" do
-      context "from 1 Apr 2022" do
+      context "from 1 Apr 2023" do
         setup do
-          @calculator = MinimumWageCalculator.new(date: Date.parse("2022-04-01"))
+          @calculator = MinimumWageCalculator.new(date: Date.parse("2023-04-01"))
         end
 
         should "be correct for those under 18" do
           [0, 17].each do |age|
             @calculator.age = age
-            assert_equal 4.81, @calculator.per_hour_minimum_wage
+            assert_equal 5.28, @calculator.per_hour_minimum_wage
           end
         end
 
         should "be correct for 18 to 20 year olds" do
           [18, 20].each do |age|
             @calculator.age = age
-            assert_equal 6.83, @calculator.per_hour_minimum_wage
+            assert_equal 7.49, @calculator.per_hour_minimum_wage
           end
         end
 
         should "be correct for 21 to 22 year olds" do
           [21, 22].each do |age|
             @calculator.age = age
-            assert_equal 9.18, @calculator.per_hour_minimum_wage
+            assert_equal 10.18, @calculator.per_hour_minimum_wage
           end
         end
 
         should "be correct for those aged 23 and over" do
           [23, 100].each do |age|
             @calculator.age = age
-            assert_equal 9.50, @calculator.per_hour_minimum_wage
+            assert_equal 10.42, @calculator.per_hour_minimum_wage
           end
         end
 
         should "have correct apprentice rate" do
-          assert_equal 4.81, @calculator.apprentice_rate
+          assert_equal 5.28, @calculator.apprentice_rate
         end
 
         should "have correct accommodation rate" do
-          assert_equal 8.7, @calculator.free_accommodation_rate
+          assert_equal 9.1, @calculator.free_accommodation_rate
         end
       end
     end
@@ -410,7 +410,7 @@ module SmartAnswer::Calculators
 
         should "[with accommodation_adjustment] return rate total (216.39)" do
           @calculator.accommodation_adjustment(20, 4)
-          assert_equal 227.73, @calculator.total_pay
+          assert_equal 228.87, @calculator.total_pay
         end
       end
     end
@@ -456,7 +456,7 @@ module SmartAnswer::Calculators
         )
       end
       should "return total_entitlement" do
-        assert_equal 370.5, @calculator.total_entitlement
+        assert_equal 406.38, @calculator.total_entitlement
       end
       should "return total_underpayment" do
         assert_equal 100.0, @calculator.total_pay


### PR DESCRIPTION
Please view [Trello Card](https://trello.com/c/oTjs0Tzb/406-uprating-national-minimum-wage-living-wage-calculator-increases-2023)

The National Living wage rates will increase from the 1st April 2023, the following changes are:
- for 23 year olds and over - from £9.50 per hour to £10.42
- for 21 to 22 year olds – from £9.18 per hour to £10.18
- for 18 to 20 year olds – from £6.83 per hour to £7.49
- for those under 18 – from £4.81 per hour to £5.28
- for apprentices – from £4.81 per hour to £5.28

Accommodation offset rates will also change:
- daily – from £8.70 to £9.10
- weekly – from £60.90 to £63.70

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
