### PR TITLE
Erb lint update

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -1,0 +1,40 @@
+---
+EnableDefaultLinters: false
+glob: "**/*.{html,text,js}{+*,}.erb"
+exclude:
+  - '**/vendor/**/*'
+  - '**/node_modules/**/*'
+linters:
+  SpaceAroundErbTag:
+    enabled: true
+  Rubocop:
+    enabled: true
+    exclude:
+      - "**/vendor/**/*"
+      - "**/vendor/**/.*"
+      - "bin/**"
+      - "db/**/*"
+      - "spec/**/*"
+      - "config/**/*"
+      - "node_modules/**/*"
+    rubocop_config:
+      inherit_from:
+        - .rubocop.yml
+      AllCops:
+        DisabledByDefault: true
+      Layout/InitialIndentation:
+        Enabled: false
+      Layout/TrailingEmptyLines:
+        Enabled: false
+      Layout/TrailingWhitespace:
+        Enabled: false
+      Naming/FileName:
+        Enabled: false
+      Style/FrozenStringLiteralComment:
+        Enabled: false
+      Layout/LineLength:
+        Enabled: false
+      Lint/UselessAssignment:
+        Enabled: false
+      Layout/FirstHashElementIndentation:
+        Enabled: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,10 @@ jobs:
     name: Lint Ruby
     uses: alphagov/govuk-infrastructure/.github/workflows/rubocop.yml@main
 
+  lint-erb:
+    name: Lint Ruby
+    uses: alphagov/govuk-infrastructure/.github/workflows/erblint.yml@main
+
   test-javascript:
     name: Test JavaScript
     uses: alphagov/govuk-infrastructure/.github/workflows/jasmine.yml@main

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem "rails", "7.1.3.4"
 gem "ast"
 gem "bootsnap", require: false
 gem "dartsass-rails"
+gem "erb_lint"
 gem "gds-api-adapters"
 gem "gds_zendesk"
 gem "govspeak"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,13 @@ GEM
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
       rouge (>= 1.0.0)
+    better_html (2.1.1)
+      actionview (>= 6.0)
+      activesupport (>= 6.0)
+      ast (~> 2.0)
+      erubi (~> 1.4)
+      parser (>= 2.4)
+      smart_properties
     bigdecimal (3.1.8)
     binding_of_caller (1.0.1)
       debug_inspector (>= 1.2.0)
@@ -118,6 +125,13 @@ GEM
     docile (1.4.0)
     domain_name (0.6.20240107)
     drb (2.2.1)
+    erb_lint (0.6.0)
+      activesupport
+      better_html (>= 2.0.1)
+      parser (>= 2.7.1.4)
+      rainbow
+      rubocop (>= 1)
+      smart_properties
     erubi (1.13.0)
     execjs (2.9.1)
     faker (3.4.1)
@@ -639,6 +653,7 @@ GEM
       plek (>= 1.1.0)
       rack (>= 3.0)
       rest-client
+    smart_properties (1.17.0)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -692,6 +707,7 @@ DEPENDENCIES
   bootsnap
   byebug
   dartsass-rails
+  erb_lint
   gds-api-adapters
   gds_zendesk
   govspeak

--- a/app/views/components/_result_card.html.erb
+++ b/app/views/components/_result_card.html.erb
@@ -13,7 +13,7 @@
     text: title,
     heading_level: 2,
     margin_bottom: 2,
-    font_size: "m"
+    font_size: "m",
   } %>
 
   <% if description %>
@@ -25,6 +25,6 @@
   <%= link_to url_text, url,
   class: "govuk-link app-c-result-card__link",
   data: {
-    "ga4-ecommerce-path": url.delete_prefix("https://www.gov.uk")
+    "ga4-ecommerce-path": url.delete_prefix("https://www.gov.uk"),
   } %>
 </div>

--- a/app/views/components/_result_sections.html.erb
+++ b/app/views/components/_result_sections.html.erb
@@ -16,7 +16,7 @@
         <%= render "components/result_item", {
           highlighted: highlighted,
           group_index: group_index,
-          result_index: result_index
+          result_index: result_index,
         }.merge(result.symbolize_keys) %>
         <% result_index += 1 %>
       <% end %>

