### PR TITLE
Add GA4 scroll tracking

### DIFF
--- a/app/views/smart_answers/landing.html.erb
+++ b/app/views/smart_answers/landing.html.erb
@@ -15,6 +15,24 @@
       content_item: content_item %>
   <% end %>
   <link title="Search" rel="search" type="application/opensearchdescription+xml" href="/search/opensearch.xml"/>
+  <%
+    ga4_scroll_track_headings_paths = [
+      "/check-uk-visa",
+      "/check-benefits-financial-support",
+      "/state-pension-age",
+      "/calculate-your-holiday-entitlement",
+      "/calculate-your-redundancy-pay",
+      "/student-finance-calculator",
+      "/child-benefit-tax-calculator",
+      "/maternity-paternity-pay-leave",
+      "/maternity-paternity-calculator",
+      "/calculate-statutory-sick-pay",
+      "/am-i-getting-minimum-wage"
+    ]
+  %>
+  <% if ga4_scroll_track_headings_paths.include?(@content_item["base_path"]) %>
+    <meta name="govuk:scroll-tracker" content="" data-module="ga4-scroll-tracker"/>
+  <% end %>
 <% end %>
 
 <% content_for :breadcrumbs do %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

- adds scroll tracking to the top most visited smart answer start pages

## Why
Part of the GA4 migration.

## Visual changes
None.

Trello card: https://trello.com/c/JfkV5NSI/750-add-scroll-tracking-top-100-pages
