### PR TITLE
Marriage abroad brazil broken link

### DIFF
--- a/app/flows/marriage_abroad_flow/outcomes/countries/brazil/third_country/partner_british/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/brazil/third_country/partner_british/_opposite_sex.erb
@@ -1,4 +1,4 @@
-Contact the [Embassy of Brazil](https://www.gov.br/mre/en/subjects/missions/brazilian-missions-abroad-1) in the country you’re in to find out about local marriage laws, including what documents you’ll need.
+Contact the [Embassy of Brazil](https://www.gov.br/mre/pt-br/assuntos/Embaixadas-Consulados-Missoes/do-brasil-no-exterior) in the country you’re in to find out about local marriage laws, including what documents you’ll need.
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Brazil](/foreign-travel-advice/brazil) before making any plans.
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/brazil/third_country/partner_british/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/brazil/third_country/partner_british/_same_sex.erb
@@ -1,4 +1,4 @@
-Contact the [Embassy of Brazil](https://www.gov.br/mre/en/subjects/missions/brazilian-missions-abroad-1) in the country you’re in to find out about local marriage laws, including what documents you’ll need.
+Contact the [Embassy of Brazil](https://www.gov.br/mre/pt-br/assuntos/Embaixadas-Consulados-Missoes/do-brasil-no-exterior) in the country you’re in to find out about local marriage laws, including what documents you’ll need.
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Brazil](/foreign-travel-advice/brazil) before making any plans.
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/brazil/third_country/partner_local/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/brazil/third_country/partner_local/_opposite_sex.erb
@@ -1,4 +1,4 @@
-Contact the [Embassy of Brazil](https://www.gov.br/mre/en/subjects/missions/brazilian-missions-abroad-1) in the country you’re in to find out about local marriage laws, including what documents you’ll need.
+Contact the [Embassy of Brazil](https://www.gov.br/mre/pt-br/assuntos/Embaixadas-Consulados-Missoes/do-brasil-no-exterior) in the country you’re in to find out about local marriage laws, including what documents you’ll need.
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Brazil](/foreign-travel-advice/brazil) before making any plans.
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/brazil/third_country/partner_local/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/brazil/third_country/partner_local/_same_sex.erb
@@ -1,4 +1,4 @@
-Contact the [Embassy of Brazil](https://www.gov.br/mre/en/subjects/missions/brazilian-missions-abroad-1) in the country you’re in to find out about local marriage laws, including what documents you’ll need.
+Contact the [Embassy of Brazil](https://www.gov.br/mre/pt-br/assuntos/Embaixadas-Consulados-Missoes/do-brasil-no-exterior) in the country you’re in to find out about local marriage laws, including what documents you’ll need.
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Brazil](/foreign-travel-advice/brazil) before making any plans.
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/brazil/third_country/partner_other/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/brazil/third_country/partner_other/_opposite_sex.erb
@@ -1,4 +1,4 @@
-Contact the [Embassy of Brazil](https://www.gov.br/mre/en/subjects/missions/brazilian-missions-abroad-1) in the country you’re in to find out about local marriage laws, including what documents you’ll need.
+Contact the [Embassy of Brazil](https://www.gov.br/mre/pt-br/assuntos/Embaixadas-Consulados-Missoes/do-brasil-no-exterior) in the country you’re in to find out about local marriage laws, including what documents you’ll need.
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Brazil](/foreign-travel-advice/brazil) before making any plans.
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/brazil/third_country/partner_other/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/brazil/third_country/partner_other/_same_sex.erb
@@ -1,4 +1,4 @@
-Contact the [Embassy of Brazil](https://www.gov.br/mre/en/subjects/missions/brazilian-missions-abroad-1) in the country you’re in to find out about local marriage laws, including what documents you’ll need.
+Contact the [Embassy of Brazil](https://www.gov.br/mre/pt-br/assuntos/Embaixadas-Consulados-Missoes/do-brasil-no-exterior) in the country you’re in to find out about local marriage laws, including what documents you’ll need.
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Brazil](/foreign-travel-advice/brazil) before making any plans.
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

Update to correct broken link in Brazil listed in Trello card: https://trello.com/c/gePCDnGp/4216-smart-answers-broken-link-report-15-february-2023

Change:
Contact the [Embassy of Brazil](https://www.gov.br/mre/en/subjects/missions/brazilian-missions-abroad-1) in the country you’re in to find out about local marriage laws, including what documents you’ll need.

To:
Contact the [Embassy of Brazil](https://www.gov.br/mre/pt-br/assuntos/Embaixadas-Consulados-Missoes/do-brasil-no-exterior) in the country you’re in to find out about local marriage laws, including what documents you’ll need.