### PR TITLE
Updated radio group label

### DIFF
--- a/app/flows/check_benefits_financial_support_flow/questions/on_benefits.erb
+++ b/app/flows/check_benefits_financial_support_flow/questions/on_benefits.erb
@@ -15,7 +15,7 @@
 <% end %>
 
 <% text_for :radio_heading do %>
-  Are you getting any of these?
+  Do you get any of the benefits or tax credits included in the list?
 <% end %>
 
 <% options(


### PR DESCRIPTION
https://trello.com/c/BhdhiczX/240-unclear-radio-group-label

I've updated the radio group label because the GOV.UK accessibility audit found that the previous wording was not clear enough for screen reader users. 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
