### PR TITLE
Redirect Marriage Abroad start page to new flow

### DIFF
--- a/app/flows/marriage_abroad_flow/start.erb
+++ b/app/flows/marriage_abroad_flow/start.erb
@@ -1,5 +1,5 @@
 <% text_for :title do %>
-  Getting married abroad
+  Getting married or registering a civil partnership abroad
 <% end %>
 
 <% text_for :meta_description do %>

--- a/app/presenters/flow_presenter.rb
+++ b/app/presenters/flow_presenter.rb
@@ -55,7 +55,9 @@ class FlowPresenter
   end
 
   def start_page_link(forwarding_responses)
-    if response_store
+    if @flow.name.eql? "marriage-abroad" # Nasty hack to allow migration of old service to new one. Will be stripped asap
+      "https://www.prove-eligibility-foreign-government.service.gov.uk/before-you-start/which-country-are-you-getting-married-in"
+    elsif response_store
       start_flow_path(name, params: forwarding_responses)
     else
       smart_answer_path(name)

--- a/test/unit/flow_presenter_test.rb
+++ b/test/unit/flow_presenter_test.rb
@@ -141,4 +141,15 @@ class FlowPresenterTest < ActiveSupport::TestCase
   test "#start_page_link returns the start page link for a non response store flow" do
     assert_equal "/flow-name/y", @flow_presenter.start_page_link({ "key" => "value" })
   end
+
+  test "#start_page_link returns the new flow when we're in marriage-abroad" do
+    @flow = SmartAnswer::Flow.build do
+      name "marriage-abroad"
+    end
+    @flow_presenter = FlowPresenter.new(@flow, nil)
+    assert_equal(
+      "https://www.prove-eligibility-foreign-government.service.gov.uk/before-you-start/which-country-are-you-getting-married-in",
+      @flow_presenter.start_page_link({ "key" => "value" }),
+    )
+  end
 end


### PR DESCRIPTION
We can't simply unpublish the old start page as this would remove the entire flow as well - something we don't want to do. As a mitigation, the old start page will now redirect to the new flow until the migration is complete.

The heading has been updated to match the new flow.

This must be stripped out ASAP when migration is complete as highest priority.

https://trello.com/c/trq5xjK4/265-get-married-abroad-redirect-the-current-start-page-github-to-the-new-one-via-mainstream

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
