### PR TITLE
Simply Portugal to be a one-question country

### DIFF
--- a/app/flows/marriage_abroad_flow/outcomes/countries/portugal/_portugal.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/portugal/_portugal.erb
@@ -1,0 +1,5 @@
+Opposite sex and same sex couples can get married in Portugal. Contact your nearest [Civil Register Office](https://irn.justica.gov.pt/Contactos/Lista) (in Portuguese) to find out about local marriage laws, including what documents you’ll need. 
+
+You will not need a [certificate of no impediment (CNI) for marriages in Portugal](https://www.gov.uk/guidance/notarial-and-documentary-services-guide-for-portugal). 
+
+^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.

--- a/app/flows/marriage_abroad_flow/outcomes/countries/portugal/_title.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/portugal/_title.erb
@@ -1,7 +1,3 @@
 <% text_for :title do %>
-  <% if calculator.partner_is_same_sex? %>
-    Same-sex marriage in Portugal
-  <% else %>
     Marriage in Portugal
-  <% end %>
 <% end %>

--- a/app/flows/marriage_abroad_flow/outcomes/countries/portugal/ceremony_country/partner_british/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/portugal/ceremony_country/partner_british/_opposite_sex.erb
@@ -1,3 +1,0 @@
-Contact your nearest [Civil Register Office](https://irn.justica.gov.pt/Contactos/Lista) in Portugal to find out about local marriage laws, including what documents you’ll need.
-
-You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.

--- a/app/flows/marriage_abroad_flow/outcomes/countries/portugal/ceremony_country/partner_british/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/portugal/ceremony_country/partner_british/_same_sex.erb
@@ -1,3 +1,0 @@
-Contact your nearest [Civil Register Office](https://irn.justica.gov.pt/Contactos/Lista) in Portugal to find out about local marriage laws, including what documents you’ll need.
-
-You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.

--- a/app/flows/marriage_abroad_flow/outcomes/countries/portugal/ceremony_country/partner_local/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/portugal/ceremony_country/partner_local/_opposite_sex.erb
@@ -1,3 +1,0 @@
-Contact your nearest [Civil Register Office](https://irn.justica.gov.pt/Contactos/Lista) in Portugal to find out about local marriage laws, including what documents you’ll need.
-
-You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.

--- a/app/flows/marriage_abroad_flow/outcomes/countries/portugal/ceremony_country/partner_local/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/portugal/ceremony_country/partner_local/_same_sex.erb
@@ -1,3 +1,0 @@
-Contact your nearest [Civil Register Office](https://irn.justica.gov.pt/Contactos/Lista) in Portugal to find out about local marriage laws, including what documents you’ll need.
-
-You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.

--- a/app/flows/marriage_abroad_flow/outcomes/countries/portugal/ceremony_country/partner_other/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/portugal/ceremony_country/partner_other/_opposite_sex.erb
@@ -1,3 +1,0 @@
-Contact your nearest [Civil Register Office](https://irn.justica.gov.pt/Contactos/Lista) in Portugal to find out about local marriage laws, including what documents you’ll need.
-
-You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.

--- a/app/flows/marriage_abroad_flow/outcomes/countries/portugal/ceremony_country/partner_other/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/portugal/ceremony_country/partner_other/_same_sex.erb
@@ -1,3 +1,0 @@
-Contact your nearest [Civil Register Office](https://irn.justica.gov.pt/Contactos/Lista) in Portugal to find out about local marriage laws, including what documents you’ll need.
-
-You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.

--- a/app/flows/marriage_abroad_flow/outcomes/countries/portugal/third_country/partner_british/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/portugal/third_country/partner_british/_opposite_sex.erb
@@ -1,3 +1,0 @@
-Contact your nearest [Civil Register Office](https://irn.justica.gov.pt/Contactos/Lista) in Portugal to find out about local marriage laws, including what documents you’ll need.
-
-You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.

--- a/app/flows/marriage_abroad_flow/outcomes/countries/portugal/third_country/partner_british/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/portugal/third_country/partner_british/_same_sex.erb
@@ -1,3 +1,0 @@
-Contact your nearest [Civil Register Office](https://irn.justica.gov.pt/Contactos/Lista) in Portugal to find out about local marriage laws, including what documents you’ll need.
-
-You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.

--- a/app/flows/marriage_abroad_flow/outcomes/countries/portugal/third_country/partner_local/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/portugal/third_country/partner_local/_opposite_sex.erb
@@ -1,3 +1,0 @@
-Contact your nearest [Civil Register Office](https://irn.justica.gov.pt/Contactos/Lista) in Portugal to find out about local marriage laws, including what documents you’ll need.
-
-You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.

--- a/app/flows/marriage_abroad_flow/outcomes/countries/portugal/third_country/partner_local/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/portugal/third_country/partner_local/_same_sex.erb
@@ -1,3 +1,0 @@
-Contact your nearest [Civil Register Office](https://irn.justica.gov.pt/Contactos/Lista) in Portugal to find out about local marriage laws, including what documents you’ll need.
-
-You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.

--- a/app/flows/marriage_abroad_flow/outcomes/countries/portugal/third_country/partner_other/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/portugal/third_country/partner_other/_opposite_sex.erb
@@ -1,3 +1,0 @@
-Contact your nearest [Civil Register Office](https://irn.justica.gov.pt/Contactos/Lista) in Portugal to find out about local marriage laws, including what documents you’ll need.
-
-You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.

--- a/app/flows/marriage_abroad_flow/outcomes/countries/portugal/third_country/partner_other/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/portugal/third_country/partner_other/_same_sex.erb
@@ -1,3 +1,0 @@
-Contact your nearest [Civil Register Office](https://irn.justica.gov.pt/Contactos/Lista) in Portugal to find out about local marriage laws, including what documents you’ll need.
-
-You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.

--- a/app/flows/marriage_abroad_flow/outcomes/countries/portugal/uk/partner_british/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/portugal/uk/partner_british/_opposite_sex.erb
@@ -1,3 +1,0 @@
-Contact your nearest [Civil Register Office](https://irn.justica.gov.pt/Contactos/Lista) in Portugal to find out about local marriage laws, including what documents you’ll need.
-
-You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.

--- a/app/flows/marriage_abroad_flow/outcomes/countries/portugal/uk/partner_british/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/portugal/uk/partner_british/_same_sex.erb
@@ -1,3 +1,0 @@
-Contact your nearest [Civil Register Office](https://irn.justica.gov.pt/Contactos/Lista) in Portugal to find out about local marriage laws, including what documents you’ll need.
-
-You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.

--- a/app/flows/marriage_abroad_flow/outcomes/countries/portugal/uk/partner_local/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/portugal/uk/partner_local/_opposite_sex.erb
@@ -1,3 +1,0 @@
-Contact your nearest [Civil Register Office](https://irn.justica.gov.pt/Contactos/Lista) in Portugal to find out about local marriage laws, including what documents you’ll need.
-
-You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.

--- a/app/flows/marriage_abroad_flow/outcomes/countries/portugal/uk/partner_local/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/portugal/uk/partner_local/_same_sex.erb
@@ -1,3 +1,0 @@
-Contact your nearest [Civil Register Office](https://irn.justica.gov.pt/Contactos/Lista) in Portugal to find out about local marriage laws, including what documents you’ll need.
-
-You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.

--- a/app/flows/marriage_abroad_flow/outcomes/countries/portugal/uk/partner_other/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/portugal/uk/partner_other/_opposite_sex.erb
@@ -1,3 +1,0 @@
-Contact your nearest [Civil Register Office](https://irn.justica.gov.pt/Contactos/Lista) in Portugal to find out about local marriage laws, including what documents you’ll need.
-
-You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.

--- a/app/flows/marriage_abroad_flow/outcomes/countries/portugal/uk/partner_other/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/portugal/uk/partner_other/_same_sex.erb
@@ -1,3 +1,0 @@
-Contact your nearest [Civil Register Office](https://irn.justica.gov.pt/Contactos/Lista) in Portugal to find out about local marriage laws, including what documents you’ll need.
-
-You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.

--- a/config/smart_answers/marriage_abroad_data.yml
+++ b/config/smart_answers/marriage_abroad_data.yml
@@ -130,7 +130,6 @@ countries_with_18_outcomes:
   - paraguay
   - peru
   - pitcairn-island
-  - portugal
   - qatar
   - romania
   - russia
@@ -230,6 +229,7 @@ countries_with_1_outcome:
   - martinique
   - mayotte
   - new-caledonia
+  - portugal
   - reunion
   - st-pierre-and-miquelon
   - wallis-and-futuna


### PR DESCRIPTION
This PR Removes all branches from the marriage abroad smart answer for Portugal so it works in a similar way to France. This is because all the branches for Portugal serve up the same content and are therefore redundant. 

[Trello](https://trello.com/c/HF3nbdRa/393-marriage-abroad-portugal)

[Outcome markdown doc](https://docs.google.com/document/d/1SPvm46hJQ643zFqyDIxFriGC2RoSEg726VuqU_WNIJQ/edit)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
