### PR TITLE
Set up DWP user research banner

### DIFF
--- a/app/controllers/smart_answers_controller.rb
+++ b/app/controllers/smart_answers_controller.rb
@@ -1,5 +1,6 @@
 class SmartAnswersController < ApplicationController
   include Slimmer::Headers
+  include RecruitmentBannerHelper
 
   before_action :find_smart_answer, except: %w[index]
   before_action :redirect_response_to_canonical_path, only: %w[show]

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,6 @@
 <% content_for :body do %>
   <div class="smart_answer">
+    <%= render partial: 'shared/intervention_banner' %>
     <%= yield :breadcrumbs %>
     <main id="content" role="main">
       <%= yield %>

--- a/lib/data/recruitment_banners.yml
+++ b/lib/data/recruitment_banners.yml
@@ -9,3 +9,10 @@
   #     - /foreign-travel-advice
 
 banners:
+- name: DWP user research banner
+  suggestion_text: Help improve GOV.UK
+  suggestion_link_text: Take part in user research (opens in a new tab)
+  survey_url: https://forms.office.com/e/CkfCRwdLQj
+  page_paths:
+    - /check-benefits-financial-support
+    - /check-benefits-financial-support/y/england/no/yes/sixteen_or_more_per_week/no/no/no/no/over_16000

--- a/test/integration/recruitment_banner_test.rb
+++ b/test/integration/recruitment_banner_test.rb
@@ -1,0 +1,38 @@
+require_relative "../integration_test_helper"
+
+class RecruitmentBannerTest < ActionDispatch::IntegrationTest
+  context "brand user research banner" do
+    context "check state pension age" do
+      setup do
+        stub_content_store_has_item("/check-benefits-financial-support")
+      end
+
+      should "display Brand User Research Banner on the landing page" do
+        visit "/check-benefits-financial-support"
+        assert page.has_css?(".gem-c-intervention")
+        assert page.has_link?("Take part in user research (opens in a new tab)", href: "https://forms.office.com/e/CkfCRwdLQj")
+      end
+
+      should "not display Brand User Research Banner on non-landing pages of the specific smart answer" do
+        visit "/check-benefits-financial-support/y"
+
+        assert_not page.has_css?(".gem-c-intervention")
+        assert_not page.has_link?("Take part in user research (opens in a new tab)", href: "https://forms.office.com/e/CkfCRwdLQj")
+      end
+
+      should "not display Brand User Research Banner unless survey URL is specified for the base path" do
+        visit "/bridge-of-death"
+
+        assert_not page.has_css?(".gem-c-intervention")
+        assert_not page.has_link?("Take part in user research (opens in a new tab)", href: "https://forms.office.com/e/CkfCRwdLQj")
+      end
+
+      should "display on outcome page" do
+        visit "/check-benefits-financial-support/y/england/no/yes/sixteen_or_more_per_week/no/no/no/no/over_16000"
+
+        assert page.has_css?(".gem-c-intervention")
+        assert page.has_link?("Take part in user research (opens in a new tab)", href: "https://forms.office.com/e/CkfCRwdLQj")
+      end
+    end
+  end
+end


### PR DESCRIPTION
The banner will be added on the following pages:   
- Start page: [/check-benefits-financial-support](https://www.gov.uk/check-benefits-financial-support) 
- Outcome page: [/check-benefits-financial-support/y/england/no/yes/sixteen_or_more_per_week/no/no/no/no/over_16000](https://www.gov.uk/check-benefits-financial-support/y/england/no/yes/sixteen_or_more_per_week/no/no/no/no/over_16000) 

## Start page: 
![image](https://github.com/alphagov/smart-answers/assets/17481621/e5c732b7-e86d-4fc1-af3b-a24980f045f1)

## Outcome page: 
![image](https://github.com/alphagov/smart-answers/assets/17481621/95e50159-1418-46c7-a145-346dfb20e5a4)

Trello card: https://trello.com/c/zfgadIUN