### PR TITLE
Ia 1 feb eta

### DIFF
--- a/app/flows/check_uk_visa_flow/outcomes/_electronic_travel_authorisation_advice.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/_electronic_travel_authorisation_advice.erb
@@ -1,3 +1,3 @@
 <% if Time.zone.now < Time.zone.local(2024, 2, 22) %>
-  ^If you're travelling on or after 22 February 2024, you can apply for an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta). You'll be able to apply for an ETA from 1 February 2024.
+  ^If you're travelling on or after 22 February 2024, you'll need to apply for an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta)instead. 
 <% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/_electronic_travel_authorisation_advice.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/_electronic_travel_authorisation_advice.erb
@@ -1,3 +1,3 @@
 <% if Time.zone.now < Time.zone.local(2024, 2, 22) %>
-  ^If you're travelling on or after 22 February 2024, you'll need to apply for an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta)instead. 
+  ^If you're travelling on or after 22 February 2024, you'll need to apply for an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta). 
 <% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_no_visa_needed.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_no_visa_needed.erb
@@ -12,9 +12,9 @@
   <% if calculator.electronic_travel_authorisation_warning_notice_required? && Time.now < Time.new(2024, 02, 22)%>
 
       <% if calculator.passport_country_is_jordan? %>
-      If you're travelling on or after 22 February 2024, you'll need to apply for an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta). You'll be able to apply for an ETA from 1 February 2024.
+      If you're travelling on or after 22 February 2024, you'll need to apply for an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta).
       <% else %>
-      If you're travelling on or after 22 February 2024, you can apply for an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta). You'll be able to apply for an ETA from 1 February 2024.
+      If you're travelling on or after 22 February 2024, you'll need to apply for an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta).
       <% end %>
 
   <% end %>

--- a/test/flows/check_uk_visa_flow_test.rb
+++ b/test/flows/check_uk_visa_flow_test.rb
@@ -19,7 +19,7 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
     @b1_b2_country = "syria"
     @youth_mobility_scheme_country = "canada"
 
-    @eta_text = "If you’re travelling on or after 22 February 2024, you can apply for an electronic travel authorisation (ETA). You’ll be able to apply for an ETA from 1 February 2024"
+    @eta_text = "If you’re travelling on or after 22 February 2024, you’ll need to apply for an electronic travel authorisation (ETA)"
 
     # stub only the countries used in this test for less of a performance impact
     stub_worldwide_api_has_locations(["china",
@@ -1018,7 +1018,7 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
                       what_passport_do_you_have?: "jordan",
                       travelling_to_cta?: "somewhere_else",
                       passing_through_uk_border_control?: "no"
-        assert_rendered_outcome text: "If you’re travelling on or after 22 February 2024, you’ll need to apply for an electronic travel authorisation (ETA). You’ll be able to apply for an ETA from 1 February 2024"
+        assert_rendered_outcome text: @eta_text
       end
 
       should "for outcome: outcome_transit_to_the_republic_of_ireland" do


### PR DESCRIPTION
Storytime ticket: https://trello.com/c/44Oby2oa/236-1-february-update-eta-callout-for-gulf-countries

Removed 'You’ll be able to apply for an ETA from 1 February 2024.' from the Gulf countries ETA callout as it will be after 1 Feb. I believe I've found all the locations to update, but please shout if I've missed one! 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