--- a/app/views/components/check_uk_visa/_result_card.html.erb
+++ b/app/views/components/check_uk_visa/_result_card.html.erb
@@ -30,7 +30,7 @@
             <%= render "govuk_publishing_components/components/heading", {
               text: calculator.visa_attribute_statement(attribute&.first),
               heading_level: 3,
-              font_size: "s"
+              font_size: "s",
             } %>
 
             <% attribute.each do |k| %>
@@ -53,8 +53,7 @@
   <% end %>
 
   <p class="govuk-body govuk-!-margin-bottom-0">
-    <%= link_to "Find out more about the #{type}", url, 
-      class: "govuk-link app-c-result-card__link"
-    %>
+    <%= link_to "Find out more about the #{type}", url,
+      class: "govuk-link app-c-result-card__link" %>
   </p>
 </div>

--- a/app/views/smart_answers/custom_result.html.erb
+++ b/app/views/smart_answers/custom_result.html.erb
@@ -24,12 +24,11 @@
       "type": "smart answer",
       "section": outcome.title,
       "action": "complete",
-      "tool_name": @presenter.title
-    }.to_json %>"
-  >
+      "tool_name": @presenter.title,
+    }.to_json %>">
     <%= render "govuk_publishing_components/components/title", {
       title: outcome.title,
-      margin_bottom: 6
+      margin_bottom: 6,
     } %>
 
     <%= outcome.description %>
@@ -41,7 +40,7 @@
         text: "Change your answers",
         font_size: "l",
         border_top: 2,
-        padding: true
+        padding: true,
       } %>
 
       <%= tag.p class: "govuk-body govuk-!-margin-bottom-8" do %>
@@ -51,8 +50,8 @@
       <% end %>
     </div>
 
-    <%= render 'govuk_publishing_components/components/print_link' %>
+    <%= render "govuk_publishing_components/components/print_link" %>
 
-    <%= render 'smart_answers/shared/debug' %>
+    <%= render "smart_answers/shared/debug" %>
   </div>
 </div>

--- a/app/views/smart_answers/index.html.erb
+++ b/app/views/smart_answers/index.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <%= render "govuk_publishing_components/components/title", {
-      title: "Smart Answers"
+      title: "Smart Answers",
     } %>
 
     <div class="smart-answers-list">
@@ -22,9 +22,9 @@
             { text: flow.questions.count },
             { text: flow.outcomes.count },
             { text: code_links(flow.class) },
-            { text: link_to('Visualise', visualise_path(flow.name), class: "govuk-link") },
+            { text: link_to("Visualise", visualise_path(flow.name), class: "govuk-link") },
           ]
-        end
+        end,
       } %>
     </div>
 

--- a/app/views/smart_answers/inputs/_checkbox_question.html.erb
+++ b/app/views/smart_answers/inputs/_checkbox_question.html.erb
@@ -8,5 +8,5 @@
   id: "response",
   error: question.error,
   hint_text: question.hint,
-  items: question.checkboxes
+  items: question.checkboxes,
 } %>

--- a/app/views/smart_answers/inputs/_country_select_question.html.erb
+++ b/app/views/smart_answers/inputs/_country_select_question.html.erb
@@ -5,5 +5,5 @@
   heading_size: "l",
   is_page_heading: true,
   error_message: question.error,
-  options: question.select_options
+  options: question.select_options,
 } %>

--- a/app/views/smart_answers/inputs/_date_question.html.erb
+++ b/app/views/smart_answers/inputs/_date_question.html.erb
@@ -27,8 +27,8 @@
         id: "response-2",
         width: 4,
         value: question.parsed_response[:year],
-      }
-    ].compact
+      },
+    ].compact,
   } %>
 <% end %>
 
@@ -37,5 +37,5 @@
   legend_text: question.title,
   heading_level: 1,
   heading_size: "l",
