### PR TITLE
Update pat leave calculations for NI

### DIFF
--- a/app/flows/maternity_paternity_calculator_flow.rb
+++ b/app/flows/maternity_paternity_calculator_flow.rb
@@ -27,7 +27,7 @@ class MaternityPaternityCalculatorFlow < SmartAnswer::Flow
         when "maternity"
           question :baby_due_date_maternity?
         when "paternity"
-          question :leave_or_pay_for_adoption?
+          question :where_does_the_employee_live?
         when "adoption"
           question :taking_paternity_or_maternity_leave_for_adoption?
         end

--- a/app/flows/maternity_paternity_calculator_flow/adoption_calculator_flow.rb
+++ b/app/flows/maternity_paternity_calculator_flow/adoption_calculator_flow.rb
@@ -8,7 +8,7 @@ class MaternityPaternityCalculatorFlow < SmartAnswer::Flow
         next_node do |response|
           case response
           when "paternity"
-            question :employee_date_matched_paternity_adoption?
+            question :where_does_the_employee_live?
           when "maternity"
             question :adoption_is_from_overseas?
           end

--- a/app/flows/maternity_paternity_calculator_flow/outcomes/_paternity_not_entitled_to_pay_outro.erb
+++ b/app/flows/maternity_paternity_calculator_flow/outcomes/_paternity_not_entitled_to_pay_outro.erb
@@ -1,4 +1,1 @@
-Send them form SPP1 confirming this within 28 days of their pay request.
-
-
-[Download form SPP1, refusing Statutory Paternity Pay](/government/publications/ordinary-statutory-paternity-pay-non-payment-explanation-ospp1).
+Send them [form SPP1](/government/publications/ordinary-statutory-paternity-pay-non-payment-explanation-ospp1) confirming this within 28 days of their pay request.

--- a/app/flows/maternity_paternity_calculator_flow/paternity_calculator_flow.rb
+++ b/app/flows/maternity_paternity_calculator_flow/paternity_calculator_flow.rb
@@ -3,7 +3,28 @@ class MaternityPaternityCalculatorFlow < SmartAnswer::Flow
     def define
       days_of_the_week = SmartAnswer::Calculators::MaternityPayCalculator::DAYS_OF_THE_WEEK
 
-      ## QP0
+      ## QP1
+      radio :where_does_the_employee_live? do
+        option "england"
+        option "scotland"
+        option "wales"
+        option "northern_ireland"
+
+        on_response do |response|
+          self.where_does_the_employee_live = response
+        end
+
+        next_node do
+          case leave_type
+          when "paternity"
+            question :leave_or_pay_for_adoption?
+          when "adoption"
+            question :employee_date_matched_paternity_adoption?
+          end
+        end
+      end
+
+      ## QP2
       radio :leave_or_pay_for_adoption? do
         option :yes
         option :no
@@ -18,11 +39,12 @@ class MaternityPaternityCalculatorFlow < SmartAnswer::Flow
         end
       end
 
-      ## QP1
+      ## QP3
       date_question :baby_due_date_paternity? do
         on_response do |response|
           self.due_date = response
           self.calculator = SmartAnswer::Calculators::PaternityPayCalculator.new(due_date)
+          calculator.where_does_the_employee_live = where_does_the_employee_live
         end
 
         next_node do
@@ -30,13 +52,14 @@ class MaternityPaternityCalculatorFlow < SmartAnswer::Flow
         end
       end
 
-      ## QAP1 - Paternity Adoption
+      ## QAP3 - Paternity Adoption
       date_question :employee_date_matched_paternity_adoption? do
         on_response do |response|
           self.matched_date = response
           self.calculator = SmartAnswer::Calculators::PaternityAdoptionPayCalculator.new(matched_date)
           self.leave_type = "paternity_adoption"
           self.paternity_adoption = true
+          calculator.where_does_the_employee_live = where_does_the_employee_live
         end
 
         next_node do
@@ -44,7 +67,7 @@ class MaternityPaternityCalculatorFlow < SmartAnswer::Flow
         end
       end
 
-      ## QP2
+      ## QP4
       date_question :baby_birth_date_paternity? do
         on_response do |response|
           self.date_of_birth = response
@@ -56,7 +79,7 @@ class MaternityPaternityCalculatorFlow < SmartAnswer::Flow
         end
       end
 
-      ## QAP2 - Paternity Adoption
+      ## QAP4 - Paternity Adoption
       date_question :padoption_date_of_adoption_placement? do
         on_response do |response|
           self.ap_adoption_date = response
@@ -74,7 +97,7 @@ class MaternityPaternityCalculatorFlow < SmartAnswer::Flow
         end
       end
 
-      ## QP3
+      ## QP5
       radio :employee_responsible_for_upbringing? do
         option :yes
         option :no
@@ -97,7 +120,7 @@ class MaternityPaternityCalculatorFlow < SmartAnswer::Flow
         end
       end
 
