### PR TITLE
Move Colombia to the "visa-national" list

### DIFF
--- a/app/flows/check_uk_visa_flow/outcomes/colombia/_outcome_marriage_visa_nat_direct_airside_transit_visa.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/colombia/_outcome_marriage_visa_nat_direct_airside_transit_visa.erb
@@ -1,0 +1,18 @@
+<% if calculator.show_colombia_visa_change_transition_text? %>
+  ##If you want to convert a civil partnership into a marriage
+
+  You can come to the UK for up to 6 months without a visa if all of the following apply:
+
+  * you booked and paid for your journey to the UK before 3pm (UK time) on 26 November 2024
+  * you’re arriving in the UK before 3pm (UK time) on 24 December 2024
+  * you meet the [Standard Visitor](/standard-visitor) eligibility requirements
+
+  [Check what documents you need to bring](/government/publications/visitor-visa-guide-to-supporting-documents) to show officers at the UK border.
+
+  ###If you need to leave and re-enter the UK
+
+  You’ll need a visa to re-enter the UK if either of the following apply:
+
+  * you did not book your return journey to the UK before 3pm (UK time) on 26 November 2024
+  * you’re returning to the UK on or after 3pm (UK time) on 24 December 2024
+<% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/colombia/_outcome_medical_y.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/colombia/_outcome_medical_y.erb
@@ -1,0 +1,22 @@
+<% if calculator.show_colombia_visa_change_transition_text? %>
+  ##If you’re arriving in the UK before 3pm (UK time) on 24 December 2024
+
+  You can stay in the UK for up to 6 months without a visa if all of the following apply:
+
+  * you booked and paid for your journey to the UK before 3pm (UK time) on 26 November 2024
+  * you’re arriving in the UK before 3pm (UK time) on 24 December 2024
+  * you meet the [Standard Visitor](/standard-visitor) eligibility requirements
+
+  [Check what documents you need to bring](/government/publications/visitor-visa-guide-to-supporting-documents) to show officers at the UK border.
+
+  The rules on what you’ll need to enter the UK may be different if you’re [travelling from Ireland, Jersey, Guernsey or the Isle of Man](/guidance/travelling-between-the-uk-and-ireland-isle-of-man-guernsey-or-jersey).
+
+  %You may want to [apply for a Standard Visitor visa](/standard-visitor/apply-standard-visitor-visa) if you have a criminal record or you’ve previously been refused entry into the UK.%
+
+  ###If you need to leave and re-enter the UK
+
+  You’ll need a visa to re-enter the UK if either of the following apply:
+
+  * you did not book your return journey to the UK before 3pm (UK time) on 26 November 2024
+  * you’re returning to the UK on or after 3pm (UK time) on 24 December 2024
+<% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/colombia/_outcome_partner_family_british_citizen_y.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/colombia/_outcome_partner_family_british_citizen_y.erb
@@ -1,0 +1,19 @@
+<% if calculator.show_colombia_visa_change_transition_text? %>
+  ##If you’re arriving in the UK before 3pm (UK time) on 24 December 2024
+
+  You do not need a visa to come to the UK if both of the following apply:
+
+  *you booked and paid for your journey to the UK before 3pm (UK time) on 26 November 2024
+  * you’re arriving in the UK before 3pm (UK time) on 24 December 2024
+
+  You should bring evidence of your onward journey to show to officers at the UK border.
+
+  %You may want to [apply for a visa](/browse/visas-immigration/tourist-short-stay-visas) if you have a criminal record or you’ve previously been refused entry into the UK.%
+
+  ###If you need to leave and re-enter the UK
+
+  You’ll need a visa to re-enter the UK if either of the following apply:
+
+  * you did not book your return journey to the UK before 3pm (UK time) on 26 November 2024
+  * you’re returning to the UK on or after 3pm (UK time) on 24 December 2024
+<% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/colombia/_outcome_partner_family_british_citizen_y.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/colombia/_outcome_partner_family_british_citizen_y.erb
@@ -3,7 +3,7 @@
 
   You do not need a visa to come to the UK if both of the following apply:
 
-  *you booked and paid for your journey to the UK before 3pm (UK time) on 26 November 2024
+  * you booked and paid for your journey to the UK before 3pm (UK time) on 26 November 2024
   * you’re arriving in the UK before 3pm (UK time) on 24 December 2024
 
   You should bring evidence of your onward journey to show to officers at the UK border.

--- a/app/flows/check_uk_visa_flow/outcomes/colombia/_outcome_partner_family_eea_n_1.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/colombia/_outcome_partner_family_eea_n_1.erb
@@ -1,0 +1,3 @@
+<% if calculator.show_colombia_visa_change_transition_text? %>
+  ^The rules on what you’ll need to come to the UK may be different if you're arriving in the UK before 3pm (UK time) on 24 December 2024.
+<% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/colombia/_outcome_partner_family_eea_n_2.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/colombia/_outcome_partner_family_eea_n_2.erb
@@ -1,0 +1,15 @@
+<% if calculator.show_colombia_visa_change_transition_text? %>
+  ##If you’re arriving in the UK before 3pm (UK time) on 24 December 2024
+
+  You can join your partner or family member for up to 6 months without a visa if both of the following apply:
+
+  * you booked and paid for your journey to the UK before 3pm (UK time) on 26 November 2024
+  * you’re arriving in the UK before 3pm (UK time) on 24 December 2024
+
+  ###If you need to leave and re-enter the UK
+
+  You’ll need a visa to re-enter the UK if either of the following apply:
+
+  * you did not book your return journey to the UK before 3pm (UK time) on 26 November 2024
+  * you’re returning to the UK on or after 3pm (UK time) on 24 December 2024
+<% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/colombia/_outcome_partner_family_eea_y.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/colombia/_outcome_partner_family_eea_y.erb
@@ -1,0 +1,15 @@
+<% if calculator.show_colombia_visa_change_transition_text? %>
+  ###If you’re arriving in the UK before 3pm (UK time) on 24 December 2024
+
+  You can join your partner or family member for up to 6 months without a visa if both of the following apply:
+
+  * you booked and paid for your journey to the UK before 3pm (UK time) on 26 November 2024
+  * you’re arriving in the UK before 3pm (UK time) on 24 December 2024
+
+  ###If you need to leave and re-enter the UK
+
+  You’ll need a visa or family permit to re-enter the UK if either of the following apply:
+
+  * you did not book your return journey to the UK before 3pm (UK time) on 26 November 2024
+  * you’re returning to the UK on or after 3pm (UK time) on 24 December 2024
+<% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/colombia/_outcome_school_y.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/colombia/_outcome_school_y.erb
@@ -1,0 +1,22 @@
+<% if calculator.show_colombia_visa_change_transition_text? %>
+  ##If you’re arriving in the UK before 3pm (UK time) on 24 December 2024
+
+  You can stay in the UK for up to 6 months without a visa if all of the following apply:
+
+  * you booked and paid for your journey to the UK before 3pm (UK time) on 26 November 2024
+  * you’re arriving in the UK before 3pm (UK time) on 24 December 2024
+  * you meet the [Standard Visitor](/standard-visitor) eligibility requirements
+
+  [Check what documents you need to bring](/government/publications/visitor-visa-guide-to-supporting-documents) to show officers at the UK border.
+
+  The rules on what you’ll need to enter the UK may be different if you’re [travelling from Ireland, Jersey, Guernsey or the Isle of Man](/guidance/travelling-between-the-uk-and-ireland-isle-of-man-guernsey-or-jersey).
+
+  %You may want to [apply for a Standard Visitor visa](/standard-visitor/apply-standard-visitor-visa) if you have a criminal record or you’ve previously been refused entry into the UK.%
+
+  ###If you need to leave and re-enter the UK
+
+  You’ll need a visa to re-enter the UK if either of the following apply:
+
+  * you did not book your return journey to the UK before 3pm (UK time) on 26 November 2024
+  * you’re returning to the UK on or after 3pm (UK time) on 24 December 2024
+<% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/colombia/_outcome_standard_visitor_visa.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/colombia/_outcome_standard_visitor_visa.erb
@@ -11,13 +11,16 @@
 
   ###What you can and cannot do
   You can visit the UK on holiday or to spend time with family and friends.
