### PR TITLE
Uprate minimum wage calculator for 2024/2025

### DIFF
--- a/app/flows/am_i_getting_minimum_wage_flow/start.erb
+++ b/app/flows/am_i_getting_minimum_wage_flow/start.erb
@@ -13,7 +13,7 @@
   - you’re getting paid the National Living Wage
   - your employer owes you past payments from the previous year because of underpayment
 
-  ^You must be at least 23 years old to get the National Living Wage.^
+  ^You must be at least <%= this_year_living_wage_min_age("minimum_wage") %> years old to get the National Living Wage.^
 
   Check [National Minimum Wage and National Living Wage rates](/national-minimum-wage-rates) before <%= last_year_end_text("minimum_wage") %>.
 <% end %>

--- a/app/flows/minimum_wage_calculator_employers_flow/start.erb
+++ b/app/flows/minimum_wage_calculator_employers_flow/start.erb
@@ -13,7 +13,7 @@
   - you’re paying a worker the National Living Wage
   - you owe your employee payments from the previous year because you underpaid them
 
-  ^Your employee must be at least 23 years old to get the National Living Wage.^
+  ^Your employee must be at least <%= this_year_living_wage_min_age("minimum_wage") %> years old to get the National Living Wage.^
 
 Check [National Minimum Wage and National Living Wage rates](/national-minimum-wage-rates) before <%= last_year_end_text("minimum_wage") %>.
 <% end %>

--- a/app/flows/shared/minimum_wage_flow.rb
+++ b/app/flows/shared/minimum_wage_flow.rb
@@ -6,8 +6,7 @@ class MinimumWageFlow < SmartAnswer::Flow
       option "past_payment"
 
       on_response do |response|
-        self.calculator = SmartAnswer::Calculators::MinimumWageCalculator.new
-        calculator.date = calculator.previous_period_start_date if response == "past_payment"
+        self.calculator = SmartAnswer::Calculators::MinimumWageCalculator.new(past_or_current_payment: response)
         self.accommodation_charge = nil
       end
 

--- a/config/smart_answers/rates/minimum_wage.yml
+++ b/config/smart_answers/rates/minimum_wage.yml
@@ -19,6 +19,7 @@
     :rate: 9.50
   :apprentice_rate: 4.81
   :accommodation_rate: 8.70
+  :living_wage_min_age: 23
 
 - :start_date: 2023-04-01
   :end_date: 3000-01-01
@@ -37,3 +38,4 @@
     :rate: 10.42
   :apprentice_rate: 5.28
   :accommodation_rate: 9.10
+  :living_wage_min_age: 23

--- a/config/smart_answers/rates/minimum_wage.yml
+++ b/config/smart_answers/rates/minimum_wage.yml
@@ -38,4 +38,4 @@
     :rate: 11.44
   :apprentice_rate: 6.40
   :accommodation_rate: 9.99
-  :living_wage_min_age: 23
+  :living_wage_min_age: 21

--- a/config/smart_answers/rates/minimum_wage.yml
+++ b/config/smart_answers/rates/minimum_wage.yml
@@ -2,27 +2,8 @@
 # make sure we have that at least. If adding a new set of data at
 # the end, you may have to update dates/values in the test file.
 ---
-- :start_date: 2022-04-01
-  :end_date: 2023-03-31
-  :minimum_rates:
-  - :min_age: 0
-    :max_age: 18
-    :rate: 4.81
-  - :min_age: 18
-    :max_age: 21
-    :rate: 6.83
-  - :min_age: 21
-    :max_age: 23
-    :rate: 9.18
-  - :min_age: 23
-    :max_age: 1000
-    :rate: 9.50
-  :apprentice_rate: 4.81
-  :accommodation_rate: 8.70
-  :living_wage_min_age: 23
-
 - :start_date: 2023-04-01
-  :end_date: 3000-01-01
+  :end_date: 2024-03-31
   :minimum_rates:
   - :min_age: 0
     :max_age: 18
@@ -38,4 +19,23 @@
     :rate: 10.42
   :apprentice_rate: 5.28
   :accommodation_rate: 9.10
