### PR TITLE
[Uprating 2024] Uprate married couples allowance

### DIFF
--- a/config/smart_answers/rates/married_couples_allowance.yml
+++ b/config/smart_answers/rates/married_couples_allowance.yml
@@ -3,12 +3,12 @@
 # and usually 1. The last item in the file should have an end
 # date of 2999-01-01
 ---
-- start_date: 2022-04-06
-  end_date: 2023-04-05
-  maximum_married_couple_allowance: 9415
-  minimum_married_couple_allowance: 3640
-
 - start_date: 2023-04-06
-  end_date: 2999-01-01
+  end_date: 2024-04-05
   maximum_married_couple_allowance: 10375
   minimum_married_couple_allowance: 4010
+
+- start_date: 2024-04-06
+  end_date: 2999-01-01
+  maximum_married_couple_allowance: 11080
+  minimum_married_couple_allowance: 4270

--- a/config/smart_answers/rates/personal_allowance.yml
+++ b/config/smart_answers/rates/personal_allowance.yml
@@ -3,12 +3,12 @@
 # and usually 1. The last item in the file should have an end
 # date of 2999-01-01
 ---
-- start_date: 2022-04-06
-  end_date: 2023-04-05
-  personal_allowance: 12570
-  income_limit_for_personal_allowances: 31400.0
-
 - start_date: 2023-04-06
-  end_date: 2999-01-01
+  end_date: 2024-04-05
   personal_allowance: 12570
   income_limit_for_personal_allowances: 34600.0
+
+- start_date: 2024-04-06
+  end_date: 2999-01-01
+  personal_allowance: 12570
+  income_limit_for_personal_allowances: 37700.0

--- a/test/unit/calculators/married_couple_allowance_calculator_test.rb
+++ b/test/unit/calculators/married_couple_allowance_calculator_test.rb
@@ -108,17 +108,6 @@ module SmartAnswer::Calculators
       assert_equal SmartAnswer::Money.new("28250"), result
     end
 
-    test "rate values for 2022/23" do
-      travel_to("2022-06-01") do
-        calculator = MarriedCouplesAllowanceCalculator.new
-
-        assert_equal 12_570, calculator.personal_allowance
-        assert_equal 31_400.0, calculator.income_limit_for_personal_allowances
-        assert_equal 9415, calculator.maximum_mca
-        assert_equal 3640, calculator.minimum_mca
-      end
-    end
-
     test "rate values for 2023/24" do
       travel_to("2023-06-01") do
         calculator = MarriedCouplesAllowanceCalculator.new
@@ -127,6 +116,17 @@ module SmartAnswer::Calculators
         assert_equal 34_600.0, calculator.income_limit_for_personal_allowances
         assert_equal 10_375, calculator.maximum_mca
         assert_equal 4010, calculator.minimum_mca
+      end
+    end
+
+    test "rate values for 2024/25" do
+      travel_to("2024-06-01") do
+        calculator = MarriedCouplesAllowanceCalculator.new
+
+        assert_equal 12_570, calculator.personal_allowance
+        assert_equal 37_700.0, calculator.income_limit_for_personal_allowances
+        assert_equal 11_080, calculator.maximum_mca
+        assert_equal 4270, calculator.minimum_mca
       end
     end
   end


### PR DESCRIPTION
[Trello card](https://trello.com/c/OmQ3AeVP/258-uprating-calculate-your-married-couples-allowance)

This is part of the April 2024 uprating. This will uprate the married couples allowance smart answer. 

Minimum from £4,010 to £4,270
Maximum from £10,375 to £11,080

The income limit will increase from £34,600 to £37,700

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
