### PR TITLE
Update Belgium civil partnerships information

### DIFF
--- a/app/flows/marriage_abroad_flow/outcomes/countries/belgium/_title.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/belgium/_title.erb
@@ -1,5 +1,1 @@
-<% if calculator.partner_is_same_sex? %>
-  Civil Partnership in Belgium
-<% else %>
-  Marriage in Belgium
-<% end %>
+Marriage in Belgium

--- a/app/flows/marriage_abroad_flow/outcomes/countries/belgium/ceremony_country/partner_british/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/belgium/ceremony_country/partner_british/_opposite_sex.erb
@@ -1,9 +1,6 @@
+Contact the relevant local authorities in Belgium to find out about local marriage laws, including what documents you’ll need.
 
-Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](/notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
-
-^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^
-
-You might be able to form an opposite sex civil partnership. Check the local rules with the [British embassy](/world/organisations/british-embassy-brussels).
+^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
 
 ## What you need to do
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/belgium/ceremony_country/partner_british/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/belgium/ceremony_country/partner_british/_same_sex.erb
@@ -1,11 +1,6 @@
-Same-sex relationships in Belgium that are recognised as civil partnerships under British law are known as:
+Contact the relevant local authorities in Belgium to find out about local marriage laws, including what documents you’ll need.
 
-- marriage
-- ’cohabitation légale’, ’wettelijke samenwoning’, or ’gesetzliches zusammenwohnen’ (’statutory cohabitation’)
-
-Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](/notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
-
-^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^
+^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
 
 ##What you need to do
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/belgium/ceremony_country/partner_local/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/belgium/ceremony_country/partner_local/_opposite_sex.erb
@@ -1,9 +1,6 @@
+Contact the relevant local authorities in Belgium to find out about local marriage laws, including what documents you’ll need.
 
-Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](/notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
-
-^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^
-
-You might be able to form an opposite sex civil partnership. Check the local rules with the [British embassy](/world/organisations/british-embassy-brussels).
+^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
 
 ## What you need to do
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/belgium/ceremony_country/partner_local/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/belgium/ceremony_country/partner_local/_same_sex.erb
@@ -1,11 +1,6 @@
-Same-sex relationships in Belgium that are recognised as civil partnerships under British law are known as:
+Contact the relevant local authorities in Belgium to find out about local marriage laws, including what documents you’ll need.
 
-- marriage
-- ’cohabitation légale’, ’wettelijke samenwoning’, or ’gesetzliches zusammenwohnen’ (’statutory cohabitation’)
-
-Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](/notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
-
-^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^
+^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
 
 ##What you need to do
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/belgium/ceremony_country/partner_other/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/belgium/ceremony_country/partner_other/_opposite_sex.erb
@@ -1,9 +1,6 @@
+Contact the relevant local authorities in Belgium to find out about local marriage laws, including what documents you’ll need.
 
-Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](/notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
-
-^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^
-
-You might be able to form an opposite sex civil partnership. Check the local rules with the [British embassy](/world/organisations/british-embassy-brussels).
+^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
 
 ## What you need to do
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/belgium/ceremony_country/partner_other/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/belgium/ceremony_country/partner_other/_same_sex.erb
@@ -1,11 +1,6 @@
-Same-sex relationships in Belgium that are recognised as civil partnerships under British law are known as:
+Contact the relevant local authorities in Belgium to find out about local marriage laws, including what documents you’ll need.
 
-- marriage
-- ’cohabitation légale’, ’wettelijke samenwoning’, or ’gesetzliches zusammenwohnen’ (’statutory cohabitation’)
-
-Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](/notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
-
-^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^
+^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
 
 ##What you need to do
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/belgium/third_country/partner_british/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/belgium/third_country/partner_british/_opposite_sex.erb
@@ -1,9 +1,6 @@
+Contact the relevant local authorities in Belgium to find out about local marriage laws, including what documents you’ll need.
 
-Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](/notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
-
-^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^
-
-You might be able to form an opposite sex civil partnership. Check the local rules with the [British embassy](/world/organisations/british-embassy-brussels).
+^You should [get legal advice](/government/collections/list-of-lawyers) and [check the travel advice for Belgium](/foreign-travel-advice/belgium) before making any plans.^
 
 ## What you need to do
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/belgium/third_country/partner_british/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/belgium/third_country/partner_british/_same_sex.erb
@@ -1,11 +1,6 @@
-Same-sex relationships in Belgium that are recognised as civil partnerships under British law are known as:
+Contact the relevant local authorities in Belgium to find out about local marriage laws, including what documents you’ll need.
 
-- marriage
-- ’cohabitation légale’, ’wettelijke samenwoning’, or ’gesetzliches zusammenwohnen’ (’statutory cohabitation’)
-
-Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](/notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
-
-^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^
+^You should [get legal advice](/government/collections/list-of-lawyers) and [check the travel advice for Belgium](/foreign-travel-advice/belgium) before making any plans.^
 
 ##What you need to do
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/belgium/third_country/partner_local/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/belgium/third_country/partner_local/_opposite_sex.erb
@@ -1,9 +1,6 @@
+Contact the relevant local authorities in Belgium to find out about local marriage laws, including what documents you’ll need.
 
-Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](/notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
-
-^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^
-
-You might be able to form an opposite sex civil partnership. Check the local rules with the [British embassy](/world/organisations/british-embassy-brussels).
+^You should [get legal advice](/government/collections/list-of-lawyers) and [check the travel advice for Belgium](/foreign-travel-advice/belgium) before making any plans.^
 
 ## What you need to do
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/belgium/third_country/partner_local/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/belgium/third_country/partner_local/_same_sex.erb
@@ -1,11 +1,6 @@
-Same-sex relationships in Belgium that are recognised as civil partnerships under British law are known as:
+Contact the relevant local authorities in Belgium to find out about local marriage laws, including what documents you’ll need.
 
-- marriage
-- ’cohabitation légale’, ’wettelijke samenwoning’, or ’gesetzliches zusammenwohnen’ (’statutory cohabitation’)
-
-Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](/notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
-
-^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^
+^You should [get legal advice](/government/collections/list-of-lawyers) and [check the travel advice for Belgium](/foreign-travel-advice/belgium) before making any plans.^
 
 ##What you need to do
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/belgium/third_country/partner_other/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/belgium/third_country/partner_other/_opposite_sex.erb
@@ -1,9 +1,6 @@
+Contact the relevant local authorities in Belgium to find out about local marriage laws, including what documents you’ll need.
 
-Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](/notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
-
-^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^
-
-You might be able to form an opposite sex civil partnership. Check the local rules with the [British embassy](/world/organisations/british-embassy-brussels).
+^You should [get legal advice](/government/collections/list-of-lawyers) and [check the travel advice for Belgium](/foreign-travel-advice/belgium) before making any plans.^
 
 ## What you need to do
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/belgium/third_country/partner_other/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/belgium/third_country/partner_other/_same_sex.erb
@@ -1,11 +1,6 @@
-Same-sex relationships in Belgium that are recognised as civil partnerships under British law are known as:
+Contact the relevant local authorities in Belgium to find out about local marriage laws, including what documents you’ll need.
 
-- marriage
-- ’cohabitation légale’, ’wettelijke samenwoning’, or ’gesetzliches zusammenwohnen’ (’statutory cohabitation’)
-
-Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](/notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
-
-^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^
+^You should [get legal advice](/government/collections/list-of-lawyers) and [check the travel advice for Belgium](/foreign-travel-advice/belgium) before making any plans.^
 
 ##What you need to do
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/belgium/uk/partner_british/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/belgium/uk/partner_british/_opposite_sex.erb
@@ -1,9 +1,6 @@
+Contact the relevant local authorities in Belgium to find out about local marriage laws, including what documents you’ll need.
 
-Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](/notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
-
-^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^
-
-You might be able to form an opposite sex civil partnership. Check the local rules with the [British embassy](/world/organisations/british-embassy-brussels).
+^You should [get legal advice](/government/collections/list-of-lawyers) and [check the travel advice for Belgium](/foreign-travel-advice/belgium) before making any plans.^
 
 ## What you need to do
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/belgium/uk/partner_british/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/belgium/uk/partner_british/_same_sex.erb
@@ -1,11 +1,6 @@
-Same-sex relationships in Belgium that are recognised as civil partnerships under British law are known as:
+Contact the relevant local authorities in Belgium to find out about local marriage laws, including what documents you’ll need.
 
-- marriage
-- ’cohabitation légale’, ’wettelijke samenwoning’, or ’gesetzliches zusammenwohnen’ (’statutory cohabitation’)
-
-Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](/notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
-
-^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^
+^You should [get legal advice](/government/collections/list-of-lawyers) and [check the travel advice for Belgium](/foreign-travel-advice/belgium) before making any plans.^
 
 ##What you need to do
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/belgium/uk/partner_local/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/belgium/uk/partner_local/_opposite_sex.erb
@@ -1,9 +1,6 @@
+Contact the relevant local authorities in Belgium to find out about local marriage laws, including what documents you’ll need.
 
-Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](/notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
-
-^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^
-
-You might be able to form an opposite sex civil partnership. Check the local rules with the [British embassy](/world/organisations/british-embassy-brussels).
+^You should [get legal advice](/government/collections/list-of-lawyers) and [check the travel advice for Belgium](/foreign-travel-advice/belgium) before making any plans.^
 
 ## What you need to do
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/belgium/uk/partner_local/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/belgium/uk/partner_local/_same_sex.erb
@@ -1,11 +1,6 @@
-Same-sex relationships in Belgium that are recognised as civil partnerships under British law are known as:
+Contact the relevant local authorities in Belgium to find out about local marriage laws, including what documents you’ll need.
 
-- marriage
-- ’cohabitation légale’, ’wettelijke samenwoning’, or ’gesetzliches zusammenwohnen’ (’statutory cohabitation’)
-
-Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](/notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
-
-^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^
+^You should [get legal advice](/government/collections/list-of-lawyers) and [check the travel advice for Belgium](/foreign-travel-advice/belgium) before making any plans.^
 
 ##What you need to do
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/belgium/uk/partner_other/_opposite_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/belgium/uk/partner_other/_opposite_sex.erb
@@ -1,9 +1,6 @@
+Contact the relevant local authorities in Belgium to find out about local marriage laws, including what documents you’ll need.
 
-Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](/notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
-
-^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^
-
-You might be able to form an opposite sex civil partnership. Check the local rules with the [British embassy](/world/organisations/british-embassy-brussels).
+^You should [get legal advice](/government/collections/list-of-lawyers) and [check the travel advice for Belgium](/foreign-travel-advice/belgium) before making any plans.^
 
 ## What you need to do
 

--- a/app/flows/marriage_abroad_flow/outcomes/countries/belgium/uk/partner_other/_same_sex.erb
+++ b/app/flows/marriage_abroad_flow/outcomes/countries/belgium/uk/partner_other/_same_sex.erb
@@ -1,11 +1,6 @@
-Same-sex relationships in Belgium that are recognised as civil partnerships under British law are known as:
+Contact the relevant local authorities in Belgium to find out about local marriage laws, including what documents you’ll need.
 
-- marriage
-- ’cohabitation légale’, ’wettelijke samenwoning’, or ’gesetzliches zusammenwohnen’ (’statutory cohabitation’)
-
-Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](/notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
-
-^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^
+^You should [get legal advice](/government/collections/list-of-lawyers) and [check the travel advice for Belgium](/foreign-travel-advice/belgium) before making any plans.^
 
 ##What you need to do
 


### PR DESCRIPTION
Removing any mention of civil partnerships, as the embassy in Belgium cannot help users with getting a civil partnership.

Also removing old links about documents you'll need, as the information in the link does not exist anymore.
