### PR TITLE
Move jordan from non visa national to visa national

### DIFF
--- a/app/flows/check_uk_visa_flow/outcomes/jordan/_outcome_marriage_visa_nat_direct_airside_transit_visa.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/jordan/_outcome_marriage_visa_nat_direct_airside_transit_visa.erb
@@ -1,0 +1,30 @@
+<% if calculator.passport_country_is_jordan? && Time.zone.now <= Time.zone.local(2024, 10, 8) %>
+  ## If you want to convert a civil partnership into a marriage
+
+  You do not need a Marriage Visitor visa to [convert your civil partnership into a marriage](/convert-civil-partnership).
+
+  You’ll usually need to apply for a [Standard Visitor visa](/standard-visitor/apply-standard-visitor-visa).
+
+  ###If you’re arriving in the UK before 3pm (UK time) on 8 October 2024
+
+  You may be able to use an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta) to come to the UK if you already have one.
+
+
+  All of the following must apply:
+
+  * you booked and paid for your journey to the UK before 3pm (UK time) on 10 September 2024
+  * you’re arriving in the UK before 3pm (UK time) on 8 October 2024
+  * you meet the [Standard Visitor visa](/standard-visitor) eligibility requirements
+
+  An ETA lets you stay in the UK for up to 6 months.
+
+  If you leave the UK and need to re-enter, you may not be able to use your ETA to return.
+
+  You’ll usually need a Standard Visitor visa to re-enter the UK if either of the following apply:
+
+
+
+  * you did not book your return journey to the UK before 3pm (UK time) on 10 September 2024
+
+  * you’re returning to the UK on or after 3pm (UK time) on 8 October 2024
+<% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/jordan/_outcome_medical_y.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/jordan/_outcome_medical_y.erb
@@ -1,0 +1,37 @@
+<% if calculator.passport_country_is_jordan? && Time.zone.now <= Time.zone.local(2024, 10, 8) %>
+  ##If you’re arriving in the UK before 3pm (UK time) on 8 October 2024
+
+  What you'll need to come to the UK may be different if both the following apply:
+
+  * you booked and paid for your journey to the UK before 3pm (UK time) on 10 September 2024
+  * you’re arriving in the UK before 3pm (UK time) on 8 October 2024
+
+  You can come to the UK with either of the following:
+
+  * a [Standard Visitor visa](/standard-visitor)
+  * an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta), if you already have one
+
+  You must meet the [Standard Visitor visa](/standard-visitor) eligibility requirements even if you have an ETA.
+
+  ^The rules on what you’ll need to enter the UK may be different if you’re [travelling from Ireland, Jersey, Guernsey or the Isle of Man](/guidance/travelling-between-the-uk-and-ireland-isle-of-man-guernsey-or-jersey).
+
+  ###If your treatment will last longer than 6 months
+
+  You must apply for a Standard Visitor visa for medical treatment lasting longer than 6 months.
+
+  You can either:
+
+  - [apply for a Standard Visitor visa](/standard-visitor/apply-standard-visitor-visa) before you come to the UK - this lasts for up to 11 months and costs £200
+  - visit for up to 6 months and [apply to stay for a further 6 months when you’re in the UK](/standard-visitor/extend-your-stay) for a fee of £1,000
+
+  There is no limit on how many times you can extend your stay. It costs £1,000 each time you do.
+
+  Depending on where you come from, you may also need a certificate that proves you do not have tuberculosis (TB). [Check if you’ll need to take a TB test](/tb-test-visa).
+
+  ###If you need to leave and re-enter the UK
+
+  You’ll usually need a Standard Visitor visa to re-enter the UK if either of the following apply:
+
+  * you did not book your return journey to the UK before 3pm (UK time) on 10 September 2024
+  * you’re returning to the UK on or after 3pm (UK time) on 8 October 2024
+<% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/jordan/_outcome_partner_family_british_citizen_y_1.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/jordan/_outcome_partner_family_british_citizen_y_1.erb
@@ -1,0 +1,6 @@
+<% if calculator.passport_country_is_jordan? && Time.zone.now <= Time.zone.local(2024, 10, 8) %>
+  Depending on your circumstances, you may also be able to:
+
+  - apply for a free family permit
+  - use an electronic travel authorisation (ETA) if you’re arriving in the UK before 3pm (UK time) on 8 October 2024
+<% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/jordan/_outcome_partner_family_british_citizen_y_2.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/jordan/_outcome_partner_family_british_citizen_y_2.erb
@@ -1,0 +1,21 @@
+<% if calculator.passport_country_is_jordan? && Time.zone.now <= Time.zone.local(2024, 10, 8) %>
+  ##If you’re arriving in the UK before 3pm (UK time) on 8 October 2024
+
+  You may be able to use an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta) to stay in the UK if you already have one.
+
+  All of the following must apply:
+
+  * you booked and paid for your journey to the UK before 3pm (UK time) on 10 September 2024
+  * you’re arriving in the UK before 3pm (UK time) on 8 October 2024
+  * you meet the [Standard Visitor visa](/standard-visitor) eligibility requirements
+
+  An ETA lets you stay in the UK for up to 6 months.
+
+  ###If you need to leave and re-enter the UK
+
+  You’ll usually need a visa or family permit to re-enter the UK if either of the following apply:
+
+  * you did not book your return journey to the UK before 3pm (UK time) on 10 September 2024
+
+  * you’re returning to the UK on or after 3pm (UK time) on 8 October 2024
+<% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/jordan/_outcome_partner_family_eea_n_1.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/jordan/_outcome_partner_family_eea_n_1.erb
@@ -1,0 +1,3 @@
+<% if calculator.passport_country_is_jordan? && Time.zone.now <= Time.zone.local(2024, 10, 8) %>
+  ^The rules on what you’ll need to come to the UK may be different if you're arriving in the UK before 3pm (UK time) on 8 October 2024.
+<% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/jordan/_outcome_partner_family_eea_n_2.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/jordan/_outcome_partner_family_eea_n_2.erb
@@ -1,0 +1,25 @@
+<% if calculator.passport_country_is_jordan? && Time.zone.now <= Time.zone.local(2024, 10, 8) %>
+  ##If you’re arriving in the UK before 3pm (UK time) on 8 October 2024
+
+  You may be able to use your [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta) to stay in the UK if you already have one.
+
+  All of the following must apply:
+
+  * you booked and paid for your journey to the UK before 3pm (UK time) on 10 September 2024
+  * you’re arriving in the UK before 3pm (UK time) on 8 October 2024
+  * you meet the [Standard Visitor visa](/standard-visitor) eligibility requirements
+
+  An ETA lets you stay in the UK for up to 6 months.
+
+  ###If you need to leave and re-enter the UK
+
+  You cannot use your ETA to re-enter the UK if either of the following apply:
+
+
+
+  * you did not book your return journey to the UK before 3pm (UK time) on 10 September 2024
+
+  * you’re returning to the UK on or after 3pm (UK time) on 8 October 2024
+
+  You’ll usually need a Standard Visitor visa or permission to stay as a ‘dependant’ of your family member’s visa category instead.
+<% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/jordan/_outcome_partner_family_eea_y.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/jordan/_outcome_partner_family_eea_y.erb
@@ -1,0 +1,21 @@
+<% if calculator.passport_country_is_jordan? && Time.zone.now <= Time.zone.local(2024, 10, 8) %>
+  ###If you’re arriving in the UK before 3pm (UK time) on 8 October 2024
+
+  You may be able to use an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta) to come to the UK if you already have one.
+
+  All of the following must apply:
+
+  * you booked and paid for your journey to the UK before 3pm (UK time) on 10 September 2024
+  * you’re arriving in the UK before 3pm (UK time) on 8 October 2024
+  * you meet the [Standard Visitor visa](/standard-visitor) eligibility requirements
+
+  An ETA lets you stay in the UK for up to 6 months.
+
+  If you leave the UK and need to re-enter, you may not be able to use your ETA to return.
+
+  You’ll usually need a visa or a family permit to re-enter the UK if either of the following apply:
+
+  * you did not book your return journey to the UK before 3pm (UK time) on 10 September 2024
+
+  * you’re returning to the UK on or after 3pm (UK time) on 8 October 2024
+<% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/jordan/_outcome_school_y.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/jordan/_outcome_school_y.erb
@@ -1,0 +1,22 @@
+<% if calculator.passport_country_is_jordan? && Time.zone.now <= Time.zone.local(2024, 10, 8) %>
+  ##If you’re arriving in the UK before 3pm (UK time) on 8 October 2024
+
+  You may be able to use an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta) to stay in the UK if you already have one.
+
+  All of the following must apply:
+
+  * you booked and paid for your journey to the UK before 3pm (UK time) on 10 September 2024
+  * you’re arriving in the UK before 3pm (UK time) on 8 October 2024
+  * you meet the [Standard Visitor visa](/standard-visitor) eligibility requirements
+
+  An ETA lets you stay in the UK for up to 6 months.
+
+  ###If you need to leave and re-enter the UK
+
+  You cannot use your ETA to re-enter the UK if either of the following apply:
+
+  * you did not book your return journey to the UK before 3pm (UK time) on 10 September 2024
+  * you’re returning to the UK on or after 3pm (UK time) on 8 October 2024
+
+  You’ll need to get a Standard Visitor visa or Parent of a Child Student visa instead.
+<% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/jordan/_outcome_standard_visitor_visa.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/jordan/_outcome_standard_visitor_visa.erb
@@ -1,0 +1,63 @@
+<% if calculator.passport_country_is_jordan? && Time.zone.now <= Time.zone.local(2024, 10, 8) %>
+  ##If you’re arriving in the UK before 3pm (UK time) on 8 October 2024
+
+  You may be able to use an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta) to come to the UK if you already have one.
+
+  All of the following must apply:
+
+  * you booked and paid for your journey to the UK before 3pm (UK time) on 10 September 2024
+  * you’re arriving in the UK before 3pm (UK time) on 8 October 2024
+  * you meet the [Standard Visitor visa](/standard-visitor) eligibility requirements
+
+  ###If you need to leave and re-enter the UK
+
+  You’ll usually need a Standard Visitor visa to re-enter the UK if either of the following apply:
+
+  * you did not book your return journey to the UK before 3pm (UK time) on 10 September 2024
+
+  * you’re returning to the UK on or after 3pm (UK time) on 8 October 2024
+
+  ## What you can and cannot do with an ETA
+
+  You can visit the UK on holiday or to spend time with family and friends.
+
+  You can also do [other permitted activities as a Standard Visitor](/standard-visitor).
+
+  While in the UK as a tourist, you cannot:
+
+  - do paid or unpaid work for a UK company or as a self-employed person
+  - claim [public funds](/government/publications/public-funds--2) (benefits)
+  - live in the UK for long periods of time through frequent or successive visits
+  - marry or register a civil partnership, or give notice of marriage or civil partnership. You’ll need a [Marriage Visitor visa](/marriage-visa) instead
+
+  ## What you need at the UK border if you have an ETA
+
+  You must provide a valid passport or travel document. Your passport should be valid for the whole of your stay in the UK.
+
+  You may also be asked to prove that:
+
+  - you’re visiting for tourism
+  - you’re able to support yourself and your dependents during your trip (or have funding from someone else to support you)
+  - you’ve arranged accommodation for your stay
+  - you’re able to pay for your return or onward journey (or have funding from someone else)
+  - you’ll leave the UK at the end of your visit
+
+  ^The rules on what you’ll need to enter the UK may be different if you’re [travelling from Ireland, Jersey, Guernsey or the Isle of Man](/guidance/travelling-between-the-uk-and-ireland-isle-of-man-guernsey-or-jersey).
+
+  ## If you’re under 18 and travelling alone with an ETA
+
+  You may need to show a letter from your parent or guardian giving:
+
+  - their contact details and consent for you to travel to the UK
+  - the name, date of birth, address and relationship to you of the person you’re staying with
+  - their consent for you to stay with the person named in the letter
+
+  ###If you’re not staying with a close relative
+
+  Your parent or guardian must tell the relevant local authority about your visit if you’re both of the following:
+
+  - under 16 (or under 18 if you have a disability)
+  - going to be looked after for more than 28 days by someone who is not a close relative (called ‘private foster care’)
+
+  You should bring a reply from the local authority if you have one.
+<% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/jordan/_outcome_study_m.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/jordan/_outcome_study_m.erb
@@ -1,0 +1,81 @@
+<% if calculator.passport_country_is_jordan? && Time.zone.now <= Time.zone.local(2024, 10, 8) %>
+  ##If you’re arriving in the UK before 3pm (UK time) on 8 October 2024
+
+  You may be able to use an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta) to come to the UK if you already have one.
+
+  All of the following must apply:
+
+  * you booked and paid for your journey to the UK before 3pm (UK time) on 10 September 2024
+  * you’re arriving in the UK before 3pm (UK time) on 8 October 2024
+  * you meet the [Standard Visitor visa](/standard-visitor) eligibility requirements
+
+  ^The rules on what you’ll need to enter the UK may be different if you’re [travelling from Ireland, Jersey, Guernsey or the Isle of Man](/guidance/travelling-between-the-uk-and-ireland-isle-of-man-guernsey-or-jersey).
+
+  ###If you need to leave and re-enter the UK
+
+  You’ll usually need a Standard Visitor visa to re-enter the UK if either of the following apply:
+
+  * you did not book your return journey to the UK before 3pm (UK time) on 10 September 2024
+
+  * you’re returning to the UK on or after 3pm (UK time) on 8 October 2024
+
+  ## What you can and cannot do with an ETA
+
+  You can visit the UK to study at an [accredited institution](/visa-to-study-english/your-course) for up to 6 months, this includes English language courses.
+
+  You can also do:
+
+  - a short piece of research that’s relevant to your course overseas, if you have been accepted by a UK higher education institution
+  - an ‘elective’ (an optional additional placement) at a UK higher education institution, if you’re studying medicine, nursing, midwifery, dentistry or veterinary medicine and science
+  - an unpaid clinical attachment or dental observer post, if you’re an overseas graduate from a medical, dental or nursing school
+  - a recreational course of up to 30 days, for example a dance course
+
+  You can do [other permitted activities as a Standard Visitor](/standard-visitor).
+
+  You cannot:
+
+  - study at a [state funded school or academy](/types-of-school)
+  - do a course that lasts longer than 6 months (except if you’re doing a distance learning course)
+  - do paid or unpaid work (this includes work experience or work placements, unless it is an eligible medical, nursing, midwifery, dentistry or veterinary medicine and science placement)
+  - live in the UK for long periods of time through frequent or successive visits get [public funds](/government/publications/public-funds--2) (benefits)
+
+  To study or research certain subjects at postgraduate level or above, you may need an [Academic Technology Approval Scheme (ATAS) certificate](/guidance/find-out-if-you-require-an-atas-certificate). If you do need one, you’ll need to get your ATAS certificate before starting your study or research.
+
+  ## What you need at the UK border if you have an ETA
+
+  You need a valid passport or travel document. Your passport should be valid for the whole of your stay in the UK.
+
+  You must provide written confirmation from a higher education provider if you’re visiting to do research or an elective.
+
+  If you’re visiting to do an unpaid clinical attachment or dental observer post you must:
+
+  - provide written confirmation of your offer
+  - confirm you’ve not done a clinical attachment or dental observer post in the UK before
+
+  You may also be asked to prove that:
+
+  - you’ve been accepted on to a course by an accredited institution, for example a letter of acceptance on official headed paper stating the course name, duration and cost
+  - you’re able to support yourself and your dependents during your trip (or have funding from someone else to support you)
+  - you’re able to pay for your return or onward journey (or have funding from someone else)
+  - you’ve arranged accommodation for your stay
+  - you’ll leave the UK at the end of your visit
+
+  [Find out more about visiting the UK to study](/standard-visitor/visit-to-study).
+
+  ## If you’re under 18 and travelling alone with an ETA
+
+  You may need to show a letter from your parent or guardian giving:
+
+  - their contact details and consent for you to travel to the UK
+  - the name, date of birth, address and relationship to you of the person you’re staying with
+  - their consent for you to stay with the person named in the letter
+
+  ### If you’re not staying with a close relative
+
+  Your parent or guardian must tell the relevant local authority about your visit if you’re both of the following:
+
+  - under 16 (or under 18 if you have a disability)
+  - going to be looked after for more than 28 days by someone who is not a close relative (called ‘private foster care’)
+
+  You should bring a reply from the local authority if you have one.
+<% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/jordan/_outcome_tourism_visa_partner.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/jordan/_outcome_tourism_visa_partner.erb
@@ -1,0 +1,62 @@
+<% if calculator.passport_country_is_jordan? && Time.zone.now <= Time.zone.local(2024, 10, 8) %>
+  ##If you’re arriving in the UK before 3pm (UK time) on 8 October 2024
+
+  You may be able to use an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta) to come to the UK if you already have one.
+
+  All of the following must apply:
+
+  * you booked and paid for your journey to the UK before 3pm (UK time) on 10 September 2024
+  * you’re arriving in the UK before 3pm (UK time) on 8 October 2024
+  * you meet the [Standard Visitor visa](/standard-visitor) eligibility requirements
+
+  ###If you need to leave and re-enter the UK
+
+  You’ll usually need a Standard Visitor visa or family permit to re-enter the UK if either of the following apply:
+
+  * you did not book your return journey to the UK before 3pm (UK time) on 10 September 2024
+  * you’re returning to the UK on or after 3pm (UK time) on 8 October 2024
+
+  ## What you can and cannot do with an ETA
+
+  You can visit the UK on holiday or to spend time with family and friends.
+
+  You can also do [other permitted activities as a Standard Visitor](/standard-visitor).
+
+  While in the UK as a tourist, you cannot:
+
+  - do paid or unpaid work for a UK company or as a self-employed person
+  - claim [public funds](/government/publications/public-funds--2) (benefits)
+  - live in the UK for long periods of time through frequent or successive visits
+  - marry or register a civil partnership, or give notice of marriage or civil partnership. You’ll need a [Marriage Visitor visa](/marriage-visa) instead
+
+  ## What you need at the UK border if you have an ETA
+
+  You must provide a valid passport or travel document. Your passport should be valid for the whole of your stay in the UK.
+
+  You may also be asked to prove that:
+
+  - you’re visiting for tourism
+  - you’re able to support yourself and your dependents during your trip (or have funding from someone else to support you)
+  - you’ve arranged accommodation for your stay
+  - you’re able to pay for your return or onward journey (or have funding from someone else)
+  - you’ll leave the UK at the end of your visit
+
+  ^The rules on what you’ll need to enter the UK may be different if you’re [travelling from Ireland, Jersey, Guernsey or the Isle of Man](/guidance/travelling-between-the-uk-and-ireland-isle-of-man-guernsey-or-jersey).
+
+  ## If you’re under 18 and travelling alone with an ETA
+
+  You may need to show a letter from your parent or guardian giving:
+
+  - their contact details and consent for you to travel to the UK
+  - the name, date of birth, address and relationship to you of the person you’re staying with
+  - their consent for you to stay with the person named in the letter
+
+  ###If you’re not staying with a close relative
+
+  Your parent or guardian must tell the relevant local authority about your visit if you’re both of the following:
+
+  - under 16 (or under 18 if you have a disability)
+  - going to be looked after for more than 28 days by someone who is not a close relative (called ‘private foster care’)
+
+  You should bring a reply from the local authority if you have one.
+<% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/jordan/_outcome_transit_leaving_airport_direct_airside_transit_visa_1.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/jordan/_outcome_transit_leaving_airport_direct_airside_transit_visa_1.erb
@@ -1,0 +1,6 @@
+<% if calculator.passport_country_is_jordan? && Time.zone.now <= Time.zone.local(2024, 10, 8) %>
+  Depending on your circumstances, you may be able to:
+
+  - transit without a visa
+  - use an electronic travel authorisation (ETA) if you’re arriving in the UK before 3pm (UK time) on 8 October 2024
+<% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/jordan/_outcome_transit_leaving_airport_direct_airside_transit_visa_2.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/jordan/_outcome_transit_leaving_airport_direct_airside_transit_visa_2.erb
@@ -1,0 +1,11 @@
+<% if calculator.passport_country_is_jordan? && Time.zone.now <= Time.zone.local(2024, 10, 8) %>
+  ##If you’re arriving in the UK before 3pm (UK time) on 8 October 2024
+
+  You may be able to use an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta) to pass through the UK if you already have one.
+
+  All of the following must apply:
+
+  * you booked and paid for your journey to the UK before 3pm (UK time) on 10 September 2024
+  * you’re arriving in the UK before 3pm (UK time) on 8 October 2024
+  * you meet the [Standard Visitor visa](/standard-visitor) eligibility requirements
+<% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/jordan/_outcome_transit_not_leaving_airport_1.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/jordan/_outcome_transit_not_leaving_airport_1.erb
@@ -1,0 +1,8 @@
+<% if calculator.passport_country_is_jordan? && Time.zone.now <= Time.zone.local(2024, 10, 8) %>
+  Depending on your circumstances you may be able to:
+
+  transit without a visa, if you’re exempt
+  use an electronic travel authorisation (ETA) if you’re arriving in the UK before 3pm (UK time) on 8 October 2024
+
+  ^If you arrive in the UK on a flight and leave again before 00:01 on 11 September 2024, you do not need a visa.
+<% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/jordan/_outcome_transit_not_leaving_airport_2.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/jordan/_outcome_transit_not_leaving_airport_2.erb
@@ -1,0 +1,11 @@
+<% if calculator.passport_country_is_jordan? && Time.zone.now <= Time.zone.local(2024, 10, 8) %>
+  ##If you’re arriving in the UK before 3pm (UK time) on 8 October 2024
+
+  You may be able to use an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta) to pass through the UK if you already have one.
+
+  All of the following must apply:
+
+  * you booked and paid for your journey to the UK before 3pm (UK time) on 10 September 2024
+  * you’re arriving in the UK before 3pm (UK time) on 8 October 2024
+  * you meet the [Standard Visitor visa](/standard-visitor) eligibility requirements
+<% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/jordan/_outcome_transit_to_the_republic_of_ireland_1.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/jordan/_outcome_transit_to_the_republic_of_ireland_1.erb
@@ -1,0 +1,6 @@
+<% if calculator.passport_country_is_jordan? && Time.zone.now <= Time.zone.local(2024, 10, 8) %>
+  Depending on your circumstances, you may be able to:
+
+  - transit without a visa
+  - use an electronic travel authorisation (ETA) if you’re arriving in the UK before 3pm (UK time) on 8 October 2024
+<% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/jordan/_outcome_transit_to_the_republic_of_ireland_2.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/jordan/_outcome_transit_to_the_republic_of_ireland_2.erb
@@ -1,0 +1,11 @@
+<% if calculator.passport_country_is_jordan? && Time.zone.now <= Time.zone.local(2024, 10, 8) %>
+  ##If you’re arriving in the UK before 3pm (UK time) on 8 October 2024
+
+  You may be able to use an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta) to pass through the UK if you already have one.
+
+  All of the following must apply:
+
+  * you booked and paid for your journey to the UK before 3pm (UK time) on 10 September 2024
+  * you’re arriving in the UK before 3pm (UK time) on 8 October 2024
+  * you meet the [Standard Visitor visa](/standard-visitor) eligibility requirements
+<% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/jordan/_outcome_work_m_1.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/jordan/_outcome_work_m_1.erb
@@ -1,0 +1,3 @@
+<% if calculator.passport_country_is_jordan? && Time.zone.now <= Time.zone.local(2024, 10, 8) %>
+  ^The rules on what you’ll need to come to the UK may be different if you're arriving in the UK before 3pm (UK time) on 8 October 2024.
+<% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/jordan/_outcome_work_m_2.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/jordan/_outcome_work_m_2.erb
@@ -1,0 +1,98 @@
+<% if calculator.passport_country_is_jordan? && Time.zone.now <= Time.zone.local(2024, 10, 8) %>
+  ##If you’re arriving in the UK before 3pm (UK time) on 8 October 2024
+
+  You may be able to use an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta) to come to the UK if you already have one.
+
+  All of the following must apply:
+
+  * you booked and paid for your journey to the UK before 3pm (UK time) on 10 September 2024
+  * you’re arriving in the UK before 3pm (UK time) on 8 October 2024
+  * you're only going to do activities that are permitted with an ETA
+
+  You can use an ETA for some business and academic activities, but you must get a visa if you plan to work in the UK.
+
+  You can use [an ETA](/guidance/apply-for-an-electronic-travel-authorisation-eta) to come to the UK if you’re either:
+
+  - invited as an expert in your profession doing a ‘[permitted paid engagement](/standard-visitor/paid-engagement-event)’
+  - visiting for certain business or academic activities, but not working in the UK
+
+  You must meet the eligibility requirements and only be doing permitted activities.
+
+  ## If you’re invited as an expert in your profession and you have an ETA
+
+  You can use [an ETA](/guidance/apply-for-an-electronic-travel-authorisation-eta) to stay in the UK for up to 1 month. You can only be paid by a UK-based organisation to do certain things, for example:
+
+  - give guest lectures at a higher education institution
+  - provide advocacy in legal proceedings
+  - take part in arts, entertainment or sporting activities
+
+  If you’re doing a permitted paid engagement, you must do it within one month of arriving. You can stay in the UK for up to 6 months, but cannot do any paid engagements after the first month.
+
+  Check the full list of [business activities](/standard-visitor/visit-on-business), [academic activities](/standard-visitor/visit-as-an-academic) or [permitted paid engagements](/standard-visitor/paid-engagement) you can do as a Standard Visitor.
+
+  To research certain subjects at postgraduate level or above, you may need an [Academic Technology Approval Scheme (ATAS) certificate](/guidance/find-out-if-you-require-an-atas-certificate). If you do need one, you’ll need to get your ATAS certificate before starting your research.
+
+  ### What you need at the UK border
+
+  You must go to a border control officer to get a stamp in your passport. Do not use the automatic ePassport gates. You need a stamp to do the activities you came to the UK to do.
+
+  You must provide a valid passport or travel document. Your passport should be valid for the whole of your stay in the UK.
+
+  You may also be asked to prove that:
+
+  - you’re eligible for the activities you want to do
+  - you’ve arranged accommodation for your stay
+  - you’ll leave at the end of your visit
+  - you’re able to support yourself and your dependents during your trip (or have funding from someone else to support you)
+
+  ^The rules on what you’ll need to enter the UK may be different if you’re [travelling from Ireland, Jersey, Guernsey or the Isle of Man](/guidance/travelling-between-the-uk-and-ireland-isle-of-man-guernsey-or-jersey).
+
+  ## If you’re visiting for certain business or academic activities and you have an ETA
+
+  You can come to the UK as a Standard Visitor for up to 6 months using [an ETA](/guidance/apply-for-an-electronic-travel-authorisation-eta) if you already have one. You can only do certain business or academic activities, for example go to a conference or a meeting.
+
+  You cannot:
+
+  - do paid or unpaid work for a UK company or as a self-employed person
+  - do a work placement or internship
+  - sell directly to the public or provide goods and services
+
+  Check the full list of [business activities](/standard-visitor/visit-on-business) and [academic activities](/standard-visitor/visit-as-an-academic) you can do as a Standard Visitor.
+
+  To research certain subjects at postgraduate level or above, you may need an [Academic Technology Approval Scheme (ATAS) certificate](/guidance/find-out-if-you-require-an-atas-certificate). If you do need one, you’ll need to get your ATAS certificate before starting your research.
+
+  ### What you need at the UK border
+
+  You must provide a valid passport or travel document. Your passport should be valid for the whole of your stay in the UK.
+
+  You may also be asked to prove:
+
+  - you’re eligible for the activities you want to do
+  - you’ve arranged accommodation for your stay
+  - you’ll leave at the end of your visit
+  - you’re able to support yourself and your dependents during your trip (or have funding from someone else to support you)
+
+  Find out more about [visiting the UK as a Standard Visitor](/standard-visitor).
+
+  ^The rules on what you’ll need to enter the UK may be different if you’re [travelling from Ireland, Jersey, Guernsey or the Isle of Man](/guidance/travelling-between-the-uk-and-ireland-isle-of-man-guernsey-or-jersey).
+
+  ## If you want to do paid work in the UK and you have an ETA
+
+  You usually need to apply for a visa if you want to work.
+
+  ### If you want to work in arts or entertainment for 3 months or less
+
+  You can use an ETA if you’re coming to the UK using the [Creative Worker visa concession](/creative-worker-visa/creative-worker-concession).
+
+  You must bring a [certificate of sponsorship and evidence of savings](/creative-worker-visa/eligibility) to show officers at the UK border.
+
+  You must see a Border Force officer - do not use the automatic ePassport gates
+
+  ##If you come to the UK with an ETA and need to leave and re-enter
+
+  You’ll usually need a visa to re-enter the UK if either of the following apply:
+
+  * you did not book your return journey to the UK before 3pm (UK time) on 10 September 2024
+
+  * you’re returning to the UK on or after 3pm (UK time) on 8 October 2024
+<% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_marriage_visa_nat_direct_airside_transit_visa.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_marriage_visa_nat_direct_airside_transit_visa.erb
@@ -16,4 +16,5 @@
   + has settled or pre-settled status under the EU Settlement Scheme
   + has a Turkish worker or businessperson visa
 