-  text: form_contents
+  text: form_contents,
 } %>

--- a/app/views/smart_answers/inputs/_money_question.html.erb
+++ b/app/views/smart_answers/inputs/_money_question.html.erb
@@ -2,7 +2,7 @@
 <%= render "govuk_publishing_components/components/input", {
   label: {
     text: question.title,
-    is_page_heading: true
+    is_page_heading: true,
   },
   name: "response",
   id: "response",
@@ -12,5 +12,5 @@
   suffix: question.suffix_label,
   value: question.current_response,
   error_message: question.error,
-  prefix: question.prefix_label
+  prefix: question.prefix_label,
 } %>

--- a/app/views/smart_answers/inputs/_postcode_question.html.erb
+++ b/app/views/smart_answers/inputs/_postcode_question.html.erb
@@ -2,7 +2,7 @@
 <%= render "govuk_publishing_components/components/input", {
   label: {
     text: question.title,
-    is_page_heading: true
+    is_page_heading: true,
   },
   name: "response",
   id: "response",

--- a/app/views/smart_answers/inputs/_radio_question.html.erb
+++ b/app/views/smart_answers/inputs/_radio_question.html.erb
@@ -10,5 +10,5 @@
   id_prefix: "response",
   description: question.body,
   error_message: question.error,
-  items: question.radio_buttons
+  items: question.radio_buttons,
 } %>

--- a/app/views/smart_answers/inputs/_radio_with_intro_question.html.erb
+++ b/app/views/smart_answers/inputs/_radio_with_intro_question.html.erb
@@ -14,5 +14,5 @@
   heading_level: 2,
   id_prefix: "response",
   error_message: question.error,
-  items: question.radio_buttons
+  items: question.radio_buttons,
 } %>

--- a/app/views/smart_answers/inputs/_salary_question.html.erb
+++ b/app/views/smart_answers/inputs/_salary_question.html.erb
@@ -2,7 +2,7 @@
 <%= render "govuk_publishing_components/components/input", {
   label: {
     text: question.title,
-    is_page_heading: true
+    is_page_heading: true,
   },
   name: "response[amount]",
   id: "response",
@@ -11,7 +11,7 @@
   hint: question.hint,
   suffix: "£",
   error_message: question.error,
-  value: question.parsed_response[:amount]
+  value: question.parsed_response[:amount],
 } %>
 <%= render "govuk_publishing_components/components/select", {
   id: "response_month",
@@ -22,17 +22,17 @@
     {
       text: "per week",
       value: "week",
-      selected: question.parsed_response[:period] == "week"
+      selected: question.parsed_response[:period] == "week",
     },
     {
       text: "per month",
       value: "month",
-      selected: question.parsed_response[:period] == "month"
+      selected: question.parsed_response[:period] == "month",
     },
     {
       text: "per year",
       value: "year",
-      selected: question.parsed_response[:period] == "year"
-    }
-  ]
+      selected: question.parsed_response[:period] == "year",
+    },
+  ],
 } %>

--- a/app/views/smart_answers/inputs/_value_question.html.erb
+++ b/app/views/smart_answers/inputs/_value_question.html.erb
@@ -2,7 +2,7 @@
 <%= render "govuk_publishing_components/components/input", {
   label: {
     text: question.title,
-    is_page_heading: true
+    is_page_heading: true,
   },
   name: "response",
   id: "response",
@@ -12,5 +12,5 @@
   suffix: question.suffix_label,
   value: question.current_response,
   error_message: question.error,
-  prefix: question.prefix_label
+  prefix: question.prefix_label,
 } %>

--- a/app/views/smart_answers/inputs/_year_question.html.erb
+++ b/app/views/smart_answers/inputs/_year_question.html.erb
@@ -7,14 +7,14 @@
     error_message: question.error,
     hint: question.hint,
     items: [
-       {
-        label: "Year",
-        name: "response[year]",
-        id: "response",
-        width: 4,
-        value: question.parsed_response[:year],
-      }
-    ]
+      {
+       label: "Year",
+       name: "response[year]",
+       id: "response",
+       width: 4,
+       value: question.parsed_response[:year],
+     },
+    ],
   } %>
 <% end %>
 
