### PR TITLE
Remove unneeded instances of ga4_tracking: true

### DIFF
--- a/app/views/smart_answers/landing.html.erb
+++ b/app/views/smart_answers/landing.html.erb
@@ -18,7 +18,7 @@
 <% end %>
 
 <% content_for :breadcrumbs do %>
-  <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: content_item, ga4_tracking: true %>
+  <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: content_item %>
 <% end %>
 
 <div class="govuk-grid-row">
@@ -66,9 +66,9 @@
       <% end %>
     </article>
 
-    <%= render 'govuk_publishing_components/components/contextual_footer', content_item: content_item, ga4_tracking: true %>
+    <%= render 'govuk_publishing_components/components/contextual_footer', content_item: content_item %>
   </div>
   <div class="govuk-grid-column-one-third">
-    <%= render 'govuk_publishing_components/components/contextual_sidebar', content_item: content_item, ga4_tracking: true %>
+    <%= render 'govuk_publishing_components/components/contextual_sidebar', content_item: content_item %>
   </div>
 </div>

--- a/app/views/smart_answers/result.html.erb
+++ b/app/views/smart_answers/result.html.erb
@@ -86,7 +86,7 @@
 
   <% if defined?(@presenter.finished?) and @presenter.finished? %>
     <div class="govuk-grid-column-one-third govuk-!-margin-top-9">
-      <%= render 'govuk_publishing_components/components/contextual_sidebar', content_item: content_item, ga4_tracking: true %>
+      <%= render 'govuk_publishing_components/components/contextual_sidebar', content_item: content_item %>
     </div>
   <% end %>
 </div>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Remove options passed to components for enabling GA4 tracking. All components referenced now have tracking enabled by default, and this option has been removed.

## Why
Unneeded code.

## Visual changes
None.

Trello card: https://trello.com/c/Xwp7dgJN/294-tracking-auditing-tracking-by-default
