### PR TITLE
Add user research banner for One Login

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,7 +8,9 @@ $govuk-new-link-styles: true;
 $govuk-include-default-font-face: false;
 
 @import "govuk_publishing_components/govuk_frontend_support";
+@import "govuk_publishing_components/components/intervention";
 
+@import "components/intervention";
 @import "smart_answers";
 
 .desktop-min-height {

--- a/app/assets/stylesheets/components/_intervention.scss
+++ b/app/assets/stylesheets/components/_intervention.scss
@@ -1,0 +1,3 @@
+.gem-c-intervention {
+  margin-top: govuk-spacing(4);
+}

--- a/app/presenters/start_node/recruitment_banner.rb
+++ b/app/presenters/start_node/recruitment_banner.rb
@@ -1,0 +1,21 @@
+module StartNode
+  module RecruitmentBanner
+    SURVEY_URLS = {
+      "/childcare-costs-for-tax-credits" => "https://surveys.publishing.service.gov.uk/s/4J4QD4/",
+    }.freeze
+
+    def survey_url(path)
+      landing_page?(path) && SURVEY_URLS[base_path]
+    end
+
+  private
+
+    def base_path
+      "/#{@flow_presenter.name}"
+    end
+
+    def landing_page?(current_path)
+      base_path == current_path
+    end
+  end
+end

--- a/app/presenters/start_node_presenter.rb
+++ b/app/presenters/start_node_presenter.rb
@@ -1,4 +1,6 @@
 class StartNodePresenter < NodePresenter
+  include StartNode::RecruitmentBanner
+
   def initialize(node, flow_presenter, state = nil, options = {})
     super(node, flow_presenter, state)
     @renderer = options[:renderer] || SmartAnswer::ErbRenderer.new(

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,6 +1,16 @@
 <% content_for :body do %>
   <div class="smart_answer">
     <%= yield :breadcrumbs %>
+    <% if @presenter && @presenter.start_node.survey_url(request.path) %>
+      <div class="banner-container">
+          <%= render "govuk_publishing_components/components/intervention", {
+            suggestion_text: "Help improve GOV.UK",
+            suggestion_link_text: "Take part in user research",
+            suggestion_link_url: @presenter.start_node.survey_url(request.path),
+            new_tab: true,
+          } %>
+      </div>
+    <% end %>
     <main id="content" role="main">
       <%= yield %>
     </main>

--- a/test/integration/recruitment_banner_test.rb
+++ b/test/integration/recruitment_banner_test.rb
@@ -1,0 +1,31 @@
+require_relative "../integration_test_helper"
+
+class RecruitmentBannerTest < ActionDispatch::IntegrationTest
+  context "user research banner" do
+    context "childcare costs for tax credits" do
+      setup do
+        stub_content_store_has_item("/childcare-costs-for-tax-credits")
+      end
+
+      should "display User Research Banner on the landing page" do
+        visit "/childcare-costs-for-tax-credits"
+        assert page.has_css?(".gem-c-intervention")
+        assert page.has_link?("Take part in user research (opens in a new tab)", href: "https://surveys.publishing.service.gov.uk/s/4J4QD4/")
+      end
+
+      should "not display User Research Banner on non-landing pages of the specific smart answer" do
+        visit "/childcare-costs-for-tax-credits/y"
+
+        assert_not page.has_css?(".gem-c-intervention")
+        assert_not page.has_link?("Take part in user research (opens in a new tab)", href: "https://surveys.publishing.service.gov.uk/s/4J4QD4/")
+      end
+
+      should "not display User Research Banner unless survey URL is specified for the base path" do
+        visit "/bridge-of-death"
+
+        assert_not page.has_css?(".gem-c-intervention")
+        assert_not page.has_link?("Take part in user research (opens in a new tab)", href: "https://surveys.publishing.service.gov.uk/s/4J4QD4/")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add user research banner on `/childcare-costs-for-tax-credits` page.

Trello card: https://trello.com/c/95rRCft2/1999-authentication-team-one-login-program-user-research-banner-request-for-going-live-m

![Screenshot 2023-08-22 at 12 04 07](https://github.com/alphagov/smart-answers/assets/96050928/bdff0113-1dbf-4d60-bbbc-59ba31212080)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
