### PR TITLE
Duplicate ecommerce data attributes, appending GA4 to the names

### DIFF
--- a/app/views/smart_answers/result.html.erb
+++ b/app/views/smart_answers/result.html.erb
@@ -64,6 +64,8 @@
     }'
     data-ecommerce-start-index="1"
     data-list-title="<%= @presenter.title %>"
+    data-ga4-ecommerce-start-index="1"
+    data-ga4-list-title="<%= @presenter.title %>"
   >
     <%= render 'smart_answers/shared/debug' %>
     <%= render "govuk_publishing_components/components/title", {


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## What
- Duplicate `data-ecommerce-start-index` `data-list-title`, appending `-ga4` to them so that we have `data-ga4-ecommerce-start-index` and `data-ga4-list-title`
- We can remove  `data-ecommerce-start-index` `data-list-title` once we are happy everything is working, since these aren't used by UA in this repo - they were added to this repo for GA4 ecommerce tracking, see here: https://github.com/alphagov/smart-answers/pull/6304/files#diff-4e2b0858c05e663175ed84444487f82b594a5e3d95564a599e0a8f294838ef77R26
- Related to https://github.com/alphagov/govuk_publishing_components/pull/3688

## Why
https://trello.com/c/gFiJmH3D/553-audit-and-ensure-that-every-data-attribute-relies-on-has-ga4-somewhere-in-its-name