### PR TITLE
Remove GA4 tracking on 'print page' buttons

### DIFF
--- a/app/views/smart_answers/custom_result.html.erb
+++ b/app/views/smart_answers/custom_result.html.erb
@@ -55,18 +55,7 @@
         } %>
     <% end %>
 
-    <%= render 'govuk_publishing_components/components/print_link', {
-      data_attributes: {
-        module: "ga4-event-tracker",
-        ga4_event: {
-          event_name: 'print_page',
-          type: 'print page',
-          index_link: 1,
-          index_total: 1,
-          section: 'Footer',
-        },
-      },
-    } %>
+    <%= render 'govuk_publishing_components/components/print_link' %>
 
     <%= render 'smart_answers/shared/debug' %>
   </div>


### PR DESCRIPTION
## What
Removes GA4 tracking on 'print page' buttons

## Why
- We now have a tracker that tracks the browser's print dialog, so we remove this tracking to prevent duplicate print events.
- https://trello.com/c/8tv1YU8b/718-print-page-button-click-triggers-a-browser-print-event-duplicate-printpage-tracking

## Pages affected

According to #6075, it only affects this smart answer: http://127.0.0.1:3010/next-steps-for-your-business/results?activities%5B%5D=none&annual_turnover_over_85k=yes&business_premises%5B%5D=home&employ_someone=no&financial_support=no