### PR TITLE
Move from Uglifier to Terser

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,8 +22,8 @@ gem "rails-i18n"
 gem "railties"
 gem "slimmer"
 gem "sprockets-rails"
+gem "terser"
 gem "tilt"
-gem "uglifier"
 gem "uk_postcode"
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,7 +119,7 @@ GEM
     domain_name (0.6.20240107)
     drb (2.2.1)
     erubi (1.12.0)
-    execjs (2.8.1)
+    execjs (2.9.1)
     faraday (2.9.0)
       faraday-net_http (>= 2.0, < 3.2)
     faraday-multipart (1.0.4)
@@ -644,13 +644,13 @@ GEM
       sprockets (>= 3.0.0)
     statsd-ruby (1.5.0)
     stringio (3.1.0)
+    terser (1.2.2)
+      execjs (>= 0.3.0, < 3)
     thor (1.3.1)
     tilt (2.3.0)
     timeout (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    uglifier (4.2.0)
-      execjs (>= 0.3.0, < 3)
     uk_postcode (2.1.8)
     unicode-display_width (2.5.0)
     uri (0.13.0)
@@ -717,8 +717,8 @@ DEPENDENCIES
   simplecov-rcov
   slimmer
   sprockets-rails
+  terser
   tilt
-  uglifier
   uk_postcode
   webmock
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -25,7 +25,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
   # Compress JavaScripts.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = :terser
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false


### PR DESCRIPTION
## What

Use Terser instead of Uglifier to compile JavaScript.

## Why

This change is preparation for upgrading to V5 of govuk-frontend in the govuk-publishing-components gem.

govuk-frontend v5 now targets browsers that support ES6. This means that the UMD modules used in govuk_publsihing_components from govuk-frontend use features of ES6 and so it means that Uglifier can't be used anymore because it only supports ES5.

[Trello card](https://trello.com/c/lnPFryyC/2562-prep-for-51-move-fe-applications-from-uglifier-to-terser-l)

## Further info

### JS Size

| minifier | file | minified JS | minified JS (gzip) |
| --- | --- | --- | --- |
| uglifer |  smart-answers/application.js | 92.4KB | 17.4KB |
| terser |  smart-answers/application.js | 92.6KB | 17.4KB |

### Browser testing

I've tested the changes on Integration using the browsers below, functionality works as expected without any console errors.

- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] IE11
