### PR TITLE
Fix formatting in .govuk_dependabot_merger.yml

### DIFF
--- a/.govuk_dependabot_merger.yml
+++ b/.govuk_dependabot_merger.yml
@@ -4,7 +4,15 @@ auto_merge:
     allowed_semver_bumps:
       - patch
       - minor
-  - dependency: gds_zendesk
+  - dependency: gds-sso
+    allowed_semver_bumps:
+      - patch
+      - minor
+  - dependency: govspeak
+    allowed_semver_bumps:
+      - patch
+      - minor
+  - dependency: govuk_ab_testing
     allowed_semver_bumps:
       - patch
       - minor
@@ -12,7 +20,7 @@ auto_merge:
     allowed_semver_bumps:
       - patch
       - minor
-  - dependency: govspeak
+  - dependency: govuk_frontend_toolkit
     allowed_semver_bumps:
       - patch
       - minor
@@ -24,7 +32,15 @@ auto_merge:
     allowed_semver_bumps:
       - patch
       - minor
+  - dependency: govuk_sidekiq
+    allowed_semver_bumps:
+      - patch
+      - minor
   - dependency: govuk_test
+    allowed_semver_bumps:
+      - patch
+      - minor
+  - dependency: plek
     allowed_semver_bumps:
       - patch
       - minor


### PR DESCRIPTION
This invalid YAML was causing build failures in govuk-dependabot-merger (now fixed in https://github.com/alphagov/govuk-dependabot-merger/pull/41).

This PR fixes the configuration so that Whitehall dependency PRs  can be auto-merged again.

It also rearranges the dependencies alphabetically.