### PR TITLE
Ppe visa 31 jan

### DIFF
--- a/app/flows/check_uk_visa_flow/outcomes/outcome_work_m.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_work_m.erb
@@ -19,7 +19,7 @@
 
   + going to meetings or conferences
   + doing academic research
-  + doing paid engagements or events for UK-based organisations
+  + doing certain paid engagements or events (a 'permitted paid engagement') for UK-based organisations
 
   ##Working in the UK
 

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_work_n.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_work_n.erb
@@ -10,7 +10,7 @@
 
   * going to meetings or conferences
   * doing academic research
-  * doing paid engagements or events for UK-based organisations
+  * doing certain paid engagements or events (a ‘permitted paid engagement’) for UK-based organisations
 
   You cannot:
 
@@ -18,9 +18,9 @@
   * do a work placement or internship
   * sell directly to the public or provide goods and services
 
-  If you’re doing a paid engagement or event, you must do it within one month of arriving. You can stay in the UK for up to 6 months, but cannot do any paid engagements after the first month. 
+  If you’re doing a permitted paid engagement, you must do it within one month of arriving. You can stay in the UK for up to 6 months, but cannot do any paid engagements after the first month. 
 
-  Check the full list of [business activities](/standard-visitor/visit-on-business), [academic activities](/standard-visitor/visit-as-an-academic) or [paid engagements or events](/standard-visitor/paid-engagement) you can do as a Standard Visitor.  
+  Check the full list of [business activities](/standard-visitor/visit-on-business), [academic activities](/standard-visitor/visit-as-an-academic) or [permitted paid engagements](/standard-visitor/paid-engagement) you can do as a Standard Visitor.  
 
   To research certain subjects at postgraduate level or above, you may need an [Academic Technology Approval Scheme (ATAS) certificate](/guidance/find-out-if-you-require-an-atas-certificate). If you do need one, you’ll need to get your ATAS certificate before starting your research.
 

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_work_waiver.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_work_waiver.erb
@@ -12,7 +12,7 @@
 
   + going to meetings or conferences
   + doing academic research
-  + doing paid engagements or events for UK-based organisations
+  + doing certain paid engagements or events (a 'permitted paid engagement') for UK-based organisations
 
   <% if calculator.passport_country_requires_electronic_travel_authorisation? %>
     You do not need a visa if you hold valid [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta).

--- a/test/flows/check_uk_visa_flow_test.rb
+++ b/test/flows/check_uk_visa_flow_test.rb
@@ -17,7 +17,6 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
     @eea_country = "austria"
     @travel_document_country = "hong-kong"
     @b1_b2_country = "syria"
-    @epassport_gate_country = "australia"
     @youth_mobility_scheme_country = "canada"
 
     @eta_text = "If you’re travelling on or after 22 February 2024, you can apply for an electronic travel authorisation (ETA). You’ll be able to apply for an ETA from 1 February 2024"
@@ -45,7 +44,6 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
                                       @eea_country,
                                       @travel_document_country,
                                       @b1_b2_country,
-                                      @epassport_gate_country,
                                       @youth_mobility_scheme_country].uniq)
   end
 
@@ -768,11 +766,6 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
       testing_node :outcome_work_n
       add_responses purpose_of_visit?: "work",
                     staying_for_how_long?: "six_months_or_less"
-    end
-
-    should "render epassport guidance to appropriate countries" do
-      add_responses what_passport_do_you_have?: @epassport_gate_country
-      assert_rendered_outcome text: "Do not use the automatic ePassport gates"
     end
   end
 


### PR DESCRIPTION
https://trello.com/c/vBWMIkIl/235-deadline-for-live-31st-jan-check-if-you-need-a-visa-paid-permitted-engagement-visa-becomes-part-of-standard-visitor-visa

Changes to 3 outcomes because the Permitted Paid Engagement visa is being merged into the Standard Visitor visa. References to the former needed removing or altering in work related outcomes so they pointed to the standard visitor information.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.