### PR TITLE
Fix redundancy calculator tests date issue

### DIFF
--- a/test/unit/calculators/redundancy_calculator_test.rb
+++ b/test/unit/calculators/redundancy_calculator_test.rb
@@ -31,7 +31,7 @@ module SmartAnswer::Calculators
 
       should "have max and rate for the current tax year" do
         calculator = RedundancyCalculator.redundancy_rates(Time.zone.now)
-        assert calculator.end_date > Time.zone.now, "Config file missing current redundancy rates"
+        assert calculator.end_date >= Time.zone.now.to_date, "Config file missing current redundancy rates"
         assert calculator.rate.is_a?(Numeric)
         assert calculator.max.present?
       end
@@ -50,7 +50,7 @@ module SmartAnswer::Calculators
 
       should "have max and rate for the current tax year" do
         calculator = RedundancyCalculator.northern_ireland_redundancy_rates(Time.zone.now)
-        assert calculator.end_date > Time.zone.now, "Config file missing current NI redundancy rates"
+        assert calculator.end_date >= Time.zone.now.to_date, "Config file missing current NI redundancy rates"
         assert calculator.rate.is_a?(Numeric)
         assert calculator.max.present?
       end

--- a/test/unit/calculators/redundancy_calculator_test.rb
+++ b/test/unit/calculators/redundancy_calculator_test.rb
@@ -30,10 +30,10 @@ module SmartAnswer::Calculators
       end
 
       should "have max and rate for the current tax year" do
-        calculator = RedundancyCalculator.redundancy_rates(Time.zone.now)
-        assert calculator.end_date >= Time.zone.now.to_date, "Config file missing current redundancy rates"
-        assert calculator.rate.is_a?(Numeric)
-        assert calculator.max.present?
+        rate = RedundancyCalculator.redundancy_rates(Time.zone.now)
+        assert rate.end_date >= Time.zone.now.to_date, "Config file missing current redundancy rates"
+        assert rate.rate.is_a?(Numeric)
+        assert rate.max.present?
       end
     end
 
@@ -49,10 +49,10 @@ module SmartAnswer::Calculators
       end
 
       should "have max and rate for the current tax year" do
-        calculator = RedundancyCalculator.northern_ireland_redundancy_rates(Time.zone.now)
-        assert calculator.end_date >= Time.zone.now.to_date, "Config file missing current NI redundancy rates"
-        assert calculator.rate.is_a?(Numeric)
-        assert calculator.max.present?
+        rate = RedundancyCalculator.northern_ireland_redundancy_rates(Time.zone.now)
+        assert rate.end_date >= Time.zone.now.to_date, "Config file missing current NI redundancy rates"
+        assert rate.rate.is_a?(Numeric)
+        assert rate.max.present?
       end
     end
 


### PR DESCRIPTION
A couple of tests were comparing the current *Time* to the end date specified by the retrieved rates. This comparison was wrong in a couple of ways:

1. It did a less-than comparison, rather than a less-than-or-equal-to, which meant that running the test on the end date itself would cause the test to fail, even though that is a valid date (start and end dates are inclusive).
2. It used the current *Time*, not the current *Date*, which meant that even fixing the above comparison issue, would still cause the tests to fail, as it was comparing, for example, 10am (now) with the end date (00h).

[Trello ticket
](https://trello.com/c/3fQj2IAW)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
