### PR TITLE
Error link in Radio with Intro pages now work

### DIFF
--- a/app/presenters/question_presenter.rb
+++ b/app/presenters/question_presenter.rb
@@ -16,7 +16,7 @@ class QuestionPresenter < NodePresenter
   end
 
   def error_id(template)
-    types = %w[radio_question checkbox_question date_question]
+    types = %w[radio_question checkbox_question date_question radio_with_intro_question]
 
     fragment = types.any? { |type| type == template } ? "response\-0" : "response"
     "##{fragment}"

--- a/test/unit/question_presenter_test.rb
+++ b/test/unit/question_presenter_test.rb
@@ -130,6 +130,12 @@ module SmartAnswer
       assert_nil @presenter.error_message_for("error_key")
     end
 
+    test "#error_id generated for multiple choice template types" do
+      %w[radio_question checkbox_question date_question radio_with_intro_question].each do |type|
+        assert_equal "#response-0", @presenter.error_id(type)
+      end
+    end
+
     test "#caption returns the given caption when a caption is given" do
       @renderer.stubs(:hide_caption).returns(false)
       @renderer.stubs(:content_for).with(:caption).returns("caption-text")


### PR DESCRIPTION
## What

Add `radio_with_intro_question` to `types` of the `error_id` function of the `question_presenter`.

## Why

This was flagged on this [page](https://www.gov.uk/check-benefits-financial-support/y/wales/no/yes/sixteen_or_more_per_week/yes/yes/yes_limits_work/yes/yes/16_to_17,8_to_11,pregnant/yes?next=1#response) but this will fix all instances of radio with intro pages not having correct links to error messages. 

When the radio_with_intro page type was added, the array of types in the "error_id" method of the question_presenter was not updated. This meant that errors for the radio_with_intro pages would not link to the where the error had taken place.

[Relevant Trello Card](https://trello.com/c/eTkRNdEx/7-error-link-on-smart-answer-does-not-work)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