+  :living_wage_min_age: 23
+
+- :start_date: 2024-04-01
+  :end_date: 3000-01-01
+  :minimum_rates:
+  - :min_age: 0
+    :max_age: 18
+    :rate: 6.40
+  - :min_age: 18
+    :max_age: 21
+    :rate: 8.60
+  - :min_age: 21
+    :max_age: 23
+    :rate: 11.44
+  - :min_age: 23
+    :max_age: 1000
+    :rate: 11.44
+  :apprentice_rate: 6.40
+  :accommodation_rate: 9.99
   :living_wage_min_age: 23

--- a/lib/smart_answer/calculators/minimum_wage_calculator.rb
+++ b/lib/smart_answer/calculators/minimum_wage_calculator.rb
@@ -53,8 +53,8 @@ module SmartAnswer::Calculators
     end
 
     def valid_age_for_living_wage?(age)
-      (age.to_i >= 23 && date >= Date.parse("2021-04-01")) ||
-        age.to_i >= 25
+      living_wage_min_age = @minimum_wage_data[:living_wage_min_age]
+      age.to_i >= living_wage_min_age
     end
 
     def basic_rate
@@ -130,7 +130,7 @@ module SmartAnswer::Calculators
     end
 
     def eligible_for_living_wage?
-      valid_age_for_living_wage?(age) && date >= Date.parse("2016-04-01")
+      valid_age_for_living_wage?(age)
     end
 
     def under_school_leaving_age?

--- a/lib/smart_answer/calculators/minimum_wage_calculator.rb
+++ b/lib/smart_answer/calculators/minimum_wage_calculator.rb
@@ -102,7 +102,7 @@ module SmartAnswer::Calculators
       number_of_nights = number_of_nights.to_i
 
       accommodation_cost = if charge > 0 # rubocop:disable Style/NumericPredicate
-                             charged_accomodation_adjustment(charge, number_of_nights)
+                             charged_accommodation_adjustment(charge, number_of_nights)
                            else
                              free_accommodation_adjustment(number_of_nights)
                            end
@@ -152,7 +152,7 @@ module SmartAnswer::Calculators
       (free_accommodation_rate * number_of_nights).round(2)
     end
 
-    def charged_accomodation_adjustment(charge, number_of_nights)
+    def charged_accommodation_adjustment(charge, number_of_nights)
       if charge < free_accommodation_rate
         0
       else

--- a/lib/smart_answer/calculators/minimum_wage_calculator.rb
+++ b/lib/smart_answer/calculators/minimum_wage_calculator.rb
@@ -79,7 +79,7 @@ module SmartAnswer::Calculators
     end
 
     def total_entitlement
-      minimum_hourly_rate * total_hours
+      (minimum_hourly_rate * total_hours).round(2)
     end
 
     def historical_entitlement

--- a/lib/smart_answer/calculators/minimum_wage_calculator.rb
+++ b/lib/smart_answer/calculators/minimum_wage_calculator.rb
@@ -109,12 +109,11 @@ module SmartAnswer::Calculators
       @accommodation_cost = (accommodation_cost * weekly_multiplier).round(2)
     end
 
-    def per_hour_minimum_wage(date = @date)
-      data = rates_for_date(date)
+    def per_hour_minimum_wage
       if @is_apprentice
-        data[:apprentice_rate]
+        @minimum_wage_data[:apprentice_rate]
       else
-        rates = data[:minimum_rates]
+        rates = @minimum_wage_data[:minimum_rates]
         rate_data = rates.find do |r|
           @age >= r[:min_age] && @age < r[:max_age]
         end

--- a/lib/smart_answer/calculators/minimum_wage_calculator.rb
+++ b/lib/smart_answer/calculators/minimum_wage_calculator.rb
@@ -29,7 +29,7 @@ module SmartAnswer::Calculators
     end
 
     def previous_period_start_date
-      data.previous_period(date:)[:start_date]
+      data.previous_period[:start_date]
     end
 
     def valid_age?(age)

--- a/lib/smart_answer/calculators/rates_query.rb
+++ b/lib/smart_answer/calculators/rates_query.rb
@@ -21,6 +21,14 @@ module SmartAnswer::Calculators
       previous_period
     end
 
+    def current_period
+      current_period = nil
+      data.each do |rates_hash|
+        current_period = rates_hash if !current_period || rates_hash[:start_date] > current_period[:start_date]
+      end
+      current_period
+    end
+
     def rates(date = nil)
       date ||= SmartAnswer::DateHelper.current_day
       relevant_rates = data.find do |rates_hash|

