### PR TITLE
Add user research banner

### DIFF
--- a/app/presenters/start_node/recruitment_banner.rb
+++ b/app/presenters/start_node/recruitment_banner.rb
@@ -1,0 +1,23 @@
+module StartNode
+  module RecruitmentBanner
+    SURVERY_URL = "https://surveys.publishing.service.gov.uk/s/SNFVW1/".freeze
+    SURVEY_URLS = {
+      "/maternity-paternity-calculator" => SURVERY_URL,
+      "/calculate-statutory-sick-pay" => SURVERY_URL,
+    }.freeze
+
+    def survey_url(path)
+      landing_page?(path) && SURVEY_URLS[base_path]
+    end
+
+  private
+
+    def base_path
+      "/#{@flow_presenter.name}"
+    end
+
+    def landing_page?(current_path)
+      base_path == current_path
+    end
+  end
+end

--- a/app/presenters/start_node_presenter.rb
+++ b/app/presenters/start_node_presenter.rb
@@ -1,4 +1,6 @@
 class StartNodePresenter < NodePresenter
+  include StartNode::RecruitmentBanner
+
   def initialize(node, flow_presenter, state = nil, options = {})
     super(node, flow_presenter, state)
     @renderer = options[:renderer] || SmartAnswer::ErbRenderer.new(

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,6 +1,16 @@
 <% content_for :body do %>
   <div class="smart_answer">
     <%= yield :breadcrumbs %>
+    <% if @presenter && @presenter.start_node.survey_url(request.path) %>
+      <div class="banner-container govuk-!-static-margin-top-4">
+          <%= render "govuk_publishing_components/components/intervention", {
+            suggestion_text: "Help improve a new GOV.UK tool",
+            suggestion_link_text: "Sign up to take part in user research",
+            suggestion_link_url: @presenter.start_node.survey_url(request.path),
+            new_tab: true,
+          } %>
+      </div>
+    <% end %>
     <main id="content" role="main">
       <%= yield %>
     </main>

--- a/test/integration/recruitment_banner_test.rb
+++ b/test/integration/recruitment_banner_test.rb
@@ -1,0 +1,31 @@
+require_relative "../integration_test_helper"
+
+class RecruitmentBannerTest < ActionDispatch::IntegrationTest
+  context "brand user research banner" do
+    context "check state pension age" do
+      setup do
+        stub_content_store_has_item("/maternity-paternity-calculator")
+      end
+
+      should "display Brand User Research Banner on the landing page" do
+        visit "/maternity-paternity-calculator"
+        assert page.has_css?(".gem-c-intervention")
+        assert page.has_link?("Sign up to take part in user research (opens in a new tab)", href: "https://surveys.publishing.service.gov.uk/s/SNFVW1/")
+      end
+
+      should "not display Brand User Research Banner on non-landing pages of the specific smart answer" do
+        visit "/maternity-paternity-calculator/y"
+
+        assert_not page.has_css?(".gem-c-intervention")
+        assert_not page.has_link?("Sign up to take part in user research (opens in a new tab)", href: "https://surveys.publishing.service.gov.uk/s/SNFVW1/")
+      end
+
+      should "not display Brand User Research Banner unless survey URL is specified for the base path" do
+        visit "/bridge-of-death"
+
+        assert_not page.has_css?(".gem-c-intervention")
+        assert_not page.has_link?("Sign up to take part in user research (opens in a new tab)", href: "https://surveys.publishing.service.gov.uk/s/SNFVW1/")
+      end
+    end
+  end
+end


### PR DESCRIPTION
The banner will be applied on the following pages:
- [/maternity-paternity-calculator](https://www.gov.uk/maternity-paternity-calculator)
- [/calculate-statutory-sick-pay](https://www.gov.uk/calculate-statutory-sick-pay)

Before:
<img width="991" alt="Screenshot 2023-09-26 at 08 51 30" src="https://github.com/alphagov/smart-answers/assets/96050928/3444135a-581d-49d1-8b76-080d099f7891">

After:
<img width="987" alt="Screenshot 2023-09-26 at 08 51 04" src="https://github.com/alphagov/smart-answers/assets/96050928/2db621b7-7a17-448d-8aa5-74ee1f5d5149">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
