### PR TITLE
Update uk_result.erb

### DIFF
--- a/app/flows/register_a_death_flow/outcomes/uk_result.erb
+++ b/app/flows/register_a_death_flow/outcomes/uk_result.erb
@@ -1,5 +1,7 @@
 <% govspeak_for :body do %>
-  You should register the death within 5 days.
+You’ll be contacted by the medical examiner’s office to confirm you can register the death.
+
+You must register the death within 5 days (8 days in Scotland) of being contacted. This includes weekends and bank holidays.
 
   Contact a [register office](/register-offices) to register the death. You can contact any register office but it will be quicker if you use the one in the area where the person died.
 


### PR DESCRIPTION
Trello: https://trello.com/c/5ZA9blV6/4384-9-sept-changes-to-the-death-certification-process

Summary:

From 9 September 2024, a medical examiner must independently review the proposed cause of death on the medical certificate of cause of death (MCCD) of all deaths, except those that need to be referred to a coroner.

Only once the registrar has received the MCCD from the medical examiner, and the medical examiner has called the user to let them know that’s happened, can users register a death. It must be done within 5 days. 

In addition to this, users will no longer need to complete an ‘application for cremation’, instead they’ll get a certificate for cremation. 

We have therefore made it clear that users need to wait for a call from the medical examiner in order to register a death.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
