### PR TITLE
Update Montserrat and Pitcairn outcomes

### DIFF
--- a/app/flows/marriage_abroad_flow/outcomes/countries/montserrat/uk/partner_british/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/montserrat/uk/partner_british/_opposite_sex.erb
@@ -1,9 +1,11 @@
+##Before you start
+
 Montserrat is a British overseas territory.
 
 Contact the Montserrat Government to find out about getting married there, including what documents you’ll need.
 
 $A
-Governor&#39;s Office Brades
+Governor’s Office Brades
 8 Farara Plaza
 Brades
 Montserrat
@@ -11,10 +13,25 @@ $A
 
 $C
 Switchboard: (1) (664) 491 2688/9
-Governor&#39;s Residence: (1) (664) 491 6124
-Facsmile: (1) (664) 491 8867
-
-[Governor&#39;s Office Brades - opening hours](/world/organisations/the-governors-office-montserrat/office/governor-s-office-brades)
+Governor’s Residence: (1) (664) 491 6124
+Fax: (1) (664) 491 8867
+[Governor’s Office Brades - opening hours](/world/organisations/the-governors-office-montserrat/office/governor-s-office-brades)
 $C
 
-^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Montserrat](/foreign-travel-advice/montserrat) before making any plans.
+^You should [get legal advice](/guidance/professional-services-if-you-are-abroad) and check the [travel advice for Montserrat](/foreign-travel-advice/montserrat) before making any plans.
+
+##Prove you're free to get married
+
+You need to get a certificate of no impediment (CNI) in the UK to prove you’re legally allowed to get married in Montserrat.
+
+To get a CNI, make an appointment at your [local register office](/register-offices) to give notice of your marriage. A CNI costs £35.
+
+Your partner will need to follow the same process to get their own CNI.
+ 
+^Contact your local register office to find out what you need to do if you live in [Scotland](https://www.nrscotland.gov.uk/registration), [Northern Ireland](https://www.nidirect.gov.uk/contacts/district-registrars-northern-ireland), [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).^
+ 
+You’ll need to bring [certain documents](/marriages-civil-partnerships/documents-youll-need-to-give-notice) with you to your appointment.
+ 
+Your notice will be publicly displayed in the register office for 28 days. You can collect your CNI after this if nobody registers an objection.
+ 
+If your CNI was issued in England, Wales or Northern Ireland, it will usually be valid for 6 months. If it was issued in Scotland, it will expire after 3 months. Check with your local register office to find out how long a CNI is valid if you live in the [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).

--- a/app/flows/marriage_abroad_flow/outcomes/countries/montserrat/uk/partner_local/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/montserrat/uk/partner_local/_opposite_sex.erb
@@ -1,9 +1,11 @@
+##Before you start
+
 Montserrat is a British overseas territory.
 
 Contact the Montserrat Government to find out about getting married there, including what documents you’ll need.
 
 $A
-Governor&#39;s Office Brades
+Governor’s Office Brades
 8 Farara Plaza
 Brades
 Montserrat
@@ -11,13 +13,26 @@ $A
 
 $C
 Switchboard: (1) (664) 491 2688/9
-Governor&#39;s Residence: (1) (664) 491 6124
-Facsmile: (1) (664) 491 8867
-
-[Governor&#39;s Office Brades - opening hours](/world/organisations/the-governors-office-montserrat/office/governor-s-office-brades)
+Governor’s Residence: (1) (664) 491 6124
+Fax: (1) (664) 491 8867
+[Governor’s Office Brades - opening hours](/world/organisations/the-governors-office-montserrat/office/governor-s-office-brades)
 $C
 
-^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Montserrat](/foreign-travel-advice/montserrat) before making any plans.
+^You should [get legal advice](/guidance/professional-services-if-you-are-abroad) and check the [travel advice for Montserrat](/foreign-travel-advice/montserrat) before making any plans.
+
+##Prove you're free to get married
+
+You need to get a certificate of no impediment (CNI) in the UK to prove you’re legally allowed to get married in Montserrat.
+
+To get a CNI, make an appointment at your [local register office](/register-offices) to give notice of your marriage. A CNI costs £35.
+ 
+^Contact your local register office to find out what you need to do if you live in [Scotland](https://www.nrscotland.gov.uk/registration), [Northern Ireland](https://www.nidirect.gov.uk/contacts/district-registrars-northern-ireland), [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).^
+ 
+You’ll need to bring [certain documents](/marriages-civil-partnerships/documents-youll-need-to-give-notice) with you to your appointment.
+ 
+Your notice will be publicly displayed in the register office for 28 days. You can collect your CNI after this if nobody registers an objection.
+ 
+If your CNI was issued in England, Wales or Northern Ireland, it will usually be valid for 6 months. If it was issued in Scotland, it will expire after 3 months. Check with your local register office to find out how long a CNI is valid if you live in the [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/montserrat/uk/partner_other/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/montserrat/uk/partner_other/_opposite_sex.erb
@@ -1,9 +1,11 @@
+##Before you start
+
 Montserrat is a British overseas territory.
 
 Contact the Montserrat Government to find out about getting married there, including what documents you’ll need.
 
 $A
-Governor&#39;s Office Brades
+Governor’s Office Brades
 8 Farara Plaza
 Brades
 Montserrat
@@ -11,13 +13,26 @@ $A
 
 $C
 Switchboard: (1) (664) 491 2688/9
-Governor&#39;s Residence: (1) (664) 491 6124
-Facsmile: (1) (664) 491 8867
-
-[Governor&#39;s Office Brades - opening hours](/world/organisations/the-governors-office-montserrat/office/governor-s-office-brades)
+Governor’s Residence: (1) (664) 491 6124
+Fax: (1) (664) 491 8867
+[Governor’s Office Brades - opening hours](/world/organisations/the-governors-office-montserrat/office/governor-s-office-brades)
 $C
 
-^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Montserrat](/foreign-travel-advice/montserrat) before making any plans.
+^You should [get legal advice](/guidance/professional-services-if-you-are-abroad) and check the [travel advice for Montserrat](/foreign-travel-advice/montserrat) before making any plans.
+
+##Prove you're free to get married
+
+You need to get a certificate of no impediment (CNI) in the UK to prove you’re legally allowed to get married in Montserrat.
+
+To get a CNI, make an appointment at your [local register office](/register-offices) to give notice of your marriage. A CNI costs £35.
+ 
+^Contact your local register office to find out what you need to do if you live in [Scotland](https://www.nrscotland.gov.uk/registration), [Northern Ireland](https://www.nidirect.gov.uk/contacts/district-registrars-northern-ireland), [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).^
+ 
+You’ll need to bring [certain documents](/marriages-civil-partnerships/documents-youll-need-to-give-notice) with you to your appointment.
+ 
+Your notice will be publicly displayed in the register office for 28 days. You can collect your CNI after this if nobody registers an objection.
+ 
+If your CNI was issued in England, Wales or Northern Ireland, it will usually be valid for 6 months. If it was issued in Scotland, it will expire after 3 months. Check with your local register office to find out how long a CNI is valid if you live in the [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/pitcairn-island/ceremony_country/partner_british/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/pitcairn-island/ceremony_country/partner_british/_same_sex.erb
@@ -1,1 +1,21 @@
-It’s not possible to get legal recognition for your same-sex relationship in Pitcairn Island.
+Pitcairn Island is a British overseas territory.
+
+Contact the Pitcairn Island Government to find out about getting married there, including what documents you’ll need.
+
+$A
+British High Commission New Zealand
+British High Commission
+44 Hill Street
+Thorndon
+Wellington 6011
+New Zealand
+$A
+
+$C
+Telephone: +64 (0) 4 924 2888\\
+Fax: +64 (0) 4 473 4982
+
+[British High Commission New Zealand - opening hours](/world/organisations/british-high-commission-wellington/office/british-high-commission-new-zealand)
+$C
+
+^You should [get legal advice](/guidance/professional-services-if-you-are-abroad) before making any plans.^

--- a/app/flows/marriage_abroad_flow/outcomes/countries/pitcairn-island/ceremony_country/partner_local/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/pitcairn-island/ceremony_country/partner_local/_same_sex.erb
@@ -1,1 +1,25 @@
-It’s not possible to get legal recognition for your same-sex relationship in Pitcairn Island.
+Pitcairn Island is a British overseas territory.
+
+Contact the Pitcairn Island Government to find out about getting married there, including what documents you’ll need.
+
+$A
+British High Commission New Zealand
+British High Commission
+44 Hill Street
+Thorndon
+Wellington 6011
+New Zealand
+$A
+
+$C
+Telephone: +64 (0) 4 924 2888\\
+Fax: +64 (0) 4 473 4982
+
+[British High Commission New Zealand - opening hours](/world/organisations/british-high-commission-wellington/office/british-high-commission-new-zealand)
+$C
+
+^You should [get legal advice](/guidance/professional-services-if-you-are-abroad) before making any plans.^
+
+##Naturalisation of your partner if they move to the UK
+
+Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.

--- a/app/flows/marriage_abroad_flow/outcomes/countries/pitcairn-island/ceremony_country/partner_other/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/pitcairn-island/ceremony_country/partner_other/_same_sex.erb
@@ -1,1 +1,25 @@
-It’s not possible to get legal recognition for your same-sex relationship in Pitcairn Island.
+Pitcairn Island is a British overseas territory.
+
+Contact the Pitcairn Island Government to find out about getting married there, including what documents you’ll need.
+
+$A
+British High Commission New Zealand
+British High Commission
+44 Hill Street
+Thorndon
+Wellington 6011
+New Zealand
+$A
+
+$C
+Telephone: +64 (0) 4 924 2888\\
+Fax: +64 (0) 4 473 4982
+
+[British High Commission New Zealand - opening hours](/world/organisations/british-high-commission-wellington/office/british-high-commission-new-zealand)
+$C
+
+^You should [get legal advice](/guidance/professional-services-if-you-are-abroad) before making any plans.^
+
+##Naturalisation of your partner if they move to the UK
+
+Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.

--- a/app/flows/marriage_abroad_flow/outcomes/countries/pitcairn-island/third_country/partner_british/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/pitcairn-island/third_country/partner_british/_same_sex.erb
@@ -1,1 +1,21 @@
-It’s not possible to get legal recognition for your same-sex relationship in Pitcairn Island.
+Pitcairn Island is a British overseas territory.
+
+Contact the Pitcairn Island Government to find out about getting married there, including what documents you’ll need.
+
+$A
+British High Commission New Zealand
+British High Commission
+44 Hill Street
+Thorndon
+Wellington 6011
+New Zealand
+$A
+
+$C
+Telephone: +64 (0) 4 924 2888\\
+Fax: +64 (0) 4 473 4982
+
+[British High Commission New Zealand - opening hours](/world/organisations/british-high-commission-wellington/office/british-high-commission-new-zealand)
+$C
+
+^You should [get legal advice](/guidance/professional-services-if-you-are-abroad) and check the [travel advice for Pitcairn Island](/foreign-travel-advice/pitcairn-island) before making any plans.

--- a/app/flows/marriage_abroad_flow/outcomes/countries/pitcairn-island/third_country/partner_local/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/pitcairn-island/third_country/partner_local/_same_sex.erb
@@ -1,1 +1,25 @@
-It’s not possible to get legal recognition for your same-sex relationship in Pitcairn Island.
+Pitcairn Island is a British overseas territory.
+
+Contact the Pitcairn Island Government to find out about getting married there, including what documents you’ll need.
+
+$A
+British High Commission New Zealand
+British High Commission
+44 Hill Street
+Thorndon
+Wellington 6011
+New Zealand
+$A
+
+$C
+Telephone: +64 (0) 4 924 2888\\
+Fax: +64 (0) 4 473 4982
+
+[British High Commission New Zealand - opening hours](/world/organisations/british-high-commission-wellington/office/british-high-commission-new-zealand)
+$C
+
+^You should [get legal advice](/guidance/professional-services-if-you-are-abroad) and check the [travel advice for Pitcairn Island](/foreign-travel-advice/pitcairn-island) before making any plans.
+
+##Naturalisation of your partner if they move to the UK
+
+Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.

--- a/app/flows/marriage_abroad_flow/outcomes/countries/pitcairn-island/third_country/partner_other/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/pitcairn-island/third_country/partner_other/_same_sex.erb
@@ -1,1 +1,25 @@
-It’s not possible to get legal recognition for your same-sex relationship in Pitcairn Island.
+Pitcairn Island is a British overseas territory.
+
+Contact the Pitcairn Island Government to find out about getting married there, including what documents you’ll need.
+
+$A
+British High Commission New Zealand
+British High Commission
+44 Hill Street
+Thorndon
+Wellington 6011
+New Zealand
+$A
+
+$C
+Telephone: +64 (0) 4 924 2888\\
+Fax: +64 (0) 4 473 4982
+
+[British High Commission New Zealand - opening hours](/world/organisations/british-high-commission-wellington/office/british-high-commission-new-zealand)
+$C
+
+^You should [get legal advice](/guidance/professional-services-if-you-are-abroad) and check the [travel advice for Pitcairn Island](/foreign-travel-advice/pitcairn-island) before making any plans.
+
+##Naturalisation of your partner if they move to the UK
+
+Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.

--- a/app/flows/marriage_abroad_flow/outcomes/countries/pitcairn-island/uk/partner_british/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/pitcairn-island/uk/partner_british/_opposite_sex.erb
@@ -1,3 +1,5 @@
+##Before you start
+
 Pitcairn Island is a British overseas territory.
 
 Contact the Pitcairn Island Government to find out about getting married there, including what documents you’ll need.
@@ -12,10 +14,26 @@ New Zealand
 $A
 
 $C
-Telephone: +64 (0) 4 924 2888
+Telephone: +64 (0) 4 924 2888\\
 Fax: +64 (0) 4 473 4982
 
 [British High Commission New Zealand - opening hours](/world/organisations/british-high-commission-wellington/office/british-high-commission-new-zealand)
 $C
 
-^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Pitcairn Island](/foreign-travel-advice/pitcairn-island) before making any plans.
+^You should [get legal advice](/guidance/professional-services-if-you-are-abroad) and check the [travel advice for Pitcairn Island](/foreign-travel-advice/pitcairn-island) before making any plans.
+
+##Prove you're free to get married
+
+You need to get a certificate of no impediment (CNI) to prove you’re legally allowed to get married on Pitcairn Island.
+
+To get a CNI, make an appointment at your [local register office](/register-offices) to give notice of your marriage. A CNI costs £35.
+
+Your partner will need to follow the same process to get their own CNI.
+ 
+^Contact your local register office to find out what you need to do if you live in [Scotland](https://www.nrscotland.gov.uk/registration), [Northern Ireland](https://www.nidirect.gov.uk/contacts/district-registrars-northern-ireland), [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).^
+ 
+You’ll need to bring [certain documents](/marriages-civil-partnerships/documents-youll-need-to-give-notice) with you to your appointment.
+ 
+Your notice will be publicly displayed in the register office for 28 days. You can collect your CNI after this if nobody registers an objection.
+ 
+If your CNI was issued in England, Wales or Northern Ireland, it will usually be valid for 6 months. If it was issued in Scotland, it will expire after 3 months. Check with your local register office to find out how long a CNI is valid if you live in the [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).

--- a/app/flows/marriage_abroad_flow/outcomes/countries/pitcairn-island/uk/partner_british/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/pitcairn-island/uk/partner_british/_same_sex.erb
@@ -1,1 +1,39 @@
-It’s not possible to get legal recognition for your same-sex relationship in Pitcairn Island.
+##Before you start
+
+Pitcairn Island is a British overseas territory.
+
+Contact the Pitcairn Island Government to find out about getting married there, including what documents you’ll need.
+
+$A
+British High Commission New Zealand
+British High Commission
+44 Hill Street
+Thorndon
+Wellington 6011
+New Zealand
+$A
+
+$C
+Telephone: +64 (0) 4 924 2888\\
+Fax: +64 (0) 4 473 4982
+
+[British High Commission New Zealand - opening hours](/world/organisations/british-high-commission-wellington/office/british-high-commission-new-zealand)
+$C
+
+^You should [get legal advice](/guidance/professional-services-if-you-are-abroad) and check the [travel advice for Pitcairn Island](/foreign-travel-advice/pitcairn-island) before making any plans.
+
+##Prove you're free to get married
+
+You need to get a certificate of no impediment (CNI) to prove you’re legally allowed to get married on Pitcairn Island.
+
+To get a CNI, make an appointment at your [local register office](/register-offices) to give notice of your marriage. A CNI costs £35.
+
+Your partner will need to follow the same process to get their own CNI.
+ 
+^Contact your local register office to find out what you need to do if you live in [Scotland](https://www.nrscotland.gov.uk/registration), [Northern Ireland](https://www.nidirect.gov.uk/contacts/district-registrars-northern-ireland), [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).^
+ 
+You’ll need to bring [certain documents](/marriages-civil-partnerships/documents-youll-need-to-give-notice) with you to your appointment.
+ 
+Your notice will be publicly displayed in the register office for 28 days. You can collect your CNI after this if nobody registers an objection.
+ 
+If your CNI was issued in England, Wales or Northern Ireland, it will usually be valid for 6 months. If it was issued in Scotland, it will expire after 3 months. Check with your local register office to find out how long a CNI is valid if you live in the [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).

--- a/app/flows/marriage_abroad_flow/outcomes/countries/pitcairn-island/uk/partner_local/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/pitcairn-island/uk/partner_local/_opposite_sex.erb
@@ -1,3 +1,5 @@
+##Before you start
+
 Pitcairn Island is a British overseas territory.
 
 Contact the Pitcairn Island Government to find out about getting married there, including what documents you’ll need.
@@ -12,13 +14,27 @@ New Zealand
 $A
 
 $C
-Telephone: +64 (0) 4 924 2888
+Telephone: +64 (0) 4 924 2888\\
 Fax: +64 (0) 4 473 4982
 
 [British High Commission New Zealand - opening hours](/world/organisations/british-high-commission-wellington/office/british-high-commission-new-zealand)
 $C
 
-^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Pitcairn Island](/foreign-travel-advice/pitcairn-island) before making any plans.
+^You should [get legal advice](/guidance/professional-services-if-you-are-abroad) and check the [travel advice for Pitcairn Island](/foreign-travel-advice/pitcairn-island) before making any plans.
+
+##Prove you're free to get married
+
+You need to get a certificate of no impediment (CNI) to prove you’re legally allowed to get married on Pitcairn Island.
+
+To get a CNI, make an appointment at your [local register office](/register-offices) to give notice of your marriage. A CNI costs £35.
+ 
+^Contact your local register office to find out what you need to do if you live in [Scotland](https://www.nrscotland.gov.uk/registration), [Northern Ireland](https://www.nidirect.gov.uk/contacts/district-registrars-northern-ireland), [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).^
+ 
+You’ll need to bring [certain documents](/marriages-civil-partnerships/documents-youll-need-to-give-notice) with you to your appointment.
+ 
+Your notice will be publicly displayed in the register office for 28 days. You can collect your CNI after this if nobody registers an objection.
+ 
+If your CNI was issued in England, Wales or Northern Ireland, it will usually be valid for 6 months. If it was issued in Scotland, it will expire after 3 months. Check with your local register office to find out how long a CNI is valid if you live in the [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/pitcairn-island/uk/partner_local/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/pitcairn-island/uk/partner_local/_same_sex.erb
@@ -1,1 +1,41 @@
-It’s not possible to get legal recognition for your same-sex relationship in Pitcairn Island.
+##Before you start
+
+Pitcairn Island is a British overseas territory.
+
+Contact the Pitcairn Island Government to find out about getting married there, including what documents you’ll need.
+
+$A
+British High Commission New Zealand
+British High Commission
+44 Hill Street
+Thorndon
+Wellington 6011
+New Zealand
+$A
+
+$C
+Telephone: +64 (0) 4 924 2888\\
+Fax: +64 (0) 4 473 4982
+
+[British High Commission New Zealand - opening hours](/world/organisations/british-high-commission-wellington/office/british-high-commission-new-zealand)
+$C
+
+^You should [get legal advice](/guidance/professional-services-if-you-are-abroad) and check the [travel advice for Pitcairn Island](/foreign-travel-advice/pitcairn-island) before making any plans.
+
+##Prove you're free to get married
+
+You need to get a certificate of no impediment (CNI) to prove you’re legally allowed to get married on Pitcairn Island.
+
+To get a CNI, make an appointment at your [local register office](/register-offices) to give notice of your marriage. A CNI costs £35.
+ 
+^Contact your local register office to find out what you need to do if you live in [Scotland](https://www.nrscotland.gov.uk/registration), [Northern Ireland](https://www.nidirect.gov.uk/contacts/district-registrars-northern-ireland), [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).^
+ 
+You’ll need to bring [certain documents](/marriages-civil-partnerships/documents-youll-need-to-give-notice) with you to your appointment.
+ 
+Your notice will be publicly displayed in the register office for 28 days. You can collect your CNI after this if nobody registers an objection.
+ 
+If your CNI was issued in England, Wales or Northern Ireland, it will usually be valid for 6 months. If it was issued in Scotland, it will expire after 3 months. Check with your local register office to find out how long a CNI is valid if you live in the [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
+
+##Naturalisation of your partner if they move to the UK
+
+Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.

--- a/app/flows/marriage_abroad_flow/outcomes/countries/pitcairn-island/uk/partner_other/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/pitcairn-island/uk/partner_other/_opposite_sex.erb
@@ -1,3 +1,5 @@
+##Before you start
+
 Pitcairn Island is a British overseas territory.
 
 Contact the Pitcairn Island Government to find out about getting married there, including what documents you’ll need.
@@ -12,13 +14,27 @@ New Zealand
 $A
 
 $C
-Telephone: +64 (0) 4 924 2888
+Telephone: +64 (0) 4 924 2888\\
 Fax: +64 (0) 4 473 4982
 
 [British High Commission New Zealand - opening hours](/world/organisations/british-high-commission-wellington/office/british-high-commission-new-zealand)
 $C
 
-^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Pitcairn Island](/foreign-travel-advice/pitcairn-island) before making any plans.
+^You should [get legal advice](/guidance/professional-services-if-you-are-abroad) and check the [travel advice for Pitcairn Island](/foreign-travel-advice/pitcairn-island) before making any plans.
+
+##Prove you're free to get married
+
+You need to get a certificate of no impediment (CNI) to prove you’re legally allowed to get married on Pitcairn Island.
+
+To get a CNI, make an appointment at your [local register office](/register-offices) to give notice of your marriage. A CNI costs £35.
+ 
+^Contact your local register office to find out what you need to do if you live in [Scotland](https://www.nrscotland.gov.uk/registration), [Northern Ireland](https://www.nidirect.gov.uk/contacts/district-registrars-northern-ireland), [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).^
+ 
+You’ll need to bring [certain documents](/marriages-civil-partnerships/documents-youll-need-to-give-notice) with you to your appointment.
+ 
+Your notice will be publicly displayed in the register office for 28 days. You can collect your CNI after this if nobody registers an objection.
+ 
+If your CNI was issued in England, Wales or Northern Ireland, it will usually be valid for 6 months. If it was issued in Scotland, it will expire after 3 months. Check with your local register office to find out how long a CNI is valid if you live in the [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/pitcairn-island/uk/partner_other/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/pitcairn-island/uk/partner_other/_same_sex.erb
@@ -1,1 +1,41 @@
-It’s not possible to get legal recognition for your same-sex relationship in Pitcairn Island.
+##Before you start
+
+Pitcairn Island is a British overseas territory.
+
+Contact the Pitcairn Island Government to find out about getting married there, including what documents you’ll need.
+
+$A
+British High Commission New Zealand
+British High Commission
+44 Hill Street
+Thorndon
+Wellington 6011
+New Zealand
+$A
+
+$C
+Telephone: +64 (0) 4 924 2888\\
+Fax: +64 (0) 4 473 4982
+
+[British High Commission New Zealand - opening hours](/world/organisations/british-high-commission-wellington/office/british-high-commission-new-zealand)
+$C
+
+^You should [get legal advice](/guidance/professional-services-if-you-are-abroad) and check the [travel advice for Pitcairn Island](/foreign-travel-advice/pitcairn-island) before making any plans.
+
+##Prove you're free to get married
+
+You need to get a certificate of no impediment (CNI) to prove you’re legally allowed to get married on Pitcairn Island.
+
+To get a CNI, make an appointment at your [local register office](/register-offices) to give notice of your marriage. A CNI costs £35.
+ 
+^Contact your local register office to find out what you need to do if you live in [Scotland](https://www.nrscotland.gov.uk/registration), [Northern Ireland](https://www.nidirect.gov.uk/contacts/district-registrars-northern-ireland), [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).^
+ 
+You’ll need to bring [certain documents](/marriages-civil-partnerships/documents-youll-need-to-give-notice) with you to your appointment.
+ 
+Your notice will be publicly displayed in the register office for 28 days. You can collect your CNI after this if nobody registers an objection.
+ 
+If your CNI was issued in England, Wales or Northern Ireland, it will usually be valid for 6 months. If it was issued in Scotland, it will expire after 3 months. Check with your local register office to find out how long a CNI is valid if you live in the [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
+
+##Naturalisation of your partner if they move to the UK
+
+Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.


### PR DESCRIPTION
https://govuk.zendesk.com/agent/tickets/5330442
https://trello.com/c/4jV28ITh/4289-30-june-getting-married-abroad-montserrat-uk-cni-changes

https://govuk.zendesk.com/agent/tickets/5357598
https://trello.com/c/3hvv449B/4299-30-june-getting-married-abroad-pitcairn-uk-cni-same-sex-marriage-changes

Changes to Montserrat and Pitcairn Island outcomes to reflect that:

- users living in the UK need to get a CNI before they can get married in either of these locations
- same-sex marriage is now legal on Pitcairn Island
