### PR TITLE
Qatar 15 November - ETA, 'Check if you need a UK visa': Removing references to EVW from Qatar outcomes

### DIFF
--- a/app/flows/check_uk_visa_flow/outcomes/_electronic_travel_authorisation_advice.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/_electronic_travel_authorisation_advice.erb
@@ -1,1 +1,0 @@
-^If you're travelling on or after 15 November 2023, you'll need to apply for an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta) instead of an electronic visa waiver.

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_marriage_electronic_visa_waiver.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_marriage_electronic_visa_waiver.erb
@@ -11,9 +11,9 @@
   - settled in the UK
   - someone with humanitarian protection, for example if they have refugee status
 
-  If you want to convert a civil partnership into a marriage, you'll need to apply for an [electronic visa waiver (EVW)](/get-electronic-visa-waiver) or a [Standard Visitor visa](/standard-visitor).
-
-  <% if calculator.passport_country_requires_electronic_travel_authorisation? %>
-    <%= render partial: 'electronic_travel_authorisation_advice' %>
+  <%if calculator.passport_country_requires_electronic_travel_authorisation?  %>
+    If you want to convert a civil partnership into a marriage, you’ll need to apply for [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta) or a [Standard Visitor visa](/standard-visitor).
+  <% else %>
+    If you want to convert a civil partnership into a marriage, you'll need to apply for an [electronic visa waiver (EVW)](/get-electronic-visa-waiver) or a [Standard Visitor visa](/standard-visitor).
   <% end %>
 <% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_school_waiver.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_school_waiver.erb
@@ -1,16 +1,20 @@
 <% text_for :title do %>
-  You’ll need an electronic visa waiver (EVW) or a visa
+  <% if calculator.passport_country_requires_electronic_travel_authorisation? %>
+    You’ll need an electronic travel authorisation (ETA) or a visa.
+  <% else %>
+    You’ll need an electronic visa waiver (EVW) or a visa
+  <% end %>
 <% end %>
 
 <% govspeak_for :body do %>
-  You must either apply for:
+  You must apply for either:
 
-  + an [electronic visa waiver](/get-electronic-visa-waiver) to stay for up to 6 months
-  + a [Parent of a Child Student visa](/parent-of-a-child-at-school-visa)
-
-  <%if calculator.passport_country_requires_electronic_travel_authorisation?  %>
-    <%= render partial: 'electronic_travel_authorisation_advice'%>
+  <% if calculator.passport_country_requires_electronic_travel_authorisation? %>
+    + an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta) to stay for up to 6 months
+  <% else %>
+    + an [electronic visa waiver](/get-electronic-visa-waiver) to stay for up to 6 months
   <% end %>
+  + a [Parent of a Child Student visa](/parent-of-a-child-at-school-visa)
 
   *[EVW]: electronic visa waiver
 <% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_study_waiver.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_study_waiver.erb
@@ -1,20 +1,20 @@
 <% text_for :title do %>
-  You’ll need an electronic visa waiver (EVW) or a visa
+  <% if calculator.passport_country_requires_electronic_travel_authorisation? %>
+    You’ll need an electronic travel authorisation (ETA) or a visa.
+  <% else %>
+    You’ll need an electronic visa waiver (EVW) or a visa
+  <% end %>
 <% end %>
 
 <% govspeak_for :body do %>
+  You must apply for either:
+
   <% if calculator.passport_country_requires_electronic_travel_authorisation? %>
-    If you do not have a visa (or wet ink stamp) for the Channel Islands or the Isle of Man, you must either apply for:
+    + an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta)
   <% else %>
-    You must either apply for:
+    + an [electronic visa waiver](/get-electronic-visa-waiver)
   <% end %>
-
-  + [an electronic visa waiver](/get-electronic-visa-waiver)
   + [a Standard Visitor visa](/standard-visitor) for courses up to 6 months
-
-  <%if calculator.passport_country_requires_electronic_travel_authorisation?  %>
-    <%= render partial: 'electronic_travel_authorisation_advice'%>
-  <% end %>
 
   *[EVW]: electronic visa waiver
 <% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_transit_leaving_airport.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_transit_leaving_airport.erb
@@ -1,5 +1,7 @@
 <% text_for :title do %>
-  <% if calculator.passport_country_in_electronic_visa_waiver_list? %>
+  <% if calculator.passport_country_requires_electronic_travel_authorisation? %>
+    You’ll need an electronic travel authorisation (ETA) or a Visitor in Transit visa.
+  <% elsif calculator.passport_country_in_electronic_visa_waiver_list? %>
     You’ll need an electronic visa waiver (EVW) or a Visitor in Transit visa
   <% else %>
     You’ll need a visa to pass through the UK in transit
