### PR TITLE
Update SA penalties calculator

### DIFF
--- a/app/flows/estimate_self_assessment_penalties_flow.rb
+++ b/app/flows/estimate_self_assessment_penalties_flow.rb
@@ -5,7 +5,6 @@ class EstimateSelfAssessmentPenaltiesFlow < SmartAnswer::Flow
     status :published
 
     radio :which_year? do
-      option :"2016-17"
       option :"2017-18"
       option :"2018-19"
       option :"2019-20"

--- a/app/flows/estimate_self_assessment_penalties_flow.rb
+++ b/app/flows/estimate_self_assessment_penalties_flow.rb
@@ -11,6 +11,7 @@ class EstimateSelfAssessmentPenaltiesFlow < SmartAnswer::Flow
       option :"2020-21"
       option :"2021-22"
       option :"2022-23"
+      option :"2023-24"
 
       on_response do |response|
         self.calculator = SmartAnswer::Calculators::SelfAssessmentPenalties.new

--- a/app/flows/estimate_self_assessment_penalties_flow/questions/which_year.erb
+++ b/app/flows/estimate_self_assessment_penalties_flow/questions/which_year.erb
@@ -9,4 +9,5 @@
   "2020-21": "6 April 2020 to 5 April 2021",
   "2021-22": "6 April 2021 to 5 April 2022",
   "2022-23": "6 April 2022 to 5 April 2023",
+  "2023-24": "6 April 2023 to 5 April 2024",
 ) %>

--- a/app/flows/estimate_self_assessment_penalties_flow/questions/which_year.erb
+++ b/app/flows/estimate_self_assessment_penalties_flow/questions/which_year.erb
@@ -3,7 +3,6 @@
 <% end %>
 
 <% options(
-  "2016-17": "6 April 2016 to 5 April 2017",
   "2017-18": "6 April 2017 to 5 April 2018",
   "2018-19": "6 April 2018 to 5 April 2019",
   "2019-20": "6 April 2019 to 5 April 2020",

--- a/lib/smart_answer/calculators/self_assessment_penalties.rb
+++ b/lib/smart_answer/calculators/self_assessment_penalties.rb
@@ -56,7 +56,8 @@ module SmartAnswer::Calculators
       { start_date: "2023-05-31", end_date: "2023-07-10", value: 0.07 },
       { start_date: "2023-07-11", end_date: "2023-08-21", value: 0.075 },
       { start_date: "2023-08-22", end_date: "2024-08-19", value: 0.0775 },
-      { start_date: "2024-08-20", end_date: "2100-04-04", value: 0.075 },
+      { start_date: "2024-08-20", end_date: "2024-11-25", value: 0.075 },
+      { start_date: "2024-11-26", end_date: "2100-04-04", value: 0.0725 },
     ].freeze
 
     def tax_year_range

--- a/lib/smart_answer/calculators/self_assessment_penalties.rb
+++ b/lib/smart_answer/calculators/self_assessment_penalties.rb
@@ -18,6 +18,7 @@ module SmartAnswer::Calculators
         "2020-21-covid-easement": ONLINE_FILING_DEADLINE_YEAR_FEB.starting_in(2022).begins_on,
         "2021-22": ONLINE_FILING_DEADLINE_YEAR.starting_in(2023).begins_on,
         "2022-23": ONLINE_FILING_DEADLINE_YEAR.starting_in(2024).begins_on,
+        "2023-24": ONLINE_FILING_DEADLINE_YEAR.starting_in(2025).begins_on,
       },
       paper_filing_deadline: {
         "2017-18": OFFLINE_FILING_DEADLINE_YEAR.starting_in(2018).begins_on,
@@ -26,6 +27,7 @@ module SmartAnswer::Calculators
         "2020-21": OFFLINE_FILING_DEADLINE_YEAR.starting_in(2021).begins_on,
         "2021-22": OFFLINE_FILING_DEADLINE_YEAR.starting_in(2022).begins_on,
         "2022-23": OFFLINE_FILING_DEADLINE_YEAR.starting_in(2023).begins_on,
+        "2023-24": OFFLINE_FILING_DEADLINE_YEAR.starting_in(2025).begins_on,
       },
       payment_deadline: {
         "2017-18": PAYMENT_DEADLINE_YEAR.starting_in(2019).begins_on,
@@ -34,6 +36,7 @@ module SmartAnswer::Calculators
         "2020-21": PAYMENT_DEADLINE_YEAR.starting_in(2022).begins_on,
         "2021-22": PAYMENT_DEADLINE_YEAR.starting_in(2023).begins_on,
         "2022-23": PAYMENT_DEADLINE_YEAR.starting_in(2024).begins_on,
+        "2023-24": PAYMENT_DEADLINE_YEAR.starting_in(2025).begins_on,
       },
     }.freeze
 
@@ -70,6 +73,8 @@ module SmartAnswer::Calculators
         SmartAnswer::YearRange.tax_year.starting_in(2021)
       when "2022-23"
         SmartAnswer::YearRange.tax_year.starting_in(2022)
+      when "2023-24"
+        SmartAnswer::YearRange.tax_year.starting_in(2023)
       end
     end
 
@@ -91,6 +96,8 @@ module SmartAnswer::Calculators
         PENALTY_YEAR.starting_in(2024).begins_on
       when "2022-23"
         PENALTY_YEAR.starting_in(2025).begins_on
+      when "2023-24"
+        PENALTY_YEAR.starting_in(2026).begins_on
       end
     end
 

