### PR TITLE
Uprating 2023 redundancy pay

### DIFF
--- a/config/smart_answers/rates/redundancy_pay.yml
+++ b/config/smart_answers/rates/redundancy_pay.yml
@@ -27,3 +27,7 @@
   end_date: 2023-04-05
   max: "17,130"
   rate: 571
+- start_date: 2023-04-06
+  end_date: 2024-04-05
+  max: "19,290"
+  rate: 643

--- a/config/smart_answers/rates/redundancy_pay_northern_ireland.yml
+++ b/config/smart_answers/rates/redundancy_pay_northern_ireland.yml
@@ -27,3 +27,7 @@
   end_date: 2023-04-05
   max: "17,820"
   rate: 594
+- start_date: 2023-04-06
+  end_date: 2024-04-05
+  max: "20,070"
+  rate: 669


### PR DESCRIPTION
[Trello](https://trello.com/c/YbL0aE4s/425-uprating-update-rates-for-redundancy-pay-calculator)

[PR from 2022](https://github.com/alphagov/smart-answers/pull/5848)

The [tests were improved last year to not use specific values](https://github.com/alphagov/smart-answers/commit/857137dc7a9aa75765a9e7e3c7b4abaeb8c6738f), hence no test update.

This uprates redundancy pay for the following services:

- https://www.gov.uk/calculate-your-redundancy-pay
- https://www.gov.uk/calculate-employee-redundancy-pay

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
