### PR TITLE
Remove research banner

### DIFF
--- a/app/presenters/start_node/recruitment_banner.rb
+++ b/app/presenters/start_node/recruitment_banner.rb
@@ -1,21 +1,11 @@
 module StartNode
   module RecruitmentBanner
-    SURVERY_URL = "https://surveys.publishing.service.gov.uk/s/SNFVW1/".freeze
-    SURVEY_URLS = {
-      "/maternity-paternity-calculator" => SURVERY_URL,
-      "/calculate-statutory-sick-pay" => SURVERY_URL,
-    }.freeze
-
     BENEFITS_SURVEY_URL = "https://signup.take-part-in-research.service.gov.uk/home?utm_campaign=Content_History&utm_source=Hold_gov_to_account&utm_medium=gov.uk&t=GDS&id=16".freeze
     BENEFITS_SURVEY_URLS = {
       "/state-pension-age" => BENEFITS_SURVEY_URL,
       "/check-benefits-financial-support" => BENEFITS_SURVEY_URL,
       "/child-benefit-tax-calculator" => BENEFITS_SURVEY_URL,
     }.freeze
-
-    def survey_url(path)
-      landing_page?(path) && SURVEY_URLS[base_path]
-    end
 
     def benefits_survey_url(path)
       landing_page?(path) && BENEFITS_SURVEY_URLS[base_path]

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,16 +1,7 @@
 <% content_for :body do %>
   <div class="smart_answer">
     <%= yield :breadcrumbs %>
-    <% if @presenter && @presenter.start_node.survey_url(request.path) %>
-      <div class="banner-container govuk-!-static-margin-top-4">
-          <%= render "govuk_publishing_components/components/intervention", {
-            suggestion_text: "Help improve a new GOV.UK tool",
-            suggestion_link_text: "Sign up to take part in user research",
-            suggestion_link_url: @presenter.start_node.survey_url(request.path),
-            new_tab: true,
-          } %>
-      </div>
-    <% elsif @presenter && @presenter.start_node.benefits_survey_url(request.path) %>
+    <% if @presenter && @presenter.start_node.benefits_survey_url(request.path) %>
       <div class="banner-container govuk-!-static-margin-top-4">
           <%= render "govuk_publishing_components/components/intervention", {
             suggestion_text: "Help improve GOV.UK",

--- a/test/integration/recruitment_banner_test.rb
+++ b/test/integration/recruitment_banner_test.rb
@@ -2,32 +2,6 @@ require_relative "../integration_test_helper"
 
 class RecruitmentBannerTest < ActionDispatch::IntegrationTest
   context "user research banner" do
-    context "maternity paternity calculator" do
-      setup do
-        stub_content_store_has_item("/maternity-paternity-calculator")
-      end
-
-      should "display User Research Banner on the landing page" do
-        visit "/maternity-paternity-calculator"
-        assert page.has_css?(".gem-c-intervention")
-        assert page.has_link?("Sign up to take part in user research (opens in a new tab)", href: "https://surveys.publishing.service.gov.uk/s/SNFVW1/")
-      end
-
-      should "not display User Research Banner on non-landing pages of the specific smart answer" do
-        visit "/maternity-paternity-calculator/y"
-
-        assert_not page.has_css?(".gem-c-intervention")
-        assert_not page.has_link?("Sign up to take part in user research (opens in a new tab)", href: "https://surveys.publishing.service.gov.uk/s/SNFVW1/")
-      end
-
-      should "not display User Research Banner unless survey URL is specified for the base path" do
-        visit "/bridge-of-death"
-
-        assert_not page.has_css?(".gem-c-intervention")
-        assert_not page.has_link?("Sign up to take part in user research (opens in a new tab)", href: "https://surveys.publishing.service.gov.uk/s/SNFVW1/")
-      end
-    end
-
     context "check state pension age" do
       setup do
         stub_content_store_has_item("/state-pension-age")


### PR DESCRIPTION
## What

Remove research banner from

- [/maternity-paternity-calculator](https://www.gov.uk/maternity-paternity-calculator)
- [/calculate-statutory-sick-pay](https://www.gov.uk/calculate-statutory-sick-pay)

Reverts https://github.com/alphagov/smart-answers/pull/6564

## Why 

Target sign-ups for survey reached.

## Visual Differences

## Before

<img width="987" alt="Screenshot 2023-09-26 at 08 51 04" src="https://github.com/alphagov/smart-answers/assets/96050928/2db621b7-7a17-448d-8aa5-74ee1f5d5149">

## After

<img width="991" alt="Screenshot 2023-09-26 at 08 51 30" src="https://github.com/alphagov/smart-answers/assets/96050928/3444135a-581d-49d1-8b76-080d099f7891">

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
