### PR TITLE
Update smart answers for the two ETA rollout groups

### DIFF
--- a/app/flows/check_uk_visa_flow/outcomes/_electronic_travel_authorisation_advice.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/_electronic_travel_authorisation_advice.erb
@@ -1,5 +1,5 @@
-<% if calculator.passport_country_in_non_visa_national_list? %>
- ^You currently do not need an electronic travel authorisation (ETA) to travel to the UK. Check what you’ll need again before you travel. 
-<% elsif calculator.passport_country_in_eea? %>
- ^You currently do not need an electronic travel authorisation (ETA) to travel to the UK. Check what you’ll need again before you travel. 
+<% if calculator.passport_country_in_eta_rollout_group_1_rest_of_the_world? %>
+  ^If you’re travelling on or after 8 January 2025, you’ll need to apply for an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta). You’ll be able to apply from 27 November 2024.
+<% elsif calculator.passport_country_in_eta_rollout_group_2_eu_eea? %>
+  ^If you’re travelling on or after 2 April 2025, you’ll need to apply for an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta). You’ll be able to apply from 5 March 2025.
 <% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_joining_family_nvn.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_joining_family_nvn.erb
@@ -19,6 +19,7 @@
     You do not need a visa if you’re visiting family or a partner for 6 months or less.
   <% end %>
 
+  <%= render partial: "electronic_travel_authorisation_advice", locals: {calculator: calculator} %>
   If the family member you’re joining is from the EU, Switzerland, Norway, Iceland or Liechtenstein, you may be able to apply for a free [family permit](/family-permit). This makes it easier and quicker to enter the UK. Your family member must have been living in the UK by 31 December 2020.
 
   ##If you’re staying longer than 6 months

--- a/lib/smart_answer/calculators/uk_visa_calculator.rb
+++ b/lib/smart_answer/calculators/uk_visa_calculator.rb
@@ -86,6 +86,14 @@ module SmartAnswer::Calculators
       COUNTRY_GROUP_BRITISH_NATIONAL_OVERSEAS.include?(@passport_country)
     end
 
+    def passport_country_in_eta_rollout_group_1_rest_of_the_world?
+      COUNTRY_GROUP_ETA_ROLLOUT_GROUP_1_REST_OF_THE_WORLD.include?(@passport_country)
+    end
+
+    def passport_country_in_eta_rollout_group_2_eu_eea?
+      COUNTRY_GROUP_ETA_ROLLOUT_GROUP_2_EU_EEA.include?(@passport_country)
+    end
+
     def passport_country_in_b1_b2_visa_exception_list?
       @passport_country == "syria"
     end
@@ -617,5 +625,102 @@ module SmartAnswer::Calculators
       "british-overseas-citizen",
       "zimbabwe",
     ].flatten.freeze
+
+    COUNTRY_GROUP_ETA_ROLLOUT_GROUP_1_REST_OF_THE_WORLD = %w[
+      antigua-and-barbuda
+      argentina
+      australia
+      bahamas
+      barbados
+      belize
+      botswana
+      brazil
+      british-national-overseas
+      brunei
+      canada
+      chile
+      colombia
+      costa-rica
+      federated-states-of-micronesia
+      grenada
+      guatemala
+      guyana
+      hong-kong
+      hong-kong-(british-national-overseas)
+      israel
+      japan
+      kiribati
+      macao
+      malaysia
+      maldives
+      marshall-islands
+      mauritius
+      mexico
+      nauru
+      new-zealand
+      nicaragua
+      palau
+      panama
+      papua-new-guinea
+      paraguay
+      peru
+      samoa
+      seychelles
+      singapore
+      solomon-islands
+      south-korea
+      st-kitts-and-nevis
+      st-lucia
+      st-vincent-and-the-grenadines
+      taiwan
+      tonga
+      trinidad-and-tobago
+      tuvalu
+      uruguay
+      usa
+    ].freeze
+
+    COUNTRY_GROUP_ETA_ROLLOUT_GROUP_2_EU_EEA = %w[
+      andorra
+      austria
+      aruba
+      belgium
+      bonaire-st-eustatius-saba
+      bulgaria
+      croatia
+      curacao
+      cyprus
+      czech-republic
+      denmark
+      estonia
+      finland
+      france
+      germany
+      greece
+      hungary
+      iceland
+      italy
+      latvia
+      liechtenstein
+      lithuania
+      luxembourg
+      malta
+      monaco
+      netherlands
+      norway
+      poland
+      portugal
+      romania
+      saint-barthelemy
+      san-marino
+      slovakia
+      slovenia
+      spain
+      st-martin
+      st-maarten
+      sweden
+      switzerland
+      vatican-city
+    ].freeze
   end
 end

