### PR TITLE
Add ETA message to Check UK Visa for Qatar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ db/*.sqlite3
 log/*.log
 tmp/
 .sass-cache/
+out/
 
 # SimplCov
 coverage
@@ -20,3 +21,6 @@ public/assets
 # Yarn
 node_modules
 yarn-error.log
+
+# IntelliJ
+.idea/

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ This is a Ruby on Rails app, and should follow [our Rails app conventions](https
 
 You can use the [GOV.UK Docker environment](https://github.com/alphagov/govuk-docker) or the local `startup.sh --live` script to run the app. Read the [guidance on local frontend development](https://docs.publishing.service.gov.uk/manual/local-frontend-development.html) to find out more about each approach, before you get started.
 
+If working on a smart answer that makes use of an API, use the local `startup.sh --live` script to run the app instead of docker.
+
 If you are using GOV.UK Docker, remember to combine it with the commands that follow. See the [GOV.UK Docker usage instructions](https://github.com/alphagov/govuk-docker#usage) for examples.
 
 ### Running the test suite

--- a/app/flows/check_uk_visa_flow.rb
+++ b/app/flows/check_uk_visa_flow.rb
@@ -171,7 +171,8 @@ class CheckUkVisaFlow < SmartAnswer::Flow
           outcome :outcome_transit_refugee_not_leaving_airport
         elsif calculator.passport_country_in_direct_airside_transit_visa_list?
           outcome :outcome_transit_not_leaving_airport
-        elsif calculator.passport_country_in_visa_national_list? || calculator.travel_document?
+        elsif calculator.passport_country_in_visa_national_list? ||
+            calculator.travel_document?
           outcome :outcome_no_visa_needed
         end
       end

--- a/app/flows/check_uk_visa_flow/outcomes/_electronic_travel_authorisation_advice.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/_electronic_travel_authorisation_advice.erb
@@ -1,0 +1,1 @@
+^If you're travelling after 15 November 2023, you'll need to apply for an [electronic travel authorisation (ETA)](/electronic-travel-authorisation) instead of an electronic visa waiver. You'll be able to apply for an ETA from 25 October 2023.

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_marriage_electronic_visa_waiver.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_marriage_electronic_visa_waiver.erb
@@ -11,5 +11,9 @@
   - settled in the UK
   - someone with humanitarian protection, for example if they have refugee status
 
-  ^If you want to convert a civil partnership into a marriage, you'll need to apply for an [electronic visa waiver (EVW)](/get-electronic-visa-waiver) or a [Standard Visitor visa](/standard-visitor).
+  If you want to convert a civil partnership into a marriage, you'll need to apply for an [electronic visa waiver (EVW)](/get-electronic-visa-waiver) or a [Standard Visitor visa](/standard-visitor).
+
+  <%if calculator.passport_country_requires_electronic_travel_authorisation?  %>
+    <%= render partial: 'electronic_travel_authorisation_advice', locals: {calculator: calculator} %>
+  <% end %>
 <% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_no_visa_needed.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_no_visa_needed.erb
@@ -4,7 +4,7 @@
 
 <% govspeak_for :body do %>
   <%if calculator.passport_country_requires_electronic_travel_authorisation?  %>
-    <%= render partial: 'electronic_travel_authorisation_advice', locals: {calculator: calculator} %>
+    If you're travelling after 15 November 2023, you'll need to apply for an [electronic travel authorisation (ETA)](/electronic-travel-authorisation) instead of an electronic visa waiver. You'll be able to apply for an ETA from 25 October 2023.
   <% end %>
 
   <% if (calculator.travelling_to_elsewhere? || calculator.travelling_to_ireland?) &&

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_no_visa_needed.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_no_visa_needed.erb
@@ -3,6 +3,10 @@
 <% end %>
 
 <% govspeak_for :body do %>
+  <%if calculator.passport_country_requires_electronic_travel_authorisation?  %>
+    <%= render partial: 'electronic_travel_authorisation_advice', locals: {calculator: calculator} %>
+  <% end %>
+
   <% if (calculator.travelling_to_elsewhere? || calculator.travelling_to_ireland?) &&
       (calculator.passport_country_in_non_visa_national_list? || calculator.passport_country_in_eea? || calculator.passport_country_in_british_overseas_territories_list?) %>
 

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_school_waiver.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_school_waiver.erb
@@ -8,5 +8,9 @@
   + an [electronic visa waiver](/get-electronic-visa-waiver) to stay for up to 6 months
   + a [Parent of a Child Student visa](/parent-of-a-child-at-school-visa)
 
+  <%if calculator.passport_country_requires_electronic_travel_authorisation?  %>
+    <%= render partial: 'electronic_travel_authorisation_advice', locals: {calculator: calculator} %>
+  <% end %>
+
   *[EVW]: electronic visa waiver
 <% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_study_waiver.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_study_waiver.erb
@@ -8,5 +8,9 @@
   + [an electronic visa waiver](/get-electronic-visa-waiver)
   + [a Standard Visitor visa](/standard-visitor) for courses up to 6 months
 
+  <%if calculator.passport_country_requires_electronic_travel_authorisation?  %>
+    <%= render partial: 'electronic_travel_authorisation_advice', locals: {calculator: calculator} %>
+  <% end %>
+
   *[EVW]: electronic visa waiver
 <% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_transit_leaving_airport.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_transit_leaving_airport.erb
@@ -12,6 +12,11 @@
 
     - an [electronic visa waiver](/get-electronic-visa-waiver)
     - a [Visitor in Transit visa](/transit-visa)
+
+    <%if calculator.passport_country_requires_electronic_travel_authorisation?  %>
+      <%= render partial: 'electronic_travel_authorisation_advice', locals: {calculator: calculator} %>
+    <% end %>
+
   <% else %>
     You should apply for a [Visitor in Transit visa](/transit-visa) if you arrive on a flight and will pass through immigration control before you leave the UK.
   <% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_transit_to_the_republic_of_ireland.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_transit_to_the_republic_of_ireland.erb
@@ -22,6 +22,11 @@
 
     - an [electronic visa waiver](/get-electronic-visa-waiver)
     - a [Standard Visitor visa](/standard-visitor)
+
+    <%if calculator.passport_country_requires_electronic_travel_authorisation?  %>
+      <%= render partial: 'electronic_travel_authorisation_advice', locals: {calculator: calculator} %>
+    <% end %>
+
   <% else %>
 
     You’ll usually need to apply for a [Standard Visitor visa](/standard-visitor).

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_visit_waiver.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_visit_waiver.erb
@@ -7,4 +7,8 @@
 
   + an [electronic visa waiver](/get-electronic-visa-waiver)
   + a [Standard Visitor visa](/standard-visitor)
+
+  <%if calculator.passport_country_requires_electronic_travel_authorisation?  %>
+    <%= render partial: 'electronic_travel_authorisation_advice', locals: {calculator: calculator} %>
+  <% end %>
 <% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_work_waiver.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_work_waiver.erb
@@ -13,7 +13,11 @@
   - [Standard Visitor visa](/standard-visitor) - if you’re coming to the UK for business activities like conferences, meetings, training, academic research or a sabbatical
   - [Permitted Paid Engagement Visitor visa](/permitted-paid-engagement-visa) if you've been invited as an expert in your profession - you can only stay for up to 1 month
 
-  ^ You will not need a visa if you hold a valid [electronic visa waiver (EVW)](/get-electronic-visa-waiver).
+  You will not need a visa if you hold a valid [electronic visa waiver (EVW)](/get-electronic-visa-waiver).
+
+  <%if calculator.passport_country_requires_electronic_travel_authorisation?  %>
+    <%= render partial: 'electronic_travel_authorisation_advice', locals: {calculator: calculator} %>
+  <% end %>
 
   ##Working in the UK
 

--- a/lib/smart_answer/calculators/uk_visa_calculator.rb
+++ b/lib/smart_answer/calculators/uk_visa_calculator.rb
@@ -78,6 +78,10 @@ module SmartAnswer::Calculators
       COUNTRY_GROUP_ELECTRONIC_VISA_WAIVER.include?(@passport_country)
     end
 
+    def passport_country_requires_electronic_travel_authorisation?
+      %w[qatar].include?(@passport_country)
+    end
+
     def passport_country_in_epassport_gate_list?
       COUNTRY_GROUP_EPASSPORT_GATES.include?(@passport_country)
     end

--- a/test/flows/check_uk_visa_flow_test.rb
+++ b/test/flows/check_uk_visa_flow_test.rb
@@ -9,6 +9,7 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
   setup do
     testing_flow CheckUkVisaFlow
     @electronic_visa_waiver_country = "kuwait"
+    @electronic_travel_authorisation_country = "qatar"
     @direct_airside_transit_visa_country = "afghanistan"
     @visa_national_country = "armenia"
     @british_overseas_territory_country = "anguilla"
@@ -30,6 +31,7 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
                                       "macao",
                                       "taiwan",
                                       "venezuela",
+                                      @electronic_travel_authorisation_country,
                                       @electronic_visa_waiver_country,
                                       @direct_airside_transit_visa_country,
                                       @visa_national_country,
@@ -608,18 +610,33 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
   context "outcome: outcome_no_visa_needed" do
     setup do
       testing_node :outcome_no_visa_needed
-      add_responses what_passport_do_you_have?: @eea_country,
-                    purpose_of_visit?: "transit"
+      add_responses purpose_of_visit?: "transit"
     end
 
     should "render a suggestion of evidence for a further journey" do
-      add_responses travelling_to_cta?: "somewhere_else"
+      add_responses what_passport_do_you_have?: @eea_country,
+                    travelling_to_cta?: "somewhere_else"
       assert_rendered_outcome text: "you should bring evidence of your onward journey"
     end
 
     should "render a suggestion of a visa for a further journey to Ireland" do
-      add_responses travelling_to_cta?: "republic_of_ireland"
+      add_responses what_passport_do_you_have?: @eea_country,
+                    travelling_to_cta?: "republic_of_ireland"
       assert_rendered_outcome text: "You may want to apply for a visa"
+    end
+
+    should "render specific guidance for Electronic Travel Authorisation" do
+      add_responses what_passport_do_you_have?: @electronic_travel_authorisation_country,
+                    travelling_to_cta?: "somewhere_else",
+                    passing_through_uk_border_control?: "no"
+      assert_rendered_outcome text: "If you’re travelling after 15 November 2023, you’ll need to apply for an electronic travel authorisation (ETA) instead of an electronic visa waiver. You’ll be able to apply for an ETA from 25 October 2023."
+    end
+
+    should "not render Electronic Travel Authorisation guidance for non-ETA countries" do
+      add_responses what_passport_do_you_have?: @electronic_visa_waiver_country,
+                    travelling_to_cta?: "somewhere_else",
+                    passing_through_uk_border_control?: "no"
+      assert_no_rendered_outcome text: "If you’re travelling after 15 November 2023, you’ll need to apply for an electronic travel authorisation (ETA) instead of an electronic visa waiver. You’ll be able to apply for an ETA from 25 October 2023."
     end
   end
 
@@ -694,6 +711,16 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
       add_responses what_passport_do_you_have?: @visa_national_country
       assert_rendered_outcome text: "You’ll need a visa to pass through the UK (unless you’re exempt)"
     end
+
+    should "render specific guidance for Electronic Travel Authorisation" do
+      add_responses what_passport_do_you_have?: @electronic_travel_authorisation_country
+      assert_rendered_outcome text: "If you’re travelling after 15 November 2023, you’ll need to apply for an electronic travel authorisation (ETA) instead of an electronic visa waiver. You’ll be able to apply for an ETA from 25 October 2023."
+    end
+
+    should "not render Electronic Travel Authorisation guidance for non-ETA countries" do
+      add_responses what_passport_do_you_have?: @electronic_visa_waiver_country
+      assert_no_rendered_outcome text: "If you’re travelling after 15 November 2023, you’ll need to apply for an electronic travel authorisation (ETA) instead of an electronic visa waiver. You’ll be able to apply for an ETA from 25 October 2023."
+    end
   end
 
   context "outcome: outcome_transit_leaving_airport" do
@@ -712,6 +739,16 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
     should "render different guidance for passports from outher countries" do
       add_responses what_passport_do_you_have?: @visa_national_country
       assert_rendered_outcome text: "You’ll need a visa to pass through the UK in transit"
+    end
+
+    should "render specific guidance for Electronic Travel Authorisation" do
+      add_responses what_passport_do_you_have?: @electronic_travel_authorisation_country
+      assert_rendered_outcome text: "If you’re travelling after 15 November 2023, you’ll need to apply for an electronic travel authorisation (ETA) instead of an electronic visa waiver. You’ll be able to apply for an ETA from 25 October 2023."
+    end
+
+    should "not render Electronic Travel Authorisation guidance for non-ETA countries" do
+      add_responses what_passport_do_you_have?: @electronic_visa_waiver_country
+      assert_no_rendered_outcome text: "If you’re travelling after 15 November 2023, you’ll need to apply for an electronic travel authorisation (ETA) instead of an electronic visa waiver. You’ll be able to apply for an ETA from 25 October 2023."
     end
   end
 
@@ -884,6 +921,93 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
       test_visa_count("china", 2)
       test_visa_count("british-national-overseas", 5)
       test_visa_count("stateless-or-refugee", 2)
+    end
+  end
+
+  context "outcome: outcome_visit_waiver" do
+    setup do
+      testing_node :outcome_visit_waiver
+      add_responses purpose_of_visit?: "tourism"
+    end
+
+    should "render specific guidance for Electronic Travel Authorisation" do
+      add_responses what_passport_do_you_have?: @electronic_travel_authorisation_country
+      assert_rendered_outcome text: "If you’re travelling after 15 November 2023, you’ll need to apply for an electronic travel authorisation (ETA) instead of an electronic visa waiver. You’ll be able to apply for an ETA from 25 October 2023."
+    end
+
+    should "not render Electronic Travel Authorisation guidance for non-ETA countries" do
+      add_responses what_passport_do_you_have?: @electronic_visa_waiver_country
+      assert_no_rendered_outcome text: "If you’re travelling after 15 November 2023, you’ll need to apply for an electronic travel authorisation (ETA) instead of an electronic visa waiver. You’ll be able to apply for an ETA from 25 October 2023."
+    end
+  end
+
+  context "outcome: outcome_study_waiver" do
+    setup do
+      testing_node :outcome_study_waiver
+      add_responses purpose_of_visit?: "study",
+                    staying_for_how_long?: "six_months_or_less"
+    end
+
+    should "render specific guidance for Electronic Travel Authorisation" do
+      add_responses what_passport_do_you_have?: @electronic_travel_authorisation_country
+      assert_rendered_outcome text: "If you’re travelling after 15 November 2023, you’ll need to apply for an electronic travel authorisation (ETA) instead of an electronic visa waiver. You’ll be able to apply for an ETA from 25 October 2023."
+    end
+
+    should "not render Electronic Travel Authorisation guidance for non-ETA countries" do
+      add_responses what_passport_do_you_have?: @electronic_visa_waiver_country
+      assert_no_rendered_outcome text: "If you’re travelling after 15 November 2023, you’ll need to apply for an electronic travel authorisation (ETA) instead of an electronic visa waiver. You’ll be able to apply for an ETA from 25 October 2023."
+    end
+  end
+
+  context "outcome: outcome_work_waiver" do
+    setup do
+      testing_node :outcome_work_waiver
+      add_responses purpose_of_visit?: "work",
+                    staying_for_how_long?: "six_months_or_less"
+    end
+
+    should "render specific guidance for Electronic Travel Authorisation" do
+      add_responses what_passport_do_you_have?: @electronic_travel_authorisation_country
+      assert_rendered_outcome text: "If you’re travelling after 15 November 2023, you’ll need to apply for an electronic travel authorisation (ETA) instead of an electronic visa waiver. You’ll be able to apply for an ETA from 25 October 2023."
+    end
+
+    should "not render Electronic Travel Authorisation guidance for non-ETA countries" do
+      add_responses what_passport_do_you_have?: @electronic_visa_waiver_country
+      assert_no_rendered_outcome text: "If you’re travelling after 15 November 2023, you’ll need to apply for an electronic travel authorisation (ETA) instead of an electronic visa waiver. You’ll be able to apply for an ETA from 25 October 2023."
+    end
+  end
+
+  context "outcome: outcome_marriage_electronic_visa_waiver" do
+    setup do
+      testing_node :outcome_marriage_electronic_visa_waiver
+      add_responses purpose_of_visit?: "marriage"
+    end
+
+    should "render specific guidance for Electronic Travel Authorisation" do
+      add_responses what_passport_do_you_have?: @electronic_travel_authorisation_country
+      assert_rendered_outcome text: "If you’re travelling after 15 November 2023, you’ll need to apply for an electronic travel authorisation (ETA) instead of an electronic visa waiver. You’ll be able to apply for an ETA from 25 October 2023."
+    end
+
+    should "not render Electronic Travel Authorisation guidance for non-ETA countries" do
+      add_responses what_passport_do_you_have?: @electronic_visa_waiver_country
+      assert_no_rendered_outcome text: "If you’re travelling after 15 November 2023, you’ll need to apply for an electronic travel authorisation (ETA) instead of an electronic visa waiver. You’ll be able to apply for an ETA from 25 October 2023."
+    end
+  end
+
+  context "outcome: outcome_school_waiver" do
+    setup do
+      testing_node :outcome_school_waiver
+      add_responses purpose_of_visit?: "school"
+    end
+
+    should "render specific guidance for Electronic Travel Authorisation" do
+      add_responses what_passport_do_you_have?: @electronic_travel_authorisation_country
+      assert_rendered_outcome text: "If you’re travelling after 15 November 2023, you’ll need to apply for an electronic travel authorisation (ETA) instead of an electronic visa waiver. You’ll be able to apply for an ETA from 25 October 2023."
+    end
+
+    should "not render Electronic Travel Authorisation guidance for non-ETA countries" do
+      add_responses what_passport_do_you_have?: @electronic_visa_waiver_country
+      assert_no_rendered_outcome text: "If you’re travelling after 15 November 2023, you’ll need to apply for an electronic travel authorisation (ETA) instead of an electronic visa waiver. You’ll be able to apply for an ETA from 25 October 2023."
     end
   end
 end

--- a/test/flows/check_uk_visa_flow_test.rb
+++ b/test/flows/check_uk_visa_flow_test.rb
@@ -20,6 +20,8 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
     @epassport_gate_country = "australia"
     @youth_mobility_scheme_country = "canada"
 
+    @eta_text = "If you’re travelling after 15 November 2023, you’ll need to apply for an electronic travel authorisation (ETA) instead of an electronic visa waiver. You’ll be able to apply for an ETA from 25 October 2023."
+
     # stub only the countries used in this test for less of a performance impact
     stub_worldwide_api_has_locations(["china",
                                       "india",
@@ -629,14 +631,14 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
       add_responses what_passport_do_you_have?: @electronic_travel_authorisation_country,
                     travelling_to_cta?: "somewhere_else",
                     passing_through_uk_border_control?: "no"
-      assert_rendered_outcome text: "If you’re travelling after 15 November 2023, you’ll need to apply for an electronic travel authorisation (ETA) instead of an electronic visa waiver. You’ll be able to apply for an ETA from 25 October 2023."
+      assert_rendered_outcome text: @eta_text
     end
 
     should "not render Electronic Travel Authorisation guidance for non-ETA countries" do
       add_responses what_passport_do_you_have?: @electronic_visa_waiver_country,
                     travelling_to_cta?: "somewhere_else",
                     passing_through_uk_border_control?: "no"
-      assert_no_rendered_outcome text: "If you’re travelling after 15 November 2023, you’ll need to apply for an electronic travel authorisation (ETA) instead of an electronic visa waiver. You’ll be able to apply for an ETA from 25 October 2023."
+      assert_no_rendered_outcome text: @eta_text
     end
   end
 
@@ -714,12 +716,12 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
 
     should "render specific guidance for Electronic Travel Authorisation" do
       add_responses what_passport_do_you_have?: @electronic_travel_authorisation_country
-      assert_rendered_outcome text: "If you’re travelling after 15 November 2023, you’ll need to apply for an electronic travel authorisation (ETA) instead of an electronic visa waiver. You’ll be able to apply for an ETA from 25 October 2023."
+      assert_rendered_outcome text: @eta_text
     end
 
     should "not render Electronic Travel Authorisation guidance for non-ETA countries" do
       add_responses what_passport_do_you_have?: @electronic_visa_waiver_country
-      assert_no_rendered_outcome text: "If you’re travelling after 15 November 2023, you’ll need to apply for an electronic travel authorisation (ETA) instead of an electronic visa waiver. You’ll be able to apply for an ETA from 25 October 2023."
+      assert_no_rendered_outcome text: @eta_text
     end
   end
 
@@ -743,12 +745,12 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
 
     should "render specific guidance for Electronic Travel Authorisation" do
       add_responses what_passport_do_you_have?: @electronic_travel_authorisation_country
-      assert_rendered_outcome text: "If you’re travelling after 15 November 2023, you’ll need to apply for an electronic travel authorisation (ETA) instead of an electronic visa waiver. You’ll be able to apply for an ETA from 25 October 2023."
+      assert_rendered_outcome text: @eta_text
     end
 
     should "not render Electronic Travel Authorisation guidance for non-ETA countries" do
       add_responses what_passport_do_you_have?: @electronic_visa_waiver_country
-      assert_no_rendered_outcome text: "If you’re travelling after 15 November 2023, you’ll need to apply for an electronic travel authorisation (ETA) instead of an electronic visa waiver. You’ll be able to apply for an ETA from 25 October 2023."
+      assert_no_rendered_outcome text: @eta_text
     end
   end
 
@@ -932,12 +934,12 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
 
     should "render specific guidance for Electronic Travel Authorisation" do
       add_responses what_passport_do_you_have?: @electronic_travel_authorisation_country
-      assert_rendered_outcome text: "If you’re travelling after 15 November 2023, you’ll need to apply for an electronic travel authorisation (ETA) instead of an electronic visa waiver. You’ll be able to apply for an ETA from 25 October 2023."
+      assert_rendered_outcome text: @eta_text
     end
 
     should "not render Electronic Travel Authorisation guidance for non-ETA countries" do
       add_responses what_passport_do_you_have?: @electronic_visa_waiver_country
-      assert_no_rendered_outcome text: "If you’re travelling after 15 November 2023, you’ll need to apply for an electronic travel authorisation (ETA) instead of an electronic visa waiver. You’ll be able to apply for an ETA from 25 October 2023."
+      assert_no_rendered_outcome text: @eta_text
     end
   end
 
@@ -950,12 +952,12 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
 
     should "render specific guidance for Electronic Travel Authorisation" do
       add_responses what_passport_do_you_have?: @electronic_travel_authorisation_country
-      assert_rendered_outcome text: "If you’re travelling after 15 November 2023, you’ll need to apply for an electronic travel authorisation (ETA) instead of an electronic visa waiver. You’ll be able to apply for an ETA from 25 October 2023."
+      assert_rendered_outcome text: @eta_text
     end
 
     should "not render Electronic Travel Authorisation guidance for non-ETA countries" do
       add_responses what_passport_do_you_have?: @electronic_visa_waiver_country
-      assert_no_rendered_outcome text: "If you’re travelling after 15 November 2023, you’ll need to apply for an electronic travel authorisation (ETA) instead of an electronic visa waiver. You’ll be able to apply for an ETA from 25 October 2023."
+      assert_no_rendered_outcome text: @eta_text
     end
   end
 
@@ -968,12 +970,12 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
 
     should "render specific guidance for Electronic Travel Authorisation" do
       add_responses what_passport_do_you_have?: @electronic_travel_authorisation_country
-      assert_rendered_outcome text: "If you’re travelling after 15 November 2023, you’ll need to apply for an electronic travel authorisation (ETA) instead of an electronic visa waiver. You’ll be able to apply for an ETA from 25 October 2023."
+      assert_rendered_outcome text: @eta_text
     end
 
     should "not render Electronic Travel Authorisation guidance for non-ETA countries" do
       add_responses what_passport_do_you_have?: @electronic_visa_waiver_country
-      assert_no_rendered_outcome text: "If you’re travelling after 15 November 2023, you’ll need to apply for an electronic travel authorisation (ETA) instead of an electronic visa waiver. You’ll be able to apply for an ETA from 25 October 2023."
+      assert_no_rendered_outcome text: @eta_text
     end
   end
 
@@ -985,12 +987,12 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
 
     should "render specific guidance for Electronic Travel Authorisation" do
       add_responses what_passport_do_you_have?: @electronic_travel_authorisation_country
-      assert_rendered_outcome text: "If you’re travelling after 15 November 2023, you’ll need to apply for an electronic travel authorisation (ETA) instead of an electronic visa waiver. You’ll be able to apply for an ETA from 25 October 2023."
+      assert_rendered_outcome text: @eta_text
     end
 
     should "not render Electronic Travel Authorisation guidance for non-ETA countries" do
       add_responses what_passport_do_you_have?: @electronic_visa_waiver_country
-      assert_no_rendered_outcome text: "If you’re travelling after 15 November 2023, you’ll need to apply for an electronic travel authorisation (ETA) instead of an electronic visa waiver. You’ll be able to apply for an ETA from 25 October 2023."
+      assert_no_rendered_outcome text: @eta_text
     end
   end
 
@@ -1002,12 +1004,12 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
 
     should "render specific guidance for Electronic Travel Authorisation" do
       add_responses what_passport_do_you_have?: @electronic_travel_authorisation_country
-      assert_rendered_outcome text: "If you’re travelling after 15 November 2023, you’ll need to apply for an electronic travel authorisation (ETA) instead of an electronic visa waiver. You’ll be able to apply for an ETA from 25 October 2023."
+      assert_rendered_outcome text: @eta_text
     end
 
     should "not render Electronic Travel Authorisation guidance for non-ETA countries" do
       add_responses what_passport_do_you_have?: @electronic_visa_waiver_country
-      assert_no_rendered_outcome text: "If you’re travelling after 15 November 2023, you’ll need to apply for an electronic travel authorisation (ETA) instead of an electronic visa waiver. You’ll be able to apply for an ETA from 25 October 2023."
+      assert_no_rendered_outcome text: @eta_text
     end
   end
 end

--- a/test/unit/calculators/uk_visa_calculator_test.rb
+++ b/test/unit/calculators/uk_visa_calculator_test.rb
@@ -241,6 +241,20 @@ module SmartAnswer
         end
       end
 
+      context "#passport_country_in_electronic_travel_authorisation_list?" do
+        should "return true if passport_country is in list of countries that can apply for an electronic travel authorisation" do
+          calculator = UkVisaCalculator.new
+          calculator.passport_country = "qatar"
+          assert calculator.passport_country_requires_electronic_travel_authorisation?
+        end
+
+        should "return false if passport_country is not in list of countries that can apply for an electronic travel authorisation" do
+          calculator = UkVisaCalculator.new
+          calculator.passport_country = "made-up-country"
+          assert_not calculator.passport_country_requires_electronic_travel_authorisation?
+        end
+      end
+
       context "#passport_country_in_epassport_gate_list?" do
         should "return true if passport_country is in list of countries that can use ePassport Gates" do
           calculator = UkVisaCalculator.new


### PR DESCRIPTION
Adding the Electronic Travel Authorisation requirement message for Qatar outcomes. This is to go live by 15th August and more countries will follow in the future.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