@@ -23,5 +23,5 @@
   legend_text: question.title,
   heading_level: 1,
   heading_size: "l",
-  text: form_contents
+  text: form_contents,
 } %>

--- a/app/views/smart_answers/landing.html.erb
+++ b/app/views/smart_answers/landing.html.erb
@@ -8,26 +8,26 @@
   <% end %>
   <% if content_item.present? %>
     <% canonical_url = "https://www.gov.uk/marriages-civil-partnerships-abroad" if start_node.node_slug == "marriage-abroad" %>
-    <%= render 'govuk_publishing_components/components/machine_readable_metadata',
+    <%= render "govuk_publishing_components/components/machine_readable_metadata",
       schema: :article,
       content_item: content_item,
       canonical_url: %>
-    <%= render 'govuk_publishing_components/components/machine_readable_metadata',
+    <%= render "govuk_publishing_components/components/machine_readable_metadata",
       schema: :government_service,
       content_item: content_item,
       canonical_url: %>
   <% end %>
-  <link title="Search" rel="search" type="application/opensearchdescription+xml" href="/search/opensearch.xml"/>
+  <link title="Search" rel="search" type="application/opensearchdescription+xml" href="/search/opensearch.xml">
 <% end %>
 
 <% content_for :breadcrumbs do %>
-  <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: content_item %>
+  <%= render "govuk_publishing_components/components/contextual_breadcrumbs", content_item: content_item %>
 <% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/title", {
-      title: start_node.title
+      title: start_node.title,
     } %>
   </div>
 </div>
@@ -44,15 +44,15 @@
           rel: "nofollow",
           start: true,
           data_attributes: {
-            module: 'ga4-link-tracker',
+            module: "ga4-link-tracker",
             ga4_link: {
               event_name: "form_start",
               type: "smart answer",
               section: "start page",
               action: "start",
               tool_name: start_node.title,
-            }
-          }
+            },
+          },
         } %>
       </section>
 
@@ -61,7 +61,7 @@
           <div id="before-you-start">
             <%= render "govuk_publishing_components/components/heading", {
               text: start_node.post_body_header,
-              padding: true
+              padding: true,
             } %>
             <%= start_node.post_body %>
           </div>
@@ -69,9 +69,9 @@
       <% end %>
     </article>
 
-    <%= render 'govuk_publishing_components/components/contextual_footer', content_item: content_item %>
+    <%= render "govuk_publishing_components/components/contextual_footer", content_item: content_item %>
   </div>
   <div class="govuk-grid-column-one-third">
-    <%= render 'govuk_publishing_components/components/contextual_sidebar', content_item: content_item %>
+    <%= render "govuk_publishing_components/components/contextual_sidebar", content_item: content_item %>
   </div>
 </div>

--- a/app/views/smart_answers/question.html.erb
+++ b/app/views/smart_answers/question.html.erb
@@ -6,7 +6,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render 'smart_answers/shared/debug' %>
+    <%= render "smart_answers/shared/debug" %>
     <%
       ga4_attributes = {
         event_name: "form_response",
@@ -31,22 +31,22 @@
             id: "error-summary",
             title: "There is a problem",
             data_attributes: {
-              module: 'ga4-auto-tracker',
+              module: "ga4-auto-tracker",
               ga4_auto: {
-                event_name: 'form_error',
-                type: 'smart answer',
+                event_name: "form_error",
+                type: "smart answer",
                 text: question.error,
                 section: question.title,
-                action: 'error',
+                action: "error",
                 tool_name: @presenter.title,
               },
             },
             items: [
               {
                 text: question.error,
-                href: question.error_id(question.partial_template_name)
-              }
-            ]
+                href: question.error_id(question.partial_template_name),
+              },
+            ],
           } %>
         <% end %>
 
