### PR TITLE
Enable GA4 tracking on intervention component

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,7 @@
             suggestion_link_text: "Take part in user research",
             suggestion_link_url: @presenter.start_node.benefits_survey_url(request.path),
             new_tab: true,
+            ga4_tracking: true,
           } %>
       </div>
     <% end %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Enable tracking on the intervention component.

## Why
Part of the GA4 migration. This should be turned on when this component is used, but we're exploring alternatives (like enabling tracking by default) so developers don't have to remember to do this.

## Visual changes
None.

Trello card: https://trello.com/c/X9VRm9yV/721-add-tracking-to-intervention-component
