### PR TITLE
Remove Rails override

### DIFF
--- a/.govuk_dependabot_merger.yml
+++ b/.govuk_dependabot_merger.yml
@@ -2,6 +2,3 @@ api_version: 2
 defaults:
   auto_merge: true
   update_external_dependencies: false # TODO: enable after verifying that this repo meets the conditions
-overrides:
-  - dependency: rails # should be upgraded manually, see https://docs.publishing.service.gov.uk/manual/keeping-software-current.html#rails
-    auto_merge: false


### PR DESCRIPTION
The config already has `update_external_dependencies: false`, so Rails updates are already blocked.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
