### PR TITLE
Update timelines for swearing an affirmation

### DIFF
--- a/app/flows/marriage_abroad_flow/outcomes/countries/thailand/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/thailand/_opposite_sex.erb
@@ -9,7 +9,7 @@ Contact the local district office (also known as an ‘amphur’, ‘amphoe’ o
 To prove you can legally get married in most provinces, you’ll need to:
 
 - apply online for an affirmation of marital status
-- book an appointment to swear the affirmation at the British embassy in Bangkok - do this up to 45 days before your marriage
+- book an appointment to swear the affirmation at the British embassy in Bangkok
 - have a certified copy of your passport - if you do not have a certified copy already, you can get one when you swear your affirmation
 - get your affirmation and a certified copy of your passport translated into Thai, then ‘legalised’ (certified as genuine) by the Ministry of Foreign Affairs in Thailand
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/thailand/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/thailand/_opposite_sex.erb
@@ -25,7 +25,7 @@ To apply for an affirmation of marital status, you'll need:
 
 - a photo of your UK passport
 - your partner’s passport or Thai ID number
-- your parents' full name
+- your parents' full names
 - name and address of 2 referees who do not live in Thailand
 - the province and date of marriage registration at the district office
 - a debit or credit card


### PR DESCRIPTION
https://govuk.zendesk.com/agent/tickets/5535950
https://trello.com/c/lFPh9BEz/4655-inconsistency-in-thailand-content-in-getting-married-abroad-smart-answer

Removed the '45 days' timeline for swearing an affirmation, as this is not accurate. Users can swear their affirmation anytime after they've applied for it, which should be within 3 months of the wedding day.