### PR TITLE
Revert "Update world location code for breaking changes in `gds-api-adapters` version 89.0.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,7 +126,7 @@ GEM
     faraday-rack (1.0.0)
     faraday-retry (1.0.3)
     ffi (1.15.5)
-    gds-api-adapters (89.0.0)
+    gds-api-adapters (88.2.0)
       addressable
       link_header
       null_logger

--- a/app/models/world_location.rb
+++ b/app/models/world_location.rb
@@ -17,6 +17,7 @@ class WorldLocation
     cache_fetch("all") do
       world_locations = GdsApi.worldwide
                               .world_locations
+                              .with_subsequent_pages
                               .select { |r| valid_world_location_format?(r.to_hash) }
                               .map { |r| new(r.to_hash) }
 

--- a/test/unit/world_location_test.rb
+++ b/test/unit/world_location_test.rb
@@ -11,6 +11,17 @@ class WorldLocationTest < ActiveSupport::TestCase
       assert_equal @location_slugs, results.map(&:slug)
     end
 
+    should "load multiple pages of locations" do
+      @location_slugs = (1..30).map { |n| "location-#{n}" }
+      stub_worldwide_api_has_locations(@location_slugs)
+
+      results = WorldLocation.all
+      assert_requested :get,
+                       %r{\A#{WORLDWIDE_API_ENDPOINT}/api/world-locations},
+                       times: 2
+      assert_equal @location_slugs, results.map(&:slug)
+    end
+
     should "filter out any results that are not world locations e.g. delegations & missions" do
       @location_slugs = %w[the-shire rivendel rohan delegation-to-lorien gondor arnor mission-to-mordor]
       stub_worldwide_api_has_locations(@location_slugs)
@@ -29,7 +40,7 @@ class WorldLocationTest < ActiveSupport::TestCase
     context "caching the results" do
       setup do
         @location_slugs = (1..10).map { |n| "location-#{n}" }
-        @endpoint = %r{\A#{WORLDWIDE_API_ENDPOINT}/api/content/world}
+        @endpoint = %r{\A#{WORLDWIDE_API_ENDPOINT}/api/world-locations}
         stub_worldwide_api_has_locations(@location_slugs)
       end
 
@@ -60,7 +71,7 @@ class WorldLocationTest < ActiveSupport::TestCase
       should "use the stale value from the cache on error for a week" do
         first = WorldLocation.all
 
-        stub_request(:get, "#{WORLDWIDE_API_ENDPOINT}/api/content/world").to_timeout
+        stub_request(:get, "#{WORLDWIDE_API_ENDPOINT}/api/world-locations").to_timeout
 
         travel_to(25.hours.from_now) do
           assert_nothing_raised do
@@ -79,7 +90,7 @@ class WorldLocationTest < ActiveSupport::TestCase
 
     context "the Worldwide API returns no locations" do
       setup do
-        stub_request(:get, "#{WORLDWIDE_API_ENDPOINT}/api/content/world")
+        stub_request(:get, "#{WORLDWIDE_API_ENDPOINT}/api/world-locations")
           .to_return(
             status: 200,
             body: {
@@ -117,13 +128,14 @@ class WorldLocationTest < ActiveSupport::TestCase
     end
 
     should "return nil if not found" do
-      stub_worldwide_api_has_locations(%w[rohan gondor])
+      stub_worldwide_api_does_not_have_location("non-existent")
       assert_nil WorldLocation.find("non-existent")
     end
 
     context "caching the result" do
       setup do
-        @rohan_request = stub_worldwide_api_has_locations(%w[rohan gondor])
+        @rohan_request = stub_worldwide_api_has_location("rohan")
+        stub_worldwide_api_has_location("gondor")
       end
 
       should "cache the loaded location" do
@@ -177,7 +189,8 @@ class WorldLocationTest < ActiveSupport::TestCase
 
   context "equality" do
     setup do
-      stub_worldwide_api_has_locations(%w[rohan gondor])
+      stub_worldwide_api_has_location("rohan")
+      stub_worldwide_api_has_location("gondor")
     end
 
     should "consider 2 location instances with the same slug as ==" do


### PR DESCRIPTION
Reverts alphagov/smart-answers#6463, as it causes issues with the alphabetical ordering of countries on the "Check if you need a UK visa" smart answer.

Zendesk: https://govuk.zendesk.com/agent/tickets/5416650