### PR TITLE
Handle embassies with no contact numbers

### DIFF
--- a/app/flows/shared/_overseas_passports_embassies.erb
+++ b/app/flows/shared/_overseas_passports_embassies.erb
@@ -14,7 +14,7 @@ $A
 $A
 
 $C
-<% embassy["contact_numbers"].each do |contact| %>
+<% embassy["contact_numbers"]&.each do |contact| %>
 <%# Some labels have a trailing :, some don't %>
 <%= contact["label"].sub(/:\s*\z/, '') %>: <%= contact["number"] %>
 <% end %>


### PR DESCRIPTION
The view is assuming that embassies will have a "contact_numbers" attribute, however, for Sweden this appears to not be the case and the view is therefore erroring. Perhaps there is an issue with the API, whereby it shouldn't really be missing this attribute, however, it is an issue right now that prevents the entire page loading for users.

Update the view to handle "contact_numbers" not being present.

I haven't been able to figure out a way to stub the APIs to recreate this issue in tests, which is why this fix has no accompanying test.

[Trello ticket](https://trello.com/c/rnH7eksX)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
