### PR TITLE
Update interest rate for SA late payment penalties from 6.75 to 7

### DIFF
--- a/lib/smart_answer/calculators/self_assessment_penalties.rb
+++ b/lib/smart_answer/calculators/self_assessment_penalties.rb
@@ -52,7 +52,8 @@ module SmartAnswer::Calculators
       { start_date: "2022-11-22", end_date: "2023-01-05", value: 0.055 },
       { start_date: "2023-01-06", end_date: "2023-02-20", value: 0.06 },
       { start_date: "2023-02-21", end_date: "2023-04-12", value: 0.065 },
-      { start_date: "2023-04-13", end_date: "2100-04-04", value: 0.0675 },
+      { start_date: "2023-04-13", end_date: "2023-05-30", value: 0.0675 },
+      { start_date: "2023-05-31", end_date: "2100-04-04", value: 0.07 },
     ].freeze
 
     def tax_year_range
@@ -236,7 +237,7 @@ module SmartAnswer::Calculators
       if rate_for_date.present?
         rate_for_date[:value] / 365.0
       else
-        0.0325 / 365.0
+        0.035 / 365.0
       end
     end
   end

--- a/lib/smart_answer/calculators/self_assessment_penalties.rb
+++ b/lib/smart_answer/calculators/self_assessment_penalties.rb
@@ -237,7 +237,7 @@ module SmartAnswer::Calculators
       if rate_for_date.present?
         rate_for_date[:value] / 365.0
       else
-        0.035 / 365.0
+        0.0325 / 365.0
       end
     end
   end

--- a/test/unit/calculators/self_assessment_penalties_test.rb
+++ b/test/unit/calculators/self_assessment_penalties_test.rb
@@ -310,13 +310,13 @@ module SmartAnswer::Calculators
           @calculator.payment_date = Date.parse("2023-02-03")
           assert_equal 5001, @calculator.total_owed
           @calculator.payment_date = Date.parse("2023-08-03")
-          assert_equal 5664, @calculator.total_owed
+          assert_equal 5666, @calculator.total_owed
           @calculator.payment_date = Date.parse("2024-02-03")
           assert_equal 750, @calculator.late_payment_penalty
-          assert_equal 6085, @calculator.total_owed
+          assert_equal 6092, @calculator.total_owed
           @calculator.payment_date = Date.parse("2024-08-03")
           assert_equal 750, @calculator.late_payment_penalty
-          assert_equal 6253, @calculator.total_owed
+          assert_equal 6267, @calculator.total_owed
         end
 
         context "HMRC Covid-19 Extension to 1 April for 2019-20" do
@@ -439,6 +439,14 @@ module SmartAnswer::Calculators
         should "confirm payment was made late" do
           assert_not @calculator.paid_on_time?
         end
+      end
+    end
+
+    context "late payment interest rates" do
+      should "after May 31st, the user should have a late payment penalty of 7%" do
+        @calculator.payment_date = Date.parse("2023-06-1")
+        assert_equal 250, @calculator.late_payment_penalty
+        assert_equal 106.13, @calculator.interest.to_f
       end
     end
   end


### PR DESCRIPTION
Update interest rates from 6.75% to 7% for ‘late payments’ and from 3.25% to 3.5% on ‘repayments’.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