+  <%= render partial: "jordan/outcome_marriage_visa_nat_direct_airside_transit_visa", locals: {calculator: calculator} %>
 <% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_medical_y.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_medical_y.erb
@@ -8,4 +8,6 @@
   <%= render partial: 'stateless_or_refugee', locals: {calculator: calculator} %>
 
   <%= render partial: 'estonia_or_latvia', locals: {calculator: calculator} %>
+
+  <%= render partial: "jordan/outcome_medical_y", locals: {calculator: calculator} %>
 <% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_partner_family_british_citizen_y.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_partner_family_british_citizen_y.erb
@@ -5,6 +5,8 @@
 <% govspeak_for :body do %>
   You must usually apply for a [family visa](/uk-family-visa).
 
+  <%= render partial: "jordan/outcome_partner_family_british_citizen_y_1", locals: {calculator: calculator} %>
+
   ##When you can apply for a free permit instead
 
   You may be able to apply for a free [family permit](/family-permit/) instead of a visa. Your close family member must both:
@@ -13,4 +15,6 @@
   + have been living in the UK by 31 December 2020
 
   The family permit lets you live, work and study in the UK for up to 6 months (this may be 4 months if you come to the UK after 1 April 2021). You may then be able to apply to the free EU Settlement Scheme to stay longer in the UK.
