### PR TITLE
Fix broken tests in minimum wage calculator

### DIFF
--- a/test/unit/calculators/minimum_wage_calculator_test.rb
+++ b/test/unit/calculators/minimum_wage_calculator_test.rb
@@ -191,7 +191,7 @@ module SmartAnswer::Calculators
         context "when eligible for living wage?" do
           should "return the national living wage rate" do
             @calculator = MinimumWageCalculator.new(age: 25)
-            assert_equal 9.5, @calculator.minimum_hourly_rate
+            assert_equal 10.42, @calculator.minimum_hourly_rate
           end
         end
       end
@@ -423,7 +423,7 @@ module SmartAnswer::Calculators
           basic_pay: 312,
           basic_hours: 39,
         )
-        assert_equal 9.5, @calculator.minimum_hourly_rate
+        assert_equal 10.42, @calculator.minimum_hourly_rate
       end
       should "return today's minimum wage rate for 19 year old" do
         @calculator = MinimumWageCalculator.new(
@@ -432,7 +432,7 @@ module SmartAnswer::Calculators
           basic_pay: 312,
           basic_hours: 39,
         )
-        assert_equal 6.83, @calculator.minimum_hourly_rate
+        assert_equal 7.49, @calculator.minimum_hourly_rate
       end
       should "return today's minimum wage rate for 17 year old" do
         @calculator = MinimumWageCalculator.new(
@@ -441,7 +441,7 @@ module SmartAnswer::Calculators
           basic_pay: 312,
           basic_hours: 39,
         )
-        assert_equal 4.81, @calculator.minimum_hourly_rate
+        assert_equal 5.28, @calculator.minimum_hourly_rate
       end
     end
 


### PR DESCRIPTION
Due to replatforming changes there was a window where GitHub status checks were turned off and a previous change was allowed to be merged with a few breaking tests. This should have picked up in review - it wasn't somehow - apologies.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
