### PR TITLE
Update _electronic_travel_authorisation_advice.erb

### DIFF
--- a/app/flows/check_uk_visa_flow/outcomes/_electronic_travel_authorisation_advice.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/_electronic_travel_authorisation_advice.erb
@@ -1,5 +1,5 @@
 <% if calculator.passport_country_in_eta_rollout_group_1_rest_of_the_world? %>
-  ^If you’re travelling on or after 8 January 2025, you’ll need to apply for an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta). You’ll be able to apply from 27 November 2024.
+  ^If you’re travelling on or after 8 January 2025, you’ll need to apply for an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta). 
 <% elsif calculator.passport_country_in_eta_rollout_group_2_eu_eea? %>
   ^If you’re travelling on or after 2 April 2025, you’ll need to apply for an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta). You’ll be able to apply from 5 March 2025.
 <% end %>

--- a/test/flows/check_uk_visa_flow_test.rb
+++ b/test/flows/check_uk_visa_flow_test.rb
@@ -21,7 +21,7 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
     @youth_mobility_scheme_country = "canada"
 
     @non_visa_national_eta_text = "You currently do not need an electronic travel authorisation (ETA)"
-    @eta_rollout_group_1_rest_of_the_world_text = "If you’re travelling on or after 8 January 2025, you’ll need to apply for an electronic travel authorisation (ETA). You’ll be able to apply from 27 November 2024."
+    @eta_rollout_group_1_rest_of_the_world_text = "If you’re travelling on or after 8 January 2025, you’ll need to apply for an electronic travel authorisation (ETA)."
     @eta_rollout_group_2_eu_eea_text = "If you’re travelling on or after 2 April 2025, you’ll need to apply for an electronic travel authorisation (ETA). You’ll be able to apply from 5 March 2025."
     @eea_eta_text = "You currently do not need an electronic travel authorisation (ETA)"
 


### PR DESCRIPTION
Trello card: (https://trello.com/c/boCYBEyS/303-after-26-november-tbc-eta-change-to-callout-for-check-if-you-need-a-visa) 

Summary:

Users will be able to apply for an ETA from 27 November so we don’t need to include this date any longer.

For reference, we decided not to include ‘to travel to the UK without a visa’ to the end of the sentence (the change that the department suggested) because the outcome page already highlights whether or not the user will need a visa.

We need the preview link for fact check but it doesn't need to go live until 27 November (anytime on that day).

------------

CHANGE for ‘rest of world’ countries FROM

 ^If you’re travelling on or after 8 January 2025, you’ll need to apply for an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta). You’ll be able to apply from 27 November 2024.

TO

 ^If you’re travelling on or after 8 January 2025, you’ll need to apply for an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta).


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
