### PR TITLE
Add cost of living user research banner

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,7 +8,9 @@ $govuk-new-link-styles: true;
 $govuk-include-default-font-face: false;
 
 @import "govuk_publishing_components/govuk_frontend_support";
+@import "govuk_publishing_components/components/intervention";
 
+@import "components/intervention";
 @import "smart_answers";
 
 .desktop-min-height {

--- a/app/assets/stylesheets/components/_intervention.scss
+++ b/app/assets/stylesheets/components/_intervention.scss
@@ -1,0 +1,3 @@
+.gem-c-intervention {
+  margin-top: govuk-spacing(4);
+}

--- a/app/presenters/start_node/user_research_banner.rb
+++ b/app/presenters/start_node/user_research_banner.rb
@@ -1,0 +1,21 @@
+module StartNode
+  module UserResearchBanner
+    SURVEY_URLS = {
+      "/check-benefits-financial-support" => "https://gdsuserresearch.optimalworkshop.com/treejack/ct80d1d6",
+    }.freeze
+
+    def survey_url(path)
+      landing_page?(path) && SURVEY_URLS[base_path]
+    end
+
+  private
+
+    def base_path
+      "/#{@flow_presenter.name}"
+    end
+
+    def landing_page?(current_path)
+      base_path == current_path
+    end
+  end
+end

--- a/app/presenters/start_node_presenter.rb
+++ b/app/presenters/start_node_presenter.rb
@@ -1,4 +1,6 @@
 class StartNodePresenter < NodePresenter
+  include StartNode::UserResearchBanner
+
   def initialize(node, flow_presenter, state = nil, options = {})
     super(node, flow_presenter, state)
     @renderer = options[:renderer] || SmartAnswer::ErbRenderer.new(

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,6 +1,16 @@
 <% content_for :body do %>
   <div class="smart_answer">
     <%= yield :breadcrumbs %>
+    <% if @presenter && @presenter.start_node.survey_url(request.path) %>
+      <div class="banner-container">
+          <%= render "govuk_publishing_components/components/intervention", {
+            suggestion_text: "Help improve GOV.UK",
+            suggestion_link_text: "Take part in user research",
+            suggestion_link_url: @presenter.start_node.survey_url(request.path),
+            new_tab: true,
+          } %>
+      </div>
+    <% end %>
     <main id="content" role="main">
       <%= yield %>
     </main>

--- a/test/integration/user_research_banner_test.rb
+++ b/test/integration/user_research_banner_test.rb
@@ -1,0 +1,31 @@
+require_relative "../integration_test_helper"
+
+class UserResearchBannerTest < ActionDispatch::IntegrationTest
+  context "cost of living research banner" do
+    context "check benefits financial support" do
+      setup do
+        stub_content_store_has_item("/check-benefits-financial-support")
+      end
+
+      should "display Recruitment Banner on the landing page" do
+        visit "/check-benefits-financial-support"
+        assert page.has_css?(".gem-c-intervention")
+        assert page.has_link?("Take part in user research (opens in a new tab)", href: "https://gdsuserresearch.optimalworkshop.com/treejack/ct80d1d6")
+      end
+
+      should "not display Recruitment Banner on non-landing pages of the specific smart answer" do
+        visit "/check-benefits-financial-support/y"
+
+        assert_not page.has_css?(".gem-c-intervention")
+        assert_not page.has_link?("Take part in user research (opens in a new tab)", href: "https://gdsuserresearch.optimalworkshop.com/treejack/ct80d1d6")
+      end
+
+      should "not display Recruitment Banner unless survey URL is specified for the base path" do
+        visit "/bridge-of-death"
+
+        assert_not page.has_css?(".gem-c-intervention")
+        assert_not page.has_link?("Take part in user research (opens in a new tab)", href: "https://gdsuserresearch.optimalworkshop.com/treejack/ct80d1d6")
+      end
+    end
+  end
+end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Add recruitment banner to /check-benefits-financial-support
Trello card: https://trello.com/c/1O3pEivw/1777-govuk-user-research-banner-requests-for-col-tree-testing-study-1m

Before:
<img width="1014" alt="Screenshot 2023-04-17 at 15 07 33" src="https://user-images.githubusercontent.com/96050928/232509216-bf28f082-94fe-4c9c-8661-262070dccf7f.png">

After:
<img width="1006" alt="Screenshot 2023-04-18 at 11 09 19" src="https://user-images.githubusercontent.com/96050928/232745526-bf8ccd8d-3cbe-4480-a67e-97672d40f7a8.png">

