### PR TITLE
Correct the flow for Qatar to medical treatment outcome

### DIFF
--- a/app/flows/check_uk_visa_flow.rb
+++ b/app/flows/check_uk_visa_flow.rb
@@ -351,7 +351,7 @@ class CheckUkVisaFlow < SmartAnswer::Flow
       end
 
       if calculator.medical_visit?
-        if calculator.passport_country_in_electronic_visa_waiver_list?
+        if calculator.passport_country_requires_electronic_travel_authorisation? || calculator.passport_country_in_electronic_visa_waiver_list?
           next outcome(:outcome_visit_waiver)
         elsif calculator.passport_country_is_taiwan?
           next outcome(:outcome_visit_waiver_taiwan)


### PR DESCRIPTION
Removing Qatar from the EVW list changed the flow as no condition was in place for ETA countries to go to the correct outcome. This is a fix to the [PR](https://github.com/alphagov/smart-answers/pull/6600) that was pushed this morning. 

After that PR was merged,  the flows (Qatar->medical treatment AND Qatar-> transit -> channel_islands_or_isle_of_man -> medical treatment) led to the outcome page `outcome_medical_y.erb` where as it should go to `outcome_visit_waiver.erb`. So this has now been corrected.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
