### PR TITLE
Update benefit checker - Add Wales DAF benefit

### DIFF
--- a/config/smart_answers/check_benefits_financial_support_data.yml
+++ b/config/smart_answers/check_benefits_financial_support_data.yml
@@ -669,3 +669,10 @@
       url: https://www.mygov.scot/care-equipment-adaptations
       countries:
         - scotland
+    - name: discretionary_assistance_fund
+      title: Discretionary Assistance Fund
+      description: <p>If you’re in financial hardship, you could get money as part of the Discretionary Assistance Fund. This can be used if you need support to live independently or for essential costs, such as food, utility bills or emergency travel.</p>
+      url_text: Check if you’re eligible for the Discretionary Assistance Fund on the GOV.WALES website
+      url: https://www.gov.wales/discretionary-assistance-fund-daf/eligibility
+      countries:
+        - wales

--- a/test/flows/check_benefits_financial_support_flow_test.rb
+++ b/test/flows/check_benefits_financial_support_flow_test.rb
@@ -1196,5 +1196,12 @@ class CheckBenefitsFinancialSupportFlowTest < ActiveSupport::TestCase
       assert_rendered_outcome text: "You could get help from your local council to make changes to your home if you’re disabled or you live with someone who is."
       assert_rendered_outcome text: "Check if you’re eligible for help with house adaptations on the mygov.scot website"
     end
+
+    should "render Discretionary Assistance Fund" do
+      add_responses where_do_you_live: "wales"
+
+      assert_rendered_outcome text: "Discretionary Assistance Fund"
+      assert_rendered_outcome text: "Check if you’re eligible for the Discretionary Assistance Fund on the GOV.WALES website"
+    end
   end
 end


### PR DESCRIPTION
This PR adds a new result to this smart answer: https://www.gov.uk/check-benefits-financial-support. 

There are no conditions, other than the country being Wales, so it was unnecessary to make changes to the calculator. 

[Trello card](https://trello.com/c/iy6uZAPV/466-check-benefits-and-financial-support-you-can-get-smart-answer-small-change)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