@@ -7,15 +9,17 @@
 <% end %>
 
 <% govspeak_for :body do %>
-  <% if calculator.passport_country_in_electronic_visa_waiver_list? %>
+  <% if calculator.passport_country_requires_electronic_travel_authorisation? %>
+    You must apply for either:
+
+    + an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta)
+    + a Visitor in Transit visa
+
+  <% elsif calculator.passport_country_in_electronic_visa_waiver_list? %>
     You must either apply for:
 
-    - an [electronic visa waiver](/get-electronic-visa-waiver)
-    - a [Visitor in Transit visa](/transit-visa)
-
-    <%if calculator.passport_country_requires_electronic_travel_authorisation?  %>
-      <%= render partial: 'electronic_travel_authorisation_advice'%>
-    <% end %>
+    + an [electronic visa waiver](/get-electronic-visa-waiver)
+    + a [Visitor in Transit visa](/transit-visa)
 
   <% else %>
     You should apply for a [Visitor in Transit visa](/transit-visa) if you arrive on a flight and will pass through immigration control before you leave the UK.

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_transit_to_the_republic_of_ireland.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_transit_to_the_republic_of_ireland.erb
@@ -1,6 +1,8 @@
 <% text_for :title do %>
   <% if calculator.passport_country_is_taiwan? %>
     You will not need a visa if your passport has a personal ID number on the bio data page.
+  <% elsif calculator.passport_country_requires_electronic_travel_authorisation? %>
+    You’ll need an electronic travel authorisation (ETA) or a visa.
   <% elsif calculator.passport_country_in_electronic_visa_waiver_list? %>
     You’ll need an electronic visa waiver (EVW) or a Standard Visitor visa
   <% else %>
@@ -10,25 +12,22 @@
 
 <% govspeak_for :body do %>
   <% if calculator.passport_country_is_taiwan? %>
-
     You must meet the [Standard Visitor eligibility requirements](/standard-visitor).
 
     [Check what documents you need to bring](/government/publications/visitor-visa-guide-to-supporting-documents) to show officers at the UK border.
 
     If your passport does not have a personal ID number on the bio data page you’ll usually need to apply for a [Standard Visitor visa](/standard-visitor).
-  <% elsif calculator.passport_country_in_electronic_visa_waiver_list? %>
+  <% elsif calculator.passport_country_requires_electronic_travel_authorisation? %>
+    You must apply for either:
 
+    + an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta)
+    + a [Standard Visitor visa](/standard-visitor)
+  <% elsif calculator.passport_country_in_electronic_visa_waiver_list? %>
     You must either apply for:
 
-    - an [electronic visa waiver](/get-electronic-visa-waiver)
-    - a [Standard Visitor visa](/standard-visitor)
-
-    <%if calculator.passport_country_requires_electronic_travel_authorisation?  %>
-      <%= render partial: 'electronic_travel_authorisation_advice'%>
-    <% end %>
-
+    + an [electronic visa waiver](/get-electronic-visa-waiver)
+    + a [Standard Visitor visa](/standard-visitor)
   <% else %>
-
     You’ll usually need to apply for a [Standard Visitor visa](/standard-visitor).
   <% end %>
 

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_visit_waiver.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_visit_waiver.erb
@@ -1,18 +1,19 @@
 <% text_for :title do %>
-  You’ll need an electronic visa waiver (EVW) or a visitor visa
+  <% if calculator.passport_country_requires_electronic_travel_authorisation? %>
+    You’ll need an electronic travel authorisation (ETA) or a visitor visa.
+  <% else %>
+    You’ll need an electronic visa waiver (EVW) or a visitor visa
+  <% end %>
 <% end %>
 
 <% govspeak_for :body do %>
+    You must apply for either:
+
   <% if calculator.passport_country_requires_electronic_travel_authorisation? %>
-    If you do not have a visa (or wet ink stamp) for the Channel Islands or the Isle of Man, you must either apply for:
+    + an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta)
   <% else %>
-    You must either apply for:
+    + an [electronic visa waiver](/get-electronic-visa-waiver)
   <% end %>
 
-  + an [electronic visa waiver](/get-electronic-visa-waiver)
   + a [Standard Visitor visa](/standard-visitor)
-
-  <% if calculator.passport_country_requires_electronic_travel_authorisation?  %>
-    <%= render partial: 'electronic_travel_authorisation_advice'%>
-  <% end %>
 <% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_work_waiver.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_work_waiver.erb