+
+  <%= render partial: "jordan/outcome_partner_family_british_citizen_y_2", locals: {calculator: calculator} %>
 <% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_partner_family_eea_n.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_partner_family_eea_n.erb
@@ -5,6 +5,8 @@
 <% govspeak_for :body do %>
   The visa you need depends on your partner or family member’s situation.
 
+  <%= render partial: "jordan/outcome_partner_family_eea_n_1", locals: {calculator: calculator} %>
+
   ## They’re working or studying in the UK
 
   You may be able to apply as a ‘dependant’ of
@@ -14,4 +16,6 @@
 
   You can apply for a [Standard Visitor visa](/standard-visitor). Your
   visit must be for 6 months or less.
+
+  <%= render partial: "jordan/outcome_partner_family_eea_n_2", locals: {calculator: calculator} %>
 <% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_partner_family_eea_y.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_partner_family_eea_y.erb
@@ -9,6 +9,8 @@
 
   You may be able to apply for a free [family permit](/family-permit) to join your partner or family member for up to 6 months (this may be 4 months if you come to the UK after 1 April 2021).
 
+  <%= render partial: "jordan/outcome_partner_family_eea_y", locals: {calculator: calculator} %>
+
   ##If you’re staying longer than 6 months
 
   What you can apply for depends on your family member’s situation.

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_school_y.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_school_y.erb
@@ -12,4 +12,6 @@
   If they’re 12 or over, you can apply for a [Standard Visitor visa](/standard-visitor) to visit them for up to 6 months.
 
   <%= render partial: 'stateless_or_refugee', locals: {calculator: calculator} %>