--- a/lib/smart_answer/calculators/self_assessment_penalties.rb
+++ b/lib/smart_answer/calculators/self_assessment_penalties.rb
@@ -10,7 +10,6 @@ module SmartAnswer::Calculators
 
     DEADLINES = {
       online_filing_deadline: {
-        "2016-17": ONLINE_FILING_DEADLINE_YEAR.starting_in(2018).begins_on,
         "2017-18": ONLINE_FILING_DEADLINE_YEAR.starting_in(2019).begins_on,
         "2018-19": ONLINE_FILING_DEADLINE_YEAR.starting_in(2020).begins_on,
         "2019-20": ONLINE_FILING_DEADLINE_YEAR.starting_in(2021).begins_on,
@@ -21,7 +20,6 @@ module SmartAnswer::Calculators
         "2022-23": ONLINE_FILING_DEADLINE_YEAR.starting_in(2024).begins_on,
       },
       paper_filing_deadline: {
-        "2016-17": OFFLINE_FILING_DEADLINE_YEAR.starting_in(2017).begins_on,
         "2017-18": OFFLINE_FILING_DEADLINE_YEAR.starting_in(2018).begins_on,
         "2018-19": OFFLINE_FILING_DEADLINE_YEAR.starting_in(2019).begins_on,
         "2019-20": OFFLINE_FILING_DEADLINE_YEAR.starting_in(2020).begins_on,
@@ -30,7 +28,6 @@ module SmartAnswer::Calculators
         "2022-23": OFFLINE_FILING_DEADLINE_YEAR.starting_in(2023).begins_on,
       },
       payment_deadline: {
-        "2016-17": PAYMENT_DEADLINE_YEAR.starting_in(2018).begins_on,
         "2017-18": PAYMENT_DEADLINE_YEAR.starting_in(2019).begins_on,
         "2018-19": PAYMENT_DEADLINE_YEAR.starting_in(2020).begins_on,
         "2019-20": PAYMENT_DEADLINE_YEAR.starting_in(2021).begins_on,
@@ -61,8 +58,6 @@ module SmartAnswer::Calculators
 
     def tax_year_range
       case tax_year
-      when "2016-17"
-        SmartAnswer::YearRange.tax_year.starting_in(2016)
       when "2017-18"
         SmartAnswer::YearRange.tax_year.starting_in(2017)
       when "2018-19"
@@ -84,8 +79,6 @@ module SmartAnswer::Calculators
 
     def one_year_after_start_date_for_penalties
       case tax_year
-      when "2016-17"
-        PENALTY_YEAR.starting_in(2019).begins_on
       when "2017-18"
         PENALTY_YEAR.starting_in(2020).begins_on
       when "2018-19"

--- a/test/unit/calculators/self_assessment_penalties_test.rb
+++ b/test/unit/calculators/self_assessment_penalties_test.rb
@@ -313,10 +313,10 @@ module SmartAnswer::Calculators
           assert_equal 5695, @calculator.total_owed
           @calculator.payment_date = Date.parse("2025-02-03")
           assert_equal 750, @calculator.late_payment_penalty
-          assert_equal 6134, @calculator.total_owed
+          assert_equal 6132, @calculator.total_owed
           @calculator.payment_date = Date.parse("2025-08-03")
           assert_equal 750, @calculator.late_payment_penalty
-          assert_equal 6320, @calculator.total_owed
+          assert_equal 6311, @calculator.total_owed
         end
 
         context "HMRC Covid-19 Extension to 1 April for 2019-20" do

--- a/test/unit/calculators/self_assessment_penalties_test.rb
+++ b/test/unit/calculators/self_assessment_penalties_test.rb
@@ -43,6 +43,11 @@ module SmartAnswer::Calculators
 
         assert_equal Date.new(2023, 4, 6), @calculator.start_of_next_tax_year
       end
+      should "return 2024-04-06 if tax-year is 2023-24" do
+        @calculator.tax_year = "2023-24"
+
+        assert_equal Date.new(2024, 4, 6), @calculator.start_of_next_tax_year
+      end
     end
 
     context "one_year_after_start_date_for_penalties" do
@@ -75,6 +80,11 @@ module SmartAnswer::Calculators
         @calculator.tax_year = "2022-23"
 
         assert_equal Date.new(2025, 2, 1), @calculator.one_year_after_start_date_for_penalties
+      end
+      should "return 2026-02-01 if tax-year is 2023-24" do
+        @calculator.tax_year = "2023-24"
+
+        assert_equal Date.new(2026, 2, 1), @calculator.one_year_after_start_date_for_penalties
       end
     end
 

--- a/test/unit/calculators/self_assessment_penalties_test.rb
+++ b/test/unit/calculators/self_assessment_penalties_test.rb
@@ -13,11 +13,6 @@ module SmartAnswer::Calculators
     end
 
     context "#start_of_next_year" do
-      should "return 2017-04-06 if tax-year is 2016-17" do
-        @calculator.tax_year = "2016-17"
-
-        assert_equal Date.new(2017, 4, 6), @calculator.start_of_next_tax_year
-      end
       should "return 2018-04-06 if tax-year is 2017-18" do
         @calculator.tax_year = "2017-18"
 
@@ -51,11 +46,6 @@ module SmartAnswer::Calculators
     end
 
     context "one_year_after_start_date_for_penalties" do
-      should "return 2019-02-01 if tax-year is 2016-17" do
-        @calculator.tax_year = "2016-17"
-
-        assert_equal Date.new(2019, 2, 1), @calculator.one_year_after_start_date_for_penalties
-      end
       should "return 2020-02-01 if tax-year is 2017-18" do
         @calculator.tax_year = "2017-18"
 


### PR DESCRIPTION
This PR updates the interest rate to the Self-assessment late penalty calculator, and updates relevant tests.

The interest rate will go from 7.5% to 7.25% on 26 Nov 2024.

[Zendesk ticket](https://govuk.zendesk.com/agent/tickets/5964597)

[Trello](https://trello.com/c/pj56iM3h)