### PR TITLE
Remove mention of form BD8

### DIFF
--- a/app/flows/register_a_death_flow/outcomes/uk_result.erb
+++ b/app/flows/register_a_death_flow/outcomes/uk_result.erb
@@ -37,7 +37,7 @@
     - marriage or civil partnership certificate
     - NHS medical card
     - passport
-    - proof of address (eg utility bill)
+    - proof of address (such as a utility bill)
   
     Ask the register office what to do if you do not have them.
   <% else %>
@@ -81,18 +81,20 @@
     Documents you’ll get
     --------
 
-    When you register a death you’ll get:
+When you register a death, you’ll get a certificate for burial or cremation (the ‘green form’). This gives you permission for a burial or to apply for a cremation.
 
-    - a Certificate for Burial or Cremation (the ‘green form’) - gives permission for burial or an application for cremation
-    - a Certificate of Registration of Death (form BD8) - you may need to fill this in and return it if the person was getting a State Pension or benefits (the form will come with a pre-paid envelope so you know where to send it)
+You’ll also be able to buy death certificates - these prove the death has been registered. These certificates will be needed for [sorting out the person’s affairs](/when-someone-dies). You can:
 
-    You can buy extra death certificates - these will be needed for [sorting out the person’s affairs](/when-someone-dies).
+- buy death certificates at the register office when you register the death
+- [order death certificates online](/order-copy-birth-death-marriage-certificate)
+
   <% else %>
     Documents you’ll get
     --------
 
-    When you register a death you’ll get a Certificate of Registration of Death (form BD8). You may need to fill this in and return it if the person was getting a State Pension or benefits (the form will come with a pre-paid envelope so you know where to send it).
+When you register a death, you’ll be able to buy death certificates - these prove the death has been registered. These certificates will be needed for [sorting out the person’s affairs](/when-someone-dies). You can:
 
-    You can buy extra death certificates - these will be needed for [sorting out the person’s affairs](/when-someone-dies).
+- buy death certificates at the register office when you register the death
+- [order death certificates online](/order-copy-birth-death-marriage-certificate)
   <% end %>
 <% end %>


### PR DESCRIPTION
https://govuk.zendesk.com/agent/tickets/5333852
https://trello.com/c/ixw9gBoo/4279-chase-on-23-may-30-may-register-a-death-smart-answer-bd8-form-decommission

Form BD8 is being decommissioned from 29 May 2023, so all mentions of it from this outcome need to be removed.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