+
+  <%= render partial: "jordan/outcome_school_y", locals: {calculator: calculator} %>
 <% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_standard_visitor_visa.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_standard_visitor_visa.erb
@@ -12,4 +12,6 @@
   <% end %>
 
   <%= render partial: 'stateless_or_refugee', locals: {calculator: calculator} %>
+
+  <%= render partial: "jordan/outcome_standard_visitor_visa", locals: {calculator: calculator} %>
 <% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_study_m.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_study_m.erb
@@ -6,4 +6,6 @@
   <%= render partial: 'stateless_or_refugee', locals: {calculator: calculator} %>
 
   Apply for a [Standard Visitor visa](/standard-visitor) if you're studying for 6 months or less.
+
+  <%= render partial: "jordan/outcome_study_m", locals: {calculator: calculator} %>
 <% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_tourism_visa_partner.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_tourism_visa_partner.erb
@@ -8,4 +8,6 @@
   ##When you might not need a visa
 
   You may be able to apply for a free [family permit](/family-permit) if your partner or family member is from the EU, Switzerland, Norway, Iceland or Liechtenstein. They must have been living in the UK before by 31 December 2020.
+
+  <%= render partial: "jordan/outcome_tourism_visa_partner", locals: {calculator: calculator} %>
 <% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_transit_leaving_airport.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_transit_leaving_airport.erb