--- a/test/flows/check_uk_visa_flow_test.rb
+++ b/test/flows/check_uk_visa_flow_test.rb
@@ -14,11 +14,15 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
     @british_overseas_territory_country = "anguilla"
     @non_visa_national_country = "andorra"
     @eea_country = "austria"
+    @eta_rollout_group_1_rest_of_the_world_country = "antigua-and-barbuda"
+    @eta_rollout_group_2_eu_eea_country = "bonaire-st-eustatius-saba"
     @travel_document_country = "hong-kong"
     @b1_b2_country = "syria"
     @youth_mobility_scheme_country = "canada"
 
     @non_visa_national_eta_text = "You currently do not need an electronic travel authorisation (ETA)"
+    @eta_rollout_group_1_rest_of_the_world_text = "If you’re travelling on or after 8 January 2025, you’ll need to apply for an electronic travel authorisation (ETA). You’ll be able to apply from 27 November 2024."
+    @eta_rollout_group_2_eu_eea_text = "If you’re travelling on or after 2 April 2025, you’ll need to apply for an electronic travel authorisation (ETA). You’ll be able to apply from 5 March 2025."
     @eea_eta_text = "You currently do not need an electronic travel authorisation (ETA)"
 
     # stub only the countries used in this test for less of a performance impact
@@ -43,7 +47,9 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
                                       @eea_country,
                                       @travel_document_country,
                                       @b1_b2_country,
-                                      @youth_mobility_scheme_country].uniq)
+                                      @youth_mobility_scheme_country,
+                                      @eta_rollout_group_1_rest_of_the_world_country,
+                                      @eta_rollout_group_2_eu_eea_country].uniq)
   end
 
   should "render a start page" do
@@ -938,6 +944,16 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
       assert_no_rendered_outcome text: "You may need a visa"
       assert_no_rendered_outcome text: "Whether you need a visa depends"
     end
+
+    should "render callout box for eta_rollout_group_1_rest_of_the_world_country passport holders" do
+      add_responses what_passport_do_you_have?: @eta_rollout_group_1_rest_of_the_world_country
+      assert_rendered_outcome text: @eta_rollout_group_1_rest_of_the_world_text
+    end
+
+    should "render callout box for eta_rollout_group_2_eu_eea_country passport holders" do
+      add_responses what_passport_do_you_have?: @eta_rollout_group_2_eu_eea_country
+      assert_rendered_outcome text: @eta_rollout_group_2_eu_eea_text
+    end
   end
 
   context "ETA callout box on" do
@@ -953,14 +969,14 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
         assert_no_rendered_outcome text: @eea_eta_text
       end
 
-      should "render callout box for non_visa_national_country passport holders" do
-        add_responses what_passport_do_you_have?: @non_visa_national_country
-        assert_rendered_outcome text: @non_visa_national_eta_text
+      should "render callout box for eta_rollout_group_1_rest_of_the_world_country passport holders" do
+        add_responses what_passport_do_you_have?: @eta_rollout_group_1_rest_of_the_world_country
+        assert_rendered_outcome text: @eta_rollout_group_1_rest_of_the_world_text
       end
 