+
   You can also do other permitted activities with a [Standard Visitor visa](/standard-visitor).
+
   While in the UK as a tourist, you cannot:
 
   * do paid or unpaid work for a UK company or as a self-employed person
   * claim [public funds](/government/publications/public-funds--2) (benefits)
   * live in the UK for long periods of time through frequent or successive visits
   * marry or register a civil partnership, or give notice of marriage or civil partnership. You’ll need a [Marriage Visitor visa](/marriage-visa) instead
+
   ###What you need at the UK border
 
   You must provide a valid passport or travel document. Your passport should be valid for the whole of your stay in the UK.
@@ -41,7 +44,9 @@
   * their contact details and consent for you to travel to the UK
   * the name, date of birth, address and relationship to you of the person you’re staying with
   * their consent for you to stay with the person named in the letter
+
   Your parent or guardian must tell the relevant local authority about your visit if both of the following apply:
+
   * you’re under 16 (or under 18 if you have a disability)
   * you’re going to be looked after for more than 28 days by someone who is not a close relative (called ‘private foster care’)
 

--- a/app/flows/check_uk_visa_flow/outcomes/colombia/_outcome_standard_visitor_visa.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/colombia/_outcome_standard_visitor_visa.erb
@@ -1,0 +1,56 @@
+<% if calculator.show_colombia_visa_change_transition_text? %>
+  ##If you’re arriving in the UK before 3pm (UK time) on 24 December 2024
+
+  You can stay in the UK as a tourist for up to 6 months without a visa if all the following apply:
+
+  * you booked and paid for your journey to the UK before 3pm (UK time) on 26 November 2024
+  * you’re arriving in the UK before 3pm (UK time) on 24 December 2024
+  * you meet the [Standard Visitor](/standard-visitor) eligibility requirements
+
+  %You may want to [apply for a Standard Visitor visa](/standard-visitor/apply-standard-visitor-visa) if you have a criminal record or you’ve previously been refused entry into the UK.
+
+  ###What you can and cannot do
+  You can visit the UK on holiday or to spend time with family and friends.
+  You can also do other permitted activities with a [Standard Visitor visa](/standard-visitor).
+  While in the UK as a tourist, you cannot:
+
+  * do paid or unpaid work for a UK company or as a self-employed person
+  * claim [public funds](/government/publications/public-funds--2) (benefits)
+  * live in the UK for long periods of time through frequent or successive visits
+  * marry or register a civil partnership, or give notice of marriage or civil partnership. You’ll need a [Marriage Visitor visa](/marriage-visa) instead
+  ###What you need at the UK border
+
+  You must provide a valid passport or travel document. Your passport should be valid for the whole of your stay in the UK.
+
+  You may also be asked to prove that:
+
+
+  * you’re visiting for tourism
+  * you’re able to support yourself and your dependents during your trip (or have funding from someone else to support you)
+  * you’ve arranged accommodation for your stay
+  * you’re able to pay for your return or onward journey (or have funding from someone else)
+  * you’ll leave the UK at the end of your visit
+  * you booked your journey to the UK before 3pm (UK time) on 26 November 2024
+
+  ^The rules on what you’ll need to enter the UK may be different if you’re [travelling from Ireland, Jersey, Guernsey or the Isle of Man](/guidance/travelling-between-the-uk-and-ireland-isle-of-man-guernsey-or-jersey).
+
+  ###If you’re under 18 and travelling alone
+
+  You may need to show a letter from your parent or guardian giving:
+
+  * their contact details and consent for you to travel to the UK
+  * the name, date of birth, address and relationship to you of the person you’re staying with
+  * their consent for you to stay with the person named in the letter
+  Your parent or guardian must tell the relevant local authority about your visit if both of the following apply:
+  * you’re under 16 (or under 18 if you have a disability)
+  * you’re going to be looked after for more than 28 days by someone who is not a close relative (called ‘private foster care’)
+
+  ^You should bring a reply from the local authority if you have one.
+
+  ###If you need to leave and re-enter the UK
+
+  You’ll need a Standard Visitor visa to re-enter the UK if either of the following apply:
+
+  * you did not book your return journey to the UK before 3pm (UK time) on 26 November 2024
+  * you’re returning to the UK on or after 3pm (UK time) on 24 December 2024
+<% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/colombia/_outcome_study_m.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/colombia/_outcome_study_m.erb
@@ -11,7 +11,9 @@
 
   ###What you can and cannot do
   You can visit the UK to study at an [accredited institution](/visa-to-study-english/your-course) for up to 6 months. This includes English language courses.
+
   You can also do:
+
   * a short piece of research that’s relevant to your course overseas
   * an ‘elective’ - an optional additional placement, if you’re studying medicine, nursing, dentistry or veterinary medicine and science
   * an unpaid clinical attachment or dental observer post, if you’re an overseas graduate from a medical, dental or nursing school
@@ -54,12 +56,14 @@
   * you’ve arranged accommodation for your stay
   * you’ll leave the UK at the end of your visit
   * you booked your journey to the UK before 3pm (UK time) on 26 November 2024
+
   Find out more about [visiting the UK to study](/standard-visitor/visit-to-study).
 
   ^The rules on what you’ll need to enter the UK may be different if you’re [travelling from Ireland, Jersey, Guernsey or the Isle of Man](/guidance/travelling-between-the-uk-and-ireland-isle-of-man-guernsey-or-jersey).
 
   ###If you’re under 18 and travelling alone
   You may need to provide a letter from your parent or guardian giving:
+
   - their contact details and consent for you to travel to the UK
   - the name, date of birth, address and relationship to you of the person you’re staying with
   - their consent for you to stay with the person named in the letter

