### PR TITLE
Update start.erb

### DIFF
--- a/app/flows/report_a_lost_or_stolen_passport_flow/start.erb
+++ b/app/flows/report_a_lost_or_stolen_passport_flow/start.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% text_for :meta_description do %>
-  What you need to do if your passport has been lost or stolen and you need to travel urgently - emergency travel document and replacement passport.
+  What you need to do if your passport has been lost or stolen and you need to travel urgently.
 <% end %>
 
 <% govspeak_for :body do %>


### PR DESCRIPTION
Editing the meta description to remove reference to emergency travel docs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

FCDO think this currently causes some confusion for users on UK help and services in xxx pages (such as https://www.gov.uk/world/germany). They are concerned that mentioning emergency travel documents here encourages people into the lost or stolen passport smart answer when the link straight to the right information is 2 links further down (Travel urgently from abroad…).