### PR TITLE
Use type=module for application.js

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -194,7 +194,7 @@ GEM
     govuk_personalisation (0.16.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (41.1.1)
+    govuk_publishing_components (42.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,7 +28,7 @@
     <%= stylesheet_link_tag "application", :media => "all" %>
     <%= javascript_include_tag "test-dependencies" if Rails.env.test? %>
     <%= javascript_include_tag "es6-components", type: "module" %>
-    <%= javascript_include_tag "application", defer: true %>
+    <%= javascript_include_tag "application", defer: true, type: "module" %>
     <%= yield :head %>
     <% if content_item %>
       <%= render "govuk_publishing_components/components/meta_tags",

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,7 +26,7 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= stylesheet_link_tag "application", :media => "all" %>
-    <%= javascript_include_tag "test-dependencies" if Rails.env.test? %>
+    <%= javascript_include_tag "test-dependencies", type: "module" if Rails.env.test? %>
     <%= javascript_include_tag "es6-components", type: "module" %>
     <%= javascript_include_tag "application", defer: true, type: "module" %>
     <%= yield :head %>


### PR DESCRIPTION
## What / Why
- Use type=module for this application's JS file
- To coincide with https://github.com/alphagov/govuk_publishing_components/pull/4111
- Has [DO NOT MERGE] as we want the above PR live on `static` first before this is merged.
- We will combine `es6-components.js` again as a separate task unless you disagree with this
- To accurately test this you will need to use local static that is using a local version the `govuk_publishing_components` branch linked above. If you test without this, this app's `application.js` seems to crash.
- Trello card: https://trello.com/c/Hoa45SMD/141-turn-off-javascript-in-legacy-browsers