--- a/app/flows/check_uk_visa_flow/outcomes/colombia/_outcome_study_m.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/colombia/_outcome_study_m.erb
@@ -1,0 +1,82 @@
+<% if calculator.show_colombia_visa_change_transition_text? %>
+  ##If you’re arriving in the UK before 3pm (UK time) on 24 December 2024
+
+  You can stay in the UK as a student for up to 6 months without a visa if all the following apply:
+
+  * you booked and paid for your journey to the UK before 3pm (UK time) on 26 November 2024
+  * you’re arriving in the UK before 3pm (UK time) on 24 December 2024
+  * you meet the [Standard Visitor](/standard-visitor) eligibility requirements
+
+  %You may want to [apply for a Standard Visitor visa](/standard-visitor/apply-standard-visitor-visa) if you have a criminal record or you’ve previously been refused entry into the UK.
+
+  ###What you can and cannot do
+  You can visit the UK to study at an [accredited institution](/visa-to-study-english/your-course) for up to 6 months. This includes English language courses.
+  You can also do:
+  * a short piece of research that’s relevant to your course overseas
+  * an ‘elective’ - an optional additional placement, if you’re studying medicine, nursing, dentistry or veterinary medicine and science
+  * an unpaid clinical attachment or dental observer post, if you’re an overseas graduate from a medical, dental or nursing school
+  * a recreational course of up to 30 days, for example a dance course
+
+  Find out what else you can do with a [Standard Visitor visa](/standard-visitor).
+
+  You cannot:
+
+  * study at a [state funded school or academy](/types-of-school)
+  * do a course that lasts longer than 6 months (except if you’re doing a distance learning course)
+  * do paid or unpaid work (this includes work experience or work placements, unless it is an eligible medical, nursing, dentistry or veterinary medicine and science placement)
+  * live in the UK for long periods of time through frequent or successive visits
+  * get [public funds](/government/publications/public-funds--2) (benefits)
+
+  ^To study or research certain subjects at postgraduate level or above, you may need an [Academic Technology Approval Scheme (ATAS) certificate](/guidance/find-out-if-you-require-an-atas-certificate). If you do need one, you’ll need to get your ATAS certificate before starting your study or research.
+
+  ###What you need at the UK border
+
+
+  You need a valid passport or travel document. Your passport should be valid for the whole of your stay in the UK.
+
+
+  You must provide written confirmation from a higher education provider if you’re visiting to do research or an elective.
+
+
+  If you’re visiting to do an unpaid clinical attachment or dental observer post you must:
+
+
+  - provide written confirmation of your offer
+  - confirm you’ve not done a clinical attachment or dental observer post in the UK before
+
+
+  You may also be asked to prove that:
+
+
+  * you’ve been accepted on to a course by an accredited institution, for example a letter of acceptance on official headed paper stating the course name, duration and cost
+  * you’re able to support yourself and your dependents during your trip (or have funding from someone else to support you)
+  * you’re able to pay for your return or onward journey (or have funding from someone else)
+  * you’ve arranged accommodation for your stay
+  * you’ll leave the UK at the end of your visit
+  * you booked your journey to the UK before 3pm (UK time) on 26 November 2024
+  Find out more about [visiting the UK to study](/standard-visitor/visit-to-study).
+
+  ^The rules on what you’ll need to enter the UK may be different if you’re [travelling from Ireland, Jersey, Guernsey or the Isle of Man](/guidance/travelling-between-the-uk-and-ireland-isle-of-man-guernsey-or-jersey).
+
+  ###If you’re under 18 and travelling alone
+  You may need to provide a letter from your parent or guardian giving:
+  - their contact details and consent for you to travel to the UK
+  - the name, date of birth, address and relationship to you of the person you’re staying with
+  - their consent for you to stay with the person named in the letter
+
+  ###If you’re not staying with a close relative
+
+  Your parent, guardian or school must tell the relevant local authority about your visit if you’re both of the following:
+
+  * under 16 (or under 18 if you have a disability)
+  * going to be looked after for more than 28 days by someone who is not a close relative (called ‘private foster care’)
+
+  ^You should bring a reply from the local authority if you have one.
+
+  ###If you need to leave and re-enter the UK
+
+  You’ll need a visa to re-enter the UK if either of the following apply:
+
+  * you did not book your return journey to the UK before 3pm (UK time) on 26 November 2024
+  * you’re returning to the UK on or after 3pm (UK time) on 24 December 2024
+<% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/colombia/_outcome_tourism_visa_partner.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/colombia/_outcome_tourism_visa_partner.erb
@@ -1,0 +1,60 @@
+<% if calculator.show_colombia_visa_change_transition_text? %>
+  ##If you’re arriving in the UK before 3pm (UK time) on 24 December 2024
+
+  You can stay in the UK as a tourist for up to 6 months without a visa if all the following apply:
+
+  * you booked and paid for your journey to the UK before 3pm (UK time) on 26 November 2024
+  * you’re arriving in the UK before 3pm (UK time) on 24 December 2024
+  * you meet the [Standard Visitor](/standard-visitor) eligibility requirements
+
+  %You may want to [apply for a Standard Visitor visa](/standard-visitor/apply-standard-visitor-visa) if you have a criminal record or you’ve previously been refused entry into the UK.
+
+  ###What you can and cannot do
+
+  You can visit the UK on holiday or to spend time with family and friends.
+
+  You can also do other permitted activities with a [Standard Visitor visa](/standard-visitor).
+
+  While in the UK as a tourist, you cannot:
+
+
+  * do paid or unpaid work for a UK company or as a self-employed person
+  * claim [public funds](/government/publications/public-funds--2) (benefits)
+  * live in the UK for long periods of time through frequent or successive visits
+  * marry or register a civil partnership, or give notice of marriage or civil partnership. You’ll need a [Marriage Visitor visa](/marriage-visa) instead
+
+  ###What you need at the UK border
+
+  You must provide a valid passport or travel document. Your passport should be valid for the whole of your stay in the UK.
+
+  You may also be asked to prove that:
+
+  * you’re visiting for tourism
+  * you’re able to support yourself and your dependents during your trip (or have funding from someone else to support you)
+  * you’ve arranged accommodation for your stay
+  * you’re able to pay for your return or onward journey (or have funding from someone else)
+  * you’ll leave the UK at the end of your visit
+  * you booked your journey to the UK before 3pm (UK time) on 26 November 2024
+
+  ^The rules on what you’ll need to enter the UK may be different if you’re [travelling from Ireland, Jersey, Guernsey or the Isle of Man](/guidance/travelling-between-the-uk-and-ireland-isle-of-man-guernsey-or-jersey).
+
+  ###If you’re under 18 and travelling alone
+
+  You may need to show a letter from your parent or guardian giving:
+
+  * their contact details and consent for you to travel to the UK
+  * the name, date of birth, address and relationship to you of the person you’re staying with
+  * their consent for you to stay with the person named in the letter
+  Your parent or guardian must tell the relevant local authority about your visit if both of the following apply:
+  * you’re under 16 (or under 18 if you have a disability)
+  * you’re going to be looked after for more than 28 days by someone who is not a close relative (called ‘private foster care’)
+
+  ^You should bring a reply from the local authority if you have one.
+
+  ###If you need to leave and re-enter the UK
+
+  You’ll usually need a Standard Visitor visa or family permit to re-enter the UK if either of the following apply:
+
+  * you did not book your return journey to the UK before 3pm (UK time) on 26 November 2024
+  * you’re returning to the UK on or after 3pm (UK time) on 24 December 2024
+<% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/colombia/_outcome_transit_leaving_airport_direct_airside_transit_visa_1.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/colombia/_outcome_transit_leaving_airport_direct_airside_transit_visa_1.erb
@@ -1,0 +1,3 @@
+<% if calculator.show_colombia_visa_change_transition_text? %>
+  ^The rules on what you’ll need to come to the UK may be different if you're arriving in the UK before 3pm (UK time) on 24 December 2024.^
+<% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/colombia/_outcome_transit_leaving_airport_direct_airside_transit_visa_2.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/colombia/_outcome_transit_leaving_airport_direct_airside_transit_visa_2.erb
@@ -3,7 +3,7 @@
 
   You do not need a visa to come to the UK if both of the following apply:
 
-  *you booked and paid for your journey to the UK before 3pm (UK time) on 26 November 2024
+  * you booked and paid for your journey to the UK before 3pm (UK time) on 26 November 2024
   * you’re arriving in the UK before 3pm (UK time) on 24 December 2024
 
   You should bring evidence of your onward journey to show to officers at the UK border.

--- a/app/flows/check_uk_visa_flow/outcomes/colombia/_outcome_transit_leaving_airport_direct_airside_transit_visa_2.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/colombia/_outcome_transit_leaving_airport_direct_airside_transit_visa_2.erb
@@ -1,0 +1,12 @@
+<% if calculator.show_colombia_visa_change_transition_text? %>
+  ##If you’re arriving in the UK before 3pm (UK time) on 24 December 2024
+
+  You do not need a visa to come to the UK if both of the following apply:
+
+  *you booked and paid for your journey to the UK before 3pm (UK time) on 26 November 2024
+  * you’re arriving in the UK before 3pm (UK time) on 24 December 2024
+
+  You should bring evidence of your onward journey to show to officers at the UK border.
+
+  %You may want to [apply for a visa](/browse/visas-immigration/tourist-short-stay-visas) if you have a criminal record or you’ve previously been refused entry into the UK.%
+<% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/colombia/_outcome_transit_not_leaving_airport_1.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/colombia/_outcome_transit_not_leaving_airport_1.erb
@@ -1,0 +1,3 @@
+<% if calculator.show_colombia_visa_change_transition_text? %>
+  ^The rules on what you’ll need to come to the UK may be different if you're arriving in the UK before 11.59pm (UK time) on 24 December 2024.^
+<% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/colombia/_outcome_transit_not_leaving_airport_2.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/colombia/_outcome_transit_not_leaving_airport_2.erb
@@ -3,7 +3,7 @@
 
   You do not need a visa to come to the UK if both of the following apply:
 
