### PR TITLE
[Uprating 2024] Uprate maternity/paternity pay and allowance calculators

### DIFF
--- a/app/flows/maternity_paternity_calculator_flow/outcomes/_adoption_entitled_to_leave.erb
+++ b/app/flows/maternity_paternity_calculator_flow/outcomes/_adoption_entitled_to_leave.erb
@@ -1,6 +1,6 @@
-##Statutory Paternity Leave
+##Statutory Adoption Leave
 
-The employee is entitled to Statutory Paternity Leave.
+The employee is entitled to Statutory Adoption Leave.
 
 |Leave                         | Key dates                    |
 |------------------------------|------------------------------|

--- a/app/flows/maternity_paternity_calculator_flow/outcomes/_paternity_entitled_to_leave.erb
+++ b/app/flows/maternity_paternity_calculator_flow/outcomes/_paternity_entitled_to_leave.erb
@@ -2,8 +2,12 @@
 
 The employee is entitled to Statutory Paternity Leave.
 
-|Leave                         | Key dates                    |
-|------------------------------|------------------------------|
-|Start                         | <%= format_date(leave_start_date) %>          |
-|End                           | <%= format_date(leave_end_date) %>            |
-|Latest date to [claim leave](/employers-paternity-pay-leave/<%= leave_spp_claim_link %>)     | <%= format_date(notice_of_leave_deadline) %>  |
+<% if leave_must_be_taken_consecutively %>
+  <% consecutive_text = "They can choose to take either 1 week or 2 consecutive weeks’ leave." %>
+<% else %>
+  <% consecutive_text = "They can take 2 consecutive or non-consecutive weeks." %>
+<% end %>
+
+<%= consecutive_text %> Their leave starts on <%= format_date(leave_start_date) %> and must finish by <%= format_date(paternity_deadline) %>.
+
+The latest date they can [claim leave](/employers-paternity-pay-leave/<%= leave_spp_claim_link %>) is <%= format_date(notice_of_leave_deadline) %>.

--- a/app/flows/maternity_paternity_calculator_flow/outcomes/paternity_leave_and_pay.erb
+++ b/app/flows/maternity_paternity_calculator_flow/outcomes/paternity_leave_and_pay.erb
@@ -13,10 +13,12 @@
     <% else %>
       <%= render partial: 'paternity_entitled_to_leave',
                  locals: {
+                   leave_must_be_taken_consecutively: calculator.leave_must_be_taken_consecutively?,
                    leave_start_date: leave_start_date,
                    leave_end_date: leave_end_date,
                    leave_spp_claim_link: leave_spp_claim_link,
-                   notice_of_leave_deadline: notice_of_leave_deadline
+                   notice_of_leave_deadline: notice_of_leave_deadline,
+                   paternity_deadline: calculator.paternity_deadline,
                  } %>
     <% end %>
   <% end %>

--- a/app/flows/maternity_paternity_calculator_flow/outcomes/paternity_leave_and_pay.erb
+++ b/app/flows/maternity_paternity_calculator_flow/outcomes/paternity_leave_and_pay.erb
@@ -58,9 +58,9 @@
 
       ## SPP calculation
 
-      Date | SPP amount
+      Week | SPP amount
       -|-
-      <%= calculator.pay_dates_and_pay %>
+      <%= calculator.paternity_pay_week_and_pay %>
        | **Total SPP: <%= format_money(calculator.total_spp) %>**
 
     <% end %>

--- a/app/flows/maternity_paternity_calculator_flow/outcomes/paternity_leave_and_pay.erb
+++ b/app/flows/maternity_paternity_calculator_flow/outcomes/paternity_leave_and_pay.erb
@@ -2,14 +2,23 @@
   <% if has_contract == "no" %>
     <%= render partial: 'paternity_not_entitled_to_leave' %>
   <% else %>
-    <%= render partial: 'paternity_entitled_to_leave',
-               locals: {
-                 leave_type: calculator.leave_type,
-                 leave_start_date: leave_start_date,
-                 leave_end_date: leave_end_date,
-                 leave_spp_claim_link: leave_spp_claim_link,
-                 notice_of_leave_deadline: notice_of_leave_deadline
-               } %>
+    <% if calculator.leave_type == "adoption" %>
+      <%= render partial: 'adoption_entitled_to_leave',
+                 locals: {
+                   leave_start_date: leave_start_date,
+                   leave_end_date: leave_end_date,
+                   leave_spp_claim_link: leave_spp_claim_link,
+                   notice_of_leave_deadline: notice_of_leave_deadline
+                 } %>
+    <% else %>
+      <%= render partial: 'paternity_entitled_to_leave',
+                 locals: {
+                   leave_start_date: leave_start_date,
+                   leave_end_date: leave_end_date,
+                   leave_spp_claim_link: leave_spp_claim_link,
+                   notice_of_leave_deadline: notice_of_leave_deadline
+                 } %>
+    <% end %>
   <% end %>
 
   <% unless calculator.above_lower_earning_limit %>

--- a/app/flows/maternity_paternity_calculator_flow/outcomes/paternity_not_entitled_to_leave_or_pay.erb
+++ b/app/flows/maternity_paternity_calculator_flow/outcomes/paternity_not_entitled_to_leave_or_pay.erb
@@ -10,15 +10,17 @@
                      leave_start_date: leave_start_date,
                      leave_end_date: leave_end_date,
                      leave_spp_claim_link: leave_spp_claim_link,
-                     notice_of_leave_deadline: notice_of_leave_deadline
+                     notice_of_leave_deadline: notice_of_leave_deadline,
                    } %>
       <% else %>
         <%= render partial: 'paternity_entitled_to_leave',
                    locals: {
+                     leave_must_be_taken_consecutively: calculator.leave_must_be_taken_consecutively?,
                      leave_start_date: leave_start_date,
                      leave_end_date: leave_end_date,
                      leave_spp_claim_link: leave_spp_claim_link,
-                     notice_of_leave_deadline: notice_of_leave_deadline
+                     notice_of_leave_deadline: notice_of_leave_deadline,
+                     paternity_deadline: calculator.paternity_deadline,
                    } %>
       <% end %>
     <% end %>

--- a/app/flows/maternity_paternity_calculator_flow/outcomes/paternity_not_entitled_to_leave_or_pay.erb
+++ b/app/flows/maternity_paternity_calculator_flow/outcomes/paternity_not_entitled_to_leave_or_pay.erb
@@ -4,14 +4,23 @@
     <% if has_contract == 'no' %>
       <%= render partial: 'paternity_not_entitled_to_leave' %>
     <% elsif has_contract == 'yes' %>
