### PR TITLE
Revert "CW/SS - Remove reference to a repo during checkout in minitest.yml"

### DIFF
--- a/.github/workflows/minitest.yml
+++ b/.github/workflows/minitest.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
+          repository: alphagov/smart-answers
           ref: ${{ inputs.ref || github.ref }}
 
       - name: Checkout Publishing API (for Content Schemas)


### PR DESCRIPTION
## What

Add back in reference to `alphagov/smart-answers` repo.

## Why

Removing the repo seems to be generating an error when running **Test Content Schemas** workflows from Publishing API. See https://github.com/alphagov/publishing-api/actions/runs/6084918130/job/16536652209.