### PR TITLE
Force autoload of lib for Zeitwerk

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -64,7 +64,7 @@ module SmartAnswers
     config.action_dispatch.ignore_accept_header = true
 
     # Force lib autoload, which was removed by Rails 3.0 and enforced by Zeitwerk
-    config.eager_load_paths << Rails.root.join("lib")
+    config.autoload_paths << Rails.root.join("lib")
 
     # Allow requests for all domains e.g. <app>.dev.gov.uk
     config.hosts.clear


### PR DESCRIPTION
Zeitwerk requries lib to be autoloaded early so it can be properly initialised. Previously this had been set to eager-load erroneously.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
