### PR TITLE
Fixes infinite loop in holiday entitlement calculator 

### DIFF
--- a/app/flows/calculate_your_holiday_entitlement_flow.rb
+++ b/app/flows/calculate_your_holiday_entitlement_flow.rb
@@ -147,7 +147,6 @@ class CalculateYourHolidayEntitlementFlow < SmartAnswer::Flow
       end
     end
 
-    # Q6 - Q14 - Q22 - Q31 - Q38
     date_question :when_does_your_leave_year_start? do
       on_response do |response|
         calculator.leave_year_start_date = response

--- a/app/flows/calculate_your_holiday_entitlement_flow.rb
+++ b/app/flows/calculate_your_holiday_entitlement_flow.rb
@@ -98,7 +98,7 @@ class CalculateYourHolidayEntitlementFlow < SmartAnswer::Flow
       next_node do
         if calculator.holiday_period == "starting-and-leaving"
           question :what_is_your_leaving_date?
-        elsif calculator.leave_year_start_date < (Date.new(2024, 4, 1)) && calculator.regular_or_irregular_hours == "irregular-hours-and-part-year"
+        elsif calculator.regular_or_irregular_hours == "irregular-hours-and-part-year" && calculator.leave_year_start_date < (Date.new(2024, 4, 1))
           case calculator.calculation_basis
           when "days-worked-per-week"
             question :how_many_days_per_week?
@@ -130,7 +130,7 @@ class CalculateYourHolidayEntitlementFlow < SmartAnswer::Flow
       end
 
       next_node do
-        if calculator.holiday_period == "starting-and-leaving" || (calculator.leave_year_start_date < (Date.new(2024, 4, 1)) && calculator.regular_or_irregular_hours == "irregular-hours-and-part-year")
+        if calculator.holiday_period == "starting-and-leaving" || (calculator.regular_or_irregular_hours == "irregular-hours-and-part-year" && calculator.leave_year_start_date < (Date.new(2024, 4, 1)))
           case calculator.calculation_basis
           when "days-worked-per-week"
             question :how_many_days_per_week?

--- a/lib/smart_answer/calculators/holiday_entitlement.rb
+++ b/lib/smart_answer/calculators/holiday_entitlement.rb
@@ -19,28 +19,16 @@ module SmartAnswer::Calculators
                   :leave_year_start_date,
                   :hours_per_shift,
                   :regular_or_irregular_hours,
-                  :hours_in_pay_period
+                  :hours_in_pay_period,
+                  :start_date,
+                  :leaving_date
 
     attr_reader :hours_per_week,
-                :start_date,
-                :leaving_date,
                 :working_days_per_week,
                 :shifts_per_shift_pattern,
                 :days_per_shift_pattern
 
-    def initialize
-      @leave_year_start_date = calculate_leave_year_start_date
-    end
-
-    def start_date=(date)
-      @start_date = date
-      @leave_year_start_date = calculate_leave_year_start_date
-    end
-
-    def leaving_date=(date)
-      @leaving_date = date
-      @leave_year_start_date = calculate_leave_year_start_date
-    end
+    def initialize; end
 
     def hours_per_week=(hours)
       @hours_per_week = BigDecimal(hours, 10)
@@ -191,6 +179,8 @@ module SmartAnswer::Calculators
   private
 
     def calculate_leave_year_start_date
+      return leave_year_start_date if leave_year_start_date.present?
+
       worked_partial_year? ? start_date : Time.zone.today
     end
 
@@ -217,11 +207,11 @@ module SmartAnswer::Calculators
     end
 
     def leave_year_range
-      SmartAnswer::YearRange.resetting_on(leave_year_start_date).including(date_calc)
+      SmartAnswer::YearRange.resetting_on(calculate_leave_year_start_date).including(date_calc)
     end
 
     def date_calc
-      return leave_year_start_date if worked_full_year?
+      return calculate_leave_year_start_date if worked_full_year?
 
       return leaving_date if leaving_date
 

