### PR TITLE
Set the canonical URL for the marriage-abroad SA

### DIFF
--- a/app/views/smart_answers/landing.html.erb
+++ b/app/views/smart_answers/landing.html.erb
@@ -7,12 +7,15 @@
     <meta name="description" content="<%= start_node.meta_description %>">
   <% end %>
   <% if content_item.present? %>
+    <% canonical_url = "https://www.gov.uk/marriages-civil-partnerships-abroad" if start_node.node_slug == "marriage-abroad" %>
     <%= render 'govuk_publishing_components/components/machine_readable_metadata',
       schema: :article,
-      content_item: content_item %>
+      content_item: content_item,
+      canonical_url: %>
     <%= render 'govuk_publishing_components/components/machine_readable_metadata',
       schema: :government_service,
-      content_item: content_item %>
+      content_item: content_item,
+      canonical_url: %>
   <% end %>
   <link title="Search" rel="search" type="application/opensearchdescription+xml" href="/search/opensearch.xml"/>
 <% end %>


### PR DESCRIPTION
During the migration of this Smart Answer to FCDO, its start page is now
 a duplicate of the newly-created one in Mainstream Publisher. To aid
 search engines in resolving this, set a "canonical URL" link in the
 Smart Answer start page to that of the Mainstream Publisher-managed one.

Since we don't have access to the "content ID" within the start page
 (landing) template, use the slug to identify when it is being rendered
 for the marriage abroad Smart Answer.

The setting of a `canonical_url` variable, which is then passed to the
 render calls of the `machine_readable_metadata` component, is
 necessary, as if that variable is "inlined" no canonical URL link tag
 appears in the generated HTML.

This is a temporary hack—once the migration is complete (expected to be
 in approximately 6–8 weeks), the marriage abroad Smart Answer will be
 retired and then this change should be reverted.

I haven't identified a way to write a test for this change, which is why
 there aren't any tests.

[Trello ticket](https://trello.com/c/eUqUWQEi)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
