### PR TITLE
Update the publishing documentation for publishing-api sync on landing page change and K8S

### DIFF
--- a/docs/tasks/publishing.md
+++ b/docs/tasks/publishing.md
@@ -1,5 +1,32 @@
 ### Publishing
 
-Changes to smart answer pages need to be sent to the Publishing API for them to appear on GOV.UK.
+Changes to smart answer landing (or start) pages need to be sent to the Publishing API for them to appear on GOV.UK.
 
-The [rake task `publishing_api:sync_all`](../../lib/tasks/publishing_api.rake) needs to be run once you have deployed your changes in each environment and can be done in [Jenkins](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=smartanswers&MACHINE_CLASS=calculators_frontend&RAKE_TASK=publishing_api:sync_all).
+You will need the flow `name` and `content_id`, both of which can be found in the relevant Flow file, e.g. `ReportALostOrStolenPassportFlow`.
+
+The [rake task `publishing_api:sync[FLOW_NAME]`](../../lib/tasks/publishing_api.rake) exists for this purpose, and needs to be run once you have deployed your changes. It can be run via Kubernetes as follows:
+
+```bash
+# For each ENVIRONMENT [integration, staging, production]...
+
+# Ensure you are using the correct ENVIRONMENT
+kubectl config use-context govuk-ENVIRONMENT
+kubectl config current-context
+
+# Get a temporary AWS token
+export AWS_REGION=eu-west-1
+eval $(gds aws govuk-ENVIRONMENT-poweruser -e --art 8h)
+
+# Check the current value for your change in publishing-api
+kubectl -n apps exec -it deploy/publishing-api -- rails c
+Document.find_by(content_id: CONTENT_ID).editions.last
+
+# Run the rake task
+kubectl -n apps exec deploy/smartanswers -- rake 'publishing_api:sync[FLOW_NAME]'
+
+# Make sure your changes have been updated correctly
+kubectl -n apps exec -it deploy/publishing-api -- rails c
+Document.find_by(content_id: CONTENT_ID).editions.last
+```
+
+If you have made multiple changes to a number of flows, there is also the [rake task `publishing_api:sync_all`](../../lib/tasks/publishing_api.rake) which sync's all flows with the Publishing API. It can be run as above substituting `publishing_api:sync[FLOW_NAME]` with `publishing_api:sync_all`.


### PR DESCRIPTION
While on 2nd line, it was noted that the change made in [this PR](https://github.com/alphagov/smart-answers/pull/6505) to update the `meta` tag was not taking effect on either of these two pages:

- https://www.gov.uk/report-a-lost-or-stolen-passport
- https://www.gov.uk/world/passports-and-emergency-travel-documents-spain

This was tracked down to an old issue that I had thought had been eradicated - the Publishing API does not automatically update when Smart Answer landing page changes are made.

This change updates the [Publishing](./docs/tasks/publishing.md) document accordingly.

| Before | After |
|---|---|
| ![Screenshot 2023-08-23 at 11 51 26](https://github.com/alphagov/smart-answers/assets/44037625/e92a77fc-608a-400f-9534-0d2065372bec) | ![Screenshot 2023-08-23 at 12 40 37](https://github.com/alphagov/smart-answers/assets/44037625/55f91a7b-781a-4209-bec8-77870cd7a710) |
| ![Screenshot 2023-08-23 at 11 51 38](https://github.com/alphagov/smart-answers/assets/44037625/faa25f42-e4eb-4223-ba0c-1b183971884b) | ![Screenshot 2023-08-23 at 12 40 59](https://github.com/alphagov/smart-answers/assets/44037625/20430604-e5a0-4fe1-9a8d-eca36ce69ecd) |

[Trello](https://trello.com/c/tTubuD3f/201-editing-meta-description-on-cancel-a-lost-or-stolen-passport)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