-      ## QAP3 - Paternity Adoption
+      ## QAP5 - Paternity Adoption
       radio :padoption_employee_responsible_for_upbringing? do
         option :yes
         option :no
@@ -119,7 +142,7 @@ class MaternityPaternityCalculatorFlow < SmartAnswer::Flow
         end
       end
 
-      ## QP4 - Shared flow onwards
+      ## QP6 - Shared flow onwards
       radio :employee_work_before_employment_start? do
         option :yes
         option :no
@@ -138,7 +161,7 @@ class MaternityPaternityCalculatorFlow < SmartAnswer::Flow
         end
       end
 
-      ## QP5
+      ## QP7
       radio :employee_has_contract_paternity? do
         option :yes
         option :no
@@ -152,7 +175,7 @@ class MaternityPaternityCalculatorFlow < SmartAnswer::Flow
         end
       end
 
-      ## QP6
+      ## QP8
       radio :employee_on_payroll_paternity? do
         option :yes
         option :no
@@ -186,7 +209,7 @@ class MaternityPaternityCalculatorFlow < SmartAnswer::Flow
         end
       end
 
-      ## QP7
+      ## QP9
       radio :employee_still_employed_on_birth_date? do
         option :yes
         option :no
@@ -204,7 +227,7 @@ class MaternityPaternityCalculatorFlow < SmartAnswer::Flow
         end
       end
 
-      ## QP8
+      ## QP10
       date_question :employee_start_paternity? do
         on_response do |response|
           self.employee_leave_start = response
@@ -226,7 +249,7 @@ class MaternityPaternityCalculatorFlow < SmartAnswer::Flow
         end
       end
 
-      ## QP9
+      ## QP11
       radio :employee_paternity_length? do
         option :one_week
         option :two_weeks
@@ -246,7 +269,7 @@ class MaternityPaternityCalculatorFlow < SmartAnswer::Flow
         end
       end
 
-      ## QP10
+      ## QP12
       date_question :last_normal_payday_paternity? do
         on_response do |response|
           calculator.last_payday = response
@@ -261,7 +284,7 @@ class MaternityPaternityCalculatorFlow < SmartAnswer::Flow
         end
       end
 
-      ## QP11
+      ## QP13
       date_question :payday_eight_weeks_paternity? do
         on_response do |response|
           calculator.pre_offset_payday = response + 1.day
@@ -278,7 +301,7 @@ class MaternityPaternityCalculatorFlow < SmartAnswer::Flow
         end
       end
 
-      ## QP12
+      ## QP14
       radio :pay_frequency_paternity? do
         option :weekly
         option :every_2_weeks
@@ -294,7 +317,7 @@ class MaternityPaternityCalculatorFlow < SmartAnswer::Flow
         end
       end
 
-      ## QP13
+      ## QP15
       money_question :earnings_for_pay_period_paternity? do
         on_response do |response|
           self.earnings = response
@@ -316,7 +339,7 @@ class MaternityPaternityCalculatorFlow < SmartAnswer::Flow
         end
       end
 
-      ## QP14
+      ## QP16
       radio :how_do_you_want_the_spp_calculated? do
         option :weekly_starting
         option :usual_paydates
@@ -336,7 +359,7 @@ class MaternityPaternityCalculatorFlow < SmartAnswer::Flow
         end
       end
 
-      ## QP15 - Also shared with adoption calculator here onwards
+      ## QP17 - Also shared with adoption calculator here onwards
       date_question :next_pay_day_paternity? do
         on_response do |response|
           self.next_pay_day = response
@@ -348,7 +371,7 @@ class MaternityPaternityCalculatorFlow < SmartAnswer::Flow
         end
       end
 
-      ## QP16
+      ## QP18
       radio :monthly_pay_paternity? do
         option :first_day_of_the_month
         option :last_day_of_the_month
@@ -376,7 +399,7 @@ class MaternityPaternityCalculatorFlow < SmartAnswer::Flow
         end
       end
 
-      ## QP17
+      ## QP19
       value_question :specific_date_each_month_paternity?, parse: :to_i do
         on_response do |response|
           calculator.pay_day_in_month = response
@@ -395,7 +418,7 @@ class MaternityPaternityCalculatorFlow < SmartAnswer::Flow
         end
       end
 
-      ## QP18
+      ## QP20
       checkbox_question :days_of_the_week_paternity? do
         (0...days_of_the_week.size).each { |i| option i.to_s.to_sym }
 
@@ -413,7 +436,7 @@ class MaternityPaternityCalculatorFlow < SmartAnswer::Flow
         end
       end
 
-      ## QP19
+      ## QP21
       radio :day_of_the_month_paternity? do
         option :"0"
         option :"1"
@@ -433,7 +456,7 @@ class MaternityPaternityCalculatorFlow < SmartAnswer::Flow
         end
       end
 
-      ## QP20
+      ## QP22
       radio :pay_date_options_paternity? do
         option :first
         option :second

