### PR TITLE
Simplify path extraction for ga4_url.

### DIFF
--- a/app/views/components/_result_card.html.erb
+++ b/app/views/components/_result_card.html.erb
@@ -8,12 +8,6 @@
   if !title || !url || !url_text || !url_track_action
     raise ArgumentError, "The result card component requires a title, url, url_text and url_track_action"
   end
-
-  ga4_url = url.clone
-
-  if ga4_url.start_with?("https://www.gov.uk")
-    ga4_url = ga4_url.gsub("https://www.gov.uk", "")
-  end
 %>
 <div class="app-c-result-card">
   <%= render "govuk_publishing_components/components/heading", {
@@ -35,6 +29,6 @@
     "track-category": "SmartAnswerClicked",
     "track-action": url_track_action,
     "track-label": url,
-    "ga4-ecommerce-path": ga4_url
+    "ga4-ecommerce-path": url.delete_prefix("https://www.gov.uk")
   } %>
 </div>


### PR DESCRIPTION
Should maybe use [URI] here, but that might change some edge cases that I'm not entirely sure are covered by the tests. So let's just simplify what's there, preserving the existing behavior.

Might resolve https://github.com/alphagov/smart-answers/security/code-scanning/1. (Not an actual security issue, just a warning from a heuristic.)

[URI]: https://docs.ruby-lang.org/en/3.3/URI.html