@@ -38,5 +38,4 @@
   Australian paper confirmation slips are not accepted.
 
   ^Transiting without a visa is decided by the immigration officer at the border. You will not be allowed to transit if they decide you need a visa, so you might want to apply for a transit visa before you travel.^
-
 <% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_transit_leaving_airport_direct_airside_transit_visa.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_transit_leaving_airport_direct_airside_transit_visa.erb
@@ -5,7 +5,9 @@
 <% govspeak_for :body do %>
   You should apply for a [Visitor in Transit visa](/transit-visa) if you arrive on a flight and will pass through immigration control before you leave the UK.
 
-^ You do not need to apply for a Visitor in Transit visa if you already have a Marriage Visitor or Standard Visitor visa. ^
+  ^ You do not need to apply for a Visitor in Transit visa if you already have a Marriage Visitor or Standard Visitor visa.
+
+  <%= render partial: "jordan/outcome_transit_leaving_airport_direct_airside_transit_visa_1", locals: {calculator: calculator} %>
 
   ##Transiting without a visa
 
@@ -38,4 +40,6 @@
   All visas and residence permits must be valid.
 
   Australian paper confirmation slips are not accepted.
+
+  <%= render partial: "jordan/outcome_transit_leaving_airport_direct_airside_transit_visa_2", locals: {calculator: calculator} %>
 <% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_transit_not_leaving_airport.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_transit_not_leaving_airport.erb