-      <%= render partial: 'paternity_entitled_to_leave',
-                 locals: {
-                   leave_type: calculator.leave_type,
-                   leave_start_date: leave_start_date,
-                   leave_end_date: leave_end_date,
-                   leave_spp_claim_link: leave_spp_claim_link,
-                   notice_of_leave_deadline: notice_of_leave_deadline
-                 } %>
+      <% if calculator.leave_type == "adoption" %>
+        <%= render partial: 'adoption_entitled_to_leave',
+                   locals: {
+                     leave_start_date: leave_start_date,
+                     leave_end_date: leave_end_date,
+                     leave_spp_claim_link: leave_spp_claim_link,
+                     notice_of_leave_deadline: notice_of_leave_deadline
+                   } %>
+      <% else %>
+        <%= render partial: 'paternity_entitled_to_leave',
+                   locals: {
+                     leave_start_date: leave_start_date,
+                     leave_end_date: leave_end_date,
+                     leave_spp_claim_link: leave_spp_claim_link,
+                     notice_of_leave_deadline: notice_of_leave_deadline
+                   } %>
+      <% end %>
     <% end %>
 
     <%= render partial: 'paternity_not_entitled_to_pay_intro' %>

--- a/app/flows/maternity_paternity_calculator_flow/questions/earnings_for_pay_period.erb
+++ b/app/flows/maternity_paternity_calculator_flow/questions/earnings_for_pay_period.erb
@@ -7,7 +7,3 @@
 <% end %>
 
 <%= render partial: 'earnings_question_error_message' %>
-
-<% govspeak_for :post_body do %>
-  For leave starting after 25 April 2020: if your employee earned less than usual because they were 'on furlough' under the Coronavirus Job Retention Scheme, enter what they would have earned normally. 
-<% end %>

--- a/app/flows/maternity_paternity_calculator_flow/questions/earnings_for_pay_period_adoption.erb
+++ b/app/flows/maternity_paternity_calculator_flow/questions/earnings_for_pay_period_adoption.erb
@@ -7,7 +7,3 @@
 <% end %>
 
 <%= render partial: 'earnings_question_error_message' %>
-
-<% govspeak_for :post_body do %>
-  For leave starting after 25 April 2020: if your employee earned less than usual because they were 'on furlough' under the Coronavirus Job Retention Scheme, enter what they would have earned normally. 
-<% end %>

--- a/app/flows/maternity_paternity_calculator_flow/questions/earnings_for_pay_period_paternity.erb
+++ b/app/flows/maternity_paternity_calculator_flow/questions/earnings_for_pay_period_paternity.erb
@@ -7,7 +7,3 @@
 <% end %>
 
 <%= render partial: 'earnings_question_error_message' %>
-
-<% govspeak_for :post_body do %>
-  For leave starting after 25 April 2020: if your employee earned less than usual because they were 'on furlough' under the Coronavirus Job Retention Scheme, enter what they would have earned normally.
-<% end %>

--- a/app/flows/maternity_paternity_calculator_flow/questions/employee_paternity_length.erb
+++ b/app/flows/maternity_paternity_calculator_flow/questions/employee_paternity_length.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% govspeak_for :body do %>
-  The last day of leave the employee will be eligible for statutory paternity pay is <%= calculator.paternity_deadline %>. 
+  The last day of leave the employee will be eligible for statutory paternity pay is <%= calculator.paternity_deadline.strftime("%d-%m-%Y") %>.
   If their leave falls outside this period, this calculator may not be accurate and you'll need to use your payroll software or [calculate payments manually](/guidance/statutory-paternity-pay-manually-calculate-your-employees-payments).
 <% end %>
 

--- a/app/flows/maternity_paternity_calculator_flow/start.erb
+++ b/app/flows/maternity_paternity_calculator_flow/start.erb
@@ -12,6 +12,8 @@
   + Statutory Maternity Pay (SMP), paternity pay, adoption pay
   + relevant employment period and average weekly earnings
   + leave period
