### PR TITLE
Add user research banner to benefits pages

### DIFF
--- a/app/presenters/start_node/recruitment_banner.rb
+++ b/app/presenters/start_node/recruitment_banner.rb
@@ -6,8 +6,19 @@ module StartNode
       "/calculate-statutory-sick-pay" => SURVERY_URL,
     }.freeze
 
+    BENEFITS_SURVEY_URL = "https://signup.take-part-in-research.service.gov.uk/home?utm_campaign=Content_History&utm_source=Hold_gov_to_account&utm_medium=gov.uk&t=GDS&id=16".freeze
+    BENEFITS_SURVEY_URLS = {
+      "/state-pension-age" => BENEFITS_SURVEY_URL,
+      "/check-benefits-financial-support" => BENEFITS_SURVEY_URL,
+      "/child-benefit-tax-calculator" => BENEFITS_SURVEY_URL,
+    }.freeze
+
     def survey_url(path)
       landing_page?(path) && SURVEY_URLS[base_path]
+    end
+
+    def benefits_survey_url(path)
+      landing_page?(path) && BENEFITS_SURVEY_URLS[base_path]
     end
 
   private

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,15 @@
             new_tab: true,
           } %>
       </div>
+    <% elsif @presenter && @presenter.start_node.benefits_survey_url(request.path) %>
+      <div class="banner-container govuk-!-static-margin-top-4">
+          <%= render "govuk_publishing_components/components/intervention", {
+            suggestion_text: "Help improve GOV.UK",
+            suggestion_link_text: "Take part in user research",
+            suggestion_link_url: @presenter.start_node.benefits_survey_url(request.path),
+            new_tab: true,
+          } %>
+      </div>
     <% end %>
     <main id="content" role="main">
       <%= yield %>

--- a/test/integration/recruitment_banner_test.rb
+++ b/test/integration/recruitment_banner_test.rb
@@ -1,30 +1,56 @@
 require_relative "../integration_test_helper"
 
 class RecruitmentBannerTest < ActionDispatch::IntegrationTest
-  context "brand user research banner" do
-    context "check state pension age" do
+  context "user research banner" do
+    context "maternity paternity calculator" do
       setup do
         stub_content_store_has_item("/maternity-paternity-calculator")
       end
 
-      should "display Brand User Research Banner on the landing page" do
+      should "display User Research Banner on the landing page" do
         visit "/maternity-paternity-calculator"
         assert page.has_css?(".gem-c-intervention")
         assert page.has_link?("Sign up to take part in user research (opens in a new tab)", href: "https://surveys.publishing.service.gov.uk/s/SNFVW1/")
       end
 
-      should "not display Brand User Research Banner on non-landing pages of the specific smart answer" do
+      should "not display User Research Banner on non-landing pages of the specific smart answer" do
         visit "/maternity-paternity-calculator/y"
 
         assert_not page.has_css?(".gem-c-intervention")
         assert_not page.has_link?("Sign up to take part in user research (opens in a new tab)", href: "https://surveys.publishing.service.gov.uk/s/SNFVW1/")
       end
 
-      should "not display Brand User Research Banner unless survey URL is specified for the base path" do
+      should "not display User Research Banner unless survey URL is specified for the base path" do
         visit "/bridge-of-death"
 
         assert_not page.has_css?(".gem-c-intervention")
         assert_not page.has_link?("Sign up to take part in user research (opens in a new tab)", href: "https://surveys.publishing.service.gov.uk/s/SNFVW1/")
+      end
+    end
+
+    context "check state pension age" do
+      setup do
+        stub_content_store_has_item("/state-pension-age")
+      end
+
+      should "display Benefits User Research Banner on the landing page" do
+        visit "/state-pension-age"
+        assert page.has_css?(".gem-c-intervention")
+        assert page.has_link?("Take part in user research (opens in a new tab)", href: "https://signup.take-part-in-research.service.gov.uk/home?utm_campaign=Content_History&utm_source=Hold_gov_to_account&utm_medium=gov.uk&t=GDS&id=16")
+      end
+
+      should "not display Benefits User Research Banner on non-landing pages of the specific smart answer" do
+        visit "/state-pension-age/y"
+
+        assert_not page.has_css?(".gem-c-intervention")
+        assert_not page.has_link?("Take part in user research (opens in a new tab)", href: "https://signup.take-part-in-research.service.gov.uk/home?utm_campaign=Content_History&utm_source=Hold_gov_to_account&utm_medium=gov.uk&t=GDS&id=16")
+      end
+
+      should "not display Benefits User Research Banner unless survey URL is specified for the base path" do
+        visit "/bridge-of-death"
+
+        assert_not page.has_css?(".gem-c-intervention")
+        assert_not page.has_link?("Take part in user research (opens in a new tab)", href: "https://signup.take-part-in-research.service.gov.uk/home?utm_campaign=Content_History&utm_source=Hold_gov_to_account&utm_medium=gov.uk&t=GDS&id=16")
       end
     end
   end


### PR DESCRIPTION
The banner will be displayed on the following pages:
- /state-pension-age
- /check-benefits-financial-support
- /child-benefit-tax-calculator

Trello card: https://trello.com/c/wMUxokll/2135-benefits-pages-user-research-banner-request-set-up-m

Before:
<img width="990" alt="Screenshot 2023-10-06 at 15 57 11" src="https://github.com/alphagov/smart-answers/assets/96050928/cb7f60e7-e89c-4226-89ef-5a5fc7453788">

After:
<img width="996" alt="Screenshot 2023-10-10 at 13 45 01" src="https://github.com/alphagov/smart-answers/assets/96050928/c9348722-e248-44e9-b393-4d1f8efab310">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