-      should "render callout box for eea_country passport holders" do
-        add_responses what_passport_do_you_have?: @eea_country
-        assert_rendered_outcome text: @eea_eta_text
+      should "render callout box for eta_rollout_group_2_eu_eea_country passport holders" do
+        add_responses what_passport_do_you_have?: @eta_rollout_group_2_eu_eea_country
+        assert_rendered_outcome text: @eta_rollout_group_2_eu_eea_text
       end
     end
 
@@ -977,14 +993,14 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
         assert_no_rendered_outcome text: @eea_eta_text
       end
 
-      should "render callout box for non_visa_national_country passport holders" do
-        add_responses what_passport_do_you_have?: @non_visa_national_country
-        assert_rendered_outcome text: @non_visa_national_eta_text
+      should "render callout box for eta_rollout_group_1_rest_of_the_world_country passport holders" do
+        add_responses what_passport_do_you_have?: @eta_rollout_group_1_rest_of_the_world_country
+        assert_rendered_outcome text: @eta_rollout_group_1_rest_of_the_world_text
       end
 
-      should "render callout box for eea_country passport holders" do
-        add_responses what_passport_do_you_have?: @eea_country
-        assert_rendered_outcome text: @eea_eta_text
+      should "render callout box for eta_rollout_group_2_eu_eea_country passport holders" do
+        add_responses what_passport_do_you_have?: @eta_rollout_group_2_eu_eea_country
+        assert_rendered_outcome text: @eta_rollout_group_2_eu_eea_text
       end
     end
 
@@ -1001,14 +1017,14 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
         assert_no_rendered_outcome text: @eea_eta_text
       end
 
-      should "render callout box for non_visa_national_country passport holders" do
-        add_responses what_passport_do_you_have?: @non_visa_national_country
-        assert_rendered_outcome text: @non_visa_national_eta_text
+      should "render callout box for eta_rollout_group_1_rest_of_the_world_country passport holders" do
+        add_responses what_passport_do_you_have?: @eta_rollout_group_1_rest_of_the_world_country
+        assert_rendered_outcome text: @eta_rollout_group_1_rest_of_the_world_text
       end
 
-      should "render callout box for eea_country passport holders" do
-        add_responses what_passport_do_you_have?: @eea_country
-        assert_rendered_outcome text: @eea_eta_text
+      should "render callout box for eta_rollout_group_2_eu_eea_country passport holders" do
+        add_responses what_passport_do_you_have?: @eta_rollout_group_2_eu_eea_country
+        assert_rendered_outcome text: @eta_rollout_group_2_eu_eea_text
       end
     end
 
@@ -1024,14 +1040,14 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
         assert_no_rendered_outcome text: @eea_eta_text
       end
 
-      should "render callout box for non_visa_national_country passport holders" do
-        add_responses what_passport_do_you_have?: @non_visa_national_country
-        assert_rendered_outcome text: @non_visa_national_eta_text
+      should "render callout box for eta_rollout_group_1_rest_of_the_world_country passport holders" do
+        add_responses what_passport_do_you_have?: @eta_rollout_group_1_rest_of_the_world_country
+        assert_rendered_outcome text: @eta_rollout_group_1_rest_of_the_world_text
       end
 
-      should "render callout box for eea_country passport holders" do
-        add_responses what_passport_do_you_have?: @eea_country
-        assert_rendered_outcome text: @eea_eta_text
+      should "render callout box for eta_rollout_group_2_eu_eea_country passport holders" do
+        add_responses what_passport_do_you_have?: @eta_rollout_group_2_eu_eea_country
+        assert_rendered_outcome text: @eta_rollout_group_2_eu_eea_text
       end
     end
 
@@ -1047,14 +1063,14 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
         assert_no_rendered_outcome text: @eea_eta_text
       end
 