@@ -5,6 +5,8 @@
 <% govspeak_for :body do %>
   You normally need a [Direct Airside Transit visa](/transit-visa/direct-airside-transit-visa) if you arrive in the UK on a flight and leave again without passing through immigration control.
 
+  <%= render partial: "jordan/outcome_transit_not_leaving_airport_1", locals: {calculator: calculator} %>
+
   ##Exemptions
 
   You do not need a Direct Airside Transit visa if you have one of the following:
@@ -25,5 +27,6 @@
   All visas and residence permits must be valid.
 
   %E-visas or e-residence permits are not acceptable unless your airline is able to verify it with the issuing country. Contact your airline for more information.%
-  
+
+  <%= render partial: "jordan/outcome_transit_not_leaving_airport_2", locals: {calculator: calculator} %>
 <% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_transit_to_the_republic_of_ireland.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_transit_to_the_republic_of_ireland.erb
@@ -17,6 +17,8 @@
     You’ll usually need to apply for a [Standard Visitor visa](/standard-visitor).
   <% end %>
 
+  <%= render partial: "jordan/outcome_transit_to_the_republic_of_ireland_1", locals: {calculator: calculator} %>
+
   ##Transiting without a visa
 
   You may be eligible to transit without a visa if:
@@ -32,4 +34,6 @@
   All visas and residence permits must be valid.
 
   You will not be able to transit without a visa if a Border Force officer decides you do not qualify under the immigration rules.
