### PR TITLE
Update Winter Fuel Payment information in benefits if you live abroad

### DIFF
--- a/app/flows/uk_benefits_abroad_flow.rb
+++ b/app/flows/uk_benefits_abroad_flow.rb
@@ -653,21 +653,6 @@ class UkBenefitsAbroadFlow < SmartAnswer::Flow
       end
     end
 
-    # TODO: Is this still needed (any benefits other than winter fuel?)
-    radio :you_or_partner_pay_contributions_to_the_country? do
-      option :yes
-      option :no
-
-      next_node do |response|
-        case response
-        when "yes"
-          outcome :wfp_not_eligible_outcome
-        when "no"
-          question :you_or_partner_get_a_means_tested_benefit_in_the_country?
-        end
-      end
-    end
-
     radio :you_or_partner_get_a_means_tested_benefit_in_the_country? do
       option :yes
       option :no
@@ -682,7 +667,6 @@ class UkBenefitsAbroadFlow < SmartAnswer::Flow
       end
     end
 
-    # TODO: Do we need to check this??
     radio :is_british_or_irish? do
       option :yes
       option :no
@@ -694,7 +678,6 @@ class UkBenefitsAbroadFlow < SmartAnswer::Flow
           when "jsa"
             outcome :jsa_ireland_outcome
           when "winter_fuel_payment"
-            # outcome :wfp_ireland_outcome
             question :born_before_23_September_1958?
           when "esa"
             outcome(calculator.going_abroad ? :esa_going_abroad_eea_outcome : :esa_already_abroad_eea_outcome)
@@ -714,7 +697,6 @@ class UkBenefitsAbroadFlow < SmartAnswer::Flow
     outcome :pension_going_abroad_outcome # A2 going_abroad
     outcome :jsa_social_security_going_abroad_outcome # A6 going_abroad
     outcome :jsa_not_entitled_outcome # A7 going_abroad and A5 already_abroad
-    outcome :wfp_not_eligible_outcome # A8 going_abroad and A6 already_abroad
     outcome :maternity_benefits_maternity_allowance_outcome # A10 going_abroad and A8 already_abroad
     outcome :maternity_benefits_social_security_going_abroad_outcome # A12 going_abroad
     outcome :maternity_benefits_not_entitled_outcome # A13 going_abroad and A11 already_abroad
@@ -778,9 +760,9 @@ class UkBenefitsAbroadFlow < SmartAnswer::Flow
     outcome :jsa_eea_going_abroad_maybe_outcome
     outcome :jsa_ireland_outcome
 
-    outcome :wfp_going_abroad_eea_maybe_outcome
     outcome :wfp_ireland_outcome
     outcome :wfp_maybe_outcome
+    outcome :wfp_not_eligible_outcome
 
     outcome :db_going_abroad_ireland_outcome
   end

--- a/app/flows/uk_benefits_abroad_flow.rb
+++ b/app/flows/uk_benefits_abroad_flow.rb
@@ -106,9 +106,10 @@ class UkBenefitsAbroadFlow < SmartAnswer::Flow
           end
 
         when "winter_fuel_payment"
-          if calculator.country == "ireland" # going_abroad and already abroad
+          # The following are all the same for going_abroad and already abroad
+          if calculator.country == "ireland"
             question :is_british_or_irish?
-          elsif calculator.already_abroad && calculator.country_eligible_for_winter_fuel_payment?
+          elsif calculator.country_eligible_for_winter_fuel_payment?
             question :worked_in_eea_or_switzerland?
           else
             outcome :wfp_not_eligible_outcome

--- a/app/flows/uk_benefits_abroad_flow.rb
+++ b/app/flows/uk_benefits_abroad_flow.rb
@@ -104,16 +104,16 @@ class UkBenefitsAbroadFlow < SmartAnswer::Flow
           else
             question :employer_paying_ni? # Q10, Q11, Q16 going_abroad and Q9, Q10, Q15 already_abroad
           end
+
         when "winter_fuel_payment"
-          if calculator.country_eligible_for_winter_fuel_payment?
-            if calculator.country == "ireland"
-              question :is_british_or_irish?
-            else
-              question :worked_in_eea_or_switzerland? # A7 already_abroad
-            end
+          if calculator.country == "ireland" # going_abroad and already abroad
+            question :is_british_or_irish?
+          elsif calculator.already_abroad && calculator.country_eligible_for_winter_fuel_payment?
+            question :worked_in_eea_or_switzerland?
           else
-            outcome :wfp_not_eligible_outcome # A8 going_abroad and A6 already_abroad
+            outcome :wfp_not_eligible_outcome
           end
