### PR TITLE
Remove uk-mission-to-the-wto-un-and-other-international-organisations…

### DIFF
--- a/app/flows/marriage_abroad_flow.rb
+++ b/app/flows/marriage_abroad_flow.rb
@@ -12,7 +12,7 @@ class MarriageAbroadFlow < SmartAnswer::Flow
     name "marriage-abroad"
     status :published
 
-    exclude_countries = %w[samoa holy-see british-antarctic-territory the-occupied-palestinian-territories]
+    exclude_countries = %w[samoa holy-see british-antarctic-territory the-occupied-palestinian-territories uk-mission-to-the-wto-un-and-other-international-organisations-geneva]
 
     # Q1
     country_select(:country_of_ceremony?, exclude_countries:) do


### PR DESCRIPTION
…-geneva from country select

- This is causing the [Marriage Abroad flow to break](https://www.gov.uk/marriage-abroad/y/uk-mission-to-the-wto-un-and-other-international-organisations-geneva/third_country/partner_british) as this location does not appear in the marriage_abroad_data.yml for `countries_with_x_outcomes`.
- This requires further investigation but it is likely that an update to the World Location API has caused this to appear in the country select unexpectedly.
- In the short term it has been excluded from the country select.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