+
+  <%= render partial: "jordan/outcome_transit_to_the_republic_of_ireland_2", locals: {calculator: calculator} %>
 <% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_work_m.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_work_m.erb
@@ -9,6 +9,8 @@
 
   <%= render partial: 'estonia_or_latvia', locals: {calculator: calculator} %>
 
+  <%= render partial: "jordan/outcome_work_m_1", locals: {calculator: calculator} %>
+
   ##Business or academic visits
 
   You can apply for a [Standard Visitor visa](/standard-visitor) if you’re coming to the UK for certain business or academic activities, such as:
@@ -37,4 +39,6 @@
   + in a [fast-growing UK business (sometimes known as a ‘scale-up’ business)](/scale-up-worker-visa)
 
   You can also apply for an [international agreement](/international-agreement-worker-visa) visa if you'll be doing work covered by international law while in the UK (for example, working for a foreign government or as a private servant in a diplomatic household).
+
+  <%= render partial: "jordan/outcome_work_m_2", locals: {calculator: calculator} %>
 <% end %>

--- a/lib/smart_answer/calculators/uk_visa_calculator.rb
+++ b/lib/smart_answer/calculators/uk_visa_calculator.rb
@@ -344,7 +344,6 @@ module SmartAnswer::Calculators
       hong-kong-(british-national-overseas)
       israel
       japan
-      jordan
       kiribati
       kuwait
       macao
@@ -464,6 +463,7 @@ module SmartAnswer::Calculators
       iraq
       israel-provisional-passport
       jamaica
+      jordan
       kenya
       kosovo
       latvia-alien-passport
@@ -547,7 +547,6 @@ module SmartAnswer::Calculators
       oman
       saudi-arabia
       united-arab-emirates