@@ -13,10 +13,10 @@
   - [Standard Visitor visa](/standard-visitor) - if you’re coming to the UK for business activities like conferences, meetings, training, academic research or a sabbatical
   - [Permitted Paid Engagement Visitor visa](/permitted-paid-engagement-visa) if you've been invited as an expert in your profession - you can only stay for up to 1 month
 
-  You will not need a visa if you hold a valid [electronic visa waiver (EVW)](/get-electronic-visa-waiver).
-
   <%if calculator.passport_country_requires_electronic_travel_authorisation?  %>
-    <%= render partial: 'electronic_travel_authorisation_advice'%>
+    You do not need a visa if you hold valid [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta).
+  <% else %>
+    You will not need a visa if you hold a valid [electronic visa waiver (EVW)](/get-electronic-visa-waiver).
   <% end %>
 
   ##Working in the UK

--- a/test/flows/check_uk_visa_flow_test.rb
+++ b/test/flows/check_uk_visa_flow_test.rb
@@ -989,14 +989,9 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
       add_responses purpose_of_visit?: "school"
     end
 
-    should "render specific guidance for Electronic Travel Authorisation" do
+    should "not have any reference to electronic visa waivers (EVWs) for ETA countries" do
       add_responses what_passport_do_you_have?: @electronic_travel_authorisation_country
-      assert_rendered_outcome text: @eta_text
-    end
-
-    should "not render Electronic Travel Authorisation guidance for non-ETA countries" do
-      add_responses what_passport_do_you_have?: @electronic_visa_waiver_country
-      assert_no_rendered_outcome text: @eta_text
+      assert_no_rendered_outcome text: "electronic visa waiver"
     end
   end
 end

--- a/test/flows/check_uk_visa_flow_test.rb
+++ b/test/flows/check_uk_visa_flow_test.rb
@@ -965,14 +965,9 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
                     staying_for_how_long?: "six_months_or_less"
     end
 
-    should "render specific guidance for Electronic Travel Authorisation" do
+    should "not have any reference to electronic visa waivers (EVWs) for ETA countries" do
       add_responses what_passport_do_you_have?: @electronic_travel_authorisation_country
-      assert_rendered_outcome text: @eta_text
-    end
-
-    should "not render Electronic Travel Authorisation guidance for non-ETA countries" do
-      add_responses what_passport_do_you_have?: @electronic_visa_waiver_country
-      assert_no_rendered_outcome text: @eta_text
+      assert_no_rendered_outcome text: "electronic visa waiver"
     end
   end
 

--- a/test/flows/check_uk_visa_flow_test.rb
+++ b/test/flows/check_uk_visa_flow_test.rb
@@ -977,14 +977,9 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
       add_responses purpose_of_visit?: "marriage"
     end
 
-    should "render specific guidance for Electronic Travel Authorisation" do
+    should "not have any reference to electronic visa waivers (EVWs) for ETA countries" do
       add_responses what_passport_do_you_have?: @electronic_travel_authorisation_country
-      assert_rendered_outcome text: @eta_text
-    end
-
-    should "not render Electronic Travel Authorisation guidance for non-ETA countries" do
-      add_responses what_passport_do_you_have?: @electronic_visa_waiver_country
-      assert_no_rendered_outcome text: @eta_text
+      assert_no_rendered_outcome text: "electronic visa waiver"
     end
   end
 

--- a/test/flows/check_uk_visa_flow_test.rb
+++ b/test/flows/check_uk_visa_flow_test.rb
@@ -21,7 +21,6 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
     @youth_mobility_scheme_country = "canada"
 
     @eta_text = "If you’re travelling on or after 15 November 2023, you’ll need to apply for an electronic travel authorisation (ETA) instead of an electronic visa waiver."
