### PR TITLE
Holiday entitlement calculator: Add messaging to inform users about upcoming changes

### DIFF
--- a/app/flows/calculate_your_holiday_entitlement_flow/outcomes/_april2024_announcement_for_irregular_hours_or_part_of_the_year.erb
+++ b/app/flows/calculate_your_holiday_entitlement_flow/outcomes/_april2024_announcement_for_irregular_hours_or_part_of_the_year.erb
@@ -1,0 +1,1 @@
+^For leave years starting on or after 1 April 2024, people who work irregular hours or for part of the year will build up (‘accrue’) leave differently. This means their entitlement will be 12.07% of the hours they work in a pay period, up to a maximum of 5.6 weeks.

--- a/app/flows/calculate_your_holiday_entitlement_flow/outcomes/compressed_hours_done.erb
+++ b/app/flows/calculate_your_holiday_entitlement_flow/outcomes/compressed_hours_done.erb
@@ -8,4 +8,6 @@
   <% end %>
 
   <%= render partial: "guidance_on_calculations" %>
+
+  <%= render partial: "april2024_announcement_for_irregular_hours_or_part_of_the_year" %>
 <% end %>

--- a/app/flows/calculate_your_holiday_entitlement_flow/outcomes/days_per_week_done.erb
+++ b/app/flows/calculate_your_holiday_entitlement_flow/outcomes/days_per_week_done.erb
@@ -12,4 +12,6 @@
   <% end %>
 
   <%= render partial: "guidance_on_calculations" %>
+
+  <%= render partial: "april2024_announcement_for_irregular_hours_or_part_of_the_year" %>
 <% end %>

--- a/app/flows/calculate_your_holiday_entitlement_flow/outcomes/hours_per_week_done.erb
+++ b/app/flows/calculate_your_holiday_entitlement_flow/outcomes/hours_per_week_done.erb
@@ -12,4 +12,6 @@
   <% end %>
 
   <%= render partial: "guidance_on_calculations" %>
+
+  <%= render partial: "april2024_announcement_for_irregular_hours_or_part_of_the_year" %>
 <% end %>

--- a/app/flows/calculate_your_holiday_entitlement_flow/outcomes/irregular_and_annualised_done.erb
+++ b/app/flows/calculate_your_holiday_entitlement_flow/outcomes/irregular_and_annualised_done.erb
@@ -3,6 +3,8 @@
 
   There are no regulations on how to convert the entitlement into days or hours for workers with irregular hours.
 
+  <%= render partial: "april2024_announcement_for_irregular_hours_or_part_of_the_year" %>
+
   You may wish to [use the calculator again](/calculate-your-holiday-entitlement/y) and calculate the average days or hours worked each week based on a representative reference period instead.
 
   <%= render partial: 'your_employer_with_rounding' %>

--- a/app/flows/calculate_your_holiday_entitlement_flow/outcomes/shift_worker_done.erb
+++ b/app/flows/calculate_your_holiday_entitlement_flow/outcomes/shift_worker_done.erb
@@ -12,4 +12,6 @@
   <% end %>
 
   <%= render partial: "guidance_on_calculations" %>
+
+  <%= render partial: "april2024_announcement_for_irregular_hours_or_part_of_the_year" %>
 <% end %>

--- a/test/flows/calculate_your_holiday_entitlement_flow_test.rb
+++ b/test/flows/calculate_your_holiday_entitlement_flow_test.rb
@@ -451,4 +451,58 @@ class CalculateYourHolidayEntitlementFlowTest < ActiveSupport::TestCase
       end
     end
   end
+
+  context "Temporary guidance relevant till 1st April 2024" do
+    setup do
+      @temp_guidance = "For leave years starting on or after 1 April 2024, people who work irregular hours or for part of the year will build up (‘accrue’) leave differently. This means their entitlement will be 12.07% of the hours they work in a pay period, up to a maximum of 5.6 weeks."
+    end
+
+    should "renders on outcome: compressed_hours_done" do
+      testing_node :compressed_hours_done
+      add_responses basis_of_calculation?: "compressed-hours",
+                    calculation_period?: "full-year",
+                    how_many_hours_per_week?: "5.0",
+                    how_many_days_per_week_for_hours?: "5.0"
+
+      assert_rendered_outcome text: @temp_guidance
+    end
+
+    should "renders on outcome: days_per_week_done" do
+      testing_node :days_per_week_done
+      add_responses basis_of_calculation?: "days-worked-per-week",
+                    calculation_period?: "full-year",
+                    how_many_days_per_week?: "5.0"
+
+      assert_rendered_outcome text: @temp_guidance
+    end
+
+    should "renders on outcome: hours_per_week_done" do
+      testing_node :hours_per_week_done
+      add_responses basis_of_calculation?: "hours-worked-per-week",
+                    calculation_period?: "full-year",
+                    how_many_hours_per_week?: "35.0",
+                    how_many_days_per_week_for_hours?: "5.0"
+
+      assert_rendered_outcome text: @temp_guidance
+    end
+
+    should "renders on outcome: irregular_and_annualised_done" do
+      testing_node :irregular_and_annualised_done
+      add_responses basis_of_calculation?: "irregular-hours",
+                    calculation_period?: "full-year"
+
+      assert_rendered_outcome text: @temp_guidance
+    end
+
+    should "renders on outcome: shift_worker_done" do
+      testing_node :shift_worker_done
+      add_responses basis_of_calculation?: "shift-worker",
+                    shift_worker_basis?: "full-year",
+                    shift_worker_hours_per_shift?: "5.0",
+                    shift_worker_shifts_per_shift_pattern?: "5",
+                    shift_worker_days_per_shift_pattern?: "5.0"
+
+      assert_rendered_outcome text: @temp_guidance
+    end
+  end
 end


### PR DESCRIPTION
Add messaging to all outcomes to inform users of the upcoming change to their holiday entitlement from 1 April 2024.

This will need to be available to those users from 1 January 2024.

More information in this [trello ticket](https://trello.com/c/Fht11OVb/226-update-holiday-entitlement-calculator-part-one-add-messaging-to-inform-users-about-the-upcoming-change).