-      jordan
     ].freeze
 
     COUNTRY_GROUP_EPASSPORT_GATES = %w[

--- a/test/flows/check_uk_visa_jordan_flow_10_september_to_8_october_test.rb
+++ b/test/flows/check_uk_visa_jordan_flow_10_september_to_8_october_test.rb
@@ -1,0 +1,182 @@
+require "test_helper"
+require "support/flow_test_helper"
+require "support/flows/check_uk_visa_flow_test_helper"
+require "active_support/testing/time_helpers"
+
+class CheckUkVisaJordanFlow10SeptemberTo8OctoberTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::TimeHelpers
+  include FlowTestHelper
+  extend CheckUkVisaFlowTestHelper
+
+  setup do
+    testing_flow CheckUkVisaFlow
+
+    # stub only the countries used in this test for less of a performance impact
+    stub_worldwide_api_has_locations(%w[jordan].uniq)
+  end
+
+  context "Outcomes: for a September 10 to October 8 2024 transition period country during transition period" do
+    setup do
+      travel_to(Time.zone.local(2024, 10, 8))
+    end
+
+    context "No 1: outcome_tourism_visa_partner" do
+      should "render if arriving in the UK after September 10 and before October 8 2024" do
+        testing_node :outcome_tourism_visa_partner
+        add_responses what_passport_do_you_have?: "jordan",
+                      purpose_of_visit?: "tourism",
+                      travelling_visiting_partner_family_member?: "yes"
+
+        assert_rendered_outcome text: "If you’re arriving in the UK before 3pm (UK time) on 8 October 2024"
+        assert_rendered_outcome text: "You’ll usually need a Standard Visitor visa or family permit to re-enter the UK if either of the following apply"
+      end
+    end
+
+    context "No 2: outcome_standard_visitor_visa" do
+      should "render if arriving in the UK between September 10 to October 8 2024" do
+        testing_node :outcome_standard_visitor_visa
+        add_responses what_passport_do_you_have?: "jordan",
+                      purpose_of_visit?: "tourism",
+                      travelling_visiting_partner_family_member?: "no"
+
+        assert_rendered_outcome text: "If you’re arriving in the UK before 3pm (UK time) on 8 October 2024"
+        assert_rendered_outcome text: "You’ll usually need a Standard Visitor visa to re-enter the UK if either of the following apply"
+      end
+    end
+
+    context "No 3: outcome_work_m" do
+      should "six_months_or_less: render if arriving in the UK between September 10 to October 8 2024" do
+        testing_node :outcome_work_m
+        add_responses what_passport_do_you_have?: "jordan",
+                      purpose_of_visit?: "work",
+                      staying_for_how_long?: "six_months_or_less"
+
+        assert_rendered_outcome text: "The rules on what you’ll need to come to the UK may be different if you’re arriving in the UK before 3pm (UK time) on 8 October 2024"
+        assert_rendered_outcome text: "If you’re arriving in the UK before 3pm (UK time) on 8 October 2024"
+      end
+    end
+
+    context "No 4: outcome_study_m" do
+      should "six_months_or_less: render if arriving in the UK between September 10 to October 8 2024" do
+        testing_node :outcome_study_m
+        add_responses what_passport_do_you_have?: "jordan",
+                      purpose_of_visit?: "study",
+                      staying_for_how_long?: "six_months_or_less"
+
+        assert_rendered_outcome text: "If you’re arriving in the UK before 3pm (UK time) on 8 October 2024"
+        assert_rendered_outcome text: "Find out more about visiting the UK to study"
+      end
+    end
+
+    context "No 5: outcome_transit_to_the_republic_of_ireland" do
+      should "render if arriving in the UK between September 10 to October 8 2024" do
+        testing_node :outcome_transit_to_the_republic_of_ireland
+        add_responses what_passport_do_you_have?: "jordan",
+                      purpose_of_visit?: "transit",
+                      travelling_to_cta?: "republic_of_ireland"
+
+        assert_rendered_outcome text: "If you’re arriving in the UK before 3pm (UK time) on 8 October 2024"
+        assert_rendered_outcome text: "Depending on your circumstances, you may be able to"
+      end
+    end
+
+    context "No 6: outcome_transit_leaving_airport_direct_airside_transit_visa" do
+      should "render if arriving in the UK between September 10 to October 8 2024" do
+        testing_node :outcome_transit_leaving_airport_direct_airside_transit_visa
+        add_responses what_passport_do_you_have?: "jordan",
+                      purpose_of_visit?: "transit",
+                      travelling_to_cta?: "somewhere_else",
+                      passing_through_uk_border_control?: "yes"
+
+        assert_rendered_outcome text: "If you’re arriving in the UK before 3pm (UK time) on 8 October 2024"
+        assert_rendered_outcome text: "Depending on your circumstances, you may be able to"
+      end
+    end
+
+    context "No 7: outcome_transit_not_leaving_airport" do
+      should "render if arriving in the UK between September 10 to October 8 2024" do
+        testing_node :outcome_transit_not_leaving_airport
+        add_responses what_passport_do_you_have?: "jordan",
+                      purpose_of_visit?: "transit",
+                      travelling_to_cta?: "somewhere_else",
+                      passing_through_uk_border_control?: "no"
+
+        assert_rendered_outcome text: "If you’re arriving in the UK before 3pm (UK time) on 8 October 2024"
+        assert_rendered_outcome text: "If you arrive in the UK on a flight and leave again before 00:01 on 11 September 2024, you do not need a visa."
+      end
+    end
+
+    context "No 8: outcome_partner_family_british_citizen_y" do
+      should "render if arriving in the UK between September 10 to October 8 2024" do
+        testing_node :outcome_partner_family_british_citizen_y
+        add_responses what_passport_do_you_have?: "jordan",
+                      purpose_of_visit?: "family",
+                      partner_family_british_citizen?: "yes"
+
+        assert_rendered_outcome text: "Depending on your circumstances, you may also be able to"
+        assert_rendered_outcome text: "apply for a free family permit"
+        assert_rendered_outcome text: "If you’re arriving in the UK before 3pm (UK time) on 8 October 2024"
+      end
+    end
+
+    context "No 9: outcome_partner_family_eea_y" do
+      should "render if arriving in the UK between September 10 to October 8 2024" do
+        testing_node :outcome_partner_family_eea_y
+        add_responses what_passport_do_you_have?: "jordan",
+                      purpose_of_visit?: "family",
+                      partner_family_british_citizen?: "no",
+                      partner_family_eea?: "yes"
+
+        assert_rendered_outcome text: "If you’re arriving in the UK before 3pm (UK time) on 8 October 2024"
+      end
+    end
+
+    context "No 10: outcome_partner_family_eea_n" do
+      should "render if arriving in the UK between September 10 to October 8 2024" do
+        testing_node :outcome_partner_family_eea_n
+        add_responses what_passport_do_you_have?: "jordan",
+                      purpose_of_visit?: "family",
+                      partner_family_british_citizen?: "no",
+                      partner_family_eea?: "no"
+
+        assert_rendered_outcome text: "The rules on what you’ll need to come to the UK may be different if you’re arriving in the UK before 3pm (UK time) on 8 October 2024"
+        assert_rendered_outcome text: "If you’re arriving in the UK before 3pm (UK time) on 8 October 2024"
+        assert_rendered_outcome text: "You’ll usually need a Standard Visitor visa or permission to stay as a ‘dependant’ of your family member’s visa category instead."
+      end
+    end
+
+    context "No 11: outcome_marriage_visa_nat_direct_airside_transit_visa" do
+      should "render if arriving in the UK between September 10 to October 8 2024" do
+        testing_node :outcome_marriage_visa_nat_direct_airside_transit_visa
+        add_responses what_passport_do_you_have?: "jordan",
+                      purpose_of_visit?: "marriage"
+
+        assert_rendered_outcome text: "If you’re arriving in the UK before 3pm (UK time) on 8 October 2024"
+        assert_rendered_outcome text: "You do not need a Marriage Visitor visa to convert your civil partnership into a marriage"
+      end
+    end
+
+    context "No 12: outcome_school_y" do
+      should "render if arriving in the UK between September 10 to October 8 2024" do
+        testing_node :outcome_school_y
+        add_responses what_passport_do_you_have?: "jordan",
+                      purpose_of_visit?: "school"
+
+        assert_rendered_outcome text: "If you’re arriving in the UK before 3pm (UK time) on 8 October 2024"
+        assert_rendered_outcome text: "You’ll need to get a Standard Visitor visa or Parent of a Child Student visa instead"
+      end
+    end
+
+    context "No 13: outcome_medical_y" do
+      should "render if arriving in the UK between September 10 to October 8 2024" do
+        testing_node :outcome_medical_y
+        add_responses what_passport_do_you_have?: "jordan",
+                      purpose_of_visit?: "medical"
+
+        assert_rendered_outcome text: "If you’re arriving in the UK before 3pm (UK time) on 8 October 2024"
+        assert_rendered_outcome text: "The rules on what you’ll need to enter the UK may be different if you’re travelling from Ireland, Jersey, Guernsey or the Isle of Man."
+        assert_rendered_outcome text: "If your treatment will last longer than 6 months"
+      end
+    end
+  end
+end

--- a/test/unit/calculators/uk_visa_calculator_test.rb
+++ b/test/unit/calculators/uk_visa_calculator_test.rb
@@ -633,6 +633,15 @@ module SmartAnswer
           end
         end
       end
+
+      context "#jordan no longer require ETA" do
+        should 'return false for passport_country_requires_electronic_travel_authorisation? if passport_country is "jordan"' do
+          calculator = UkVisaCalculator.new
+          calculator.passport_country = "jordan"
+
+          assert_not calculator.passport_country_requires_electronic_travel_authorisation?
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
From 3pm on 10 September, nationals of Jordan will need to apply for a visa to visit the UK or transit the UK. They will no longer be able to apply for an electronic travel authorisation (ETA). There is a 28 day transition period during which they can use their ETA if certain conditions apply.

Changes in this PR contains all relevant partials and logic to reflect the effect of changes for Jordan national only.

[Trello](https://trello.com/c/R9XZUvxZ/292-10-september-off-sen-check-if-you-need-a-uk-visa-moving-jordan-from-non-visa-national-to-visa-national#comment-66c5c2ad1a7b13bb04ccb9db)
------
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
