### PR TITLE
Fix inline styling of bold text on a results page

### DIFF
--- a/app/flows/check_benefits_financial_support_flow/outcomes/results.erb
+++ b/app/flows/check_benefits_financial_support_flow/outcomes/results.erb
@@ -1,6 +1,6 @@
 <% text_for :body do %>
   <% if calculator.number_of_benefits > 0 %>
-    <p class="govuk-body">Based on your answers, you may be eligible for the following <span id="ga4-ecommerce-result-count" style="font-weight: bold"><%= calculator.number_of_benefits %> things</span>.</p>
+    <p class="govuk-body">Based on your answers, you may be eligible for the following <span id="ga4-ecommerce-result-count" class="govuk-!-font-weight-bold"><%= calculator.number_of_benefits %> things</span>.</p>
   <% else %>
     <p class="govuk-body">Based on your answers, you may not be eligible for any benefits.</p>
   <% end %>


### PR DESCRIPTION
## What

Fixed a styling issue with bold text on the check benefits financial support results page.

## Why

Noticed a console error when completing a review of app components, it seems inline styles are no longer applied.

### Visual Changes

| Before | After |
| --- | --- |
| <img width="665" alt="bold-before" src="https://github.com/user-attachments/assets/aebc95cd-beab-498d-b66f-b8b1cc230769"> | <img width="666" alt="bold-after" src="https://github.com/user-attachments/assets/460b7aee-2e33-4c8e-b62a-15c551b61da3"> |

Page example: https://www.gov.uk/check-benefits-financial-support/y/england/no/no/yes/yes/yes_unable_to_work/no/no/dont_know/none_16000