### PR TITLE
Uprating for statutory sick pay 2024

### DIFF
--- a/app/flows/calculate_statutory_sick_pay_flow/start.erb
+++ b/app/flows/calculate_statutory_sick_pay_flow/start.erb
@@ -17,10 +17,6 @@
 
   *[SSP]: Statutory Sick Pay
 
-  ##Sick leave because of coronavirus (COVID-19)
-  
-  Do not use the calculator if your employee became sick with COVID-19 before 25 March 2022. You’ll need to [work out the SSP manually](https://www.gov.uk/guidance/statutory-sick-pay-manually-calculate-your-employees-payments) instead.
-
   ##Different periods of sick leave
 
   You can combine periods of sick leave if the gap between them is 8 weeks or less. These are called ‘linked Periods of Incapacity for Work (PIW)’.

--- a/config/smart_answers/rates/statutory_sick_pay.yml
+++ b/config/smart_answers/rates/statutory_sick_pay.yml
@@ -65,3 +65,8 @@
   end_date: 2024-04-05
   lower_earning_limit_rate: 123
   ssp_weekly_rate: 109.40
+
+- start_date: 2024-04-06
+  end_date: 2025-04-05
+  lower_earning_limit_rate: 123
+  ssp_weekly_rate: 116.75

--- a/test/unit/calculators/statutory_sick_pay_calculator_test.rb
+++ b/test/unit/calculators/statutory_sick_pay_calculator_test.rb
@@ -852,6 +852,17 @@ module SmartAnswer
           end
         end
 
+        context "in the beginning of 2024/2025" do
+          setup do
+            @date = Date.parse("6 April 2024")
+            @lel = StatutorySickPayCalculator.lower_earning_limit_on(@date)
+          end
+
+          should "be 123" do
+            assert_equal 123.00, @lel
+          end
+        end
+
         context "fallback when no dates are matching" do
           should "not break and use the rate of the latest available fiscal year" do
             date = Date.parse("6 April 2056")
@@ -1000,6 +1011,19 @@ module SmartAnswer
           )
 
           assert_equal 109.40, calculator.ssp_payment.to_f
+        end
+
+        should "have the correct 2024/2025 value" do
+          calculator = StatutorySickPayCalculator.new(
+            sick_start_date: Date.parse("3 June 2024"),
+            sick_end_date: Date.parse("7 June 2024"),
+            days_of_the_week_worked: %w[1 2 3 4 5],
+            has_linked_sickness: true,
+            linked_sickness_start_date: Date.parse("21 Sep 2023"),
+            linked_sickness_end_date: Date.parse("28 Dec 2023"),
+          )
+
+          assert_equal 116.75, calculator.ssp_payment.to_f
         end
       end
 


### PR DESCRIPTION
Adds the Statutory Sick Pay allowance for the 2024–2025 tax year (up from £109.40 to £116.75).

The Lower Earnings Limit (LEL) remains unchanged for the new tax year.

[Trello ticket](https://trello.com/c/jJr4mHVs).

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