--- a/app/flows/maternity_paternity_calculator_flow/questions/employee_paternity_length.erb
+++ b/app/flows/maternity_paternity_calculator_flow/questions/employee_paternity_length.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% govspeak_for :body do %>
-  The last day of leave the employee will be eligible for statutory paternity pay is <%= calculator.paternity_deadline.strftime("%d-%m-%Y") %>.
+  The last day of leave the employee will be eligible for statutory paternity pay is <%= calculator.paternity_deadline.strftime("%d %B %Y") %>.
   If their leave falls outside this period, this calculator may not be accurate and you'll need to use your payroll software or [calculate payments manually](/guidance/statutory-paternity-pay-manually-calculate-your-employees-payments).
 <% end %>
 

--- a/app/flows/maternity_paternity_calculator_flow/questions/where_does_the_employee_live.erb
+++ b/app/flows/maternity_paternity_calculator_flow/questions/where_does_the_employee_live.erb
@@ -1,0 +1,10 @@
+<% text_for :title do %>
+  Where does the employee live?
+<% end %>
+
+<% options(
+  "england": "England",
+  "scotland": "Scotland",
+  "wales": "Wales",
+  "northern_ireland": "Northern Ireland"
+) %>

--- a/app/flows/maternity_paternity_calculator_flow/shared_adoption_maternity_paternity_flow.rb
+++ b/app/flows/maternity_paternity_calculator_flow/shared_adoption_maternity_paternity_flow.rb
@@ -5,7 +5,7 @@ class MaternityPaternityCalculatorFlow < SmartAnswer::Flow
 
       # This question is being used in:
       # QM8 in MaternityCalculatorFlow
-      # QP13 in PaternityCalculatorFlow
+      # QP16 in PaternityCalculatorFlow
       # QA10 in AdoptionCalculatorFlow
       radio :how_many_payments_weekly? do
         payment_options[:weekly].each_key do |payment_option|
@@ -30,7 +30,7 @@ class MaternityPaternityCalculatorFlow < SmartAnswer::Flow
 
       # This question is being used in:
       # QM8 in MaternityCalculatorFlow
-      # QP13 in PaternityCalculatorFlow
+      # QP16 in PaternityCalculatorFlow
       # QA10 in AdoptionCalculatorFlow
       radio :how_many_payments_every_2_weeks? do
         payment_options[:every_2_weeks].each_key do |payment_option|
@@ -55,7 +55,7 @@ class MaternityPaternityCalculatorFlow < SmartAnswer::Flow
 
       # This question is being used in:
       # QM8 in MaternityCalculatorFlow
-      # QP13 in PaternityCalculatorFlow
+      # QP16 in PaternityCalculatorFlow
       # QA10 in AdoptionCalculatorFlow
       radio :how_many_payments_every_4_weeks? do
         payment_options[:every_4_weeks].each_key do |payment_option|
@@ -80,7 +80,7 @@ class MaternityPaternityCalculatorFlow < SmartAnswer::Flow
 
       # This question is being used in:
       # QM8 in MaternityCalculatorFlow
-      # QP13 in PaternityCalculatorFlow
+      # QP16 in PaternityCalculatorFlow
       # QA10 in AdoptionCalculatorFlow
       radio :how_many_payments_monthly? do
         payment_options[:monthly].each_key do |payment_option|

--- a/app/flows/maternity_paternity_calculator_flow/start.erb
+++ b/app/flows/maternity_paternity_calculator_flow/start.erb
@@ -12,8 +12,6 @@
   + Statutory Maternity Pay (SMP), paternity pay, adoption pay
   + relevant employment period and average weekly earnings
   + leave period