-      should "render callout box for non_visa_national_country passport holders" do
-        add_responses what_passport_do_you_have?: @non_visa_national_country
-        assert_rendered_outcome text: @non_visa_national_eta_text
+      should "render callout box for eta_rollout_group_1_rest_of_the_world_country passport holders" do
+        add_responses what_passport_do_you_have?: @eta_rollout_group_1_rest_of_the_world_country
+        assert_rendered_outcome text: @eta_rollout_group_1_rest_of_the_world_text
       end
 
-      should "render callout box for eea_country passport holders" do
-        add_responses what_passport_do_you_have?: @eea_country
-        assert_rendered_outcome text: @eea_eta_text
+      should "render callout box for eta_rollout_group_2_eu_eea_country passport holders" do
+        add_responses what_passport_do_you_have?: @eta_rollout_group_2_eu_eea_country
+        assert_rendered_outcome text: @eta_rollout_group_2_eu_eea_text
       end
     end
 
@@ -1070,14 +1086,14 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
         assert_no_rendered_outcome text: @eea_eta_text
       end
 
-      should "render callout box for non_visa_national_country passport holders" do
-        add_responses what_passport_do_you_have?: @non_visa_national_country
-        assert_rendered_outcome text: @non_visa_national_eta_text
+      should "render callout box for eta_rollout_group_1_rest_of_the_world_country passport holders" do
+        add_responses what_passport_do_you_have?: @eta_rollout_group_1_rest_of_the_world_country
+        assert_rendered_outcome text: @eta_rollout_group_1_rest_of_the_world_text
       end
 
-      should "render callout box for eea_country passport holders" do
-        add_responses what_passport_do_you_have?: @eea_country
-        assert_rendered_outcome text: @eea_eta_text
+      should "render callout box for eta_rollout_group_2_eu_eea_country passport holders" do
+        add_responses what_passport_do_you_have?: @eta_rollout_group_2_eu_eea_country
+        assert_rendered_outcome text: @eta_rollout_group_2_eu_eea_text
       end
     end
 
@@ -1094,14 +1110,14 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
         assert_no_rendered_outcome text: @eea_eta_text
       end
 
-      should "render callout box for non_visa_national_country passport holders" do
-        add_responses what_passport_do_you_have?: @non_visa_national_country
-        assert_rendered_outcome text: @non_visa_national_eta_text
+      should "render callout box for eta_rollout_group_1_rest_of_the_world_country passport holders" do
+        add_responses what_passport_do_you_have?: @eta_rollout_group_1_rest_of_the_world_country
+        assert_rendered_outcome text: @eta_rollout_group_1_rest_of_the_world_text
       end
 
-      should "render callout box for eea_country passport holders" do
-        add_responses what_passport_do_you_have?: @eea_country
-        assert_rendered_outcome text: @eea_eta_text
+      should "render callout box for eta_rollout_group_2_eu_eea_country passport holders" do
+        add_responses what_passport_do_you_have?: @eta_rollout_group_2_eu_eea_country
+        assert_rendered_outcome text: @eta_rollout_group_2_eu_eea_text
       end
     end
   end


### PR DESCRIPTION
Update ETA rollout guidance to the countries that would require ETA authorisation for travel to UK for certain smart answer outcomes.

This PR updates the rollout text for travel authorisation advice that was already put in place for most of the outcomes explained in this [document](https://docs.google.com/document/d/1MA6BmfcnXVmeXQ7c10aga-X9QumlohvM1TZesGDvdE8/edit#heading=h.wziip1u7avac).

It was also discovered that the outcome app/flows/check_uk_visa_flow/outcomes/outcome_joining_family_nvn.erb was missing the partial app/flows/check_uk_visa_flow/outcomes/_electronic_travel_authorisation_advice.erb and hence it has been updated now.

[Trello](https://trello.com/c/FIUzwn8c/293-around-10-september-add-electronic-travel-authorisation-eta-rollout-dates-to-check-if-you-need-a-uk-visa)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
