### PR TITLE
Add the Electronic Travel Authorisation requirements message to outcome pages for Qatar

### DIFF
--- a/app/flows/check_uk_visa_flow.rb
+++ b/app/flows/check_uk_visa_flow.rb
@@ -365,7 +365,8 @@ class CheckUkVisaFlow < SmartAnswer::Flow
       end
 
       if calculator.tourism_visit?
-        if calculator.passport_country_in_electronic_visa_waiver_list?
+        if calculator.passport_country_in_electronic_visa_waiver_list? ||
+            calculator.passport_country_in_electronic_travel_authorisation_list?
           next outcome(:outcome_visit_waiver)
         elsif calculator.passport_country_is_taiwan?
           next outcome(:outcome_visit_waiver_taiwan)

--- a/app/flows/check_uk_visa_flow/outcomes/_electronic_travel_authorisation_advice.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/_electronic_travel_authorisation_advice.erb
@@ -1,0 +1,1 @@
+^If you're travelling after 15 November 2023, you'll need to apply for an [electronic travel authorisation (ETA)](/electronic-travel-authorisation) instead of an electronic visa waiver. You'll be able to apply for an ETA from 25 October 2023.

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_visit_waiver.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_visit_waiver.erb
@@ -7,4 +7,8 @@
 
   + an [electronic visa waiver](/get-electronic-visa-waiver)
   + a [Standard Visitor visa](/standard-visitor)
+
+  <%if calculator.passport_country_in_electronic_travel_authorisation_list?  %>
+    <%= render partial: 'electronic_travel_authorisation_advice', locals: {calculator: calculator} %>
+  <% end %>
 <% end %>

--- a/lib/smart_answer/calculators/uk_visa_calculator.rb
+++ b/lib/smart_answer/calculators/uk_visa_calculator.rb
@@ -78,6 +78,10 @@ module SmartAnswer::Calculators
       COUNTRY_GROUP_ELECTRONIC_VISA_WAIVER.include?(@passport_country)
     end
 
+    def passport_country_in_electronic_travel_authorisation_list?
+      %w[qatar].include?(@passport_country)
+    end
+
     def passport_country_in_epassport_gate_list?
       COUNTRY_GROUP_EPASSPORT_GATES.include?(@passport_country)
     end

--- a/test/flows/check_uk_visa_flow_test.rb
+++ b/test/flows/check_uk_visa_flow_test.rb
@@ -30,6 +30,7 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
                                       "macao",
                                       "taiwan",
                                       "venezuela",
+                                      "qatar",
                                       @electronic_visa_waiver_country,
                                       @direct_airside_transit_visa_country,
                                       @visa_national_country,
@@ -884,6 +885,18 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
       test_visa_count("china", 2)
       test_visa_count("british-national-overseas", 5)
       test_visa_count("stateless-or-refugee", 2)
+    end
+  end
+
+  context "outcome: outcome_visit_waiver" do
+    setup do
+      testing_node :outcome_visit_waiver
+      add_responses purpose_of_visit?: "tourism"
+    end
+
+    should "render specific guidance for Electronic Travel Authorisation" do
+      add_responses what_passport_do_you_have?: "qatar"
+      assert_rendered_outcome text: "If you’re travelling after 15 November 2023, you’ll need to apply for an electronic travel authorisation (ETA) instead of an electronic visa waiver. You’ll be able to apply for an ETA from 25 October 2023."
     end
   end
 end

--- a/test/unit/calculators/uk_visa_calculator_test.rb
+++ b/test/unit/calculators/uk_visa_calculator_test.rb
@@ -241,6 +241,20 @@ module SmartAnswer
         end
       end
 
+      context "#passport_country_in_electronic_travel_authorisation_list?" do
+        should "return true if passport_country is in list of countries that can apply for an electronic travel authorisation" do
+          calculator = UkVisaCalculator.new
+          calculator.passport_country = "qatar"
+          assert calculator.passport_country_in_electronic_travel_authorisation_list?
+        end
+
+        should "return false if passport_country is not in list of countries that can apply for an electronic travel authorisation" do
+          calculator = UkVisaCalculator.new
+          calculator.passport_country = "made-up-country"
+          assert_not calculator.passport_country_in_electronic_travel_authorisation_list?
+        end
+      end
+
       context "#passport_country_in_epassport_gate_list?" do
         should "return true if passport_country is in list of countries that can use ePassport Gates" do
           calculator = UkVisaCalculator.new


### PR DESCRIPTION
This is to go live by 15th August and more countries will follow in the future.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