--- a/test/flows/calculate_your_holiday_entitlement_flow_test.rb
+++ b/test/flows/calculate_your_holiday_entitlement_flow_test.rb
@@ -317,7 +317,7 @@ class CalculateYourHolidayEntitlementFlowTest < ActiveSupport::TestCase
         assert_next_node :annualised_done
       end
 
-      should "have a next node of :shift_worker? for shift workers" do
+      should "have a next node of :shift_worker_hours_per_shift? for shift workers" do
         add_responses regular_or_irregular_hours?: "regular",
                       basis_of_calculation?: "shift-worker",
                       shift_worker_basis?: "starting-and-leaving",

--- a/test/flows/calculate_your_holiday_entitlement_flow_test.rb
+++ b/test/flows/calculate_your_holiday_entitlement_flow_test.rb
@@ -327,6 +327,15 @@ class CalculateYourHolidayEntitlementFlowTest < ActiveSupport::TestCase
                       calculation_period?: "leaving"
         assert_next_node :shift_worker_hours_per_shift?
       end
+
+      should "have a next node of :how_many_hours_per_week? for irregular hours with leave start date before 1st April 2024" do
+        add_responses regular_or_irregular_hours?: "irregular-hours-and-part-year",
+                      when_does_your_leave_year_start?: "2024-01-01",
+                      basis_of_calculation?: "compressed-hours",
+                      calculation_period?: "leaving",
+                      what_is_your_leaving_date?: "2024-07-05"
+        assert_next_node :how_many_hours_per_week?
+      end
     end
   end
 

--- a/test/flows/calculate_your_holiday_entitlement_flow_test.rb
+++ b/test/flows/calculate_your_holiday_entitlement_flow_test.rb
@@ -328,13 +328,40 @@ class CalculateYourHolidayEntitlementFlowTest < ActiveSupport::TestCase
         assert_next_node :shift_worker_hours_per_shift?
       end
 
-      should "have a next node of :how_many_hours_per_week? for irregular hours with leave start date before 1st April 2024" do
+      should "have a next node of :how_many_hours_per_week? for compressed-hours irregular-hours workers" do
         add_responses regular_or_irregular_hours?: "irregular-hours-and-part-year",
                       when_does_your_leave_year_start?: "2024-01-01",
                       basis_of_calculation?: "compressed-hours",
                       calculation_period?: "leaving",
                       what_is_your_leaving_date?: "2024-07-05"
         assert_next_node :how_many_hours_per_week?
+      end
+
+      should "have a next node of :how_many_hours_per_week? for hours-worked-per-week irregular-hours workers" do
+        add_responses regular_or_irregular_hours?: "irregular-hours-and-part-year",
+                      when_does_your_leave_year_start?: "2024-01-01",
+                      basis_of_calculation?: "hours-worked-per-week",
+                      calculation_period?: "leaving",
+                      what_is_your_leaving_date?: "2024-07-05"
+        assert_next_node :how_many_hours_per_week?
+      end
+
+      should "have a next node of :how_many_days_per_week? for days-worked-per-week irregular-hours workers" do
+        add_responses regular_or_irregular_hours?: "irregular-hours-and-part-year",
+                      when_does_your_leave_year_start?: "2024-01-01",
+                      basis_of_calculation?: "days-worked-per-week",
+                      calculation_period?: "starting",
+                      what_is_your_starting_date?: "2024-03-01"
+        assert_next_node :how_many_days_per_week?
+      end
+
+      should "have a next node of :annualised_done for annualised-hours irregular-hours workers" do
+        add_responses regular_or_irregular_hours?: "irregular-hours-and-part-year",
+                      when_does_your_leave_year_start?: "2024-01-01",
+                      basis_of_calculation?: "annualised-hours",
+                      calculation_period?: "leaving",
+                      what_is_your_leaving_date?: "2024-07-05"
+        assert_next_node :annualised_done
       end
     end
   end


### PR DESCRIPTION
Fixes issue in holiday entitlement where users would be stuck on enter leave year start date

The introduction of this question earlier in the flow caused the users to get stuck on this question when they were input irregular hours. It now does not override the leave year start date if it is explicitly set by the flow.

[Trello card](https://trello.com/c/xaZRnVDF)
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