-  *you booked and paid for your journey to the UK before 3pm (UK time) on 26 November 2024
+  * you booked and paid for your journey to the UK before 3pm (UK time) on 26 November 2024
   * you’re arriving in the UK before 11.59pm (UK time) on 24 December 2024
 
   You should bring evidence of your onward journey to show to officers at the UK border.

--- a/app/flows/check_uk_visa_flow/outcomes/colombia/_outcome_transit_not_leaving_airport_2.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/colombia/_outcome_transit_not_leaving_airport_2.erb
@@ -1,0 +1,12 @@
+<% if calculator.show_colombia_visa_change_transition_text? %>
+  ##If you’re arriving in the UK before 11.59pm (UK time) on 24 December 2024
+
+  You do not need a visa to come to the UK if both of the following apply:
+
+  *you booked and paid for your journey to the UK before 3pm (UK time) on 26 November 2024
+  * you’re arriving in the UK before 11.59pm (UK time) on 24 December 2024
+
+  You should bring evidence of your onward journey to show to officers at the UK border.
+
+  %You may want to [apply for a visa](/browse/visas-immigration/tourist-short-stay-visas) if you have a criminal record or you’ve previously been refused entry into the UK.%
+<% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/colombia/_outcome_transit_to_the_republic_of_ireland_1.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/colombia/_outcome_transit_to_the_republic_of_ireland_1.erb
@@ -1,0 +1,3 @@
+<% if calculator.show_colombia_visa_change_transition_text? %>
+  ^The rules on what you’ll need to come to the UK may be different if you're arriving in the UK before 3pm (UK time) on 24 December 2024.^
+<% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/colombia/_outcome_transit_to_the_republic_of_ireland_2.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/colombia/_outcome_transit_to_the_republic_of_ireland_2.erb
@@ -3,7 +3,7 @@
 
   You do not need a visa to come to the UK if both of the following apply:
 
-  *you booked and paid for your journey to the UK before 3pm (UK time) on 26 November 2024
+  * you booked and paid for your journey to the UK before 3pm (UK time) on 26 November 2024
   * you’re arriving in the UK before 3pm (UK time) on 24 December 2024
 
   You should bring evidence of your onward journey to show to officers at the UK border.

--- a/app/flows/check_uk_visa_flow/outcomes/colombia/_outcome_transit_to_the_republic_of_ireland_2.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/colombia/_outcome_transit_to_the_republic_of_ireland_2.erb
@@ -1,0 +1,12 @@
+<% if calculator.show_colombia_visa_change_transition_text? %>
+  ##If you’re arriving in the UK before 3pm (UK time) on 24 December 2024
+
+  You do not need a visa to come to the UK if both of the following apply:
+
+  *you booked and paid for your journey to the UK before 3pm (UK time) on 26 November 2024
+  * you’re arriving in the UK before 3pm (UK time) on 24 December 2024
+
+  You should bring evidence of your onward journey to show to officers at the UK border.
+
+  %You may want to [apply for a visa](/browse/visas-immigration/tourist-short-stay-visas) if you have a criminal record or you’ve previously been refused entry into the UK.%
+<% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/colombia/_outcome_work_m_1.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/colombia/_outcome_work_m_1.erb
@@ -1,0 +1,3 @@
+<% if calculator.show_colombia_visa_change_transition_text? %>
+  ^The rules on what you’ll need to come to the UK may be different if you're arriving in the UK before 3pm (UK time) on 24 December 2024.^
+<% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/colombia/_outcome_work_m_2.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/colombia/_outcome_work_m_2.erb
@@ -1,0 +1,88 @@
+<% if calculator.show_colombia_visa_change_transition_text? %>
+  ##If you’re arriving in the UK before 3pm (UK time) on 24 December 2024
+
+  You may be able to come to the UK without a visa if both of the following apply:
+
+  * you booked and paid for your journey to the UK before 3pm (UK time) on 26 November 2024
+  * you’re arriving in the UK before 3pm (UK time) on 24 December 2024
+
+  One of the following must also apply:
+
+  * you’ve been invited as an expert in your profession for a ‘Permitted Paid Engagement’
+  * you’re visiting for certain business or academic activities, but not working in the UK
+  * you’re coming to work in arts or entertainment for 3 months or less
+
+  You must meet the eligibility requirements and only be doing permitted activities.
+
+  ###If you’re invited as an expert in your profession
+
+  You can stay in the UK for up to 1 month without a visa, but you can only be paid by a UK-based organisation to do certain things, for example:
+
+  - give guest lectures at a higher education institution
+  - provide advocacy in legal proceedings
+  - take part in arts, entertainment or sporting activities
+
+  Find out [what you can and cannot be paid to do if you’re visiting the UK for a Permitted Paid Engagement](/permitted-paid-engagement-visitor/what-you-can-do-in-the-uk).
+
+  %You may want to [apply for a Permitted Paid Engagement Visitor visa](/permitted-paid-engagement-visitor/apply-permitted-paid-engagement-visitor-visa) if you have a criminal record or you’ve previously been refused entry into the UK.%
+
+  You must provide a valid passport or travel document at the UK border. Your passport should be valid for the whole of your stay in the UK.
+
+  You may also be asked to prove that:
+
+  * you’re eligible for the activities you want to do
+  * you’ve arranged accommodation for your stay
+  * you’ll leave at the end of your visit
+  * you’re able to support yourself and your dependants during your trip (or have funding from someone else to support you)
+  * you booked your journey to the UK before 3pm (UK time) on 26 November 2024
+
+  Find out more about [visiting the UK for a Permitted Paid Engagement](/permitted-paid-engagement-visitor).
+
+  ^The rules on what you’ll need to enter the UK may be different if you’re [travelling from Ireland, Jersey, Guernsey or the Isle of Man](/guidance/travelling-between-the-uk-and-ireland-isle-of-man-guernsey-or-jersey).
+
+  ###If you’re visiting for certain business or academic activities
+
+  You can come to the UK as a Standard Visitor for up to 6 months without a visa, but you can only do certain business or academic activities, for example go to a conference or a meeting.
+
+  You cannot:
+
+  - do paid or unpaid work for a UK company or as a self-employed person
+  - do a work placement or internship
+  - sell directly to the public or provide goods and services
+
+  Check the full list of [business activities](/standard-visitor/visit-on-business) and [academic activities](/standard-visitor/visit-as-an-academic) you can do as a Standard Visitor.
+
+  To research certain subjects at postgraduate level or above, you may need an [Academic Technology Approval Scheme (ATAS) certificate](/guidance/find-out-if-you-require-an-atas-certificate). If you do need one, you’ll need to get your ATAS certificate before starting your research.
+
+  %You may want to [apply for a Standard Visitor visa](/standard-visitor/apply-standard-visitor-visa) if you have a criminal record or you’ve previously been refused entry into the UK.%
+
+  You must provide a valid passport or travel document at the UK border. Your passport should be valid for the whole of your stay in the UK.
+
+  You may also be asked to prove:
+
+  * you’re eligible for the activities you want to do
+  * you’ve arranged accommodation for your stay
+  * you’ll leave at the end of your visit
+  * you’re able to support yourself and your dependents during your trip (or have funding from someone else to support you)
+  * you booked your journey to the UK before 3pm (UK time) on 26 November 2024
+
+  Find out more about [visiting the UK as a Standard Visitor](/standard-visitor).
+
+  ^The rules on what you’ll need to enter the UK may be different if you’re [travelling from Ireland, Jersey, Guernsey or the Isle of Man](/guidance/travelling-between-the-uk-and-ireland-isle-of-man-guernsey-or-jersey).
+
+  ###If you want to work in arts or entertainment for 3 months or less
+
+  You do not need a visa for qualifying work if you’re coming to the UK for 3 months or less using the [Creative Worker visa concession](/creative-worker-visa/creative-worker-concession).
+
+  You must show officers at the UK border:
+
+  * a [certificate of sponsorship and evidence of savings](/creative-worker-visa/eligibility)
+  * proof that you booked your journey to the UK before 3pm (UK time) on 26 November 2024
+
+  ###If you need to leave and re-enter the UK
+
+  You’ll need a visa to re-enter the UK if either of the following apply:
+
+  * you did not book your return journey to the UK before 3pm (UK time) on 26 November 2024
+  * you’re returning to the UK on or after 3pm (UK time) on 24 December 2024
+<% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_marriage_visa_nat_direct_airside_transit_visa.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_marriage_visa_nat_direct_airside_transit_visa.erb
@@ -15,4 +15,6 @@
   + is settled in the UK (called having ‘indefinite leave to remain’)
   + has settled or pre-settled status under the EU Settlement Scheme
   + has a Turkish worker or businessperson visa
