### PR TITLE
Remove marriage abroad hacks

### DIFF
--- a/app/presenters/flow_presenter.rb
+++ b/app/presenters/flow_presenter.rb
@@ -55,9 +55,7 @@ class FlowPresenter
   end
 
   def start_page_link(forwarding_responses)
-    if @flow.name.eql? "marriage-abroad" # Nasty hack to allow migration of old service to new one. Will be stripped asap
-      "https://www.prove-eligibility-foreign-government.service.gov.uk/before-you-start"
-    elsif response_store
+    if response_store
       start_flow_path(name, params: forwarding_responses)
     else
       smart_answer_path(name)

--- a/app/views/smart_answers/landing.html.erb
+++ b/app/views/smart_answers/landing.html.erb
@@ -7,15 +7,12 @@
     <meta name="description" content="<%= start_node.meta_description %>">
   <% end %>
   <% if content_item.present? %>
-    <% canonical_url = "https://www.gov.uk/marriages-civil-partnerships-abroad" if start_node.node_slug == "marriage-abroad" %>
     <%= render "govuk_publishing_components/components/machine_readable_metadata",
       schema: :article,
-      content_item: content_item,
-      canonical_url: %>
+      content_item: content_item %>
     <%= render "govuk_publishing_components/components/machine_readable_metadata",
       schema: :government_service,
-      content_item: content_item,
-      canonical_url: %>
+      content_item: content_item %>
   <% end %>
   <link title="Search" rel="search" type="application/opensearchdescription+xml" href="/search/opensearch.xml">
 <% end %>

--- a/test/unit/flow_presenter_test.rb
+++ b/test/unit/flow_presenter_test.rb
@@ -141,15 +141,4 @@ class FlowPresenterTest < ActiveSupport::TestCase
   test "#start_page_link returns the start page link for a non response store flow" do
     assert_equal "/flow-name/y", @flow_presenter.start_page_link({ "key" => "value" })
   end
-
-  test "#start_page_link returns the new flow when we're in marriage-abroad" do
-    @flow = SmartAnswer::Flow.build do
-      name "marriage-abroad"
-    end
-    @flow_presenter = FlowPresenter.new(@flow, nil)
-    assert_equal(
-      "https://www.prove-eligibility-foreign-government.service.gov.uk/before-you-start",
-      @flow_presenter.start_page_link({ "key" => "value" }),
-    )
-  end
 end


### PR DESCRIPTION
This is part of the [Clean up 'Get married abroad' smart answer (post-retirement)](ttps://trello.com/c/JQUKmEBh) work
Reverts code back, removing the previously added hacks which were necessary at the time to redirect to the new FCDO Get Married abroad smart answer and to help search engines find the new version. Now that migration is complete, the hacks can safely be removed. 

The 2 commits here remove the hacks which were introduced in these 2 previous PRs (in order):

1. [Set the canonical URL for the marriage-abroad SA #6758](https://github.com/alphagov/smart-answers/pull/6758/files)
2. [Redirect Marriage Abroad start page to new flow #6754](https://github.com/alphagov/smart-answers/pull/6754/commits/571d53ed3b5d935e365e78dd4aaccd3b3128292a)