### PR TITLE
Revert "Revert "Update world location code for breaking changes in `gds-api-adapters` version 89.0.0""

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,7 +126,7 @@ GEM
     faraday-rack (1.0.0)
     faraday-retry (1.0.3)
     ffi (1.15.5)
-    gds-api-adapters (88.2.0)
+    gds-api-adapters (89.0.0)
       addressable
       link_header
       null_logger

--- a/app/models/world_location.rb
+++ b/app/models/world_location.rb
@@ -17,7 +17,6 @@ class WorldLocation
     cache_fetch("all") do
       world_locations = GdsApi.worldwide
                               .world_locations
-                              .with_subsequent_pages
                               .select { |r| valid_world_location_format?(r.to_hash) }
                               .map { |r| new(r.to_hash) }
 


### PR DESCRIPTION
Reverts alphagov/smart-answers#6469

We can revert the change, as the issue was fixed in https://github.com/alphagov/whitehall/pull/8002.

[Trello card](https://trello.com/c/eKjf7gPC)