### PR TITLE
Add error messages to check benefits smart answer

### DIFF
--- a/app/flows/check_benefits_financial_support_flow/questions/are_you_working.erb
+++ b/app/flows/check_benefits_financial_support_flow/questions/are_you_working.erb
@@ -12,3 +12,7 @@
     no_retired: "No, I'm retired and I've stopped working"
   )
 %>
+
+<% text_for :error_message do %>
+  Select if you are in paid work or not
+<% end %>

--- a/app/flows/check_benefits_financial_support_flow/questions/assets_and_savings.erb
+++ b/app/flows/check_benefits_financial_support_flow/questions/assets_and_savings.erb
@@ -12,3 +12,7 @@
     none_16000: "None"
   )
 %>
+
+<% text_for :error_message do %>
+  Select how much money, savings and investments you have
+<% end %>

--- a/app/flows/check_benefits_financial_support_flow/questions/carer_disability_or_health_condition.erb
+++ b/app/flows/check_benefits_financial_support_flow/questions/carer_disability_or_health_condition.erb
@@ -7,3 +7,7 @@
     no: "No"
   )
 %>
+
+<% text_for :error_message do %>
+  Select if you are caring for someone with a disability or health condition or not
+<% end %>

--- a/app/flows/check_benefits_financial_support_flow/questions/children_living_with_you.erb
+++ b/app/flows/check_benefits_financial_support_flow/questions/children_living_with_you.erb
@@ -11,3 +11,7 @@
     no: "No"
   )
 %>
+
+<% text_for :error_message do %>
+  Select yes if you have children living with or are expecting a child, select no if not
+<% end %>

--- a/app/flows/check_benefits_financial_support_flow/questions/children_with_disability.erb
+++ b/app/flows/check_benefits_financial_support_flow/questions/children_with_disability.erb
@@ -7,3 +7,7 @@
     no: "No"
   )
 %>
+
+<% text_for :error_message do %>
+  Select if any children living with you have a disability or not
+<% end %>

--- a/app/flows/check_benefits_financial_support_flow/questions/disability_affecting_daily_tasks.erb
+++ b/app/flows/check_benefits_financial_support_flow/questions/disability_affecting_daily_tasks.erb
@@ -7,3 +7,7 @@
     no: "No"
   )
 %>
+
+<% text_for :error_message do %>
+  Select if your disability or health condition affects your ability to do daily tasks or get around or not
+<% end %>

--- a/app/flows/check_benefits_financial_support_flow/questions/disability_affecting_work.erb
+++ b/app/flows/check_benefits_financial_support_flow/questions/disability_affecting_work.erb
@@ -8,3 +8,7 @@
     no: "No"
   )
 %>
+
+<% text_for :error_message do %>
+  Select if your disability or health condition affects your ability to work 
+<% end %>

--- a/app/flows/check_benefits_financial_support_flow/questions/disability_or_health_condition.erb
+++ b/app/flows/check_benefits_financial_support_flow/questions/disability_or_health_condition.erb
@@ -11,3 +11,7 @@
     no: "No"
   )
 %>
+
+<% text_for :error_message do %>
+  Select if you have a disability or health condition or not
+<% end %>

--- a/app/flows/check_benefits_financial_support_flow/questions/how_many_paid_hours_work.erb
+++ b/app/flows/check_benefits_financial_support_flow/questions/how_many_paid_hours_work.erb
@@ -7,3 +7,7 @@
     sixteen_or_less_per_week: "I usually work less than 16 hours a week"
   )
 %>
+
+<% text_for :error_message do %>
+  Select how many hours of work you do a week
+<% end %>

--- a/app/flows/check_benefits_financial_support_flow/questions/on_benefits.erb
+++ b/app/flows/check_benefits_financial_support_flow/questions/on_benefits.erb
@@ -23,3 +23,7 @@
   no: "No",
   dont_know: "Don't know"
 ) %>
+
+<% text_for :error_message do %>
+  Select yes if you get any of these benefits or tax credits
+<% end %>

--- a/app/flows/check_benefits_financial_support_flow/questions/over_state_pension_age.erb
+++ b/app/flows/check_benefits_financial_support_flow/questions/over_state_pension_age.erb
@@ -11,3 +11,7 @@
     "no": "No",
   )
 %>
+
+<% text_for :error_message do %>
+  Select yes if you are State Pension age or over, select no if you are below State Pension age
+<% end %>

--- a/app/flows/check_benefits_financial_support_flow/questions/where_do_you_live.erb
+++ b/app/flows/check_benefits_financial_support_flow/questions/where_do_you_live.erb
@@ -9,3 +9,7 @@
     "northern-ireland": "Northern Ireland"
   )
 %>
+
+<% text_for :error_message do %>
+  Select if you live in England, Wales, Scotland or Northern Ireland
+<% end %>


### PR DESCRIPTION
## What

Add specific error messages to nodes in 'Check benefits and financial support you can get' smart answer.

## Why

No error messages were specified, which meant previous the only error in response if the user had not selected an option was "Please answer this question". This didn't meet WCAG guidelines and so this has been changed with error messages supplied by content designers.

[Trello Card with Information and Specified Error Messages](https://trello.com/c/Xm0KFO3q/241-error-message-in-check-benefits-and-financial-support-you-can-get-smart-answer-is-not-specific-enough)

## Visual Difference

### Before

![Screenshot 2024-02-26 at 11 23 19](https://github.com/alphagov/smart-answers/assets/3727504/80c29633-4518-4610-baa4-b3ed11c9747c)

### After

![Screenshot 2024-02-26 at 11 23 32](https://github.com/alphagov/smart-answers/assets/3727504/f3cf01c5-bb60-4387-8d5f-37609fe0ca0f)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