-
-  There are [different rules for paternity leave if you’re in Northern Ireland](https://www.nidirect.gov.uk/articles/paternity-leave).
 <% end %>
 
 <% govspeak_for :post_body do %>
@@ -21,8 +19,8 @@
 
   + the baby’s due date
   + date of birth - for paternity
-  + your employee’s salary details, eg weekly rates of pay
-  + the dates for adoption, eg match date and date of placement
+  + your employee’s salary details, for example their weekly rates of pay
+  + the dates for adoption, for example their match date and date of placement
 
 
   You can’t use the calculator for:

--- a/lib/smart_answer/calculators/paternity_adoption_pay_calculator.rb
+++ b/lib/smart_answer/calculators/paternity_adoption_pay_calculator.rb
@@ -20,7 +20,7 @@ module SmartAnswer::Calculators
     end
 
     def paternity_deadline
-      deadline_period = if adoption_placement_date < Date.new(2024, 4, 6)
+      deadline_period = if employee_lives_in_northern_ireland? || adoption_placement_date < Date.new(2024, 4, 6)
                           55.days
                         else
                           364.days
@@ -33,7 +33,7 @@ module SmartAnswer::Calculators
     end
 
     def leave_must_be_taken_consecutively?
-      adoption_placement_date <= Date.new(2024, 4, 5)
+      employee_lives_in_northern_ireland? || adoption_placement_date <= Date.new(2024, 4, 5)
     end
   end
 end

--- a/lib/smart_answer/calculators/paternity_pay_calculator.rb
+++ b/lib/smart_answer/calculators/paternity_pay_calculator.rb
@@ -1,6 +1,6 @@
 module SmartAnswer::Calculators
   class PaternityPayCalculator < MaternityPayCalculator
-    attr_accessor :paternity_leave_duration
+    attr_accessor :paternity_leave_duration, :where_does_the_employee_live
 
     def initialize(due_date, leave_type = "paternity")
       super(due_date, leave_type)
@@ -13,7 +13,7 @@ module SmartAnswer::Calculators
     end
 
     def paternity_deadline
-      deadline_period = if due_date <= Date.new(2024, 4, 6)
+      deadline_period = if employee_lives_in_northern_ireland? || due_date <= Date.new(2024, 4, 6)
                           55.days
                         else
                           364.days
@@ -23,7 +23,7 @@ module SmartAnswer::Calculators
     end
 
     def leave_must_be_taken_consecutively?
-      due_date <= Date.new(2024, 4, 6)
+      employee_lives_in_northern_ireland? || due_date <= Date.new(2024, 4, 6)
     end
 
     def paternity_pay_week_and_pay
@@ -35,6 +35,10 @@ module SmartAnswer::Calculators
     end
 
   private
+
+    def employee_lives_in_northern_ireland?
+      where_does_the_employee_live == "northern_ireland"
+    end
 
     def rate_for(date)
       awe = (average_weekly_earnings.to_f * 0.9).round(2)

--- a/test/flows/maternity_paternity_calculator_flow/adoption_calculator_flow_test.rb
+++ b/test/flows/maternity_paternity_calculator_flow/adoption_calculator_flow_test.rb
@@ -19,8 +19,8 @@ class MaternityPaternityCalculatorFlow::AdoptionCalculatorFlowTest < ActiveSuppo
     end
 
     context "next_node" do
-      should "have a next node of employee_date_matched_paternity_adoption? for a 'paternity' response" do
-        assert_next_node :employee_date_matched_paternity_adoption?, for_response: "paternity"
+      should "have a next node of where_does_the_employee_live? for a 'paternity' response" do
+        assert_next_node :where_does_the_employee_live?, for_response: "paternity"
       end
 
       should "have a next node of adoption_is_from_overseas? for a 'maternity' response" do

--- a/test/flows/maternity_paternity_calculator_flow/paternity_calculator_flow_test.rb
+++ b/test/flows/maternity_paternity_calculator_flow/paternity_calculator_flow_test.rb
@@ -328,7 +328,7 @@ class MaternityPaternityCalculatorFlow::PaternityCalculatorFlowTest < ActiveSupp
       end
 
       should "render the updated paternity deadline" do
-        assert_rendered_question text: "The last day of leave the employee will be eligible for statutory paternity pay is 06-04-2025"
+        assert_rendered_question text: "The last day of leave the employee will be eligible for statutory paternity pay is 06 April 2025"
       end
     end
 

--- a/test/flows/maternity_paternity_calculator_flow/paternity_calculator_flow_test.rb
+++ b/test/flows/maternity_paternity_calculator_flow/paternity_calculator_flow_test.rb
@@ -8,10 +8,38 @@ class MaternityPaternityCalculatorFlow::PaternityCalculatorFlowTest < ActiveSupp
 
   setup { testing_flow MaternityPaternityCalculatorFlow }
 
+  context "question: where_does_the_employee_live?" do
+    setup do
+      testing_node :where_does_the_employee_live?
+    end
+
+    should "render the question" do
+      add_responses what_type_of_leave?: "paternity"
+
+      assert_rendered_question
+    end
+
+    context "next_node" do
+      should "have a next node of leave_or_pay_for_adoption? for any response when employee is taking paternity leave" do
+        add_responses what_type_of_leave?: "paternity"
+
+        assert_next_node :leave_or_pay_for_adoption?, for_response: "scotland"
+      end
+
+      should "have a next node of leave_or_pay_for_adoption? for any response when employee is taking paternity adoption leave" do
+        add_responses what_type_of_leave?: "adoption",
+                      taking_paternity_or_maternity_leave_for_adoption?: "paternity"
+
+        assert_next_node :employee_date_matched_paternity_adoption?, for_response: "scotland"
+      end
+    end
+  end
+
   context "question: leave_or_pay_for_adoption?" do
     setup do
       testing_node :leave_or_pay_for_adoption?
-      add_responses what_type_of_leave?: "paternity"
+      add_responses what_type_of_leave?: "paternity",
+                    where_does_the_employee_live?: "wales"
     end
 
     should "render the question" do
@@ -33,6 +61,7 @@ class MaternityPaternityCalculatorFlow::PaternityCalculatorFlowTest < ActiveSupp
     setup do
       testing_node :baby_due_date_paternity?
       add_responses what_type_of_leave?: "paternity",
+                    where_does_the_employee_live?: "wales",
                     leave_or_pay_for_adoption?: "no"
     end
 
@@ -51,6 +80,7 @@ class MaternityPaternityCalculatorFlow::PaternityCalculatorFlowTest < ActiveSupp
     setup do
       testing_node :employee_date_matched_paternity_adoption?
       add_responses what_type_of_leave?: "paternity",
+                    where_does_the_employee_live?: "wales",
                     leave_or_pay_for_adoption?: "yes"
     end
 
@@ -69,6 +99,7 @@ class MaternityPaternityCalculatorFlow::PaternityCalculatorFlowTest < ActiveSupp
     setup do
       testing_node :baby_birth_date_paternity?
       add_responses what_type_of_leave?: "paternity",
+                    where_does_the_employee_live?: "wales",
                     leave_or_pay_for_adoption?: "no",
                     baby_due_date_paternity?: "2020-11-01"
     end
@@ -88,6 +119,7 @@ class MaternityPaternityCalculatorFlow::PaternityCalculatorFlowTest < ActiveSupp
     setup do
       testing_node :padoption_date_of_adoption_placement?
       add_responses what_type_of_leave?: "paternity",
+                    where_does_the_employee_live?: "wales",
                     leave_or_pay_for_adoption?: "yes",
                     employee_date_matched_paternity_adoption?: "2020-11-01"
     end
@@ -107,6 +139,7 @@ class MaternityPaternityCalculatorFlow::PaternityCalculatorFlowTest < ActiveSupp
     setup do
       testing_node :employee_responsible_for_upbringing?
       add_responses what_type_of_leave?: "paternity",
+                    where_does_the_employee_live?: "wales",
                     leave_or_pay_for_adoption?: "no",
                     baby_due_date_paternity?: "2020-11-01",
                     baby_birth_date_paternity?: "2020-11-01"
@@ -131,6 +164,7 @@ class MaternityPaternityCalculatorFlow::PaternityCalculatorFlowTest < ActiveSupp
     setup do
       testing_node :padoption_employee_responsible_for_upbringing?
       add_responses what_type_of_leave?: "paternity",
+                    where_does_the_employee_live?: "wales",
                     leave_or_pay_for_adoption?: "yes",
                     employee_date_matched_paternity_adoption?: "2020-11-01",
                     padoption_date_of_adoption_placement?: "2020-11-01"
@@ -292,6 +326,7 @@ class MaternityPaternityCalculatorFlow::PaternityCalculatorFlowTest < ActiveSupp
       setup do
         add_responses paternity_responses(up_to: :employee_start_paternity?, due_date: "2024-04-07")
       end
+
       should "render the updated paternity deadline" do
         assert_rendered_question text: "The last day of leave the employee will be eligible for statutory paternity pay is 06-04-2025"
       end

--- a/test/flows/maternity_paternity_calculator_flow_test.rb
+++ b/test/flows/maternity_paternity_calculator_flow_test.rb
@@ -22,8 +22,8 @@ class MaternityPaternityCalculatorFlowTest < ActiveSupport::TestCase
         assert_next_node :baby_due_date_maternity?, for_response: "maternity"
       end
 
-      should "have a next node of leave_or_pay_for_adoption? for a 'paternity' response" do
-        assert_next_node :leave_or_pay_for_adoption?, for_response: "paternity"
+      should "have a next node of where_does_the_employee_live? for a 'paternity' response" do
+        assert_next_node :where_does_the_employee_live?, for_response: "paternity"
       end
 
       should "have a next node of taking_paternity_or_maternity_leave_for_adoption? for a 'adoption' response" do

--- a/test/support/flows/maternity_paternity_calculator_flow_test_helper.rb
+++ b/test/support/flows/maternity_paternity_calculator_flow_test_helper.rb
@@ -32,6 +32,7 @@ module MaternityPaternityCalculatorFlowTestHelper
     payday_eight_weeks = payday_eight_weeks ? Date.parse(payday_eight_weeks) : due_date - 6.months
 
     responses = { what_type_of_leave?: "paternity",
+                  where_does_the_employee_live?: "wales",
                   leave_or_pay_for_adoption?: "no",
                   baby_due_date_paternity?: due_date.to_s,
                   baby_birth_date_paternity?: due_date.to_s,
@@ -102,6 +103,7 @@ module MaternityPaternityCalculatorFlowTestHelper
     payday_eight_weeks = payday_eight_weeks ? Date.parse(payday_eight_weeks) : placement_date - 6.months
 
     responses = { what_type_of_leave?: "paternity",
+                  where_does_the_employee_live?: "wales",
                   leave_or_pay_for_adoption?: "yes",
                   employee_date_matched_paternity_adoption?: match_date.to_s,
                   padoption_date_of_adoption_placement?: placement_date.to_s,

--- a/test/unit/calculators/paternity_adoption_pay_calculator_test.rb
+++ b/test/unit/calculators/paternity_adoption_pay_calculator_test.rb
@@ -4,12 +4,12 @@ module SmartAnswer::Calculators
   class PaternityAdoptionPayCalculatorTest < ActiveSupport::TestCase
     context PaternityAdoptionPayCalculator do
       context "#paternity_deadline" do
-        context "deadline is 55 days ahead" do
+        context "placement date is on or before 5 April 2024" do
           setup do
             @placement_date = Date.parse("5 April 2024")
           end
 
-          should "give paternity deadline based on placement date" do
+          should "set the paternity deadline to 55 days after the placement date" do
             match_date = Date.parse("01 March 2024")
             calculator = PaternityAdoptionPayCalculator.new(match_date)
             calculator.adoption_placement_date = @placement_date
@@ -18,12 +18,12 @@ module SmartAnswer::Calculators
           end
         end
 
-        context "deadline is 364 days ahead" do
+        context "placement date is on or after 6 April 2024" do
           setup do
             @placement_date = Date.parse("6 April 2024")
           end
 
-          should "give paternity deadline based on placement date" do
+          should "set the paternity deadline to 364 days after the placement date" do
             match_date = Date.parse("01 March 2024")
             calculator = PaternityAdoptionPayCalculator.new(match_date)
             calculator.adoption_placement_date = @placement_date

--- a/test/unit/calculators/paternity_adoption_pay_calculator_test.rb
+++ b/test/unit/calculators/paternity_adoption_pay_calculator_test.rb
@@ -9,12 +9,15 @@ module SmartAnswer::Calculators
             @placement_date = Date.parse("5 April 2024")
           end
 
-          should "set the paternity deadline to 55 days after the placement date" do
-            match_date = Date.parse("01 March 2024")
-            calculator = PaternityAdoptionPayCalculator.new(match_date)
-            calculator.adoption_placement_date = @placement_date
+          %w[england scotland wales northern_ireland].each do |location|
+            should "set the paternity deadline to 55 days after the placement date when employee lives in #{location}" do
+              match_date = Date.parse("01 March 2024")
+              calculator = PaternityAdoptionPayCalculator.new(match_date)
+              calculator.adoption_placement_date = @placement_date
+              calculator.where_does_the_employee_live = location
 
-            assert_equal Date.parse("30-05-2024"), calculator.paternity_deadline
+              assert_equal Date.parse("30-05-2024"), calculator.paternity_deadline
+            end
           end
         end
 
@@ -23,29 +26,63 @@ module SmartAnswer::Calculators
             @placement_date = Date.parse("6 April 2024")
           end
 
-          should "set the paternity deadline to 364 days after the placement date" do
+          %w[england scotland wales].each do |location|
+            should "set the paternity deadline to 364 days after the placement date when employee lives in #{location}" do
+              match_date = Date.parse("01 March 2024")
+              calculator = PaternityAdoptionPayCalculator.new(match_date)
+              calculator.adoption_placement_date = @placement_date
+              calculator.where_does_the_employee_live = location
+
+              assert_equal Date.parse("05-04-2025"), calculator.paternity_deadline
+            end
+          end
+
+          should "set the paternity deadline to 55 days after the placement date when employee lives in northern_ireland" do
             match_date = Date.parse("01 March 2024")
             calculator = PaternityAdoptionPayCalculator.new(match_date)
             calculator.adoption_placement_date = @placement_date
+            calculator.where_does_the_employee_live = "northern_ireland"
 
-            assert_equal Date.parse("05-04-2025"), calculator.paternity_deadline
+            assert_equal Date.parse("31-05-2024"), calculator.paternity_deadline
           end
         end
       end
 
       context "#leave_must_be_taken_consecutively?" do
-        should "be false when adoption placement date is 6 April 2024 (or after)" do
-          calculator = PaternityAdoptionPayCalculator.new(Date.parse("1 April 2024"))
-          calculator.adoption_placement_date = Date.parse("6 April 2024")
+        context "placement date is 6 April 2024 (or after)" do
+          setup do
+            @calculator = PaternityAdoptionPayCalculator.new(Date.parse("1 April 2024"))
+            @calculator.adoption_placement_date = Date.parse("6 April 2024")
+          end
 
-          assert_equal false, calculator.leave_must_be_taken_consecutively?
+          %w[england scotland wales].each do |location|
+            should "be false when employee lives in #{location}" do
+              @calculator.where_does_the_employee_live = location
+
+              assert_equal false, @calculator.leave_must_be_taken_consecutively?
+            end
+          end
+
+          should "be true when employee lives in northern_ireland" do
+            @calculator.where_does_the_employee_live = "northern_ireland"
+
+            assert_equal true, @calculator.leave_must_be_taken_consecutively?
+          end
         end
 
-        should "be true when adoption placement date is before 6 April 2024" do
-          calculator = PaternityAdoptionPayCalculator.new(Date.parse("1 April 2024"))
-          calculator.adoption_placement_date = Date.parse("5 April 2024")
+        context "placement date is before 6 April 2024" do
+          setup do
+            @calculator = PaternityAdoptionPayCalculator.new(Date.parse("1 April 2024"))
+            @calculator.adoption_placement_date = Date.parse("5 April 2024")
+          end
 
-          assert_equal true, calculator.leave_must_be_taken_consecutively?
+          %w[england scotland wales northern_ireland].each do |location|
+            should "be true when employee lives in #{location} " do
+              @calculator.where_does_the_employee_live = location
+
+              assert_equal true, @calculator.leave_must_be_taken_consecutively?
+            end
+          end
         end
       end
     end

--- a/test/unit/calculators/paternity_pay_calculator_test.rb
+++ b/test/unit/calculators/paternity_pay_calculator_test.rb
@@ -79,16 +79,40 @@ module SmartAnswer::Calculators
             @calculator = PaternityPayCalculator.new(due_date)
           end
 
-          should "set the paternity deadline to 55 days after the due date when the baby is born prematurely" do
-            @calculator.date_of_birth = Date.parse("4 April 2024")
+          context "employee lives in England/Scotland/Wales" do
+            setup do
+              @calculator.where_does_the_employee_live = "england"
+            end
 
-            assert_equal Date.parse("31-05-2024"), @calculator.paternity_deadline
+            should "set the paternity deadline to 55 days after the due date when the baby is born prematurely" do
+              @calculator.date_of_birth = Date.parse("4 April 2024")
+
+              assert_equal Date.parse("31-05-2024"), @calculator.paternity_deadline
+            end
+
+            should "set the paternity deadline to 55 days after the birth date when the baby is born late" do
+              @calculator.date_of_birth = Date.parse("8 April 2024")
+
+              assert_equal Date.parse("02-06-2024"), @calculator.paternity_deadline
+            end
           end
 
-          should "set the paternity deadline to 55 days after the birth date when the baby is born late" do
-            @calculator.date_of_birth = Date.parse("8 April 2024")
+          context "employee lives in Northern Ireland" do
+            setup do
+              @calculator.where_does_the_employee_live = "northern_ireland"
+            end
 
-            assert_equal Date.parse("02-06-2024"), @calculator.paternity_deadline
+            should "set the paternity deadline to 55 days after the due date when the baby is born prematurely" do
+              @calculator.date_of_birth = Date.parse("4 April 2024")
+
+              assert_equal Date.parse("31-05-2024"), @calculator.paternity_deadline
+            end
+
+            should "set the paternity deadline to 55 days after the birth date when the baby is born late" do
+              @calculator.date_of_birth = Date.parse("8 April 2024")
+
+              assert_equal Date.parse("02-06-2024"), @calculator.paternity_deadline
+            end
           end
         end
 
@@ -98,31 +122,83 @@ module SmartAnswer::Calculators
             @calculator = PaternityPayCalculator.new(due_date)
           end
 
-          should "set the paternity deadline to 364 days after the due date when the baby is born prematurely" do
-            @calculator.date_of_birth = Date.parse("4 April 2024")
+          context "employee lives in England/Scotland/Wales" do
+            setup do
+              @calculator.where_does_the_employee_live = "england"
+            end
 
-            assert_equal Date.parse("06-04-2025"), @calculator.paternity_deadline
+            should "set the paternity deadline to 364 days after the due date when the baby is born prematurely" do
+              @calculator.date_of_birth = Date.parse("4 April 2024")
+
+              assert_equal Date.parse("06-04-2025"), @calculator.paternity_deadline
+            end
+
+            should "set the paternity to 364 days after the birth date when the baby is born late" do
+              @calculator.date_of_birth = Date.parse("8 April 2024")
+
+              assert_equal Date.parse("07-04-2025"), @calculator.paternity_deadline
+            end
           end
 
-          should "set the paternity to 364 days after the birth date when the baby is born late" do
-            @calculator.date_of_birth = Date.parse("8 April 2024")
+          context "employee lives in Northern Ireland" do
+            setup do
+              @calculator.where_does_the_employee_live = "northern_ireland"
+            end
 
-            assert_equal Date.parse("07-04-2025"), @calculator.paternity_deadline
+            should "set the paternity deadline to 55 days after the due date when the baby is born prematurely" do
+              @calculator.date_of_birth = Date.parse("4 April 2024")
+
+              assert_equal Date.parse("01-06-2024"), @calculator.paternity_deadline
+            end
+
+            should "set the paternity deadline to 55 days after the birth date when the baby is born late" do
+              @calculator.date_of_birth = Date.parse("8 April 2024")
+
+              assert_equal Date.parse("02-06-2024"), @calculator.paternity_deadline
+            end
           end
         end
       end
 
       context "#leave_must_be_taken_consecutively?" do
-        should "be false when due date is after 6 April 2024" do
-          calculator = PaternityPayCalculator.new(Date.parse("7 April 2024"))
+        context "employee lives in England/Scotland/Wales" do
+          setup do
+            @employee_location = "england"
+          end
 
-          assert_equal false, calculator.leave_must_be_taken_consecutively?
+          should "be false when due date is after 6 April 2024" do
+            calculator = PaternityPayCalculator.new(Date.parse("7 April 2024"))
+            calculator.where_does_the_employee_live = @employee_location
+
+            assert_equal false, calculator.leave_must_be_taken_consecutively?
+          end
+
+          should "be true when due date is 6 April 2024 (or before)" do
+            calculator = PaternityPayCalculator.new(Date.parse("6 April 2024"))
+            calculator.where_does_the_employee_live = @employee_location
+
+            assert_equal true, calculator.leave_must_be_taken_consecutively?
+          end
         end
 
-        should "be true when due date is 6 April 2024 (or before)" do
-          calculator = PaternityPayCalculator.new(Date.parse("6 April 2024"))
+        context "employee lives in Northern Ireland" do
+          setup do
+            @employee_location = "northern_ireland"
+          end
 
-          assert_equal true, calculator.leave_must_be_taken_consecutively?
+          should "be true when due date is after 6 April 2024" do
+            calculator = PaternityPayCalculator.new(Date.parse("7 April 2024"))
+            calculator.where_does_the_employee_live = @employee_location
+
+            assert_equal true, calculator.leave_must_be_taken_consecutively?
+          end
+
+          should "be true when due date is 6 April 2024 (or before)" do
+            calculator = PaternityPayCalculator.new(Date.parse("6 April 2024"))
+            calculator.where_does_the_employee_live = @employee_location
+
+            assert_equal true, calculator.leave_must_be_taken_consecutively?
+          end
         end
       end
     end

--- a/test/unit/calculators/paternity_pay_calculator_test.rb
+++ b/test/unit/calculators/paternity_pay_calculator_test.rb
@@ -73,43 +73,41 @@ module SmartAnswer::Calculators
       end
 
       context "#paternity_deadline" do
-        context "deadline is 55 days ahead" do
+        context "due date is on or before 6 April 2024" do
           setup do
-            @due_date = Date.parse("6 April 2024")
+            due_date = Date.parse("6 April 2024")
+            @calculator = PaternityPayCalculator.new(due_date)
           end
 
-          should "give paternity deadline based on due date when baby is born prematurely" do
-            calculator = PaternityPayCalculator.new(@due_date)
-            calculator.date_of_birth = Date.parse("4 April 2024")
+          should "set the paternity deadline to 55 days after the due date when the baby is born prematurely" do
+            @calculator.date_of_birth = Date.parse("4 April 2024")
 
-            assert_equal Date.parse("31-05-2024"), calculator.paternity_deadline
+            assert_equal Date.parse("31-05-2024"), @calculator.paternity_deadline
           end
 
-          should "give paternity deadline based on actual birth date when baby is born late" do
-            calculator = PaternityPayCalculator.new(@due_date)
-            calculator.date_of_birth = Date.parse("8 April 2024")
+          should "set the paternity deadline to 55 days after the birth date when the baby is born late" do
+            @calculator.date_of_birth = Date.parse("8 April 2024")
 
-            assert_equal Date.parse("02-06-2024"), calculator.paternity_deadline
+            assert_equal Date.parse("02-06-2024"), @calculator.paternity_deadline
           end
         end
 
-        context "deadline is 364 days ahead" do
+        context "due date is on or after 7 April 2024" do
           setup do
-            @due_date = Date.parse("7 April 2024")
+            due_date = Date.parse("7 April 2024")
+            @calculator = PaternityPayCalculator.new(due_date)
           end
 
-          should "give paternity deadline based on due date when baby is born prematurely" do
-            calculator = PaternityPayCalculator.new(@due_date)
-            calculator.date_of_birth = Date.parse("4 April 2024")
+          should "set the paternity deadline to 364 days after the due date when the baby is born prematurely" do
+            @calculator.date_of_birth = Date.parse("4 April 2024")
 
-            assert_equal Date.parse("06-04-2025"), calculator.paternity_deadline
+            assert_equal Date.parse("06-04-2025"), @calculator.paternity_deadline
           end
 
-          should "give paternity deadline based on actual birth date when baby is born late" do
-            calculator = PaternityPayCalculator.new(@due_date)
-            calculator.date_of_birth = Date.parse("8 April 2024")
+          should "set the paternity to 364 days after the birth date when the baby is born late" do
+            @calculator.date_of_birth = Date.parse("8 April 2024")
 
-            assert_equal Date.parse("07-04-2025"), calculator.paternity_deadline
+            assert_equal Date.parse("07-04-2025"), @calculator.paternity_deadline
           end
         end
       end


### PR DESCRIPTION
Update the paternity leave calculator to handle employees living in Northern Ireland.

The rules for employees living in Scotland, England, and Wales changed at the start of the new tax year in 2024. However, these changes do NOT apply to employees living in Northern Ireland. Update the calculator to handle Northern Ireland employees by inserting a new question into the flow (in two places—one for the paternity leave flow, and one for paternity adoption leave flow).

There are also a few minor text changes.

[Trello ticket](https://trello.com/c/VOJzBgOh)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
