### PR TITLE
Revert "Bump govspeak from 8.2.0 to 8.2.1"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,7 +143,7 @@ GEM
     google-protobuf (3.24.2-x86_64-linux)
     googleapis-common-protos-types (1.8.0)
       google-protobuf (~> 3.18)
-    govspeak (8.2.1)
+    govspeak (8.2.0)
       actionview (>= 6)
       addressable (>= 2.3.8, < 3)
       govuk_publishing_components (>= 35.1)
@@ -460,7 +460,7 @@ GEM
       nio4r (~> 2.0)
     racc (1.7.1)
     rack (2.2.8)
-    rack-proxy (0.7.7)
+    rack-proxy (0.7.6)
       rack
     rack-test (2.1.0)
       rack (>= 1.3)


### PR DESCRIPTION
Reverts alphagov/smart-answers#6529
Seems to not be passing checks when merging