### PR TITLE
Add Brand recruitment banner

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,7 +8,9 @@ $govuk-new-link-styles: true;
 $govuk-include-default-font-face: false;
 
 @import "govuk_publishing_components/govuk_frontend_support";
+@import "govuk_publishing_components/components/intervention";
 
+@import "components/intervention";
 @import "smart_answers";
 
 .desktop-min-height {

--- a/app/assets/stylesheets/components/_intervention.scss
+++ b/app/assets/stylesheets/components/_intervention.scss
@@ -1,0 +1,3 @@
+.gem-c-intervention {
+  margin-top: govuk-spacing(4);
+}

--- a/app/presenters/start_node/recruitment_banner.rb
+++ b/app/presenters/start_node/recruitment_banner.rb
@@ -1,0 +1,23 @@
+module StartNode
+  module RecruitmentBanner
+    BRAND_SURVERY_URL = "https://surveys.publishing.service.gov.uk/s/5G06FO/".freeze
+    SURVEY_URLS = {
+      "/check-uk-visa" => BRAND_SURVERY_URL,
+      "/state-pension-age" => BRAND_SURVERY_URL,
+    }.freeze
+
+    def survey_url(path)
+      landing_page?(path) && SURVEY_URLS[base_path]
+    end
+
+  private
+
+    def base_path
+      "/#{@flow_presenter.name}"
+    end
+
+    def landing_page?(current_path)
+      base_path == current_path
+    end
+  end
+end

--- a/app/presenters/start_node_presenter.rb
+++ b/app/presenters/start_node_presenter.rb
@@ -1,4 +1,6 @@
 class StartNodePresenter < NodePresenter
+  include StartNode::RecruitmentBanner
+
   def initialize(node, flow_presenter, state = nil, options = {})
     super(node, flow_presenter, state)
     @renderer = options[:renderer] || SmartAnswer::ErbRenderer.new(

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,15 @@
 <% content_for :body do %>
   <div class="smart_answer">
+    <% if @presenter && @presenter.start_node.survey_url(request.path) %>
+      <div class="banner-container">
+          <%= render "govuk_publishing_components/components/intervention", {
+            suggestion_text: "Help improve GOV.UK",
+            suggestion_link_text: "Take part in user research",
+            suggestion_link_url: @presenter.start_node.survey_url(request.path),
+            new_tab: true,
+          } %>
+      </div>
+    <% end %>
     <%= yield :breadcrumbs %>
     <main id="content" role="main">
       <%= yield %>

--- a/test/integration/recruitment_banner_test.rb
+++ b/test/integration/recruitment_banner_test.rb
@@ -1,0 +1,31 @@
+require_relative "../integration_test_helper"
+
+class RecruitmentBannerTest < ActionDispatch::IntegrationTest
+  context "brand user research banner" do
+    context "check state pension age" do
+      setup do
+        stub_content_store_has_item("/state-pension-age")
+      end
+
+      should "display Brand User Research Banner on the landing page" do
+        visit "/state-pension-age"
+        assert page.has_css?(".gem-c-intervention")
+        assert page.has_link?("Take part in user research (opens in a new tab)", href: "https://surveys.publishing.service.gov.uk/s/5G06FO/")
+      end
+
+      should "not display Brand User Research Banner on non-landing pages of the specific smart answer" do
+        visit "/state-pension-age/y"
+
+        assert_not page.has_css?(".gem-c-intervention")
+        assert_not page.has_link?("Take part in user research (opens in a new tab)", href: "https://surveys.publishing.service.gov.uk/s/5G06FO/")
+      end
+
+      should "not display Brand User Research Banner unless survey URL is specified for the base path" do
+        visit "/bridge-of-death"
+
+        assert_not page.has_css?(".gem-c-intervention")
+        assert_not page.has_link?("Take part in user research (opens in a new tab)", href: "https://surveys.publishing.service.gov.uk/s/5G06FO/")
+      end
+    end
+  end
+end


### PR DESCRIPTION
The banner will be applied on the following pages:
- [/check-uk-visa](https://www.gov.uk/check-uk-visa)
- [/state-pension-age](https://www.gov.uk/state-pension-age)

Trello card: https://trello.com/c/EVjvHjqE/2090-brand-team-govuk-user-research-banner-request-to-set-up-m

Before:
<img width="1002" alt="Screenshot 2023-09-21 at 15 05 59" src="https://github.com/alphagov/smart-answers/assets/96050928/8b249acf-cdc7-4629-8b27-b6329c0e1e61">

After:
<img width="1017" alt="Screenshot 2023-09-21 at 15 05 44" src="https://github.com/alphagov/smart-answers/assets/96050928/acccaf43-3728-4641-ae19-8b67c0eb7ec0">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
