### PR TITLE
Amend the guidance for Qatar ETA

### DIFF
--- a/app/flows/check_uk_visa_flow/outcomes/_electronic_travel_authorisation_advice.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/_electronic_travel_authorisation_advice.erb
@@ -1,1 +1,1 @@
-^If you're travelling on or after 15 November 2023, you'll need to apply for an [electronic travel authorisation (ETA)](/electronic-travel-authorisation) instead of an electronic visa waiver. You'll be able to apply for an ETA from 25 October 2023.
+^If you're travelling on or after 15 November 2023, you'll need to apply for an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta) instead of an electronic visa waiver.

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_no_visa_needed.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_no_visa_needed.erb
@@ -4,7 +4,7 @@
 
 <% govspeak_for :body do %>
   <%if calculator.passport_country_requires_electronic_travel_authorisation?  %>
-    If you're travelling on or after 15 November 2023, you'll need to apply for an [electronic travel authorisation (ETA)](/electronic-travel-authorisation) instead of an electronic visa waiver. You'll be able to apply for an ETA from 25 October 2023.
+    If you're travelling on or after 15 November 2023, you'll need to apply for an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta) instead of an electronic visa waiver.
   <% end %>
 
   <% if (calculator.travelling_to_elsewhere? || calculator.travelling_to_ireland?) &&

--- a/test/flows/check_uk_visa_flow_test.rb
+++ b/test/flows/check_uk_visa_flow_test.rb
@@ -20,7 +20,7 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
     @epassport_gate_country = "australia"
     @youth_mobility_scheme_country = "canada"
 
-    @eta_text = "If you’re travelling on or after 15 November 2023, you’ll need to apply for an electronic travel authorisation (ETA) instead of an electronic visa waiver. You’ll be able to apply for an ETA from 25 October 2023."
+    @eta_text = "If you’re travelling on or after 15 November 2023, you’ll need to apply for an electronic travel authorisation (ETA) instead of an electronic visa waiver."
     @channel_island_isle_of_man_text = "If you do not have a visa (or wet ink stamp) for the Channel Islands or the Isle of Man, you must either apply for:"
 
     # stub only the countries used in this test for less of a performance impact


### PR DESCRIPTION
Removing the last line relating to applying after 25 October and changing the link to the right start point.

See Trello ticket [here](https://trello.com/c/8RlgfYdi/210-check-if-you-need-a-uk-visa-amending-eta-content).

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
