### PR TITLE
Ensure all GOVUK links for GA4 tracking are relative links

### DIFF
--- a/app/views/components/_result_card.html.erb
+++ b/app/views/components/_result_card.html.erb
@@ -8,6 +8,12 @@
   if !title || !url || !url_text || !url_track_action
     raise ArgumentError, "The result card component requires a title, url, url_text and url_track_action"
   end
+
+  ga4_url = url.clone
+
+  if ga4_url.start_with?("https://www.gov.uk")
+    ga4_url = ga4_url.gsub("https://www.gov.uk", "")
+  end
 %>
 <div class="app-c-result-card">
   <%= render "govuk_publishing_components/components/heading", {
@@ -29,6 +35,6 @@
     "track-category": "SmartAnswerClicked",
     "track-action": url_track_action,
     "track-label": url,
-    "ga4-ecommerce-path": url
+    "ga4-ecommerce-path": ga4_url
   } %>
 </div>

--- a/test/components/result_card_test.rb
+++ b/test/components/result_card_test.rb
@@ -90,4 +90,32 @@ class ResultCardTest < ComponentTestCase
       assert_select ".app-c-result-card__description", text: "Result card description"
     end
   end
+
+  test "renders a result card with the GA4 ecommerce path on the URL" do
+    render_component({
+      title: "Result card title",
+      description: "Result card description",
+      url: "https://example.com/test-path",
+      url_text: "GOV.UK",
+      url_track_action: "Smart Answer Flow Name",
+    })
+
+    assert_select ".app-c-result-card" do
+      assert_select ".app-c-result-card__link[data-ga4-ecommerce-path='https://example.com/test-path']", true
+    end
+  end
+
+  test "replaces https://www.gov.uk on GA4 ecommerce path URLs" do
+    render_component({
+      title: "Result card title",
+      description: "Result card description",
+      url: "https://www.gov.uk/this-is-a-path",
+      url_text: "GOV.UK",
+      url_track_action: "Smart Answer Flow Name",
+    })
+
+    assert_select ".app-c-result-card" do
+      assert_select ".app-c-result-card__link[data-ga4-ecommerce-path='/this-is-a-path']", true
+    end
+  end
 end


### PR DESCRIPTION
Hi @gclssvglx, would you be able to approve this PR if all is OK? Thanks :+1:

In our GA4 tracking, there's an inconsistency where some of the GOVUK URLs are tracked as `/path`, and some are `https://www.gov.uk/path`. This makes it harder for the analysts to use the data as some have `https://www.gov.uk` and others do not. Therefore this change ensures all the urls appear as '/path' in their dashboard.

Example page: http://127.0.0.1:3010/check-benefits-financial-support/y/england/no/no/no/yes/no/dont_know/under_16000
see the "Check if you’re eligible for the Warm Home Discount scheme" link

https://trello.com/c/GDaFCuJT/488-remove-https-wwwgovuk-from-item-id-in-cost-of-living-smart-answer-item-id-parameter

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
