### PR TITLE
Bump `gds-api-adapters` to version 90.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,7 +126,7 @@ GEM
     faraday-rack (1.0.0)
     faraday-retry (1.0.3)
     ffi (1.15.5)
-    gds-api-adapters (89.0.0)
+    gds-api-adapters (90.0.0)
       addressable
       link_header
       null_logger

--- a/app/flows/shared/_overseas_passports_embassies.erb
+++ b/app/flows/shared/_overseas_passports_embassies.erb
@@ -6,7 +6,11 @@ if overseas_passports_embassies.any?
 
 $A
 <%= embassy["title"] %>
-<%= embassy["address"]["label"]["value"].gsub(/\s+\n/,"\n") %>
+<%= embassy.dig("address", "adr", "street-address") %>
+<%= embassy.dig("address", "adr", "locality") %>
+<%= embassy.dig("address", "adr", "region") %>
+<%= embassy.dig("address", "adr", "postal-code") %>
+<%= embassy.dig("address", "adr", "country-name") %>
 $A
 
 $C

--- a/app/models/worldwide_organisation.rb
+++ b/app/models/worldwide_organisation.rb
@@ -30,7 +30,7 @@ class WorldwideOrganisation
     return [] unless all_offices.any?
 
     embassies = all_offices.select do |office|
-      office["services"].any? do |service|
+      office["services"]&.any? do |service|
         service["title"].include?(service_title)
       end
     end

--- a/test/flows/marriage_abroad_flow_test.rb
+++ b/test/flows/marriage_abroad_flow_test.rb
@@ -20,7 +20,7 @@ class MarriageAbroadFlowTest < ActiveSupport::TestCase
     stub_worldwide_api_has_locations(country_slugs)
 
     WORLDWIDE_ORGANISATION_API_COUNTRIES.intersection(country_slugs).each do |slug|
-      stub_worldwide_api_has_organisations_for_location(slug, { results: [] })
+      stub_search_api_has_organisations_for_location(slug, [])
     end
   end
 

--- a/test/flows/register_a_birth_flow_test.rb
+++ b/test/flows/register_a_birth_flow_test.rb
@@ -14,7 +14,7 @@ class RegisterABirthFlowTest < ActiveSupport::TestCase
       %w[indonesia]
 
     stub_worldwide_api_has_locations(countries.uniq)
-    stub_worldwide_api_has_organisations_for_location("north-korea", { results: [{ title: "organisation-title" }] })
+    stub_search_api_has_organisations_for_location("north-korea", [{ "title" => "organisation-title", "base_path" => "/world/organisations/organisation" }])
   end
 
   setup do

--- a/test/flows/register_a_death_flow_test.rb
+++ b/test/flows/register_a_death_flow_test.rb
@@ -20,7 +20,7 @@ class RegisterADeathFlowTest < ActiveSupport::TestCase
       yemen
     ]
     stub_worldwide_api_has_locations(locations)
-    stub_worldwide_api_has_organisations_for_location("north-korea", { results: [{ title: "organisation-title" }] })
+    stub_search_api_has_organisations_for_location("north-korea", [{ "title" => "organisation-title", "base_path" => "/world/organisations/organisation" }])
   end
 
   setup do

--- a/test/unit/calculators/marriage_abroad_calculator_test.rb
+++ b/test/unit/calculators/marriage_abroad_calculator_test.rb
@@ -314,23 +314,30 @@ module SmartAnswer
         should "return the fco organisation for the world location" do
           organisations_data = [
             {
-              title: "organisation-1-title",
+              "title" => "organisation-1-title",
+              "base_path" => "/world/organisations/organisation-1",
             },
             {
-              title: "organisation-2-title",
-              sponsors: [{ details: { acronym: "FCDO" } }],
+              "title" => "organisation-2-title",
+              "base_path" => "/world/organisations/organisation-2",
+              "links" => {
+                "sponsoring_organisations" => [
+                  {
+                    "details" => {
+                      "acronym" => "FCDO",
+                    },
+                  },
+                ],
+              },
             },
           ]
-          stub_worldwide_api_has_organisations_for_location(
-            "world-location",
-            { results: organisations_data },
-          )
+          stub_search_api_has_organisations_for_location("world-location", organisations_data)
 
           assert_equal "organisation-2-title", @calculator.fco_organisation.title
         end
 
         should "return nil if the world location doesn't have an fco organisation" do
-          stub_worldwide_api_has_no_organisations_for_location("world-location")
+          stub_search_api_has_organisations_for_location("world-location", [])
           assert_nil @calculator.fco_organisation
         end
       end

--- a/test/unit/calculators/marriage_abroad_calculator_test.rb
+++ b/test/unit/calculators/marriage_abroad_calculator_test.rb
@@ -774,7 +774,7 @@ module SmartAnswer
       end
 
       context "outcome per path" do
-        context "#two_questions_country? " do
+        context "#two_questions_country?" do
           should "return true if this 2 outcome country is part of the outcome per path countries" do
             @calculator = MarriageAbroadCalculator.new
             @calculator.ceremony_country = "2_outcome_country"
@@ -790,7 +790,7 @@ module SmartAnswer
           end
         end
 
-        context "#three_questions_country? " do
+        context "#three_questions_country?" do
           should "return true if this 6 outcome country is part of the outcome per path countries" do
             @calculator = MarriageAbroadCalculator.new
             @calculator.ceremony_country = "6_outcome_country"
@@ -806,7 +806,7 @@ module SmartAnswer
           end
         end
 
-        context "#four_questions_country? " do
+        context "#four_questions_country?" do
           should "return true if this 18 outcome country is part of the outcome per path countries" do
             @calculator = MarriageAbroadCalculator.new
             @calculator.ceremony_country = "18_outcome_country"

--- a/test/unit/worldwide_organisation_test.rb
+++ b/test/unit/worldwide_organisation_test.rb
@@ -4,10 +4,10 @@ class WorldwideOrganisationTest < ActiveSupport::TestCase
   context ".for_location" do
     should "instantiates WorldwideOrganisation objects using data from the API" do
       organisations_data = [
-        { title: "organisation-1-title" },
-        { title: "organisation-2-title" },
+        { "title" => "organisation-1-title", "base_path" => "/world/organisations/organisation-1" },
+        { "title" => "organisation-2-title", "base_path" => "/world/organisations/organisation-2" },
       ]
-      stub_worldwide_api_has_organisations_for_location("location-slug", { results: organisations_data })
+      stub_search_api_has_organisations_for_location("location-slug", organisations_data)
 
       worldwide_organisations = WorldwideOrganisation.for_location("location-slug")
 


### PR DESCRIPTION
This version changes the test helpers associated with the `GdsApi.worldwide.organisations_for_world_location` method.  Therefore making that change in this application.

[Trello card](https://trello.com/c/jJ0SH0N3)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
