### PR TITLE
Render GOV.UK Chat promo on specific page

### DIFF
--- a/app/helpers/govuk_chat_promo_helper.rb
+++ b/app/helpers/govuk_chat_promo_helper.rb
@@ -1,0 +1,9 @@
+module GovukChatPromoHelper
+  GOVUK_CHAT_PROMO_BASE_URLS = %w[
+    /am-i-getting-minimum-wage
+  ].freeze
+
+  def show_govuk_chat_promo?(base_url)
+    ENV["GOVUK_CHAT_PROMO_ENABLED"] == "true" && GOVUK_CHAT_PROMO_BASE_URLS.include?(base_url)
+  end
+end

--- a/app/views/smart_answers/landing.html.erb
+++ b/app/views/smart_answers/landing.html.erb
@@ -69,6 +69,9 @@
     <%= render "govuk_publishing_components/components/contextual_footer", content_item: content_item %>
   </div>
   <div class="govuk-grid-column-one-third">
+    <% if content_item.present? && show_govuk_chat_promo?(content_item["base_path"]) %>
+      <%= render "govuk_publishing_components/components/chat_entry", { margin_top_until_tablet: true } %>
+    <% end %>
     <%= render "govuk_publishing_components/components/contextual_sidebar", content_item: content_item %>
   </div>
 </div>

--- a/test/helpers/govuk_chat_promo_helper_test.rb
+++ b/test/helpers/govuk_chat_promo_helper_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+
+class GovukChatPromoHelperTest < ActionView::TestCase
+  context "#show_govuk_chat_promo?" do
+    should "return false when configuration disabled" do
+      assert_not show_govuk_chat_promo?(GovukChatPromoHelper::GOVUK_CHAT_PROMO_BASE_URLS.first)
+    end
+
+    should "return false when base_url is not in allow list" do
+      ENV["GOVUK_CHAT_PROMO_ENABLED"] = "true"
+
+      assert_not show_govuk_chat_promo?("/non-matching-path")
+    ensure
+      ENV["GOVUK_CHAT_PROMO_ENABLED"] = nil
+    end
+
+    should "return true when base_url is in allow list" do
+      ENV["GOVUK_CHAT_PROMO_ENABLED"] = "true"
+
+      assert show_govuk_chat_promo?(GovukChatPromoHelper::GOVUK_CHAT_PROMO_BASE_URLS.first)
+    ensure
+      ENV["GOVUK_CHAT_PROMO_ENABLED"] = nil
+    end
+  end
+end


### PR DESCRIPTION
We want to bring more users to the GOV.UK Chat app, so we'd like to render a promo component on one specific page: https://www.gov.uk/am-i-getting-minimum-wage.

The component lives in the `govuk_publishing_components` gem and is typically rendered in the sidebar of a page. There's a live example on [this page](https://www.gov.uk/national-minimum-wage-rates).

This follows prior art in the [government-frontend](https://github.com/alphagov/government-frontend/pull/3303) and [collections](https://github.com/alphagov/collections/pull/3742) repos.

| Before  | After |
| ------------- | ------------- |
| ![localhost_3010_am-i-getting-minimum-wage](https://github.com/user-attachments/assets/d2a94a5b-2db0-44ef-9af6-0a89ef7dc478) |  ![localhost_3010_am-i-getting-minimum-wage (1)](https://github.com/user-attachments/assets/85863813-4737-429e-8d55-d0cf4b273630) |
| <img width="1005" alt="Screenshot 2024-11-25 at 17 27 11" src="https://github.com/user-attachments/assets/2ee72868-448e-4ff6-8c8d-16c2ecf34f21"> |  <img width="998" alt="Screenshot 2024-11-25 at 17 26 57" src="https://github.com/user-attachments/assets/f20efdf0-48b2-4ab3-92f3-99e6307eab94"> |