### PR TITLE
Update interest rate for SA late payment penalties from 6.5 to 6.75

### DIFF
--- a/lib/smart_answer/calculators/self_assessment_penalties.rb
+++ b/lib/smart_answer/calculators/self_assessment_penalties.rb
@@ -51,7 +51,7 @@ module SmartAnswer::Calculators
       { start_date: "2022-10-11", end_date: "2022-11-21", value: 0.0475 },
       { start_date: "2022-11-22", end_date: "2023-01-05", value: 0.055 },
       { start_date: "2023-01-06", end_date: "2023-02-20", value: 0.06 },
-      { start_date: "2023-02-21", end_date: "2023-04-13", value: 0.065 },
+      { start_date: "2023-02-21", end_date: "2023-04-12", value: 0.065 },
       { start_date: "2023-04-13", end_date: "2100-04-04", value: 0.0675 },
     ].freeze
 

--- a/lib/smart_answer/calculators/self_assessment_penalties.rb
+++ b/lib/smart_answer/calculators/self_assessment_penalties.rb
@@ -51,7 +51,8 @@ module SmartAnswer::Calculators
       { start_date: "2022-10-11", end_date: "2022-11-21", value: 0.0475 },
       { start_date: "2022-11-22", end_date: "2023-01-05", value: 0.055 },
       { start_date: "2023-01-06", end_date: "2023-02-20", value: 0.06 },
-      { start_date: "2023-02-21", end_date: "2100-04-04", value: 0.065 },
+      { start_date: "2023-02-21", end_date: "2023-04-13", value: 0.065 },
+      { start_date: "2023-04-13", end_date: "2100-04-04", value: 0.0675 },
     ].freeze
 
     def tax_year_range

--- a/test/unit/calculators/self_assessment_penalties_test.rb
+++ b/test/unit/calculators/self_assessment_penalties_test.rb
@@ -310,10 +310,13 @@ module SmartAnswer::Calculators
           @calculator.payment_date = Date.parse("2023-02-03")
           assert_equal 5001, @calculator.total_owed
           @calculator.payment_date = Date.parse("2023-08-03")
-          assert_equal 5661, @calculator.total_owed
+          assert_equal 5664, @calculator.total_owed
           @calculator.payment_date = Date.parse("2024-02-03")
           assert_equal 750, @calculator.late_payment_penalty
-          assert_equal 6075, @calculator.total_owed
+          assert_equal 6085, @calculator.total_owed
+          @calculator.payment_date = Date.parse("2024-08-03")
+          assert_equal 750, @calculator.late_payment_penalty
+          assert_equal 6253, @calculator.total_owed
         end
 
         context "HMRC Covid-19 Extension to 1 April for 2019-20" do


### PR DESCRIPTION
Update interest rate from 6.6% to 6.75% from 21 February 2023.

[Trello](https://trello.com/c/5ct2SEzF/429-update-interest-rate-for-sa-late-payment-penalties-from-65-to-675)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
