### PR TITLE
Fix section parameter value on form_start_again events

### DIFF
--- a/app/views/smart_answers/custom_result_full_width.erb
+++ b/app/views/smart_answers/custom_result_full_width.erb
@@ -79,5 +79,5 @@
     <% end %>
   </div>
 
-  <%= render 'smart_answers/shared/previous_answers' %>
+  <%= render 'smart_answers/shared/previous_answers', form_complete: true %>
 </div>

--- a/app/views/smart_answers/question.html.erb
+++ b/app/views/smart_answers/question.html.erb
@@ -72,6 +72,6 @@
       </div>
     <% end %>
 
-    <%= render 'smart_answers/shared/previous_answers' %>
+    <%= render 'smart_answers/shared/previous_answers', form_complete: false %>
   </div>
 </div>

--- a/app/views/smart_answers/result.html.erb
+++ b/app/views/smart_answers/result.html.erb
@@ -79,7 +79,7 @@
       <% end %>
     </div>
 
-    <%= render 'smart_answers/shared/previous_answers' %>
+    <%= render 'smart_answers/shared/previous_answers', form_complete: true %>
   </div>
 
   <% if defined?(@presenter.finished?) and @presenter.finished? %>

--- a/app/views/smart_answers/shared/_previous_answers.html.erb
+++ b/app/views/smart_answers/shared/_previous_answers.html.erb
@@ -1,3 +1,4 @@
+<% form_complete ||= false %>
 <% if @presenter.accepted_responses.any? %>
   <%= render "govuk_publishing_components/components/heading", {
     text: "Your answers",
@@ -17,7 +18,7 @@
         ga4_link: {
           event_name: "form_start_again",
           type: "smart answer",
-          section: @presenter.current_node.title,
+          section: form_complete ? "Information based on your answers" : @presenter.current_node.title,
           action: "start again",
           tool_name: @presenter.title,
         }

--- a/test/integration/engine/start_again_test.rb
+++ b/test/integration/engine/start_again_test.rb
@@ -1,0 +1,48 @@
+require_relative "engine_test_helper"
+
+class StartAgainTest < EngineIntegrationTest
+  should "should set the GA4 section parameter to the title of the question when the flow is in progress" do
+    visit "/session-based/start"
+
+    choose "Response 1"
+    click_on "Continue"
+
+    assert page.has_css?(".govuk-link[data-module='gem-track-click ga4-link-tracker']")
+    assert page.has_css?(".govuk-link[data-ga4-link='{\"event_name\":\"form_start_again\",\"type\":\"smart answer\",\"section\":\"Question 2 title\",\"action\":\"start again\",\"tool_name\":\"This is a test flow\"}']")
+  end
+
+  should "should set the GA4 section parameter to \"Information based on your answers\" when the flow has been completed" do
+    visit "/session-based/start"
+
+    choose "Response 1"
+    click_on "Continue"
+
+    fill_in "response", with: "Response"
+    click_on "Continue"
+
+    assert_page_has_content "Results title"
+    assert_current_url "/session-based/results"
+    assert page.has_css?(".govuk-link[data-module='gem-track-click ga4-link-tracker']")
+    assert page.has_css?(".govuk-link[data-ga4-link='{\"event_name\":\"form_start_again\",\"type\":\"smart answer\",\"section\":\"Information based on your answers\",\"action\":\"start again\",\"tool_name\":\"This is a test flow\"}']")
+  end
+
+  should "should set the GA4 section parameter to title of the question when the user revisits a section to change their answer" do
+    visit "/session-based/start"
+
+    choose "Response 1"
+    click_on "Continue"
+
+    fill_in "response", with: "Response"
+    click_on "Continue"
+
+    assert_page_has_content "Results title"
+    assert_current_url "/session-based/results"
+    assert page.has_css?(".govuk-link[data-module='gem-track-click ga4-link-tracker']")
+    assert page.has_css?(".govuk-link[data-ga4-link='{\"event_name\":\"form_start_again\",\"type\":\"smart answer\",\"section\":\"Information based on your answers\",\"action\":\"start again\",\"tool_name\":\"This is a test flow\"}']")
+
+    click_on "Change Question 2 title"
+
+    assert page.has_css?(".govuk-link[data-module='gem-track-click ga4-link-tracker']")
+    assert page.has_css?(".govuk-link[data-ga4-link='{\"event_name\":\"form_start_again\",\"type\":\"smart answer\",\"section\":\"Question 2 title\",\"action\":\"start again\",\"tool_name\":\"This is a test flow\"}']")
+  end
+end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## What
This PR fixes a bug where the incorrect value was being pulled for the `section` parameter on `form_complete` events (it should be "Information based on your answers").

## Why
Requested by the PA's.

## Visual Changes
N/A