@@ -54,24 +54,24 @@
 
         <%= content_tag(:div, question.post_body, class: "govuk-!-margin-bottom-4") if question.post_body.present? %>
 
-        <% controller_name == 'flow' && response_store.forwarding_responses.each do |name, value| %>
+        <% controller_name == "flow" && response_store.forwarding_responses.each do |name, value| %>
           <% if value.kind_of?(Array) %>
             <% value.each do |item| %>
-              <input type="hidden" name="<%= name %>[]" value="<%= item %>" />
+              <input type="hidden" name="<%= name %>[]" value="<%= item %>">
             <% end %>
           <% else %>
-            <input type="hidden" name="<%= name %>" value="<%= value %>" />
+            <input type="hidden" name="<%= name %>" value="<%= value %>">
           <% end %>
         <% end %>
 
-        <input type="hidden" name="next" value="1" />
+        <input type="hidden" name="next" value="1">
         <%= render "govuk_publishing_components/components/button", {
           text: "Continue",
-          margin_bottom: true
+          margin_bottom: true,
         } %>
       </div>
     <% end %>
 
-    <%= render 'smart_answers/shared/previous_answers', form_complete: false %>
+    <%= render "smart_answers/shared/previous_answers", form_complete: false %>
   </div>
 </div>

--- a/app/views/smart_answers/result.html.erb
+++ b/app/views/smart_answers/result.html.erb
@@ -25,12 +25,11 @@
       "type": "smart answer",
       "section": title,
       "action": "complete",
-      "tool_name": @presenter.title
+      "tool_name": @presenter.title,
     }.to_json %>"
     data-ga4-ecommerce-start-index="1"
-    data-ga4-list-title="<%= @presenter.title %>"
-  >
-    <%= render 'smart_answers/shared/debug' %>
+    data-ga4-list-title="<%= @presenter.title %>">
+    <%= render "smart_answers/shared/debug" %>
     <%= render "govuk_publishing_components/components/title", {
       title: title,
       context: @presenter.title + ":",
@@ -45,16 +44,15 @@
         "type": "smart answer",
         "section": title,
         "action": "information click",
-        "tool_name": @presenter.title
+        "tool_name": @presenter.title,
       }.to_json %>"
     data-ga4-track-links-only
-    data-ga4-set-indexes
-    >
+    data-ga4-set-indexes>
       <div class="govuk-!-margin-bottom-6">
         <% if outcome.title.present? %>
           <%= render "govuk_publishing_components/components/heading", {
             text: outcome.title,
-            margin_bottom: 6
+            margin_bottom: 6,
           } %>
         <% end %>
 
@@ -65,19 +63,19 @@
         <div class="govuk-!-margin-bottom-6">
           <%= render "govuk_publishing_components/components/heading", {
             text: "Next steps",
-            margin_bottom: 6
+            margin_bottom: 6,
           } %>
           <%= outcome.next_steps %>
         </div>
       <% end %>
     </div>
 
-    <%= render 'smart_answers/shared/previous_answers', form_complete: true %>
+    <%= render "smart_answers/shared/previous_answers", form_complete: true %>
   </div>
 
   <% if defined?(@presenter.finished?) and @presenter.finished? %>
     <div class="govuk-grid-column-one-third govuk-!-margin-top-9">
-      <%= render 'govuk_publishing_components/components/contextual_sidebar', content_item: content_item %>
+      <%= render "govuk_publishing_components/components/contextual_sidebar", content_item: content_item %>
     </div>
   <% end %>
 </div>

--- a/app/views/smart_answers/shared/_debug.html.erb
+++ b/app/views/smart_answers/shared/_debug.html.erb
@@ -3,7 +3,7 @@
     <pre class="application-notice info-notice debug">
       Debug info:
       <% @presenter.state.to_hash.each do |k, v| %>
-        <%= "#{k}: #{v.to_s}"%>
+        <%= "#{k}: #{v.to_s}" %>
       <% end %>
     </pre>
   </article>