+
+  There are [different rules for paternity leave if you’re in Northern Ireland](https://www.nidirect.gov.uk/articles/paternity-leave).
 <% end %>
 
 <% govspeak_for :post_body do %>

--- a/app/flows/maternity_paternity_calculator_flow/start.erb
+++ b/app/flows/maternity_paternity_calculator_flow/start.erb
@@ -28,6 +28,5 @@
   + births 15 weeks before the due date
   + paternity leave or pay for [overseas adoptions](/employers-paternity-pay-leave/adoption)
   + [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide)
-  + [paternity leave](/employers-paternity-pay-leave) for births expected after 6 April 2024 (on or after 6 April 2024 for adoptions).
 
 <% end %>

--- a/app/flows/maternity_paternity_pay_leave_flow/outcomes/_mat_allowance.erb
+++ b/app/flows/maternity_paternity_pay_leave_flow/outcomes/_mat_allowance.erb
@@ -86,4 +86,16 @@ Weekly rate (between <%= calculator.formatted_first_day_in_year(2023) %> and <%=
   <% end %>
 <% end %>
 
+<% if calculator.paid_leave_is_in_year?(2024) %>
+  <% if calculator.employment_status_of_mother == "self-employed" %>
+
+Weekly rate (between <%= calculator.formatted_first_day_in_year(2024) %> and <%= calculator.formatted_last_day_in_year(2024) %>) | £184.03 - or £27 if they’re [self-employed but have not paid enough Class 2 National Insurance](/maternity-allowance/eligibility)
+
+  <% else %>
+
+Weekly rate (between <%= calculator.formatted_first_day_in_year(2024) %> and <%= calculator.formatted_last_day_in_year(2024) %>) | £184.03 or 90% of their average weekly earnings (whichever is lower)
+
+  <% end %>
+<% end %>
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.

--- a/app/flows/maternity_paternity_pay_leave_flow/outcomes/_mat_pay.erb
+++ b/app/flows/maternity_paternity_pay_leave_flow/outcomes/_mat_pay.erb
@@ -72,6 +72,12 @@ Remaining weeks (between <%= calculator.formatted_first_day_in_year(2023) %> and
 
 <% end %>
 
+<% if calculator.paid_leave_is_in_year?(2024) %>
+
+Remaining weeks (between <%= calculator.formatted_first_day_in_year(2024) %> and <%= calculator.formatted_last_day_in_year(2024) %>) | £184.03 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+<% end %>
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/app/flows/maternity_paternity_pay_leave_flow/outcomes/_pat_leave.erb
+++ b/app/flows/maternity_paternity_pay_leave_flow/outcomes/_pat_leave.erb
@@ -1,8 +1,11 @@
 ##Paternity leave
 
-The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+The mother’s partner can take up to 2 weeks' [paternity leave](/paternity-pay-leave/leave).
 
- | Dates
-- | -
-Paternity leave must be used | within 52 weeks of the birth.
-Tell the partner’s employer | by <%= format_date(calculator.paternity_leave_notice_date) %>
+<% if calculator.due_date >= Date.new(2024, 4, 7) %>
+  Paternity leave must be used within 364 days of <%= format_date(calculator.due_date) %>.
+<% else %>
+  Paternity leave must be used within 56 days of <%= format_date(calculator.due_date) %>.
+<% end %>
+
+Tell the partner’s employer by <%= format_date(calculator.paternity_leave_notice_date) %>.

--- a/app/flows/maternity_paternity_pay_leave_flow/outcomes/_pat_leave.erb
+++ b/app/flows/maternity_paternity_pay_leave_flow/outcomes/_pat_leave.erb
@@ -2,10 +2,6 @@
 
 The mother’s partner can take up to 2 weeks' [paternity leave](/paternity-pay-leave/leave).
 
-<% if calculator.due_date >= Date.new(2024, 4, 7) %>
-  Paternity leave must be used within 364 days of <%= format_date(calculator.due_date) %>.
-<% else %>
-  Paternity leave must be used within 56 days of <%= format_date(calculator.due_date) %>.
-<% end %>
+Paternity leave must be used by <%= format_date(calculator.paternity_leave_deadline_date) %>.
 
 Tell the partner’s employer by <%= format_date(calculator.paternity_leave_notice_date) %>.

--- a/app/flows/maternity_paternity_pay_leave_flow/outcomes/_pat_leave.erb
+++ b/app/flows/maternity_paternity_pay_leave_flow/outcomes/_pat_leave.erb
@@ -4,5 +4,5 @@ The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pa
 
  | Dates
 - | -
-Paternity leave must be used | within 56 days of the birth.
+Paternity leave must be used | within 52 weeks of the birth.
 Tell the partner’s employer | by <%= format_date(calculator.paternity_leave_notice_date) %>

--- a/app/flows/maternity_paternity_pay_leave_flow/outcomes/_pat_pay.erb
+++ b/app/flows/maternity_paternity_pay_leave_flow/outcomes/_pat_pay.erb
@@ -70,6 +70,12 @@ Weekly rate (between <%= calculator.formatted_first_day_in_year(2023) %> and <%=
 
 <% end %>
 
+<% if calculator.paid_leave_is_in_year?(2024) %>
+
+Weekly rate (between <%= calculator.formatted_first_day_in_year(2024) %> and <%= calculator.formatted_last_day_in_year(2024) %>) | £184.03 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+<% end %>
+
 <% if calculator.paid_leave_is_in_year?(2013) %>
 
 Tell the partner’s employer | 28 days before they want to start paternity pay

--- a/app/flows/maternity_paternity_pay_leave_flow/outcomes/_pat_pay.erb
+++ b/app/flows/maternity_paternity_pay_leave_flow/outcomes/_pat_pay.erb
@@ -82,6 +82,6 @@ Tell the partner’s employer | 28 days before they want to start paternity pay
 
 <% else %>
 
-Tell the partner’s employer | <%= format_date(calculator.paternity_leave_notice_date) %>
+Tell the partner’s employer | by <%= format_date(calculator.paternity_leave_notice_date) %>
 
 <% end %>

--- a/app/flows/maternity_paternity_pay_leave_flow/questions/mother_earned_at_least_390.erb
+++ b/app/flows/maternity_paternity_pay_leave_flow/questions/mother_earned_at_least_390.erb
@@ -9,7 +9,3 @@ The 13 weeks do not need to be in a row.
   "yes": "Yes",
   "no": "No"
 ) %>
-
-<% govspeak_for :post_body do %>
-  For leave starting after 25 April 2020: if they earned less than usual in any weeks because they were 'on furlough' under the Coronavirus Job Retention Scheme, you can use what they would have earned normally. 
-<% end %>

--- a/app/flows/maternity_paternity_pay_leave_flow/questions/mother_earned_more_than_lower_earnings_limit.erb
+++ b/app/flows/maternity_paternity_pay_leave_flow/questions/mother_earned_more_than_lower_earnings_limit.erb
@@ -6,7 +6,3 @@
   "yes": "Yes",
   "no": "No"
 ) %>
-
-<% govspeak_for :post_body do %>
-  For leave starting after 25 April 2020: if they earned less than usual in any weeks because they were 'on furlough' under the Coronavirus Job Retention Scheme, you can use what they would have earned normally.
-<% end %>

--- a/app/flows/maternity_paternity_pay_leave_flow/questions/partner_earned_more_than_lower_earnings_limit.erb
+++ b/app/flows/maternity_paternity_pay_leave_flow/questions/partner_earned_more_than_lower_earnings_limit.erb
@@ -6,7 +6,3 @@
   "yes": "Yes",
   "no": "No"
 ) %>
-
-<% govspeak_for :post_body do %>
-  For leave starting after 25 April 2020: if they earned less than usual in any weeks because they were 'on furlough' under the Coronavirus Job Retention Scheme, you can use what they would have earned normally. 
-<% end %>

--- a/app/flows/maternity_paternity_pay_leave_flow/start.erb
+++ b/app/flows/maternity_paternity_pay_leave_flow/start.erb
@@ -16,7 +16,6 @@
   There are different rules if you’re:
 
   * [claiming adoption pay and leave](/adoption-pay-leave) for adoptions or surrogacies
-  * [calculating the paternity leave period](/paternity-pay-leave/leave) for births expected after 6 April 2024 (on or after 6 April 2024 for adoptions)
 
 <% end %>
 

--- a/app/flows/maternity_paternity_pay_leave_flow/start.erb
+++ b/app/flows/maternity_paternity_pay_leave_flow/start.erb
@@ -13,11 +13,11 @@
   * Statutory Paternity Leave or Pay
   * Maternity Allowance
 
-  There are different rules if you’re:
+  There are different rules for:
 
+  * [paternity leave if you’re in Northern Ireland](https://www.nidirect.gov.uk/articles/paternity-leave)
   * [claiming adoption pay and leave](/adoption-pay-leave) for adoptions or surrogacies
 
-  There are [different rules for paternity leave if you’re in Northern Ireland](https://www.nidirect.gov.uk/articles/paternity-leave).
 <% end %>
 
 <% govspeak_for :post_body do %>

--- a/app/flows/maternity_paternity_pay_leave_flow/start.erb
+++ b/app/flows/maternity_paternity_pay_leave_flow/start.erb
@@ -17,6 +17,7 @@
 
   * [claiming adoption pay and leave](/adoption-pay-leave) for adoptions or surrogacies
 
+  There are [different rules for paternity leave if you’re in Northern Ireland](https://www.nidirect.gov.uk/articles/paternity-leave).
 <% end %>
 
 <% govspeak_for :post_body do %>

--- a/lib/smart_answer/calculators/maternity_paternity_pay_leave_calculator.rb
+++ b/lib/smart_answer/calculators/maternity_paternity_pay_leave_calculator.rb
@@ -160,6 +160,14 @@ module SmartAnswer::Calculators
       end
     end
 
+    def paternity_leave_deadline_date
+      if due_date >= Date.new(2024, 4, 7)
+        due_date + 364.days
+      else
+        due_date + 56.days
+      end
+    end
+
   private
 
     def saturday_before(date)

--- a/lib/smart_answer/calculators/maternity_paternity_pay_leave_calculator.rb
+++ b/lib/smart_answer/calculators/maternity_paternity_pay_leave_calculator.rb
@@ -15,6 +15,8 @@ module SmartAnswer::Calculators
                   :partner_still_working_on_continuity_end_date,
                   :partner_earned_more_than_lower_earnings_limit
 
+    DATE_TO_APPLY_28_DAY_PATERNITY_LEAVE_NOTICE_PERIOD_FROM = Date.new(2024, 4, 7)
+
     def first_day_in_year(year)
       date = Date.new(year, 4, 1)
       offset = (7 - date.wday) % 7
@@ -148,7 +150,15 @@ module SmartAnswer::Calculators
     def maternity_leave_notice_date
       saturday_before(due_date - 14.weeks)
     end
-    alias_method :paternity_leave_notice_date, :maternity_leave_notice_date
+
+    def paternity_leave_notice_date
+      if due_date >= DATE_TO_APPLY_28_DAY_PATERNITY_LEAVE_NOTICE_PERIOD_FROM
+        due_date - 28.days
+      else
+        # Preserve the previous behaviour
+        maternity_leave_notice_date
+      end
+    end
 
   private
 

--- a/lib/smart_answer/calculators/maternity_pay_calculator.rb
+++ b/lib/smart_answer/calculators/maternity_pay_calculator.rb
@@ -316,7 +316,8 @@ module SmartAnswer::Calculators
         { min: uprating_date(2020), max: uprating_date(2021), amount: 151.20 },
         { min: uprating_date(2021), max: uprating_date(2022), amount: 151.97 },
         { min: uprating_date(2022), max: uprating_date(2023), amount: 156.66 },
-        { min: uprating_date(2023), max: uprating_date(2200), amount: 172.48 },
+        { min: uprating_date(2023), max: uprating_date(2024), amount: 172.48 },
+        { min: uprating_date(2023), max: uprating_date(2200), amount: 184.03 },
         ### Change year in future
       ]
       rate = rates.find { |r| r[:min] <= date && date < r[:max] } || rates.last

--- a/lib/smart_answer/calculators/paternity_adoption_pay_calculator.rb
+++ b/lib/smart_answer/calculators/paternity_adoption_pay_calculator.rb
@@ -20,7 +20,12 @@ module SmartAnswer::Calculators
     end
 
     def paternity_deadline
-      (adoption_placement_date + 55.days).strftime("%d-%m-%Y")
+      deadline_period = if adoption_placement_date < Date.new(2024, 4, 6)
+                          55.days
+                        else
+                          364.days
+                        end
+      (adoption_placement_date + deadline_period).strftime("%d-%m-%Y")
     end
 
     def relevant_week

--- a/lib/smart_answer/calculators/paternity_adoption_pay_calculator.rb
+++ b/lib/smart_answer/calculators/paternity_adoption_pay_calculator.rb
@@ -31,5 +31,9 @@ module SmartAnswer::Calculators
     def relevant_week
       @matched_week
     end
+
+    def leave_must_be_taken_consecutively?
+      adoption_placement_date <= Date.new(2024, 4, 5)
+    end
   end
 end

--- a/lib/smart_answer/calculators/paternity_adoption_pay_calculator.rb
+++ b/lib/smart_answer/calculators/paternity_adoption_pay_calculator.rb
@@ -25,7 +25,7 @@ module SmartAnswer::Calculators
                         else
                           364.days
                         end
-      (adoption_placement_date + deadline_period).strftime("%d-%m-%Y")
+      adoption_placement_date + deadline_period
     end
 
     def relevant_week

--- a/lib/smart_answer/calculators/paternity_pay_calculator.rb
+++ b/lib/smart_answer/calculators/paternity_pay_calculator.rb
@@ -26,6 +26,14 @@ module SmartAnswer::Calculators
       due_date <= Date.new(2024, 4, 6)
     end
 
+    def paternity_pay_week_and_pay
+      pay_week = 0
+      lines = paydates_and_pay.map do |date_and_pay|
+        %(Week #{pay_week += 1}|£#{sprintf('%.2f', date_and_pay[:pay])})
+      end
+      lines.join("\n")
+    end
+
   private
 
     def rate_for(date)

--- a/lib/smart_answer/calculators/paternity_pay_calculator.rb
+++ b/lib/smart_answer/calculators/paternity_pay_calculator.rb
@@ -22,6 +22,10 @@ module SmartAnswer::Calculators
       start_date + deadline_period
     end
 
+    def leave_must_be_taken_consecutively?
+      due_date <= Date.new(2024, 4, 6)
+    end
+
   private
 
     def rate_for(date)

--- a/lib/smart_answer/calculators/paternity_pay_calculator.rb
+++ b/lib/smart_answer/calculators/paternity_pay_calculator.rb
@@ -13,8 +13,13 @@ module SmartAnswer::Calculators
     end
 
     def paternity_deadline
+      deadline_period = if due_date <= Date.new(2024, 4, 6)
+                          55.days
+                        else
+                          364.days
+                        end
       start_date = [date_of_birth, due_date].max
-      (start_date + 55.days).strftime("%d-%m-%Y")
+      (start_date + deadline_period).strftime("%d-%m-%Y")
     end
 
   private

--- a/lib/smart_answer/calculators/paternity_pay_calculator.rb
+++ b/lib/smart_answer/calculators/paternity_pay_calculator.rb
@@ -19,7 +19,7 @@ module SmartAnswer::Calculators
                           364.days
                         end
       start_date = [date_of_birth, due_date].max
-      (start_date + deadline_period).strftime("%d-%m-%Y")
+      start_date + deadline_period
     end
 
   private

--- a/test/flows/maternity_paternity_calculator_flow/adoption_calculator_flow_test.rb
+++ b/test/flows/maternity_paternity_calculator_flow/adoption_calculator_flow_test.rb
@@ -393,13 +393,13 @@ class MaternityPaternityCalculatorFlow::AdoptionCalculatorFlowTest < ActiveSuppo
     end
 
     should "render when an employee is entitled to statutory adoption pay" do
-      add_responses maternity_adoption_responses(pay_frequency: "weekly", pay_per_frequency: 1_000, placement_date: "2023-05-01")
+      add_responses maternity_adoption_responses(pay_frequency: "weekly", pay_per_frequency: 1_000, placement_date: "2024-05-01")
 
       assert_rendered_outcome text: "The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP)"
 
-      # 90% of 1000 a week for 6 weeks + (39 - 6) * 172.48 statutory (rate for 2023)
-      # = 900 * 6 + 33 * 172.48
-      assert_match(/Total SAP:\s*£11,091.84/, @test_flow.outcome_text)
+      # 90% of 1000 a week for 6 weeks + (39 - 6) * 184.03 statutory (rate for 2024)
+      # = (900 * 6) + (33 * 184.03)
+      assert_match(/Total SAP:\s*£11,472.99/, @test_flow.outcome_text)
     end
 
     should "render when an employee is entitled to statutory adoption pay and exactly on the threshold" do

--- a/test/flows/maternity_paternity_calculator_flow/paternity_calculator_flow_test.rb
+++ b/test/flows/maternity_paternity_calculator_flow/paternity_calculator_flow_test.rb
@@ -288,6 +288,15 @@ class MaternityPaternityCalculatorFlow::PaternityCalculatorFlowTest < ActiveSupp
       assert_rendered_question
     end
 
+    context "due date is after 6 April 2024" do
+      setup do
+        add_responses paternity_responses(up_to: :employee_start_paternity?, due_date: "2024-04-07")
+      end
+      should "render the updated paternity deadline" do
+        assert_rendered_question text: "The last day of leave the employee will be eligible for statutory paternity pay is 06-04-2025"
+      end
+    end
+
     context "next_node" do
       should "have a next node of paternity_not_entitled_to_leave_or_pay when the employee has contract " \
              "paternity and is not on on payroll" do

--- a/test/flows/maternity_paternity_calculator_flow/paternity_calculator_flow_test.rb
+++ b/test/flows/maternity_paternity_calculator_flow/paternity_calculator_flow_test.rb
@@ -693,6 +693,18 @@ class MaternityPaternityCalculatorFlow::PaternityCalculatorFlowTest < ActiveSupp
                                     "Saturday, 01 April 2023 must be at least £123"
     end
 
+    should "render pre-April 2024 guidance when due date is before 7 April 2024" do
+      add_responses paternity_responses(due_date: "2024-04-06")
+
+      assert_rendered_outcome text: "They can choose to take either 1 week or 2 consecutive weeks’ leave."
+    end
+
+    should "render post-April 2024 guidance when due date is 7 April 2024 (or after)" do
+      add_responses paternity_responses(due_date: "2024-04-07")
+
+      assert_rendered_outcome text: "They can take 2 consecutive or non-consecutive weeks."
+    end
+
     context "when an employee is entitled to pay" do
       should "render when the eligibility is for statutory adoption pay" do
         add_responses @maternity_adoption_responses

--- a/test/flows/maternity_paternity_calculator_flow/paternity_calculator_flow_test.rb
+++ b/test/flows/maternity_paternity_calculator_flow/paternity_calculator_flow_test.rb
@@ -694,7 +694,7 @@ class MaternityPaternityCalculatorFlow::PaternityCalculatorFlowTest < ActiveSupp
     end
 
     context "when an employee is entitled to pay" do
-      should "render when the eligiblity is for statutory adoption pay" do
+      should "render when the eligibility is for statutory adoption pay" do
         add_responses @maternity_adoption_responses
 
         assert_rendered_outcome text: "The employee is entitled to SAP"

--- a/test/flows/maternity_paternity_pay_leave_flow_test.rb
+++ b/test/flows/maternity_paternity_pay_leave_flow_test.rb
@@ -4028,7 +4028,7 @@ class MaternityPaternityPayLeaveFlowTest < ActiveSupport::TestCase
       end
 
       should "render _pat_leave partial with 56 days leave deadline" do
-        assert_rendered_outcome text: "within 56 days of  6 April 2024"
+        assert_rendered_outcome text: "Paternity leave must be used by  1 June 2024"
       end
 
       should "render _pat_leave partial with 15 weeks notice period" do
@@ -4042,7 +4042,7 @@ class MaternityPaternityPayLeaveFlowTest < ActiveSupport::TestCase
       end
 
       should "render _pat_leave partial with 364 days leave deadline" do
-        assert_rendered_outcome text: "within 364 days of  7 April 2024"
+        assert_rendered_outcome text: "Paternity leave must be used by  6 April 2025"
       end
 
       should "render _pat_leave partial with 28 days notice period" do

--- a/test/flows/maternity_paternity_pay_leave_flow_test.rb
+++ b/test/flows/maternity_paternity_pay_leave_flow_test.rb
@@ -4001,7 +4001,7 @@ class MaternityPaternityPayLeaveFlowTest < ActiveSupport::TestCase
 
     should "render _pat_pay partial paid leave on a saturday" do
       add_responses due_date: "2021-12-25"
-      assert_rendered_outcome text: "Tell the partner’s employer\n      11 September 2021"
+      assert_rendered_outcome text: "Tell the partner’s employer\n      by 11 September 2021"
     end
   end
 

--- a/test/flows/maternity_paternity_pay_leave_flow_test.rb
+++ b/test/flows/maternity_paternity_pay_leave_flow_test.rb
@@ -4004,4 +4004,50 @@ class MaternityPaternityPayLeaveFlowTest < ActiveSupport::TestCase
       assert_rendered_outcome text: "Tell the partner’s employer\n      11 September 2021"
     end
   end
+
+  context "outcome: outcome_pat_leave" do
+    setup do
+      testing_node :outcome_pat_leave
+      add_responses two_carers: "yes",
+                    due_date: "2016-1-1",
+                    employment_status_of_mother: "worker",
+                    employment_status_of_partner: "employee",
+                    mother_started_working_before_continuity_start_date: "yes",
+                    mother_still_working_on_continuity_end_date: "no",
+                    mother_earned_more_than_lower_earnings_limit: "no",
+                    mother_worked_at_least_26_weeks: "no",
+                    mother_earned_at_least_390: "yes",
+                    partner_started_working_before_continuity_start_date: "yes",
+                    partner_still_working_on_continuity_end_date: "yes",
+                    partner_earned_more_than_lower_earnings_limit: "no"
+    end
+
+    context "for births on 6 April 2024" do
+      setup do
+        add_responses due_date: "2024-04-6"
+      end
+
+      should "render _pat_leave partial with 56 days leave deadline" do
+        assert_rendered_outcome text: "within 56 days of  6 April 2024"
+      end
+
+      should "render _pat_leave partial with 15 weeks notice period" do
+        assert_rendered_outcome text: "Tell the partner’s employer by 23 December 2023"
+      end
+    end
+
+    context "for births on 7 April 2024" do
+      setup do
+        add_responses due_date: "2024-04-07"
+      end
+
+      should "render _pat_leave partial with 364 days leave deadline" do
+        assert_rendered_outcome text: "within 364 days of  7 April 2024"
+      end
+
+      should "render _pat_leave partial with 28 days notice period" do
+        assert_rendered_outcome text: "Tell the partner’s employer by 10 March 2024"
+      end
+    end
+  end
 end

--- a/test/flows/maternity_paternity_pay_leave_flow_test.rb
+++ b/test/flows/maternity_paternity_pay_leave_flow_test.rb
@@ -3727,6 +3727,11 @@ class MaternityPaternityPayLeaveFlowTest < ActiveSupport::TestCase
       add_responses due_date: "2023-1-1"
       assert_rendered_outcome text: "£172.48"
     end
+
+    should "render _mat_allowance partial weekly rate for 2024" do
+      add_responses due_date: "2024-1-1"
+      assert_rendered_outcome text: "£184.03"
+    end
   end
 
   context "outcome: outcome_mat_allowance_14_weeks" do
@@ -3876,6 +3881,11 @@ class MaternityPaternityPayLeaveFlowTest < ActiveSupport::TestCase
       add_responses due_date: "2023-1-1"
       assert_rendered_outcome text: "£172.48 per week"
     end
+
+    should "render _mat_pay partial weekly rate for 2024" do
+      add_responses due_date: "2024-1-1"
+      assert_rendered_outcome text: "£184.03 per week"
+    end
   end
 
   context "outcome: outcome_pat_pay" do
@@ -3947,6 +3957,11 @@ class MaternityPaternityPayLeaveFlowTest < ActiveSupport::TestCase
     should "render _pat_pay partial weekly rate for 2023" do
       add_responses due_date: "2023-1-1"
       assert_rendered_outcome text: "£172.48 per week"
+    end
+
+    should "render _pat_pay partial weekly rate for 2024" do
+      add_responses due_date: "2024-1-1"
+      assert_rendered_outcome text: "£184.03 per week"
     end
 
     should "render _pat_pay partial paid leave is in year 2013" do

--- a/test/flows/maternity_paternity_pay_leave_flow_test.rb
+++ b/test/flows/maternity_paternity_pay_leave_flow_test.rb
@@ -3657,7 +3657,7 @@ class MaternityPaternityPayLeaveFlowTest < ActiveSupport::TestCase
     end
   end
 
-  context "outcome: outcome_mat_allowance" do
+  context "outcome: outcome_mat_allowance, self-employed mother" do
     setup do
       testing_node :outcome_mat_allowance
       add_responses two_carers: "yes",
@@ -3716,6 +3716,36 @@ class MaternityPaternityPayLeaveFlowTest < ActiveSupport::TestCase
     should "render _mat_allowance partial weekly rate for 2021" do
       add_responses due_date: "2021-1-1"
       assert_rendered_outcome text: "£151.97 or 90%"
+    end
+
+    should "render _mat_allowance partial weekly rate for 2022" do
+      add_responses due_date: "2022-1-1"
+      assert_rendered_outcome text: "£156.66"
+    end
+
+    should "render _mat_allowance partial weekly rate for 2023" do
+      add_responses due_date: "2023-1-1"
+      assert_rendered_outcome text: "£172.48"
+    end
+
+    should "render _mat_allowance partial weekly rate for 2024" do
+      add_responses due_date: "2024-1-1"
+      assert_rendered_outcome text: "£184.03"
+    end
+  end
+
+  context "outcome: outcome_mat_allowance, employee mother" do
+    setup do
+      testing_node :outcome_mat_allowance
+      add_responses two_carers: "yes",
+                    # due_date: "2016-1-1",
+                    employment_status_of_mother: "employee",
+                    employment_status_of_partner: "self-employed",
+                    mother_started_working_before_continuity_start_date: "yes",
+                    mother_still_working_on_continuity_end_date: "no",
+                    mother_earned_more_than_lower_earnings_limit: "no",
+                    mother_worked_at_least_26_weeks: "yes",
+                    mother_earned_at_least_390: "yes"
     end
 
     should "render _mat_allowance partial weekly rate for 2022" do

--- a/test/unit/calculators/maternity_paternity_pay_leave_calculator_test.rb
+++ b/test/unit/calculators/maternity_paternity_pay_leave_calculator_test.rb
@@ -93,10 +93,26 @@ module SmartAnswer
         assert_equal expected, @calculator.maternity_leave_notice_date
       end
 
-      test "paternity_leave_notice_date" do
-        @calculator.due_date = @due_date
-        expected = Date.parse("2014-09-20")
-        assert_equal expected, @calculator.paternity_leave_notice_date
+      context "paternity_leave_notice_date" do
+        context "due date is on 6 April" do
+          setup do
+            @calculator.due_date = Date.parse("2024-04-06")
+          end
+
+          should "apply paternity leave notice period of 15 weeks" do
+            assert_equal Date.parse("2023-12-23"), @calculator.paternity_leave_notice_date
+          end
+        end
+
+        context "due date is after 6 April" do
+          setup do
+            @calculator.due_date = Date.parse("2024-04-07")
+          end
+
+          should "apply paternity leave notice period of 28 days" do
+            assert_equal Date.parse("2024-03-10"), @calculator.paternity_leave_notice_date
+          end
+        end
       end
 
       context "due date in 2013-2014 range" do

--- a/test/unit/calculators/maternity_paternity_pay_leave_calculator_test.rb
+++ b/test/unit/calculators/maternity_paternity_pay_leave_calculator_test.rb
@@ -94,7 +94,7 @@ module SmartAnswer
       end
 
       context "paternity_leave_notice_date" do
-        context "due date is on 6 April" do
+        context "due date is on 6 April 2024" do
           setup do
             @calculator.due_date = Date.parse("2024-04-06")
           end
@@ -104,13 +104,35 @@ module SmartAnswer
           end
         end
 
-        context "due date is after 6 April" do
+        context "due date is after 6 April 2024" do
           setup do
             @calculator.due_date = Date.parse("2024-04-07")
           end
 
           should "apply paternity leave notice period of 28 days" do
             assert_equal Date.parse("2024-03-10"), @calculator.paternity_leave_notice_date
+          end
+        end
+      end
+
+      context "paternity_leave_deadline_date" do
+        context "due date is on or before 6 April 2024" do
+          setup do
+            @calculator.due_date = Date.parse("2024-04-06")
+          end
+
+          should "render a paternity leave deadline date of 56 days after the due date" do
+            assert_equal Date.parse("2024-06-01"), @calculator.paternity_leave_deadline_date
+          end
+        end
+
+        context "due date is after 6 April 2024" do
+          setup do
+            @calculator.due_date = Date.parse("2024-04-07")
+          end
+
+          should "render a paternity leave deadline date of 364 days after the due date" do
+            assert_equal Date.parse("2025-04-06"), @calculator.paternity_leave_deadline_date
           end
         end
       end

--- a/test/unit/calculators/maternity_pay_calculator_test.rb
+++ b/test/unit/calculators/maternity_pay_calculator_test.rb
@@ -359,6 +359,7 @@ module SmartAnswer::Calculators
 
       context "statutory pay rate for given year" do
         {
+          2024 => 184.03,
           2023 => 172.48,
           2022 => 156.66,
           2021 => 151.97,

--- a/test/unit/calculators/paternity_adoption_pay_calculator_test.rb
+++ b/test/unit/calculators/paternity_adoption_pay_calculator_test.rb
@@ -32,6 +32,22 @@ module SmartAnswer::Calculators
           end
         end
       end
+
+      context "#leave_must_be_taken_consecutively?" do
+        should "be false when adoption placement date is 6 April 2024 (or after)" do
+          calculator = PaternityAdoptionPayCalculator.new(Date.parse("1 April 2024"))
+          calculator.adoption_placement_date = Date.parse("6 April 2024")
+
+          assert_equal false, calculator.leave_must_be_taken_consecutively?
+        end
+
+        should "be true when adoption placement date is before 6 April 2024" do
+          calculator = PaternityAdoptionPayCalculator.new(Date.parse("1 April 2024"))
+          calculator.adoption_placement_date = Date.parse("5 April 2024")
+
+          assert_equal true, calculator.leave_must_be_taken_consecutively?
+        end
+      end
     end
   end
 end

--- a/test/unit/calculators/paternity_adoption_pay_calculator_test.rb
+++ b/test/unit/calculators/paternity_adoption_pay_calculator_test.rb
@@ -1,0 +1,17 @@
+require_relative "../../test_helper"
+
+module SmartAnswer::Calculators
+  class PaternityAdoptionPayCalculatorTest < ActiveSupport::TestCase
+    context PaternityAdoptionPayCalculator do
+      context "#paternity_deadline" do
+        should "give paternity deadlne based on placement date" do
+          match_date = Date.parse("01 July 2020")
+          placement_date = Date.parse("01 August 2020")
+          calculator = PaternityAdoptionPayCalculator.new(match_date)
+          calculator.adoption_placement_date = placement_date
+          assert_equal "25-09-2020", calculator.paternity_deadline
+        end
+      end
+    end
+  end
+end

--- a/test/unit/calculators/paternity_adoption_pay_calculator_test.rb
+++ b/test/unit/calculators/paternity_adoption_pay_calculator_test.rb
@@ -14,7 +14,7 @@ module SmartAnswer::Calculators
             calculator = PaternityAdoptionPayCalculator.new(match_date)
             calculator.adoption_placement_date = @placement_date
 
-            assert_equal "30-05-2024", calculator.paternity_deadline
+            assert_equal Date.parse("30-05-2024"), calculator.paternity_deadline
           end
         end
 
@@ -28,7 +28,7 @@ module SmartAnswer::Calculators
             calculator = PaternityAdoptionPayCalculator.new(match_date)
             calculator.adoption_placement_date = @placement_date
 
-            assert_equal "05-04-2025", calculator.paternity_deadline
+            assert_equal Date.parse("05-04-2025"), calculator.paternity_deadline
           end
         end
       end

--- a/test/unit/calculators/paternity_adoption_pay_calculator_test.rb
+++ b/test/unit/calculators/paternity_adoption_pay_calculator_test.rb
@@ -4,12 +4,32 @@ module SmartAnswer::Calculators
   class PaternityAdoptionPayCalculatorTest < ActiveSupport::TestCase
     context PaternityAdoptionPayCalculator do
       context "#paternity_deadline" do
-        should "give paternity deadlne based on placement date" do
-          match_date = Date.parse("01 July 2020")
-          placement_date = Date.parse("01 August 2020")
-          calculator = PaternityAdoptionPayCalculator.new(match_date)
-          calculator.adoption_placement_date = placement_date
-          assert_equal "25-09-2020", calculator.paternity_deadline
+        context "deadline is 55 days ahead" do
+          setup do
+            @placement_date = Date.parse("5 April 2024")
+          end
+
+          should "give paternity deadline based on placement date" do
+            match_date = Date.parse("01 March 2024")
+            calculator = PaternityAdoptionPayCalculator.new(match_date)
+            calculator.adoption_placement_date = @placement_date
+
+            assert_equal "30-05-2024", calculator.paternity_deadline
+          end
+        end
+
+        context "deadline is 364 days ahead" do
+          setup do
+            @placement_date = Date.parse("6 April 2024")
+          end
+
+          should "give paternity deadline based on placement date" do
+            match_date = Date.parse("01 March 2024")
+            calculator = PaternityAdoptionPayCalculator.new(match_date)
+            calculator.adoption_placement_date = @placement_date
+
+            assert_equal "05-04-2025", calculator.paternity_deadline
+          end
         end
       end
     end

--- a/test/unit/calculators/paternity_pay_calculator_test.rb
+++ b/test/unit/calculators/paternity_pay_calculator_test.rb
@@ -68,14 +68,14 @@ module SmartAnswer::Calculators
             calculator = PaternityPayCalculator.new(@due_date)
             calculator.date_of_birth = Date.parse("4 April 2024")
 
-            assert_equal "31-05-2024", calculator.paternity_deadline
+            assert_equal Date.parse("31-05-2024"), calculator.paternity_deadline
           end
 
           should "give paternity deadline based on actual birth date when baby is born late" do
             calculator = PaternityPayCalculator.new(@due_date)
             calculator.date_of_birth = Date.parse("8 April 2024")
 
-            assert_equal "02-06-2024", calculator.paternity_deadline
+            assert_equal Date.parse("02-06-2024"), calculator.paternity_deadline
           end
         end
 
@@ -88,14 +88,14 @@ module SmartAnswer::Calculators
             calculator = PaternityPayCalculator.new(@due_date)
             calculator.date_of_birth = Date.parse("4 April 2024")
 
-            assert_equal "06-04-2025", calculator.paternity_deadline
+            assert_equal Date.parse("06-04-2025"), calculator.paternity_deadline
           end
 
           should "give paternity deadline based on actual birth date when baby is born late" do
             calculator = PaternityPayCalculator.new(@due_date)
             calculator.date_of_birth = Date.parse("8 April 2024")
 
-            assert_equal "07-04-2025", calculator.paternity_deadline
+            assert_equal Date.parse("07-04-2025"), calculator.paternity_deadline
           end
         end
       end

--- a/test/unit/calculators/paternity_pay_calculator_test.rb
+++ b/test/unit/calculators/paternity_pay_calculator_test.rb
@@ -67,6 +67,15 @@ module SmartAnswer::Calculators
 
           assert_equal "06-04-2021", calculator.paternity_deadline
         end
+
+        should "give paternity deadline based on actual birth date when baby is born late" do
+          due_date = Date.parse("8 February 2021")
+          birth_date = Date.parse("10 February 2021")
+          calculator = PaternityPayCalculator.new(due_date)
+          calculator.date_of_birth = birth_date
+
+          assert_equal "06-04-2021", calculator.paternity_deadline
+        end
       end
     end
   end

--- a/test/unit/calculators/paternity_pay_calculator_test.rb
+++ b/test/unit/calculators/paternity_pay_calculator_test.rb
@@ -99,6 +99,20 @@ module SmartAnswer::Calculators
           end
         end
       end
+
+      context "#leave_must_be_taken_consecutively?" do
+        should "be false when due date is after 6 April 2024" do
+          calculator = PaternityPayCalculator.new(Date.parse("7 April 2024"))
+
+          assert_equal false, calculator.leave_must_be_taken_consecutively?
+        end
+
+        should "be true when due date is 6 April 2024 (or before)" do
+          calculator = PaternityPayCalculator.new(Date.parse("6 April 2024"))
+
+          assert_equal true, calculator.leave_must_be_taken_consecutively?
+        end
+      end
     end
   end
 end

--- a/test/unit/calculators/paternity_pay_calculator_test.rb
+++ b/test/unit/calculators/paternity_pay_calculator_test.rb
@@ -21,6 +21,20 @@ module SmartAnswer::Calculators
         end
       end
 
+      context "#paternity_pay_week_and_pay" do
+        setup do
+          due_date = Date.parse("1 May 2014")
+          @calculator = PaternityPayCalculator.new(due_date)
+          @calculator.leave_start_date = due_date
+          @calculator.pay_method = "weekly_starting"
+          @calculator.stubs(:average_weekly_earnings).returns("125.00")
+        end
+
+        should "produce 2 weeks of pay dates and pay at 90% of wage" do
+          assert_equal "Week 1|£112.50\nWeek 2|£112.50", @calculator.paternity_pay_week_and_pay
+        end
+      end
+
       context "paternity leave duration weekly payment dates" do
         setup do
           due_date = Date.parse("1 October 2015")

--- a/test/unit/calculators/paternity_pay_calculator_test.rb
+++ b/test/unit/calculators/paternity_pay_calculator_test.rb
@@ -3,7 +3,7 @@ require_relative "../../test_helper"
 module SmartAnswer::Calculators
   class PaternityPayCalculatorTest < ActiveSupport::TestCase
     context PaternityPayCalculator do
-      context "test for paternity pay weekly dates and pay" do
+      context "#paydates_and_pay" do
         setup do
           due_date = Date.parse("1 May 2014")
           @calculator = PaternityPayCalculator.new(due_date)
@@ -53,25 +53,19 @@ module SmartAnswer::Calculators
           calculator.leave_start_date = date
           calculator.pay_method = "last_day_of_the_month"
           calculator.stubs(:average_weekly_earnings).returns(500.00)
+
           assert_equal (calculator.statutory_rate(date) * 2), calculator.paydates_and_pay.first[:pay]
         end
       end
-      context "for premature birth paternity dates" do
-        should "give paternity deadline based on due date" do
+
+      context "#paternity_deadline" do
+        should "give paternity deadline based on due date when baby is born prematurely" do
           due_date = Date.parse("10 February 2021")
           birth_date = Date.parse("8 February 2021")
           calculator = PaternityPayCalculator.new(due_date)
           calculator.date_of_birth = birth_date
+
           assert_equal "06-04-2021", calculator.paternity_deadline
-        end
-      end
-      context "for paternity adoption leave dates" do
-        should "give paternity deadlne based on placement date" do
-          match_date = Date.parse("01 July 2020")
-          placement_date = Date.parse("01 August 2020")
-          calculator = PaternityAdoptionPayCalculator.new(match_date)
-          calculator.adoption_placement_date = placement_date
-          assert_equal "25-09-2020", calculator.paternity_deadline
         end
       end
     end

--- a/test/unit/calculators/paternity_pay_calculator_test.rb
+++ b/test/unit/calculators/paternity_pay_calculator_test.rb
@@ -59,22 +59,44 @@ module SmartAnswer::Calculators
       end
 
       context "#paternity_deadline" do
-        should "give paternity deadline based on due date when baby is born prematurely" do
-          due_date = Date.parse("10 February 2021")
-          birth_date = Date.parse("8 February 2021")
-          calculator = PaternityPayCalculator.new(due_date)
-          calculator.date_of_birth = birth_date
+        context "deadline is 55 days ahead" do
+          setup do
+            @due_date = Date.parse("6 April 2024")
+          end
 
-          assert_equal "06-04-2021", calculator.paternity_deadline
+          should "give paternity deadline based on due date when baby is born prematurely" do
+            calculator = PaternityPayCalculator.new(@due_date)
+            calculator.date_of_birth = Date.parse("4 April 2024")
+
+            assert_equal "31-05-2024", calculator.paternity_deadline
+          end
+
+          should "give paternity deadline based on actual birth date when baby is born late" do
+            calculator = PaternityPayCalculator.new(@due_date)
+            calculator.date_of_birth = Date.parse("8 April 2024")
+
+            assert_equal "02-06-2024", calculator.paternity_deadline
+          end
         end
 
-        should "give paternity deadline based on actual birth date when baby is born late" do
-          due_date = Date.parse("8 February 2021")
-          birth_date = Date.parse("10 February 2021")
-          calculator = PaternityPayCalculator.new(due_date)
-          calculator.date_of_birth = birth_date
+        context "deadline is 364 days ahead" do
+          setup do
+            @due_date = Date.parse("7 April 2024")
+          end
 
-          assert_equal "06-04-2021", calculator.paternity_deadline
+          should "give paternity deadline based on due date when baby is born prematurely" do
+            calculator = PaternityPayCalculator.new(@due_date)
+            calculator.date_of_birth = Date.parse("4 April 2024")
+
+            assert_equal "06-04-2025", calculator.paternity_deadline
+          end
+
+          should "give paternity deadline based on actual birth date when baby is born late" do
+            calculator = PaternityPayCalculator.new(@due_date)
+            calculator.date_of_birth = Date.parse("8 April 2024")
+
+            assert_equal "07-04-2025", calculator.paternity_deadline
+          end
         end
       end
     end


### PR DESCRIPTION
## What

Add the new pay rates for the 2024/2025 tax year.

Also removes a temporary holding message that is no longer needed, and updates a message regarding the time period within which paternity leave must be taken.

Some branches in one of the outcome files wasn't covered by any tests, so that missing coverage has been addressed.

## Trello tickets

[Check if you can get Maternity or Paternity Leave or Pay, or Maternity Allowance Trello ticket](https://trello.com/c/YGkZ2HSF)

[Maternity, Adoption and paternity calculator for employers Trello ticket](https://trello.com/c/67TamOSs)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
