### PR TITLE
Update outcome_joining_family_nvn.erb

### DIFF
--- a/app/flows/check_uk_visa_flow/outcomes/outcome_joining_family_nvn.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_joining_family_nvn.erb
@@ -55,7 +55,7 @@
   To be eligible to apply from outside the UK, you must either:
 
   + be a citizen of an EU country, Switzerland, Norway, Iceland or Liechtenstein and have a biometric passport or national identity card
-  + have a biometric residence card (BRC) or biometric residence permit (BRP) issued in the UK which has not expired
+  + have a biometric residence card (BRC) issued in the UK which has not expired
 
   Otherwise you'll need to apply for a free [family permit](/family-permit) to come to the UK. Once you're in the UK you can apply to the EU Settlement Scheme.
 <% end %>


### PR DESCRIPTION
Removing 'biometric residence permits (BRPs)' from the list of documents family members can use to apply for the EU Settlement Scheme.

Content trello: https://trello.com/c/DM1VIA4Q/618-december-2024-brps-evisas-euss-smart-answer
Dev trello: https://trello.com/c/BvSIHjnw/307-brps-evisas-euss-smart-answer

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