+
+  <%= render partial: "colombia/outcome_marriage_visa_nat_direct_airside_transit_visa", locals: {calculator: calculator} %>
 <% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_medical_y.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_medical_y.erb
@@ -8,4 +8,6 @@
   <%= render partial: 'stateless_or_refugee', locals: {calculator: calculator} %>
 
   <%= render partial: 'estonia_or_latvia', locals: {calculator: calculator} %>
+
+  <%= render partial: "colombia/outcome_medical_y", locals: {calculator: calculator} %>
 <% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_partner_family_british_citizen_y.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_partner_family_british_citizen_y.erb
@@ -13,4 +13,6 @@
   + have been living in the UK by 31 December 2020
 
   The family permit lets you live, work and study in the UK for up to 6 months (this may be 4 months if you come to the UK after 1 April 2021). You may then be able to apply to the free EU Settlement Scheme to stay longer in the UK.
+
+  <%= render partial: "colombia/outcome_partner_family_british_citizen_y", locals: {calculator: calculator} %>
 <% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_partner_family_eea_n.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_partner_family_eea_n.erb
@@ -4,7 +4,9 @@
 
 <% govspeak_for :body do %>
   The visa you need depends on your partner or family member’s situation.
-  
+
+  <%= render partial: "colombia/outcome_partner_family_eea_n_1", locals: {calculator: calculator} %>
+
   ## They’re working or studying in the UK
 
   You may be able to apply as a ‘dependant’ of
@@ -14,4 +16,6 @@
 
   You can apply for a [Standard Visitor visa](/standard-visitor). Your
   visit must be for 6 months or less.
+
+  <%= render partial: "colombia/outcome_partner_family_eea_n_2", locals: {calculator: calculator} %>
 <% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_partner_family_eea_y.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_partner_family_eea_y.erb
@@ -9,6 +9,8 @@
 
   You may be able to apply for a free [family permit](/family-permit) to join your partner or family member for up to 6 months (this may be 4 months if you come to the UK after 1 April 2021).
 
+  <%= render partial: "colombia/outcome_partner_family_eea_y", locals: {calculator: calculator} %>
+
   ##If you’re staying longer than 6 months
 
   What you can apply for depends on your family member’s situation.

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_school_y.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_school_y.erb
@@ -12,4 +12,6 @@
   If they’re 12 or over, you can apply for a [Standard Visitor visa](/standard-visitor) to visit them for up to 6 months.
 
   <%= render partial: 'stateless_or_refugee', locals: {calculator: calculator} %>
+
+  <%= render partial: "colombia/outcome_school_y", locals: {calculator: calculator} %>
 <% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_standard_visitor_visa.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_standard_visitor_visa.erb
@@ -12,4 +12,6 @@
   <% end %>
 
   <%= render partial: 'stateless_or_refugee', locals: {calculator: calculator} %>
+
+  <%= render partial: "colombia/outcome_standard_visitor_visa", locals: {calculator: calculator} %>
 <% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_study_m.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_study_m.erb
@@ -6,4 +6,6 @@
   <%= render partial: 'stateless_or_refugee', locals: {calculator: calculator} %>
 
   Apply for a [Standard Visitor visa](/standard-visitor) if you're studying for 6 months or less.
+
+  <%= render partial: "colombia/outcome_study_m", locals: {calculator: calculator} %>
 <% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_tourism_visa_partner.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_tourism_visa_partner.erb
@@ -8,4 +8,6 @@
   ##When you might not need a visa
 
   You may be able to apply for a free [family permit](/family-permit) if your partner or family member is from the EU, Switzerland, Norway, Iceland or Liechtenstein. They must have been living in the UK before by 31 December 2020.
+
+  <%= render partial: "colombia/outcome_tourism_visa_partner", locals: {calculator: calculator} %>
 <% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_transit_leaving_airport_direct_airside_transit_visa.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_transit_leaving_airport_direct_airside_transit_visa.erb
@@ -7,6 +7,8 @@
 
   ^ You do not need to apply for a Visitor in Transit visa if you already have a Marriage Visitor or Standard Visitor visa.
 
+  <%= render partial: "colombia/outcome_transit_leaving_airport_direct_airside_transit_visa_1", locals: {calculator: calculator} %>
+
   ##Transiting without a visa
 
   You may be eligible to transit without a visa if:
@@ -38,4 +40,6 @@
   All visas and residence permits must be valid.
 
   Australian paper confirmation slips are not accepted.
+
+  <%= render partial: "colombia/outcome_transit_leaving_airport_direct_airside_transit_visa_2", locals: {calculator: calculator} %>
 <% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_transit_not_leaving_airport.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_transit_not_leaving_airport.erb
@@ -5,6 +5,8 @@
 <% govspeak_for :body do %>
   You normally need a [Direct Airside Transit visa](/transit-visa/direct-airside-transit-visa) if you arrive in the UK on a flight and leave again without passing through immigration control.
 
+  <%= render partial: "colombia/outcome_transit_not_leaving_airport_1", locals: {calculator: calculator} %>
+
   ##Exemptions
 
   You do not need a Direct Airside Transit visa if you have one of the following:
@@ -25,4 +27,6 @@
   All visas and residence permits must be valid.
 
   %E-visas or e-residence permits are not acceptable unless your airline is able to verify it with the issuing country. Contact your airline for more information.%
+
+  <%= render partial: "colombia/outcome_transit_not_leaving_airport_2", locals: {calculator: calculator} %>
 <% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_transit_to_the_republic_of_ireland.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_transit_to_the_republic_of_ireland.erb
@@ -17,6 +17,8 @@
     You’ll usually need to apply for a [Standard Visitor visa](/standard-visitor).
   <% end %>
 
+  <%= render partial: "colombia/outcome_transit_to_the_republic_of_ireland_1", locals: {calculator: calculator} %>
+
   ##Transiting without a visa
 
   You may be eligible to transit without a visa if:
@@ -32,4 +34,6 @@
   All visas and residence permits must be valid.
 
   You will not be able to transit without a visa if a Border Force officer decides you do not qualify under the immigration rules.
+
+  <%= render partial: "colombia/outcome_transit_to_the_republic_of_ireland_2", locals: {calculator: calculator} %>
 <% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_work_m.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_work_m.erb
@@ -9,6 +9,8 @@
 
   <%= render partial: 'estonia_or_latvia', locals: {calculator: calculator} %>
 
+  <%= render partial: "colombia/outcome_work_m_1", locals: {calculator: calculator} %>
+
   ##Business or academic visits
 
   You can apply for a [Standard Visitor visa](/standard-visitor) if you’re coming to the UK for certain business or academic activities, such as:
@@ -37,4 +39,6 @@
   + in a [fast-growing UK business (sometimes known as a ‘scale-up’ business)](/scale-up-worker-visa)
 
   You can also apply for an [international agreement](/international-agreement-worker-visa) visa if you'll be doing work covered by international law while in the UK (for example, working for a foreign government or as a private servant in a diplomatic household).
+
+  <%= render partial: "colombia/outcome_work_m_2", locals: {calculator: calculator} %>
 <% end %>

--- a/lib/smart_answer/calculators/uk_visa_calculator.rb
+++ b/lib/smart_answer/calculators/uk_visa_calculator.rb
@@ -234,6 +234,10 @@ module SmartAnswer::Calculators
       @passport_country == "india" && work_visit? && staying_for_over_six_months? && @what_type_of_work != "sports"
     end
 