+
         when "child_benefit"
           if calculator.eea_country?
             question :do_either_of_the_following_apply? # Q13 going_abroad and Q12 already_abroad
@@ -579,7 +579,7 @@ class UkBenefitsAbroadFlow < SmartAnswer::Flow
           when "jsa"
             outcome :jsa_eea_going_abroad_maybe_outcome
           when "winter_fuel_payment"
-            outcome :wfp_going_abroad_eea_maybe_outcome
+            question :born_before_23_September_1958?
           when "esa"
             outcome(calculator.going_abroad ? :esa_going_abroad_eea_outcome : :esa_already_abroad_eea_outcome)
           when "disability_benefits"
@@ -603,7 +603,7 @@ class UkBenefitsAbroadFlow < SmartAnswer::Flow
           when "jsa"
             outcome :jsa_eea_going_abroad_maybe_outcome
           when "winter_fuel_payment"
-            outcome :wfp_going_abroad_eea_maybe_outcome
+            question :born_before_23_September_1958?
           when "esa"
             outcome(calculator.going_abroad ? :esa_going_abroad_eea_outcome : :esa_already_abroad_eea_outcome)
           when "disability_benefits"
@@ -624,6 +624,64 @@ class UkBenefitsAbroadFlow < SmartAnswer::Flow
       end
     end
 
+    radio :born_before_23_September_1958? do
+      option :yes
+      option :no
+
+      next_node do |response|
+        case response
+        when "yes"
+          question :you_or_partner_get_a_benefit_in_the_country?
+        when "no"
+          outcome :wfp_not_eligible_outcome
+        end
+      end
+    end
+
+    radio :you_or_partner_get_a_benefit_in_the_country? do
+      option :yes
+      option :no
+
+      next_node do |response|
+        case response
+        when "yes"
+          outcome :wfp_not_eligible_outcome
+        when "no"
+          question :you_or_partner_get_a_means_tested_benefit_in_the_country?
+        end
+      end
+    end
+
+    # TODO: Is this still needed (any benefits other than winter fuel?)
+    radio :you_or_partner_pay_contributions_to_the_country? do
+      option :yes
+      option :no
+
+      next_node do |response|
+        case response
+        when "yes"
+          outcome :wfp_not_eligible_outcome
+        when "no"
+          question :you_or_partner_get_a_means_tested_benefit_in_the_country?
+        end
+      end
+    end
+
+    radio :you_or_partner_get_a_means_tested_benefit_in_the_country? do
+      option :yes
+      option :no
+
+      next_node do |response|
+        case response
+        when "yes"
+          outcome :wfp_maybe_outcome
+        when "no"
+          outcome :wfp_not_eligible_outcome
+        end
+      end
+    end
+
+    # TODO: Do we need to check this??
     radio :is_british_or_irish? do
       option :yes
       option :no
@@ -635,14 +693,19 @@ class UkBenefitsAbroadFlow < SmartAnswer::Flow
           when "jsa"
             outcome :jsa_ireland_outcome
           when "winter_fuel_payment"
-            outcome :wfp_ireland_outcome
+            # outcome :wfp_ireland_outcome
+            question :born_before_23_September_1958?
           when "esa"
             outcome(calculator.going_abroad ? :esa_going_abroad_eea_outcome : :esa_already_abroad_eea_outcome)
           when "disability_benefits"
             outcome :db_going_abroad_ireland_outcome
           end
         when "no"
-          question :worked_in_eea_or_switzerland?
+          if calculator.benefit == "winter_fuel_payment" && calculator.going_abroad
+            outcome :wfp_not_eligible_outcome
+          else
+            question :worked_in_eea_or_switzerland?
+          end
         end
       end
     end
@@ -716,6 +779,7 @@ class UkBenefitsAbroadFlow < SmartAnswer::Flow
 
     outcome :wfp_going_abroad_eea_maybe_outcome
     outcome :wfp_ireland_outcome
+    outcome :wfp_maybe_outcome
 
     outcome :db_going_abroad_ireland_outcome
   end

