### PR TITLE
Update SPP calculator with Uprating 2024 values

### DIFF
--- a/config/smart_answers/rates/statutory_sick_pay.yml
+++ b/config/smart_answers/rates/statutory_sick_pay.yml
@@ -65,3 +65,8 @@
   end_date: 2024-04-05
   lower_earning_limit_rate: 123
   ssp_weekly_rate: 109.40
+
+- start_date: 2024-04-06
+  end_date: 2025-04-05
+  lower_earning_limit_rate: 123
+  ssp_weekly_rate: 116.75

--- a/test/unit/calculators/statutory_sick_pay_calculator_test.rb
+++ b/test/unit/calculators/statutory_sick_pay_calculator_test.rb
@@ -1001,6 +1001,19 @@ module SmartAnswer
 
           assert_equal 109.40, calculator.ssp_payment.to_f
         end
+
+        should "have the correct 2024/2025 value" do
+          calculator = StatutorySickPayCalculator.new(
+            sick_start_date: Date.parse("6 June 2024"),
+            sick_end_date: Date.parse("10 June 2024"),
+            days_of_the_week_worked: %w[1 2 3 4 5],
+            has_linked_sickness: true,
+            linked_sickness_start_date: Date.parse("21 Sep 2023"),
+            linked_sickness_end_date: Date.parse("28 Dec 2023"),
+          )
+
+          assert_equal 116.75, calculator.ssp_payment.to_f
+        end
       end
 
       context "average weekly earnings for new employees who fell sick before first payday" do


### PR DESCRIPTION
This changes the following:

- updates the ssp allowance from £109.40 to £116.75
- updates test with relevant

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