+    def show_colombia_visa_change_transition_text?
+      @passport_country == "colombia" && Time.zone.now <= Time.zone.local(2024, 12, 24)
+    end
+
     EXCLUDE_COUNTRIES = %w[
       american-samoa
       british-antarctic-territory
@@ -341,7 +345,6 @@ module SmartAnswer::Calculators
       brunei
       canada
       chile
-      colombia
       costa-rica
       curacao
       federated-states-of-micronesia
@@ -450,6 +453,7 @@ module SmartAnswer::Calculators
       burundi
       cameroon
       china
+      colombia
       congo
       cote-d-ivoire
       cyprus-north

--- a/test/flows/check_uk_visa_colombia_transition_to_visa_national_flow_test.rb
+++ b/test/flows/check_uk_visa_colombia_transition_to_visa_national_flow_test.rb
@@ -1,0 +1,489 @@
+require "test_helper"
+require "support/flow_test_helper"
+require "support/flows/check_uk_visa_flow_test_helper"
+require "active_support/testing/time_helpers"
+
+class CheckUkVisaColombiaTransitionToVisaNationalFlowTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::TimeHelpers
+  include FlowTestHelper
+
+  setup do
+    testing_flow CheckUkVisaFlow
+
+    # stub only the countries used in these tests for less of a performance impact
+    stub_worldwide_api_has_locations(%w[colombia jordan].uniq)
+  end
+
+  # The transitional partials will display as soon as the code is merged; hence the start date is not embedded in the
+  # code anywhere—it will be handled by merging at the appropriate datetime
+  context "when viewing colombian passport outcomes on or before the transition period end date" do
+    setup do
+      # The transition end date is 24 December 2024
+      travel_to(Time.zone.local(2024, 12, 24))
+      add_responses what_passport_do_you_have?: "colombia"
+    end
+
+    context "No 1: outcome_tourism_visa_partner" do
+      should "render transition text" do
+        testing_node :outcome_tourism_visa_partner
+        add_responses purpose_of_visit?: "tourism",
+                      travelling_visiting_partner_family_member?: "yes"
+
+        assert_rendered_outcome text: "You’ll usually need a visa to come to the UK"
+        assert_rendered_outcome text: "If you’re arriving in the UK before 3pm (UK time) on 24 December 2024"
+      end
+    end
+
+    context "No 2: outcome_standard_visitor_visa" do
+      should "render transition text" do
+        testing_node :outcome_standard_visitor_visa
+        add_responses purpose_of_visit?: "tourism",
+                      travelling_visiting_partner_family_member?: "no"
+
+        assert_rendered_outcome text: "You’ll need a visa to come to the UK"
+        assert_rendered_outcome text: "If you’re arriving in the UK before 3pm (UK time) on 24 December 2024"
+      end
+    end
+
+    context "No 3: outcome_work_m" do
+      should "render transition text" do
+        testing_node :outcome_work_m
+        add_responses purpose_of_visit?: "work",
+                      staying_for_how_long?: "six_months_or_less"
+
+        assert_rendered_outcome text: "You'll need a visa to work, do business or academic research in the UK"
+        assert_rendered_outcome text: "The rules on what you’ll need to come to the UK may be different"
+        assert_rendered_outcome text: "If you’re arriving in the UK before 3pm (UK time) on 24 December 2024"
+      end
+    end
+
+    context "No 4: outcome_study_m" do
+      should "render transition text" do
+        testing_node :outcome_study_m
+        add_responses purpose_of_visit?: "study",
+                      staying_for_how_long?: "six_months_or_less"
+
+        assert_rendered_outcome text: "You’ll need a visa to come to the UK"
+        assert_rendered_outcome text: "If you’re arriving in the UK before 3pm (UK time) on 24 December 2024"
+      end
+    end
+
+    context "No 5: outcome_transit_to_the_republic_of_ireland" do
+      should "render transition text" do
+        testing_node :outcome_transit_to_the_republic_of_ireland
+        add_responses purpose_of_visit?: "transit",
+                      travelling_to_cta?: "republic_of_ireland"
+
+        assert_rendered_outcome text: "You’ll need a visa to pass through the UK (unless you’re exempt)"
+        assert_rendered_outcome text: "The rules on what you’ll need to come to the UK may be different"
+        assert_rendered_outcome text: "If you’re arriving in the UK before 3pm (UK time) on 24 December 2024"
+      end
+    end
+
+    context "No 6: outcome_transit_leaving_airport_direct_airside_transit_visa" do
+      should "render transition text" do
+        testing_node :outcome_transit_leaving_airport_direct_airside_transit_visa
+        add_responses purpose_of_visit?: "transit",
+                      travelling_to_cta?: "somewhere_else",
+                      passing_through_uk_border_control?: "yes"
+
+        assert_rendered_outcome text: "You’ll need a visa to pass through the UK in transit"
+        assert_rendered_outcome text: "The rules on what you’ll need to come to the UK may be different"
+        assert_rendered_outcome text: "If you’re arriving in the UK before 3pm (UK time) on 24 December 2024"
+      end
+    end
+
+    context "No 7: outcome_transit_not_leaving_airport" do
+      should "render transition text" do
+        testing_node :outcome_transit_not_leaving_airport
+        add_responses purpose_of_visit?: "transit",
+                      travelling_to_cta?: "somewhere_else",
+                      passing_through_uk_border_control?: "no"
+
+        assert_rendered_outcome text: "You’ll need a visa to pass through the UK in transit"
+        assert_rendered_outcome text: "The rules on what you’ll need to come to the UK may be different"
+        assert_rendered_outcome text: "If you’re arriving in the UK before 11.59pm (UK time) on 24 December 2024"
+      end
+    end
+
+    context "No 8: outcome_partner_family_british_citizen_y" do
+      should "render transition text" do
+        testing_node :outcome_partner_family_british_citizen_y
+        add_responses purpose_of_visit?: "family",
+                      partner_family_british_citizen?: "yes"
+
+        assert_rendered_outcome text: "You’ll need a visa to join your family or partner in the UK"
+        assert_rendered_outcome text: "If you’re arriving in the UK before 3pm (UK time) on 24 December 2024"
+      end
+    end
+
+    context "No 9: outcome_partner_family_eea_y" do
+      should "render transition text" do
+        testing_node :outcome_partner_family_eea_y
+        add_responses purpose_of_visit?: "family",
+                      partner_family_british_citizen?: "no",
+                      partner_family_eea?: "yes"
+
+        assert_rendered_outcome text: "You may need a visa"
+        assert_rendered_outcome text: "If you’re arriving in the UK before 3pm (UK time) on 24 December 2024"
+      end
+    end
+
+    context "No 10: outcome_partner_family_eea_n" do
+      should "render transition text" do
+        testing_node :outcome_partner_family_eea_n
+        add_responses purpose_of_visit?: "family",
+                      partner_family_british_citizen?: "no",
+                      partner_family_eea?: "no"
+
+        assert_rendered_outcome text: "You’ll need a visa to join your family or partner in the UK"
+        assert_rendered_outcome text: "The rules on what you’ll need to come to the UK may be different"
+        assert_rendered_outcome text: "If you’re arriving in the UK before 3pm (UK time) on 24 December 2024"
+      end
+    end
+
+    context "No 11: outcome_marriage_visa_nat_direct_airside_transit_visa" do
+      should "render transition text" do
+        testing_node :outcome_marriage_visa_nat_direct_airside_transit_visa
+        add_responses purpose_of_visit?: "marriage"
+
+        assert_rendered_outcome text: "You’ll need a visa to come to the UK"
+        assert_rendered_outcome text: "If you want to convert a civil partnership into a marriage"
+      end
+    end
+
+    context "No 12: outcome_school_y" do
+      should "render transition text" do
+        testing_node :outcome_school_y
+        add_responses purpose_of_visit?: "school"
+
+        assert_rendered_outcome text: "You’ll need a visa to stay with your child"
+        assert_rendered_outcome text: "If you’re arriving in the UK before 3pm (UK time) on 24 December 2024"
+      end
+    end
+
+    context "No 13: outcome_medical_y" do
+      should "render transition text" do
+        testing_node :outcome_medical_y
+        add_responses purpose_of_visit?: "medical"
+
+        assert_rendered_outcome text: "You’ll need a visa to visit the UK"
+        assert_rendered_outcome text: "If you’re arriving in the UK before 3pm (UK time) on 24 December 2024"
+      end
+    end
+  end
+
+  context "when viewing colombian passport outcomes after the transition period end date" do
+    setup do
+      # The transition end date is 24 December 2024
+      travel_to(Time.zone.local(2024, 12, 25))
+      add_responses what_passport_do_you_have?: "colombia"
+    end
+
+    context "No 1: outcome_tourism_visa_partner" do
+      should "not render transition text" do
+        testing_node :outcome_tourism_visa_partner
+        add_responses purpose_of_visit?: "tourism",
+                      travelling_visiting_partner_family_member?: "yes"
+
+        assert_rendered_outcome text: "You’ll usually need a visa to come to the UK"
+        assert_no_rendered_outcome text: "If you’re arriving in the UK before 3pm (UK time) on 24 December 2024"
+      end
+    end
+
+    context "No 2: outcome_standard_visitor_visa" do
+      should "not render transition text" do
+        testing_node :outcome_standard_visitor_visa
+        add_responses purpose_of_visit?: "tourism",
+                      travelling_visiting_partner_family_member?: "no"
+
+        assert_rendered_outcome text: "You’ll need a visa to come to the UK"
+        assert_no_rendered_outcome text: "If you’re arriving in the UK before 3pm (UK time) on 24 December 2024"
+      end
+    end
+
+    context "No 3: outcome_work_m" do
+      should "not render transition text" do
+        testing_node :outcome_work_m
+        add_responses purpose_of_visit?: "work",
+                      staying_for_how_long?: "six_months_or_less"
+
+        assert_rendered_outcome text: "You'll need a visa to work, do business or academic research in the UK"
+        assert_no_rendered_outcome text: "The rules on what you’ll need to come to the UK may be different if you're arriving in the UK before 3pm (UK time) on 24 December 2024."
+        assert_no_rendered_outcome text: "If you’re arriving in the UK before 3pm (UK time) on 24 December 2024"
+      end
+    end
+
+    context "No 4: outcome_study_m" do
+      should "not render transition text" do
+        testing_node :outcome_study_m
+        add_responses purpose_of_visit?: "study",
+                      staying_for_how_long?: "six_months_or_less"
+
+        assert_rendered_outcome text: "You’ll need a visa to come to the UK"
+        assert_no_rendered_outcome text: "If you’re arriving in the UK before 3pm (UK time) on 24 December 2024"
+      end
+    end
+
+    context "No 5: outcome_transit_to_the_republic_of_ireland" do
+      should "not render transition text" do
+        testing_node :outcome_transit_to_the_republic_of_ireland
+        add_responses purpose_of_visit?: "transit",
+                      travelling_to_cta?: "republic_of_ireland"
+
+        assert_rendered_outcome text: "You’ll need a visa to pass through the UK (unless you’re exempt)"
+        assert_no_rendered_outcome text: "The rules on what you’ll need to come to the UK may be different if you're arriving in the UK before 3pm (UK time) on 24 December 2024."
+        assert_no_rendered_outcome text: "If you’re arriving in the UK before 3pm (UK time) on 24 December 2024"
+      end
+    end
+
+    context "No 6: outcome_transit_leaving_airport_direct_airside_transit_visa" do
+      should "not render transition text" do
+        testing_node :outcome_transit_leaving_airport_direct_airside_transit_visa
+        add_responses purpose_of_visit?: "transit",
+                      travelling_to_cta?: "somewhere_else",
+                      passing_through_uk_border_control?: "yes"
+
+        assert_rendered_outcome text: "You’ll need a visa to pass through the UK in transit"
+        assert_no_rendered_outcome text: "The rules on what you’ll need to come to the UK may be different if you're arriving in the UK before 3pm (UK time) on 24 December 2024."
+        assert_no_rendered_outcome text: "If you’re arriving in the UK before 3pm (UK time) on 24 December 2024"
+      end
+    end
+
+    context "No 7: outcome_transit_not_leaving_airport" do
+      should "not render transition text" do
+        testing_node :outcome_transit_not_leaving_airport
+        add_responses purpose_of_visit?: "transit",
+                      travelling_to_cta?: "somewhere_else",
+                      passing_through_uk_border_control?: "no"
+
+        assert_rendered_outcome text: "You’ll need a visa to pass through the UK in transit"
+        assert_no_rendered_outcome text: "The rules on what you’ll need to come to the UK may be different if you're arriving in the UK before 3pm (UK time) on 24 December 2024."
+        assert_no_rendered_outcome text: "If you’re arriving in the UK before 11.59pm (UK time) on 24 December 2024"
+      end
+    end
+
+    context "No 8: outcome_partner_family_british_citizen_y" do
+      should "not render transition text" do
+        testing_node :outcome_partner_family_british_citizen_y
+        add_responses purpose_of_visit?: "family",
+                      partner_family_british_citizen?: "yes"
+
+        assert_rendered_outcome text: "You’ll need a visa to join your family or partner in the UK"
+        assert_no_rendered_outcome text: "If you’re arriving in the UK before 3pm (UK time) on 24 December 2024"
+      end
+    end
+
+    context "No 9: outcome_partner_family_eea_y" do
+      should "not render transition text" do
+        testing_node :outcome_partner_family_eea_y
+        add_responses purpose_of_visit?: "family",
+                      partner_family_british_citizen?: "no",
+                      partner_family_eea?: "yes"
+
+        assert_rendered_outcome text: "You may need a visa"
+        assert_no_rendered_outcome text: "If you’re arriving in the UK before 3pm (UK time) on 24 December 2024"
+      end
+    end
+
+    context "No 10: outcome_partner_family_eea_n" do
+      should "not render transition text" do
+        testing_node :outcome_partner_family_eea_n
+        add_responses purpose_of_visit?: "family",
+                      partner_family_british_citizen?: "no",
+                      partner_family_eea?: "no"
+
+        assert_rendered_outcome text: "You’ll need a visa to join your family or partner in the UK"
+        assert_no_rendered_outcome text: "The rules on what you’ll need to come to the UK may be different if you're arriving in the UK before 3pm (UK time) on 24 December 2024."
+        assert_no_rendered_outcome text: "If you’re arriving in the UK before 3pm (UK time) on 24 December 2024"
+      end
+    end
+
+    context "No 11: outcome_marriage_visa_nat_direct_airside_transit_visa" do
+      should "not render transition text" do
+        testing_node :outcome_marriage_visa_nat_direct_airside_transit_visa
+        add_responses purpose_of_visit?: "marriage"
+
+        assert_rendered_outcome text: "You’ll need a visa to come to the UK"
+        assert_no_rendered_outcome text: "If you want to convert a civil partnership into a marriage"
+      end
+    end
+
+    context "No 12: outcome_school_y" do
+      should "not render transition text" do
+        testing_node :outcome_school_y
+        add_responses purpose_of_visit?: "school"
+
+        assert_rendered_outcome text: "You’ll need a visa to stay with your child"
+        assert_no_rendered_outcome text: "If you’re arriving in the UK before 3pm (UK time) on 24 December 2024"
+      end
+    end
+
+    context "No 13: outcome_medical_y" do
+      should "not render transition text" do
+        testing_node :outcome_medical_y
+        add_responses purpose_of_visit?: "medical"
+
+        assert_rendered_outcome text: "You’ll need a visa to visit the UK"
+        assert_no_rendered_outcome text: "If you’re arriving in the UK before 3pm (UK time) on 24 December 2024"
+      end
+    end
+  end
+
+  context "when viewing non-colombian passport outcomes on or before the transition period end date" do
+    setup do
+      # The transition end date is 24 December 2024
+      travel_to(Time.zone.local(2024, 12, 24))
+      add_responses what_passport_do_you_have?: "jordan"
+    end
+
+    context "No 1: outcome_tourism_visa_partner" do
+      should "not render transition text" do
+        testing_node :outcome_tourism_visa_partner
+        add_responses purpose_of_visit?: "tourism",
+                      travelling_visiting_partner_family_member?: "yes"
+
+        assert_rendered_outcome text: "You’ll usually need a visa to come to the UK"
+        assert_no_rendered_outcome text: "If you’re arriving in the UK before 3pm (UK time) on 24 December 2024"
+      end
+    end
+
+    context "No 2: outcome_standard_visitor_visa" do
+      should "not render transition text" do
+        testing_node :outcome_standard_visitor_visa
+        add_responses purpose_of_visit?: "tourism",
+                      travelling_visiting_partner_family_member?: "no"
+
+        assert_rendered_outcome text: "You’ll need a visa to come to the UK"
+        assert_no_rendered_outcome text: "If you’re arriving in the UK before 3pm (UK time) on 24 December 2024"
+      end
+    end
+
+    context "No 3: outcome_work_m" do
+      should "not render transition text" do
+        testing_node :outcome_work_m
+        add_responses purpose_of_visit?: "work",
+                      staying_for_how_long?: "six_months_or_less"
+
+        assert_rendered_outcome text: "You'll need a visa to work, do business or academic research in the UK"
+        assert_no_rendered_outcome text: "The rules on what you’ll need to come to the UK may be different if you're arriving in the UK before 3pm (UK time) on 24 December 2024."
+        assert_no_rendered_outcome text: "If you’re arriving in the UK before 3pm (UK time) on 24 December 2024"
+      end
+    end
+
+    context "No 4: outcome_study_m" do
+      should "not render transition text" do
+        testing_node :outcome_study_m
+        add_responses purpose_of_visit?: "study",
+                      staying_for_how_long?: "six_months_or_less"
+
+        assert_rendered_outcome text: "You’ll need a visa to come to the UK"
+        assert_no_rendered_outcome text: "If you’re arriving in the UK before 3pm (UK time) on 24 December 2024"
+      end
+    end
+
+    context "No 5: outcome_transit_to_the_republic_of_ireland" do
+      should "not render transition text" do
+        testing_node :outcome_transit_to_the_republic_of_ireland
+        add_responses purpose_of_visit?: "transit",
+                      travelling_to_cta?: "republic_of_ireland"
+
+        assert_rendered_outcome text: "You’ll need a visa to pass through the UK (unless you’re exempt)"
+        assert_no_rendered_outcome text: "The rules on what you’ll need to come to the UK may be different if you're arriving in the UK before 3pm (UK time) on 24 December 2024."
+        assert_no_rendered_outcome text: "If you’re arriving in the UK before 3pm (UK time) on 24 December 2024"
+      end
+    end
+
+    context "No 6: outcome_transit_leaving_airport_direct_airside_transit_visa" do
+      should "not render transition text" do
+        testing_node :outcome_transit_leaving_airport_direct_airside_transit_visa
+        add_responses purpose_of_visit?: "transit",
+                      travelling_to_cta?: "somewhere_else",
+                      passing_through_uk_border_control?: "yes"
+
+        assert_rendered_outcome text: "You’ll need a visa to pass through the UK in transit"
+        assert_no_rendered_outcome text: "The rules on what you’ll need to come to the UK may be different if you're arriving in the UK before 3pm (UK time) on 24 December 2024."
+        assert_no_rendered_outcome text: "If you’re arriving in the UK before 3pm (UK time) on 24 December 2024"
+      end
+    end
+
+    context "No 7: outcome_transit_not_leaving_airport" do
+      should "not render transition text" do
+        testing_node :outcome_transit_not_leaving_airport
+        add_responses purpose_of_visit?: "transit",
+                      travelling_to_cta?: "somewhere_else",
+                      passing_through_uk_border_control?: "no"
+
+        assert_rendered_outcome text: "You’ll need a visa to pass through the UK in transit"
+        assert_no_rendered_outcome text: "The rules on what you’ll need to come to the UK may be different if you're arriving in the UK before 3pm (UK time) on 24 December 2024."
+        assert_no_rendered_outcome text: "If you’re arriving in the UK before 11.59pm (UK time) on 24 December 2024"
+      end
+    end
+
+    context "No 8: outcome_partner_family_british_citizen_y" do
+      should "not render transition text" do
+        testing_node :outcome_partner_family_british_citizen_y
+        add_responses purpose_of_visit?: "family",
+                      partner_family_british_citizen?: "yes"
+
+        assert_rendered_outcome text: "You’ll need a visa to join your family or partner in the UK"
+        assert_no_rendered_outcome text: "If you’re arriving in the UK before 3pm (UK time) on 24 December 2024"
+      end
+    end
+
+    context "No 9: outcome_partner_family_eea_y" do
+      should "not render transition text" do
+        testing_node :outcome_partner_family_eea_y
+        add_responses purpose_of_visit?: "family",
+                      partner_family_british_citizen?: "no",
+                      partner_family_eea?: "yes"
+
+        assert_rendered_outcome text: "You may need a visa"
+        assert_no_rendered_outcome text: "If you’re arriving in the UK before 3pm (UK time) on 24 December 2024"
+      end
+    end
+
+    context "No 10: outcome_partner_family_eea_n" do
+      should "not render transition text" do
+        testing_node :outcome_partner_family_eea_n
+        add_responses purpose_of_visit?: "family",
+                      partner_family_british_citizen?: "no",
+                      partner_family_eea?: "no"
+
+        assert_rendered_outcome text: "You’ll need a visa to join your family or partner in the UK"
+        assert_no_rendered_outcome text: "The rules on what you’ll need to come to the UK may be different if you're arriving in the UK before 3pm (UK time) on 24 December 2024."
+        assert_no_rendered_outcome text: "If you’re arriving in the UK before 3pm (UK time) on 24 December 2024"
+      end
+    end
+
+    context "No 11: outcome_marriage_visa_nat_direct_airside_transit_visa" do
+      should "not render transition text" do
+        testing_node :outcome_marriage_visa_nat_direct_airside_transit_visa
+        add_responses purpose_of_visit?: "marriage"
+
+        assert_rendered_outcome text: "You’ll need a visa to come to the UK"
+        assert_no_rendered_outcome text: "If you want to convert a civil partnership into a marriage"
+      end
+    end
+
+    context "No 12: outcome_school_y" do
+      should "not render transition text" do
+        testing_node :outcome_school_y
+        add_responses purpose_of_visit?: "school"
+
+        assert_rendered_outcome text: "You’ll need a visa to stay with your child"
+        assert_no_rendered_outcome text: "If you’re arriving in the UK before 3pm (UK time) on 24 December 2024"
+      end
+    end
+
+    context "No 13: outcome_medical_y" do
+      should "not render transition text" do
+        testing_node :outcome_medical_y
+        add_responses purpose_of_visit?: "medical"
+
+        assert_rendered_outcome text: "You’ll need a visa to visit the UK"
+        assert_no_rendered_outcome text: "If you’re arriving in the UK before 3pm (UK time) on 24 December 2024"
+      end
+    end
+  end
+end


### PR DESCRIPTION
[Trello card](https://trello.com/c/kET5fwoL/302-26-november-tbc-off-sen-check-if-you-need-a-uk-visa-moving-colombia-from-non-visa-national-to-visa-national)


Colombia is moving from being a "non-visa national" country to a
 "visa-national" country. Update the "check UK visa" smart answer logic
 to reflect this.

There is a 4-week grace period following the policy change date for
 travellers who made their travel arrangements before the policy was
 announced. During this time, anyone who booked their travel before the
 new rules came in can come to the UK with whatever they needed to use
 before.

Add some clarifying text to outcomes in the "check UK visa" Smart Answer
 during the grace period following the visa rule changes for those
 entering the UK on a Colombian passport. This extra text should only be
 displayed up until the end of the grace period.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
