### PR TITLE
Implement routes redirect for register-a-death abroad

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,9 @@ Rails.application.routes.draw do
   get "/:id", to: "flow#landing", as: :flow_landing
 
   get "/:id/y/visualise(.:format)", to: "smart_answers#visualise", as: :visualise
+
+  get "/register-a-death/y/overseas/*other", to: redirect("/register-a-death/y/overseas")
+
   get "/:id(/y(/*responses))", to: "smart_answers#show", as: :smart_answer, format: false
 
   get "/:id/start", to: "flow#start", as: :start_flow

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
 
   get "/:id/y/visualise(.:format)", to: "smart_answers#visualise", as: :visualise
 
+  # This code has been added to specifically handle the retired register a death abroad URLs, which were a subset of the register a death smart answer
   get "/register-a-death/y/overseas/*other", to: redirect("/register-a-death/y/overseas")
 
   get "/:id(/y(/*responses))", to: "smart_answers#show", as: :smart_answer, format: false

--- a/test/integration/engine/register_a_death_redirect_test.rb
+++ b/test/integration/engine/register_a_death_redirect_test.rb
@@ -1,0 +1,11 @@
+require_relative "engine_test_helper"
+
+class RegisterADeathRedirectTest < EngineIntegrationTest
+  should "redirect" do
+    stub_content_store_has_item("/register-a-death")
+
+    visit "/register-a-death/y/overseas/afghanistan/another_country/algeria"
+
+    assert_current_url "/register-a-death/y/overseas"
+  end
+end


### PR DESCRIPTION
This PR will implement a basic redirect solution for orphaned register a death abroad URLs.

The implemented code specifically handles register a death abroad only. Arguably to improve quality this could be made more generic, however we believe this is beyond the scope of the register a death abroad ticket and we will raise another tech debt ticket to cover the generic case.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