--- a/lib/smart_answer/calculators/rates_query.rb
+++ b/lib/smart_answer/calculators/rates_query.rb
@@ -13,13 +13,10 @@ module SmartAnswer::Calculators
       @data = rates_data
     end
 
-    def previous_period(date: nil)
-      date ||= SmartAnswer::DateHelper.current_day
+    def previous_period
       previous_period = nil
       data.each do |rates_hash|
-        break if rates_hash[:start_date] <= date && rates_hash[:end_date] >= date
-
-        previous_period = rates_hash
+        previous_period = rates_hash if !previous_period || rates_hash[:start_date] <= previous_period[:start_date]
       end
       previous_period
     end

--- a/lib/smart_answer/rate_dates_helper.rb
+++ b/lib/smart_answer/rate_dates_helper.rb
@@ -10,7 +10,7 @@ module SmartAnswer
 
     def last_year(rates_file)
       data = SmartAnswer::Calculators::RatesQuery.from_file(rates_file)
-      data.previous_period(date: SmartAnswer::DateHelper.current_day)
+      data.previous_period
     end
   end
 end

--- a/lib/smart_answer/rate_dates_helper.rb
+++ b/lib/smart_answer/rate_dates_helper.rb
@@ -8,6 +8,15 @@ module SmartAnswer
       last_year(rates_file)[:end_date].strftime("%B %Y").to_s
     end
 
+    def this_year_living_wage_min_age(rates_file)
+      this_year(rates_file)[:living_wage_min_age]
+    end
+
+    def this_year(rates_file)
+      data = SmartAnswer::Calculators::RatesQuery.from_file(rates_file)
+      data.current_period
+    end
+
     def last_year(rates_file)
       data = SmartAnswer::Calculators::RatesQuery.from_file(rates_file)
       data.previous_period

--- a/test/unit/calculators/minimum_wage_calculator_test.rb
+++ b/test/unit/calculators/minimum_wage_calculator_test.rb
@@ -4,14 +4,14 @@ module SmartAnswer::Calculators
   class MinimumWageCalculatorTest < ActiveSupport::TestCase
     context "Initialisation" do
       should "reject invalid 'past_or_current_payment' values" do
-        assert_raises(ArgumentError, "Invalid past_or_current_payment value: 'bad value'") {
+        assert_raises(ArgumentError, "Invalid past_or_current_payment value: 'bad value'") do
           MinimumWageCalculator.new(past_or_current_payment: "bad value")
-        }
+        end
       end
       should "reject missing 'past_or_current_payment' argument" do
-        assert_raises(ArgumentError, "Missing past_or_current_payment argument") {
+        assert_raises(ArgumentError, "Missing past_or_current_payment argument") do
           MinimumWageCalculator.new
-        }
+        end
       end
     end
 

--- a/test/unit/calculators/minimum_wage_calculator_test.rb
+++ b/test/unit/calculators/minimum_wage_calculator_test.rb
@@ -98,19 +98,6 @@ module SmartAnswer::Calculators
           assert @calculator.valid_age_for_living_wage?(23)
           assert @calculator.valid_age_for_living_wage?(24)
         end
-
-        context "when a date is before 1 April 2021" do
-          setup { @calculator.date = Date.parse("2020-04-01") }
-
-          should "not accept ages below 25" do
-            assert_not @calculator.valid_age_for_living_wage?(23)
-          end
-
-          should "accept ages 25 or above" do
-            assert @calculator.valid_age_for_living_wage?(25)
-            assert @calculator.valid_age_for_living_wage?(26)
-          end
-        end
       end
     end
 
@@ -119,33 +106,30 @@ module SmartAnswer::Calculators
         @calculator = MinimumWageCalculator.new
       end
 
-      should "return true if the age is 25 or over" do
-        %w[25 26].each do |age|
-          @calculator.age = age
-          assert @calculator.eligible_for_living_wage?
-        end
-      end
-
-      should "return true if the age is 23 or over, and the date is on or after 2022-04-01" do
+      should "return true if the age is the minimum for the living wage or higher" do
         %w[23 24].each do |age|
-          @calculator.date = Date.parse("2022-04-01")
           @calculator.age = age
