### PR TITLE
Update late payment interest rate

### DIFF
--- a/lib/smart_answer/calculators/self_assessment_penalties.rb
+++ b/lib/smart_answer/calculators/self_assessment_penalties.rb
@@ -55,7 +55,8 @@ module SmartAnswer::Calculators
       { start_date: "2023-04-13", end_date: "2023-05-30", value: 0.0675 },
       { start_date: "2023-05-31", end_date: "2023-07-10", value: 0.07 },
       { start_date: "2023-07-11", end_date: "2023-08-21", value: 0.075 },
-      { start_date: "2023-08-22", end_date: "2100-04-04", value: 0.0775 },
+      { start_date: "2023-08-22", end_date: "2024-08-19", value: 0.0775 },
+      { start_date: "2024-08-20", end_date: "2100-04-04", value: 0.075 },
     ].freeze
 
     def tax_year_range

--- a/test/unit/calculators/self_assessment_penalties_test.rb
+++ b/test/unit/calculators/self_assessment_penalties_test.rb
@@ -313,10 +313,10 @@ module SmartAnswer::Calculators
           assert_equal 5695, @calculator.total_owed
           @calculator.payment_date = Date.parse("2025-02-03")
           assert_equal 750, @calculator.late_payment_penalty
-          assert_equal 6140, @calculator.total_owed
+          assert_equal 6134, @calculator.total_owed
           @calculator.payment_date = Date.parse("2025-08-03")
           assert_equal 750, @calculator.late_payment_penalty
-          assert_equal 6332, @calculator.total_owed
+          assert_equal 6320, @calculator.total_owed
         end
 
         context "HMRC Covid-19 Extension to 1 April for 2019-20" do
@@ -443,10 +443,10 @@ module SmartAnswer::Calculators
     end
 
     context "late payment interest rates" do
-      should "after May 31st, the user should have a late payment penalty of 7.75%" do
-        @calculator.payment_date = Date.parse("2024-06-1")
-        assert_equal 250, @calculator.late_payment_penalty
-        assert_equal 128.46, @calculator.interest.to_f
+      should "user should have a late payment penalty of 7.5% after August 19th 2024" do
+        @calculator.payment_date = Date.parse("2024-08-20")
+        assert_equal 500, @calculator.late_payment_penalty
+        assert_equal 213.39, @calculator.interest.to_f
       end
     end
   end


### PR DESCRIPTION
Interest rate for late payment penalty for self assessment is changing from after 20th August 2024, its going down from 7.75% to 7.5%

details are in [Trello:](https://trello.com/c/wRb7OoFK/285-change-interest-rate-in-estimate-your-penalty-for-late-self-assessment-tax-returns-and-payments)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