--- a/app/views/smart_answers/shared/_previous_answers.html.erb
+++ b/app/views/smart_answers/shared/_previous_answers.html.erb
@@ -4,7 +4,7 @@
     text: "Your answers",
     heading_level: 2,
     font_size: "m",
-    margin_bottom: 4
+    margin_bottom: 4,
   } %>
   <%= tag.p class: "govuk-body" do %>
     <%= link_to "Start again",
@@ -18,7 +18,7 @@
           section: form_complete ? "Information based on your answers" : @presenter.current_node.title,
           action: "start again",
           tool_name: @presenter.title,
-        }
+        },
       } %>
   <% end %>
   <% items = @presenter.answered_questions.map do |question|
@@ -26,7 +26,7 @@
 
     if question.multiple_responses?
       value = render "govuk_publishing_components/components/list", {
-        items: question.response_labels(accepted_response)
+        items: question.response_labels(accepted_response),
       }
     else
       value = question.response_label(accepted_response)
@@ -45,13 +45,13 @@
             section: question.title,
             action: "change response",
             tool_name: @presenter.title,
-          }
-        }
-      }
+          },
+        },
+      },
     }
   end %>
   <%= render "govuk_publishing_components/components/summary_list", {
     wide_title: true,
-    items: items
+    items: items,
   } %>
 <% end %>

--- a/app/views/smart_answers/visualise.html.erb
+++ b/app/views/smart_answers/visualise.html.erb
@@ -1,12 +1,12 @@
 <% content_for :head do %>
 <meta name="robots" content="noindex, nofollow">
-<%= javascript_include_tag 'joint.patch' %>
-<%= javascript_include_tag 'joint' %>
-<%= javascript_include_tag 'joint.layout.DirectedGraph' %>
-<%= javascript_include_tag 'dagre' %>
-<%= javascript_include_tag 'visualise' %>
-<%= stylesheet_link_tag 'joint' %>
-<%= stylesheet_link_tag 'visualise' %>
+<%= javascript_include_tag "joint.patch" %>
+<%= javascript_include_tag "joint" %>
+<%= javascript_include_tag "joint.layout.DirectedGraph" %>
+<%= javascript_include_tag "dagre" %>
+<%= javascript_include_tag "visualise" %>
+<%= stylesheet_link_tag "joint" %>
+<%= stylesheet_link_tag "visualise" %>
 <% end %>
 
 <%# Use of defer is to hoist this JS to head with slimmer, it's totally a hack %>
@@ -16,13 +16,13 @@
 
 <%= render "govuk_publishing_components/components/title", {
   context: "Flow visualisation for",
-  title: @title
+  title: @title,
 } %>
 
 <p class="govuk-body">This is a visualisation of the <%= link_to @title, smart_answer_path(params[:id]) %> questions and outcomes.</p>
 <% if ! @graph_presenter.visualisable? %>
   <%= render "govuk_publishing_components/components/warning_text", {
-    text: "This visualisation does not show all transitions correctly."
+    text: "This visualisation does not show all transitions correctly.",
   } %>
 <% end %>
 
@@ -31,8 +31,8 @@
   text: "Show in landscape",
   margin_bottom: true,
   data_attributes: {
-    click_action: "visualise"
-  }
+    click_action: "visualise",
+  },
 } %>
 
 <div class="visualisation">

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,5 +1,6 @@
 desc "Run all linters"
 task lint: [:environment] do
+  sh "bundle exec erblint --lint-all"
   sh "bundle exec rubocop --parallel"
   sh "yarn run lint"
 end


### PR DESCRIPTION
Currently in most(may be all) of our app there is no linting mechanism for erb files. We want some way of linting erb files and hence we have introduced [erb_lint](https://rubygems.org/gems/erb_lint/versions/0.5.0?locale=en) gem for the same.

The changes in this PR allows us to have a workflow to run erb lint.
All the files that have been linted after running erblint.

When we run the command 'erblint --lint-all' it uses the default '.erb_lint.yml' file inside the project to apply any custom rules.

[**Trello Card**](https://trello.com/c/eaAMsrJ0)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
