### PR TITLE
Amend ga4 'action' values

### DIFF
--- a/app/views/smart_answers/question.html.erb
+++ b/app/views/smart_answers/question.html.erb
@@ -8,12 +8,11 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render 'smart_answers/shared/debug' %>
     <%
-      continue_button_text = "Continue"
       ga4_attributes = {
         event_name: "form_response",
         type: "smart answer",
         section: question.title,
-        action: continue_button_text,
+        action: "continue",
         tool_name: @presenter.title,
       }
     %>
@@ -67,7 +66,7 @@
 
         <input type="hidden" name="next" value="1" />
         <%= render "govuk_publishing_components/components/button", {
-          text: continue_button_text,
+          text: "Continue",
           margin_bottom: true
         } %>
       </div>

--- a/app/views/smart_answers/result.html.erb
+++ b/app/views/smart_answers/result.html.erb
@@ -50,7 +50,7 @@
       "event_name": "information_click", 
       "type": "smart answer",
       "section": "<%= title %>", 
-      "action": "information_click",
+      "action": "information click",
       "tool_name": "<%= @presenter.title %>" 
     }'
     data-ga4-track-links-only


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
This PR renames the value of the `action` parameter on `form_response` and `information_click` events to `continue` and `information click` respectively.

## Why
Requested by the PA's.

## Visual Changes
N/A
