### PR TITLE
Flatten GA4 attributes

### DIFF
--- a/app/views/smart_answers/custom_result.html.erb
+++ b/app/views/smart_answers/custom_result.html.erb
@@ -61,9 +61,7 @@
         ga4_event: {
           event_name: 'print_page',
           type: 'print page',
-          index: {
-            index_link: 1,
-          },
+          index_link: 1,
           index_total: 1,
           section: 'Footer',
         },


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why

- we no longer need to nest GA4 attributes attached to elements, notably the index attributes
- these attributes when collected by trackers are automatically nested based on the structure of the GA4 schema, held in the gem
- flattening them here saves code and complexity

## Visual changes
None.

Trello card: https://trello.com/c/IseA05Fd/644-remove-nesting-of-ga4-attributes