### PR TITLE
Ensure double quotes are used for GA4 JSON

### DIFF
--- a/app/views/smart_answers/custom_result.html.erb
+++ b/app/views/smart_answers/custom_result.html.erb
@@ -19,13 +19,13 @@
   <div
     class="govuk-grid-column-two-thirds"
     data-module="ga4-auto-tracker"
-    data-ga4-auto='{
+    data-ga4-auto="<%= {
       "event_name": "form_complete",
       "type": "smart answer",
-      "section": "<%= outcome.title %>",
+      "section": outcome.title,
       "action": "complete",
-      "tool_name": "<%= @presenter.title %>"
-    }'
+      "tool_name": @presenter.title
+    }.to_json %>"
   >
     <%= render "govuk_publishing_components/components/title", {
       title: outcome.title,

--- a/app/views/smart_answers/custom_result_full_width.erb
+++ b/app/views/smart_answers/custom_result_full_width.erb
@@ -26,13 +26,13 @@
   data-track-action="Completed"
   data-track-label="<%= @name %>"
   data-track-options='{"nonInteraction": true}'
-  data-ga4-auto='{
+  data-ga4-auto="<%={
     "event_name": "form_complete",
     "type": "smart answer",
-    "section": "<%= title %>",
+    "section": title,
     "action": "complete",
-    "tool_name": "<%= @presenter.title %>"
-  }'
+    "tool_name":  @presenter.title
+  }.to_json %>"
 >
   <%= render 'smart_answers/shared/debug' %>
   <%= render "govuk_publishing_components/components/title", {
@@ -46,13 +46,13 @@
     data-module="gem-track-click ga4-link-tracker"
     data-track-category="Internal Link Clicked"
     data-track-action="<%= @name %> results"
-    data-ga4-link='{
-      "event_name": "information_click", 
+    data-ga4-link="<%= {
+      "event_name": "information_click",
       "type": "smart answer",
-      "section": "<%= title %>", 
+      "section": title,
       "action": "information_click",
-      "tool_name": "<%= @presenter.title %>" 
-    }'
+      "tool_name": @presenter.title
+    }.to_json %>"
     data-ga4-track-links-only
     data-ga4-set-indexes
     data-track-links-only

--- a/app/views/smart_answers/result.html.erb
+++ b/app/views/smart_answers/result.html.erb
@@ -24,13 +24,13 @@
     data-track-action="Completed"
     data-track-label="<%= @name %>"
     data-track-options='{"nonInteraction": true}'
-    data-ga4-auto='{
+    data-ga4-auto="<%= {
       "event_name": "form_complete",
       "type": "smart answer",
-      "section": "<%= title %>",
+      "section": title,
       "action": "complete",
-      "tool_name": "<%= @presenter.title %>"
-    }'
+      "tool_name": @presenter.title
+    }.to_json %>"
     data-ecommerce-start-index="1"
     data-list-title="<%= @presenter.title %>"
     data-ga4-ecommerce-start-index="1"
@@ -48,13 +48,13 @@
       data-module="gem-track-click ga4-link-tracker"
       data-track-category="Internal Link Clicked"
       data-track-action="<%= @name %> results"
-      data-ga4-link='{
-      "event_name": "information_click",
-      "type": "smart answer",
-      "section": "<%= title %>",
-      "action": "information click",
-      "tool_name": "<%= @presenter.title %>"
-    }'
+      data-ga4-link="<%= {
+        "event_name": "information_click",
+        "type": "smart answer",
+        "section": title,
+        "action": "information click",
+        "tool_name": @presenter.title
+      }.to_json %>"
     data-ga4-track-links-only
     data-ga4-set-indexes
       data-track-links-only


### PR DESCRIPTION
Prevents JSON errors when a string within the JSON is using a single quote. E.g. if a text value was `It's a nice day` or this page: http://127.0.0.1:3010/check-building-safety-costs/y/yes/no/no/no/post_feb_2022/2020/140000.0/no/no/1500.0

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