+          @calculator.date = Date.parse("2023-04-01")
+          assert @calculator.eligible_for_living_wage?
+        end
+        %w[23 24].each do |age|
+          @calculator.age = age
+          @calculator.date = Date.parse("2024-04-01")
           assert @calculator.eligible_for_living_wage?
         end
       end
 
-      should "return false if age is lower than 24 or nil, and date is before 2021-04-01" do
-        %w[nil 0 24].each do |age|
-          @calculator.date = Date.parse("2020-04-01")
+      should "return false if age is lower than the minimum or nil" do
+        %w[nil 0 22].each do |age|
+          @calculator.date = Date.parse("2023-04-01")
           @calculator.age = age
           assert_not @calculator.eligible_for_living_wage?
         end
-      end
-
-      should "return false if age is over 25, and date is on or before 2016-04-01" do
-        @calculator.date = Date.parse("2016-03-30")
-        @calculator.age = 26
-        assert_not @calculator.eligible_for_living_wage?
+        %w[nil 0 22].each do |age|
+          @calculator.date = Date.parse("2024-04-01")
+          @calculator.age = age
+          assert_not @calculator.eligible_for_living_wage?
+        end
       end
     end
 

--- a/test/unit/calculators/rates_query_test.rb
+++ b/test/unit/calculators/rates_query_test.rb
@@ -85,5 +85,19 @@ module SmartAnswer::Calculators
         assert_equal "earliest", rates.previous_period[:rate]
       end
     end
+
+    context "#current_period" do
+      should "be rates with latest start date when loaded in ascending date order" do
+        rates = RatesQuery.new([{ start_date: Date.parse("2012-01-01"), rate: "earliest" }, { start_date: Date.parse("2013-01-01"), rate: "latest" }])
+
+        assert_equal "latest", rates.current_period[:rate]
+      end
+
+      should "be rates with latest start date when loaded in descending date order" do
+        rates = RatesQuery.new([{ start_date: Date.parse("2013-01-01"), rate: "latest" }, { start_date: Date.parse("2012-01-01"), rate: "earliest" }])
+
+        assert_equal "latest", rates.current_period[:rate]
+      end
+    end
   end
 end

--- a/test/unit/calculators/rates_query_test.rb
+++ b/test/unit/calculators/rates_query_test.rb
@@ -73,19 +73,16 @@ module SmartAnswer::Calculators
     end
 
     context "#previous_period" do
-      setup do
-        @test_rate = RatesQuery.from_file(
-          "exact_date_rates",
-          load_path: "test/fixtures/rates",
-        )
+      should "be rates with earliest start date when loaded in ascending date order" do
+        rates = RatesQuery.new([{ start_date: Date.parse("2012-01-01"), rate: "earliest" }, { start_date: Date.parse("2013-01-01"), rate: "latest" }])
+
+        assert_equal "earliest", rates.previous_period[:rate]
       end
 
-      should "be nil for 2013-01-31" do
-        assert_nil @test_rate.previous_period(date: Date.parse("2013-01-31"))
-      end
+      should "be rates with earliest start date when loaded in descending date order" do
+        rates = RatesQuery.new([{ start_date: Date.parse("2013-01-01"), rate: "latest" }, { start_date: Date.parse("2012-01-01"), rate: "earliest" }])
 
-      should "be 2013-01-31 for 2013-02-01" do
-        assert_equal Date.parse("2012-01-01"), @test_rate.previous_period(date: Date.parse("2013-02-01"))[:start_date]
+        assert_equal "earliest", rates.previous_period[:rate]
       end
     end
   end


### PR DESCRIPTION
Update the values used by the minimum wage calculator (which backs both the [National Minimum Wage and Living Wage calculator for workers](https://www.gov.uk/am-i-getting-minimum-wage) and [National Minimum Wage and Living Wage calculator for employers](https://www.gov.uk/minimum-wage-calculator-employers) Smart Answers).

As well as rate changes, the minimum age to be eligible for the living wage has changed.

Other changes in this PR:
- Fix a typo in the `charged_accomodation_adjustment` method name ("accommodation" mis-spelled).
- Simplify the code logic by extracting the minimum age for living wage to the config, instead of hard-coding logic around it.
- Replace storing a date and then figuring out whether the calculation is for the current or past tax year, with simply storing which tax year is being calculated for.

[Trello ticket](https://trello.com/c/jL5Jswee)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
