### PR TITLE
Deadline for endorsement in start-up visa

### DIFF
--- a/config/smart_answers/check_uk_visa_data.yml
+++ b/config/smart_answers/check_uk_visa_data.yml
@@ -830,7 +830,7 @@
         You may be able to start a business if you have:
 
         + a business idea that’s different from anything else on the market
-        + your idea was assessed by an ‘endorsing body’ before 13 April 2023
+        + an idea that was assessed by an ‘endorsing body’ before 13 April 2023
       attributes:
         job_offer:
           answer: "No"

--- a/config/smart_answers/check_uk_visa_data.yml
+++ b/config/smart_answers/check_uk_visa_data.yml
@@ -830,7 +830,7 @@
         You may be able to start a business if you have:
 
         + a business idea that’s different from anything else on the market
-        + your idea assessed by an ‘endorsing body’
+        + your idea was assessed by an ‘endorsing body’ before 13 April 2023
       attributes:
         job_offer:
           answer: "No"


### PR DESCRIPTION
In the type: 'Start-up visa' I changed a bullet to:
        + your idea was assessed by an ‘endorsing body’ before 13 April 2023

Red Content Design trello: https://trello.com/c/no8EW2lf/3722-13-april-closure-of-startup-visa-route

Developer trello: https://trello.com/c/v80IdIvq/411-add-deadline-for-endorsements-for-start-up-visa-to-check-if-you-need-a-uk-visa-smart-answer



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
