### PR TITLE
Update winter fuel payments eligibility calculation

### DIFF
--- a/config/smart_answers/check_benefits_financial_support_data.yml
+++ b/config/smart_answers/check_benefits_financial_support_data.yml
@@ -227,10 +227,10 @@
         - england
     - name: winter_fuel_payment
       title: Winter Fuel Payment
-      description: <p>You'll automatically get a Winter Fuel Payment if you’re getting the State Pension. You may have to apply if you've reached State Pension age but are not getting your State Pension, for example because you deferred it. This winter the amount you’ll get will include a ‘Pensioner Cost of Living Payment’.</p>
+      description: <p>You'll automatically get a Winter Fuel Payment if you get Pension Credit or certain benefits. You should get a letter in October or November telling you how much you'll get, if you’re eligible.</p>
       condition: eligible_for_winter_fuel_payment?
-      url: /winter-fuel-payment
-      url_text: Check if you're eligible and whether you need to apply for a Winter Fuel Payment
+      url: /winter-fuel-payment/how-to-claim
+      url_text: If you do not get a letter, check if you're eligible and whether you need to claim a Winter Fuel Payment
       countries:
         - england
         - wales

--- a/lib/smart_answer/calculators/check_benefits_financial_support_calculator.rb
+++ b/lib/smart_answer/calculators/check_benefits_financial_support_calculator.rb
@@ -230,7 +230,16 @@ module SmartAnswer::Calculators
     end
 
     def eligible_for_winter_fuel_payment?
-      @over_state_pension_age == "yes"
+      return false if @where_do_you_live == "scotland"
+      return false unless @over_state_pension_age == "yes"
+      return false if @on_benefits == "no"
+      return true if @on_benefits == "dont_know"
+
+      qualifying_benefits = %w[universal_credit jobseekers_allowance employment_and_support_allowance pension_credit income_support]
+      qualifying_benefits.each do |benefit|
+        return true if @current_benefits.include?(benefit)
+      end
+      false
     end
 
     def eligible_for_carers_allowance?

--- a/test/flows/check_benefits_financial_support_flow_test.rb
+++ b/test/flows/check_benefits_financial_support_flow_test.rb
@@ -637,7 +637,7 @@ class CheckBenefitsFinancialSupportFlowTest < ActiveSupport::TestCase
     end
 
     should "render Winter Fuel Payment" do
-      %w[england wales northern-ireland scotland].each do |country|
+      %w[england wales northern-ireland].each do |country|
         add_responses where_do_you_live: country, over_state_pension_age: "yes"
 
         assert_rendered_outcome text: "Winter Fuel Payment"

--- a/test/flows/check_benefits_financial_support_flow_test.rb
+++ b/test/flows/check_benefits_financial_support_flow_test.rb
@@ -641,7 +641,7 @@ class CheckBenefitsFinancialSupportFlowTest < ActiveSupport::TestCase
         add_responses where_do_you_live: country, over_state_pension_age: "yes"
 
         assert_rendered_outcome text: "Winter Fuel Payment"
-        assert_rendered_outcome text: "You'll automatically get a Winter Fuel Payment if you’re getting the State Pension."
+        assert_rendered_outcome text: "You'll automatically get a Winter Fuel Payment if you get Pension Credit or certain benefits."
       end
     end
 


### PR DESCRIPTION
Update the logic for deciding whether someone is eligible for the winter fuel payment. Instead of merely being eligible by virtue of being over state pension age, you must now:

- live in England, Northern Ireland or Wales (not Scotland)
- be on at least one qualifying benefit.

Also updates the outcome text for winter fuel payments.

[Trello card](https://trello.com/c/QB8Q2m4v)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