--- a/app/flows/uk_benefits_abroad_flow/outcomes/wfp_going_abroad_eea_maybe_outcome.erb
+++ b/app/flows/uk_benefits_abroad_flow/outcomes/wfp_going_abroad_eea_maybe_outcome.erb
@@ -1,5 +1,0 @@
-<% govspeak_for :body do %>
-Eligibility for Winter Fuel Payment has changed for winter 2024. 
-
-[Read the Winter Fuel Payment if you live abroad guidance](https://www.gov.uk/winter-fuel-payment/if-you-live-abroad) for more information.
-<% end %>

--- a/app/flows/uk_benefits_abroad_flow/outcomes/wfp_maybe_outcome.erb
+++ b/app/flows/uk_benefits_abroad_flow/outcomes/wfp_maybe_outcome.erb
@@ -1,0 +1,4 @@
+<% govspeak_for :body do %>
+  You might be eligible for Winter Fuel Payment.
+  Find out [how to apply for Winter Fuel Payment if you live abroad](https://www.gov.uk/winter-fuel-payment/if-you-live-abroad).
+<% end %>

--- a/app/flows/uk_benefits_abroad_flow/outcomes/wfp_not_eligible_outcome.erb
+++ b/app/flows/uk_benefits_abroad_flow/outcomes/wfp_not_eligible_outcome.erb
@@ -1,3 +1,3 @@
 <% govspeak_for :body do %>
-  You cannot get a [Winter Fuel Payment](/winter-fuel-payment).
+  You cannot get a [Winter Fuel Payment](/winter-fuel-payment) abroad.
 <% end %>

--- a/app/flows/uk_benefits_abroad_flow/questions/born_before_23_September_1958.erb
+++ b/app/flows/uk_benefits_abroad_flow/questions/born_before_23_September_1958.erb
@@ -1,0 +1,8 @@
+<% text_for :title do %>
+  Were you born before 23 September 1958?
+<% end %>
+
+<% options(
+  "yes": "Yes",
+  "no": "No"
+) %>

--- a/app/flows/uk_benefits_abroad_flow/questions/you_or_partner_get_a_benefit_in_the_country.erb
+++ b/app/flows/uk_benefits_abroad_flow/questions/you_or_partner_get_a_benefit_in_the_country.erb
@@ -1,0 +1,8 @@
+<% text_for :title do %>
+  Do you or your partner get a pension or a benefit based on your work contributions in the country you are living in?
+<% end %>
+
+<% options(
+  "yes": "Yes",
+  "no": "No"
+) %>

--- a/app/flows/uk_benefits_abroad_flow/questions/you_or_partner_get_a_means_tested_benefit_in_the_country.erb
+++ b/app/flows/uk_benefits_abroad_flow/questions/you_or_partner_get_a_means_tested_benefit_in_the_country.erb
@@ -1,0 +1,21 @@
+<% text_for :title do %>
+  Did you or your partner get a means-tested benefit in the country you are living in between 16 and 22 September 2024?
+<% end %>
+
+<% govspeak_for :body do %>
+  You must have been getting a benefit from the country you live in that’s equivalent to:
+
+    - Pension Credit
+    - Universal Credit
+    - Income-related Employment and Support Allowance (ESA)
+    - Income-based Jobseeker’s Allowance (JSA)
+    - Income Support
+    - Working Tax Credit
+    - Child Tax Credit
+
+<% end %>
+
+<% options(
+  "yes": "Yes",
+  "no": "No"
+) %>

--- a/app/flows/uk_benefits_abroad_flow/questions/you_or_partner_pay_contributions_to_the_country.erb
+++ b/app/flows/uk_benefits_abroad_flow/questions/you_or_partner_pay_contributions_to_the_country.erb
@@ -1,8 +1,0 @@
-<% text_for :title do %>
-  Do you or your partner work or pay contributions (similar to [National Insurance](https://www.gov.uk/national-insurance)) to the country you are living in?
-<% end %>
-
-<% options(
-  "yes": "Yes",
-  "no": "No"
-) %>

--- a/app/flows/uk_benefits_abroad_flow/questions/you_or_partner_pay_contributions_to_the_country.erb
+++ b/app/flows/uk_benefits_abroad_flow/questions/you_or_partner_pay_contributions_to_the_country.erb
@@ -1,0 +1,8 @@
+<% text_for :title do %>
+  Do you or your partner work or pay contributions (similar to [National Insurance](https://www.gov.uk/national-insurance)) to the country you are living in?
+<% end %>
+
+<% options(
+  "yes": "Yes",
+  "no": "No"
+) %>

--- a/test/flows/uk_benefits_abroad_flow_test.rb
+++ b/test/flows/uk_benefits_abroad_flow_test.rb
@@ -1,6 +1,7 @@
 require "test_helper"
 require "support/flow_test_helper"
 
+# noinspection RubyResolve
 class UkBenefitsAbroadFlowTest < ActiveSupport::TestCase
   include FlowTestHelper
 
@@ -63,20 +64,12 @@ class UkBenefitsAbroadFlowTest < ActiveSupport::TestCase
         should "have a next node of which_country? for a '#{benefit}' response if going_abroad" do
           assert_next_node :which_country?, for_response: benefit
         end
-
-        # Repeat of above for an 'already_abroad' response
-        # TODO: Could this could be refactored to use contexts for the different responses?
-        should "have a next node of which_country? for a '#{benefit}' response if already_abroad" do
-          add_responses going_or_already_abroad?: "already_abroad"
-          assert_next_node :which_country?, for_response: benefit
-        end
       end
 
       should "have a next node of iidb_already_claiming? for an 'iidb' response" do
         assert_next_node :iidb_already_claiming?, for_response: "iidb"
       end
 
-      # TODO: Example - what is the response needed for ESA and already_abroad? This is only testing going_abroad.
       should "have a next node of esa_how_long_abroad? for an 'esa' response" do
         assert_next_node :esa_how_long_abroad?, for_response: "esa"
       end
@@ -172,21 +165,16 @@ class UkBenefitsAbroadFlowTest < ActiveSupport::TestCase
           add_responses which_benefit?: "winter_fuel_payment"
         end
 
-        %w[going_abroad already_abroad].each do |location|
-          should "have next node of is_british_or_irish? for an 'ireland' response if #{location}" do
-            add_responses going_or_already_abroad?: location
-            assert_next_node :is_british_or_irish?, for_response: "ireland"
-          end
+        should "have next node of is_british_or_irish? for an 'ireland' response" do
+          assert_next_node :is_british_or_irish?, for_response: "ireland"
+        end
 
-          should "have a next node of worked_in_eea_or_switzerland? for any EEA country response except ireland if #{location}" do
-            add_responses going_or_already_abroad?: location
-            assert_next_node :worked_in_eea_or_switzerland?, for_response: "liechtenstein"
-          end
+        should "have a next node of worked_in_eea_or_switzerland? for any EEA country response except ireland" do
+          assert_next_node :worked_in_eea_or_switzerland?, for_response: "liechtenstein"
+        end
 
-          should "have a next node of wfp_not_eligible_outcome for any non-EEA country response if #{location}" do
-            add_responses going_or_already_abroad?: location
-            assert_next_node :wfp_not_eligible_outcome, for_response: "australia"
-          end
+        should "have a next node of wfp_not_eligible_outcome for any non-EEA country response" do
+          assert_next_node :wfp_not_eligible_outcome, for_response: "australia"
         end
       end
 
@@ -980,7 +968,7 @@ class UkBenefitsAbroadFlowTest < ActiveSupport::TestCase
         assert_next_node :db_already_abroad_eea_outcome, for_response: "before_jan_2021"
       end
 
-      # TODO: Should we cycle through the different benefits for the following tests?
+      # TODO: Do we need to cycle through the different benefits for the following tests?
       should "have a next node of jsa_eea_going_abroad_maybe_outcome for a 'before_jan_2021' response if benefit is jsa" do
         assert_next_node :jsa_eea_going_abroad_maybe_outcome, for_response: "before_jan_2021"
       end
@@ -1040,7 +1028,7 @@ class UkBenefitsAbroadFlowTest < ActiveSupport::TestCase
       end
 
       context "winter_fuel_payment" do
-        should "have a next node of born_before_23_September_1958 for a 'before_jan_2021' response if benefit is winter_fuel_payment and going_abroad" do
+        should "have a next node of born_before_23_September_1958 for a 'before_jan_2021' response if benefit is winter_fuel_payment" do
           add_responses which_benefit?: "winter_fuel_payment"
           assert_next_node :born_before_23_September_1958?, for_response: "before_jan_2021"
         end
@@ -1051,7 +1039,7 @@ class UkBenefitsAbroadFlowTest < ActiveSupport::TestCase
           assert_next_node :jsa_not_entitled_outcome, for_response: response
         end
 
-        should "have a next node of wfp_not_eligible_outcome for a '#{response}' response if benefit is winter_fuel_payment and going_abroad" do
+        should "have a next node of wfp_not_eligible_outcome for a '#{response}' response if benefit is winter_fuel_payment" do
           add_responses which_benefit?: "winter_fuel_payment"
           assert_next_node :wfp_not_eligible_outcome, for_response: response
         end


### PR DESCRIPTION
[Trello card](https://trello.com/c/GqfoNzu3/300-uk-benefits-abroad-add-questions-for-winter-fuel-payment)

This request is primarily about replacing this holding message with new questions which help users determine their eligibility for Winter Fuel Payment abroad this winter, but change 1 is about another simplification we can make.

Further to the changes above, the Smart Answer has also been updated with alternate flows and new questions. (See flow chart on Trello card)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