-    @channel_island_isle_of_man_text = "If you do not have a visa (or wet ink stamp) for the Channel Islands or the Isle of Man, you must either apply for:"
 
     # stub only the countries used in this test for less of a performance impact
     stub_worldwide_api_has_locations(["china",

--- a/test/flows/check_uk_visa_flow_test.rb
+++ b/test/flows/check_uk_visa_flow_test.rb
@@ -957,22 +957,9 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
                     staying_for_how_long?: "six_months_or_less"
     end
 
-    should "render specific guidance for Electronic Travel Authorisation" do
+    should "not have any reference to electronic visa waivers (EVWs) for ETA countries" do
       add_responses what_passport_do_you_have?: @electronic_travel_authorisation_country
-      assert_rendered_outcome text: @eta_text
-    end
-
-    should "not render Electronic Travel Authorisation guidance for non-ETA countries" do
-      add_responses what_passport_do_you_have?: @electronic_visa_waiver_country
-      assert_no_rendered_outcome text: @eta_text
-    end
-
-    should "render ETA specific instructions for visiting Channel Islands or Isle of Man" do
-      add_responses what_passport_do_you_have?: @electronic_travel_authorisation_country,
-                    travelling_to_cta?: "channel_islands_or_isle_of_man"
-      assert_rendered_outcome text: @eta_text
-      assert_rendered_outcome text: @channel_island_isle_of_man_text
-      assert_no_rendered_outcome text: "You must either apply for:"
+      assert_no_rendered_outcome text: "electronic visa waiver"
     end
   end
 

--- a/test/flows/check_uk_visa_flow_test.rb
+++ b/test/flows/check_uk_visa_flow_test.rb
@@ -750,14 +750,9 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
       assert_rendered_outcome text: "You’ll need a visa to pass through the UK in transit"
     end
 
-    should "render specific guidance for Electronic Travel Authorisation" do
+    should "not have any reference to electronic visa waivers (EVWs) for ETA countries" do
       add_responses what_passport_do_you_have?: @electronic_travel_authorisation_country
-      assert_rendered_outcome text: @eta_text
-    end
-
-    should "not render Electronic Travel Authorisation guidance for non-ETA countries" do
-      add_responses what_passport_do_you_have?: @electronic_visa_waiver_country
-      assert_no_rendered_outcome text: @eta_text
+      assert_no_rendered_outcome text: "electronic visa waiver"
     end
   end
 

--- a/test/flows/check_uk_visa_flow_test.rb
+++ b/test/flows/check_uk_visa_flow_test.rb
@@ -726,14 +726,9 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
       assert_rendered_outcome text: "You’ll need a visa to pass through the UK (unless you’re exempt)"
     end
 
-    should "render specific guidance for Electronic Travel Authorisation" do
+    should "not have any reference to electronic visa waivers (EVWs) for ETA countries" do
       add_responses what_passport_do_you_have?: @electronic_travel_authorisation_country
-      assert_rendered_outcome text: @eta_text
-    end
-
-    should "not render Electronic Travel Authorisation guidance for non-ETA countries" do
-      add_responses what_passport_do_you_have?: @electronic_visa_waiver_country
-      assert_no_rendered_outcome text: @eta_text
+      assert_no_rendered_outcome text: "electronic visa waiver"
     end
   end
 

--- a/test/flows/check_uk_visa_flow_test.rb
+++ b/test/flows/check_uk_visa_flow_test.rb
@@ -944,22 +944,9 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
       add_responses purpose_of_visit?: "tourism"
     end
 
-    should "render specific guidance for Electronic Travel Authorisation" do
+    should "not have any reference to electronic visa waivers (EVWs) for ETA countries" do
       add_responses what_passport_do_you_have?: @electronic_travel_authorisation_country
-      assert_rendered_outcome text: @eta_text
-    end
-
-    should "not render Electronic Travel Authorisation guidance for non-ETA countries" do
-      add_responses what_passport_do_you_have?: @electronic_visa_waiver_country
-      assert_no_rendered_outcome text: @eta_text
-    end
-
-    should "render ETA specific instructions for visiting Channel Islands or Isle of Man" do
-      add_responses what_passport_do_you_have?: @electronic_travel_authorisation_country,
-                    travelling_to_cta?: "channel_islands_or_isle_of_man"
-      assert_rendered_outcome text: @eta_text
-      assert_rendered_outcome text: @channel_island_isle_of_man_text
-      assert_no_rendered_outcome text: "You must either apply for:"
+      assert_no_rendered_outcome text: "electronic visa waiver"
     end
   end
 


### PR DESCRIPTION
On 25 October 2023, the electronic travel authorisation (ETA) service launched for users travelling using a passport from Qatar. Between 25 October and 15 November, users from Qatar who did not need a visa could choose to get an electronic visa waiver (EVW) or an ETA.

The 15 November update involves making ETA the sole route for Qatari users who do not need to get a visa. They will no longer be able to choose to get an EVW. However other countries CAN still get an EVW, until February 2024. Users from Qatar will still need to get a visa if they need to - for example to stay longer than 6 months to study.

This PR changes the content on Qatar outcomes so that users from Qatar no longer see any information related to EVWs, and instead only see information related to ETAs (where necessary).

More info can be found in this [trello ticket](https://trello.com/c/ecZrRS9J/216-15-november-eta-check-if-you-need-a-uk-visa-making-qatar-a-non-visa-national-and-removing-evw-from-their-outcomes)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
