### PR TITLE
Update world location code for breaking changes in `gds-api-adapters` version 89.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,7 +126,7 @@ GEM
     faraday-rack (1.0.0)
     faraday-retry (1.0.3)
     ffi (1.15.5)
-    gds-api-adapters (88.2.0)
+    gds-api-adapters (89.0.0)
       addressable
       link_header
       null_logger

--- a/app/models/world_location.rb
+++ b/app/models/world_location.rb
@@ -17,7 +17,6 @@ class WorldLocation
     cache_fetch("all") do
       world_locations = GdsApi.worldwide
                               .world_locations
-                              .with_subsequent_pages
                               .select { |r| valid_world_location_format?(r.to_hash) }
                               .map { |r| new(r.to_hash) }
 


### PR DESCRIPTION
This version of `gds-api-adapters` removes pagination of the world locations, so we need to update this application accordingly.

[Trello card](https://trello.com/c/4r5uSD2R)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
