### PR TITLE
Updated interest rate to 7.5% (0.075) from 11 July 2023

### DIFF
--- a/lib/smart_answer/calculators/self_assessment_penalties.rb
+++ b/lib/smart_answer/calculators/self_assessment_penalties.rb
@@ -53,7 +53,8 @@ module SmartAnswer::Calculators
       { start_date: "2023-01-06", end_date: "2023-02-20", value: 0.06 },
       { start_date: "2023-02-21", end_date: "2023-04-12", value: 0.065 },
       { start_date: "2023-04-13", end_date: "2023-05-30", value: 0.0675 },
-      { start_date: "2023-05-31", end_date: "2100-04-04", value: 0.07 },
+      { start_date: "2023-05-31", end_date: "2023-07-10", value: 0.07 },
+      { start_date: "2023-07-11", end_date: "2100-04-04", value: 0.075 },
     ].freeze
 
     def tax_year_range

--- a/test/unit/calculators/self_assessment_penalties_test.rb
+++ b/test/unit/calculators/self_assessment_penalties_test.rb
@@ -310,13 +310,13 @@ module SmartAnswer::Calculators
           @calculator.payment_date = Date.parse("2023-02-03")
           assert_equal 5001, @calculator.total_owed
           @calculator.payment_date = Date.parse("2023-08-03")
-          assert_equal 5666, @calculator.total_owed
+          assert_equal 5667, @calculator.total_owed
           @calculator.payment_date = Date.parse("2024-02-03")
           assert_equal 750, @calculator.late_payment_penalty
-          assert_equal 6092, @calculator.total_owed
+          assert_equal 6106, @calculator.total_owed
           @calculator.payment_date = Date.parse("2024-08-03")
           assert_equal 750, @calculator.late_payment_penalty
-          assert_equal 6267, @calculator.total_owed
+          assert_equal 6293, @calculator.total_owed
         end
 
         context "HMRC Covid-19 Extension to 1 April for 2019-20" do


### PR DESCRIPTION
Update interest rate from 7% to 7.5% from 11 July February 2023.

[Trello](https://trello.com/c/kqhaIvkE/4482-estimate-your-penalty-for-late-self-assessment-tax-returns-and-payments-change-of-interest-rate-content-change-request)



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
