### PR TITLE
Disable GA4 tracking on the govspeak component

### DIFF
--- a/lib/smart_answer/erb_renderer/format_capture_helper.rb
+++ b/lib/smart_answer/erb_renderer/format_capture_helper.rb
@@ -54,7 +54,7 @@ module SmartAnswer
       content = Govspeak::Document.new(content, sanitize: false).to_html
 
       if content.present?
-        render("govuk_publishing_components/components/govspeak") { content.html_safe }
+        render("govuk_publishing_components/components/govspeak", { disable_ga4: true }) { content.html_safe }
       else
         ""
       end

--- a/test/unit/format_capture_helper_test.rb
+++ b/test/unit/format_capture_helper_test.rb
@@ -17,7 +17,7 @@ module SmartAnswer
           block.call
         end
 
-        def render(component, &block)
+        def render(component, _component_args, &block)
           if component == "govuk_publishing_components/components/govspeak"
             "<govspeak>#{block.call}</govspeak>"
           else


### PR DESCRIPTION
## What
Disable GA4 tracking on the govspeak component

## Why
Tracking had already been added to the govspeak component in smart answers (using a parent element wrapper) so the links ended up with two trackers on them trying to do different things, which caused tracking issues on production.

## Testing

I have checked that there is no longer `callout` tracking on http://127.0.0.1:3010/state-pension-age/y/age/1995-07-25 - there is only the original `information_click` tracking now on the links.
