### PR TITLE
Update ETA wording in check if you need a UK visa

### DIFF
--- a/app/flows/check_uk_visa_flow.rb
+++ b/app/flows/check_uk_visa_flow.rb
@@ -108,7 +108,9 @@ class CheckUkVisaFlow < SmartAnswer::Flow
         if calculator.travelling_to_channel_islands_or_isle_of_man?
           next question(:channel_islands_or_isle_of_man?)
         elsif calculator.travelling_to_ireland?
-          if calculator.passport_country_requires_electronic_travel_authorisation?
+          if calculator.passport_country_is_taiwan?
+            next outcome(:outcome_transit_to_the_republic_of_ireland)
+          elsif calculator.passport_country_requires_electronic_travel_authorisation?
             next outcome(:outcome_transit_to_the_republic_of_ireland_electronic_travel_authorisation)
           elsif (calculator.passport_country_in_non_visa_national_list? ||
             calculator.passport_country_in_eea? ||
@@ -197,10 +199,10 @@ class CheckUkVisaFlow < SmartAnswer::Flow
           end
         elsif calculator.staying_for_six_months_or_less?
           if calculator.study_visit?
-            if calculator.passport_country_requires_electronic_travel_authorisation?
-              outcome :outcome_study_electronic_travel_authorisation
-            elsif calculator.passport_country_is_taiwan?
+            if calculator.passport_country_is_taiwan?
               outcome :outcome_study_waiver_taiwan
+            elsif calculator.passport_country_requires_electronic_travel_authorisation?
+              outcome :outcome_study_electronic_travel_authorisation
             elsif calculator.passport_country_in_direct_airside_transit_visa_list? ||
                 calculator.passport_country_in_visa_national_list? ||
                 calculator.travel_document?
@@ -209,10 +211,11 @@ class CheckUkVisaFlow < SmartAnswer::Flow
               outcome :outcome_study_no_visa_needed # outcome 1 no visa needed
             end
           elsif calculator.work_visit?
-            if calculator.passport_country_requires_electronic_travel_authorisation?
+            if calculator.passport_country_is_taiwan?
+              outcome :outcome_work_n
+            elsif calculator.passport_country_requires_electronic_travel_authorisation?
               outcome :outcome_work_electronic_travel_authorisation
             elsif (calculator.passport_country_in_british_overseas_territories_list? ||
-                calculator.passport_country_is_taiwan? ||
                 calculator.passport_country_in_non_visa_national_list? ||
                 calculator.passport_country_in_eea?) &&
                 !calculator.travel_document?
@@ -341,10 +344,10 @@ class CheckUkVisaFlow < SmartAnswer::Flow
       end
 
       if calculator.school_visit?
-        if calculator.passport_country_requires_electronic_travel_authorisation?
-          next outcome(:outcome_school_electronic_travel_authorisation)
-        elsif calculator.passport_country_is_taiwan?
+        if calculator.passport_country_is_taiwan?
           next outcome(:outcome_study_waiver_taiwan)
+        elsif calculator.passport_country_requires_electronic_travel_authorisation?
+          next outcome(:outcome_school_electronic_travel_authorisation)
         elsif calculator.passport_country_in_non_visa_national_list? || calculator.passport_country_in_british_overseas_territories_list? || calculator.passport_country_in_eea?
           next outcome(:outcome_school_n)
         else
@@ -353,10 +356,10 @@ class CheckUkVisaFlow < SmartAnswer::Flow
       end
 
       if calculator.medical_visit?
-        if calculator.passport_country_requires_electronic_travel_authorisation?
-          next outcome(:outcome_medical_electronic_travel_authorisation)
-        elsif calculator.passport_country_is_taiwan?
+        if calculator.passport_country_is_taiwan?
           next outcome(:outcome_visit_waiver_taiwan)
+        elsif calculator.passport_country_requires_electronic_travel_authorisation?
+          next outcome(:outcome_medical_electronic_travel_authorisation)
         elsif (calculator.passport_country_in_non_visa_national_list? ||
             calculator.passport_country_in_eea? ||
             calculator.passport_country_in_british_overseas_territories_list?) &&
@@ -368,10 +371,10 @@ class CheckUkVisaFlow < SmartAnswer::Flow
       end
 
       if calculator.tourism_visit?
-        if calculator.passport_country_requires_electronic_travel_authorisation?
-          next outcome(:outcome_tourism_electronic_travel_authorisation)
-        elsif calculator.passport_country_is_taiwan?
+        if calculator.passport_country_is_taiwan?
           next outcome(:outcome_visit_waiver_taiwan)
+        elsif calculator.passport_country_requires_electronic_travel_authorisation?
+          next outcome(:outcome_tourism_electronic_travel_authorisation)
         elsif (calculator.passport_country_in_non_visa_national_list? ||
             calculator.passport_country_in_eea? ||
             calculator.passport_country_in_british_overseas_territories_list?) &&

--- a/app/flows/check_uk_visa_flow/outcomes/_electronic_travel_authorisation_advice.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/_electronic_travel_authorisation_advice.erb
@@ -1,5 +1,3 @@
-<% if calculator.passport_country_in_eta_rollout_group_1_rest_of_the_world? %>
-  ^If you’re travelling on or after 8 January 2025, you’ll need to apply for an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta). 
-<% elsif calculator.passport_country_in_eta_rollout_group_2_eu_eea? %>
+<% if calculator.passport_country_in_eta_rollout_group_2_eu_eea? %>
   ^If you’re travelling on or after 2 April 2025, you’ll need to apply for an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta). You’ll be able to apply from 5 March 2025.
 <% end %>

--- a/lib/smart_answer/calculators/uk_visa_calculator.rb
+++ b/lib/smart_answer/calculators/uk_visa_calculator.rb
@@ -86,10 +86,6 @@ module SmartAnswer::Calculators
       COUNTRY_GROUP_BRITISH_NATIONAL_OVERSEAS.include?(@passport_country)
     end
 
-    def passport_country_in_eta_rollout_group_1_rest_of_the_world?
-      COUNTRY_GROUP_ETA_ROLLOUT_GROUP_1_REST_OF_THE_WORLD.include?(@passport_country)
-    end
-
     def passport_country_in_eta_rollout_group_2_eu_eea?
       COUNTRY_GROUP_ETA_ROLLOUT_GROUP_2_EU_EEA.include?(@passport_country)
     end
@@ -549,12 +545,63 @@ module SmartAnswer::Calculators
     ].freeze
 
     COUNTRY_GROUP_ELECTRONIC_TRAVEL_AUTHORISATION = %w[
-      qatar
+      antigua-and-barbuda
+      argentina
+      australia
+      bahamas
       bahrain
+      barbados
+      belize
+      botswana
+      brazil
+      british-national-overseas
+      brunei
+      canada
+      chile
+      colombia
+      costa-rica
+      federated-states-of-micronesia
+      grenada
+      guatemala
+      guyana
+      hong-kong
+      hong-kong-(british-national-overseas)
+      israel
+      japan
+      kiribati
       kuwait
+      macao
+      malaysia
+      maldives
+      marshall-islands
+      mauritius
+      mexico
+      nauru
+      new-zealand
+      nicaragua
       oman
+      palau
+      panama
+      papua-new-guinea
+      paraguay
+      peru
+      qatar
+      samoa
       saudi-arabia
+      seychelles
+      singapore
+      solomon-islands
+      south-korea
+      st-kitts-and-nevis
+      st-lucia
+      st-vincent-and-the-grenadines
+      taiwan
+      tonga
+      trinidad-and-tobago
+      tuvalu
       united-arab-emirates
+      uruguay
+      usa
     ].freeze
 
     COUNTRY_GROUP_EPASSPORT_GATES = %w[
@@ -625,60 +672,6 @@ module SmartAnswer::Calculators
       "british-overseas-citizen",
       "zimbabwe",
     ].flatten.freeze
-
-    COUNTRY_GROUP_ETA_ROLLOUT_GROUP_1_REST_OF_THE_WORLD = %w[
-      antigua-and-barbuda
-      argentina
-      australia
-      bahamas
-      barbados
-      belize
-      botswana
-      brazil
-      british-national-overseas
-      brunei
-      canada
-      chile
-      colombia
-      costa-rica
-      federated-states-of-micronesia
-      grenada
-      guatemala
-      guyana
-      hong-kong
-      hong-kong-(british-national-overseas)
-      israel
-      japan
-      kiribati
-      macao
-      malaysia
-      maldives
-      marshall-islands
-      mauritius
-      mexico
-      nauru
-      new-zealand
-      nicaragua
-      palau
-      panama
-      papua-new-guinea
-      paraguay
-      peru
-      samoa
-      seychelles
-      singapore
-      solomon-islands
-      south-korea
-      st-kitts-and-nevis
-      st-lucia
-      st-vincent-and-the-grenadines
-      taiwan
-      tonga
-      trinidad-and-tobago
-      tuvalu
-      uruguay
-      usa
-    ].freeze
 
     COUNTRY_GROUP_ETA_ROLLOUT_GROUP_2_EU_EEA = %w[
       andorra

--- a/test/flows/check_uk_visa_flow_test.rb
+++ b/test/flows/check_uk_visa_flow_test.rb
@@ -14,14 +14,13 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
     @british_overseas_territory_country = "anguilla"
     @non_visa_national_country = "andorra"
     @eea_country = "austria"
-    @eta_rollout_group_1_rest_of_the_world_country = "antigua-and-barbuda"
     @eta_rollout_group_2_eu_eea_country = "bonaire-st-eustatius-saba"
     @travel_document_country = "hong-kong"
     @b1_b2_country = "syria"
     @youth_mobility_scheme_country = "canada"
 
     @non_visa_national_eta_text = "You currently do not need an electronic travel authorisation (ETA)"
-    @eta_rollout_group_1_rest_of_the_world_text = "If you’re travelling on or after 8 January 2025, you’ll need to apply for an electronic travel authorisation (ETA)."
+    @electronic_travel_authorisation_text = "You'll need an electronic travel authorisation (ETA) or a visa"
     @eta_rollout_group_2_eu_eea_text = "If you’re travelling on or after 2 April 2025, you’ll need to apply for an electronic travel authorisation (ETA). You’ll be able to apply from 5 March 2025."
     @eea_eta_text = "You currently do not need an electronic travel authorisation (ETA)"
 
@@ -48,7 +47,6 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
                                       @travel_document_country,
                                       @b1_b2_country,
                                       @youth_mobility_scheme_country,
-                                      @eta_rollout_group_1_rest_of_the_world_country,
                                       @eta_rollout_group_2_eu_eea_country].uniq)
   end
 
@@ -243,19 +241,19 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
           assert_next_node :outcome_no_visa_needed, for_response: response
         end
 
-        should "have a next node of outcome_no_visa_needed for a travel document country with a passport " \
+        should "have a next node of outcome_transit_to_the_republic_of_ireland_electronic_travel_authorisation for a travel document country with a passport " \
                "and a '#{response}' response" do
           add_responses what_passport_do_you_have?: @travel_document_country,
                         what_sort_of_travel_document?: "passport"
-          assert_next_node :outcome_no_visa_needed, for_response: response
+          assert_next_node :outcome_transit_to_the_republic_of_ireland_electronic_travel_authorisation, for_response: response
         end
       end
 
-      should "have a next node of outcome_transit_to_the_republic_of_ireland for a travel document country with " \
+      should "have a next node of outcome_transit_to_the_republic_of_ireland_electronic_travel_authorisation for a travel document country with " \
              "a travel document and a 'republic_of_ireland' response" do
         add_responses what_passport_do_you_have?: @travel_document_country,
                       what_sort_of_travel_document?: "travel_document"
-        assert_next_node :outcome_transit_to_the_republic_of_ireland, for_response: "republic_of_ireland"
+        assert_next_node :outcome_transit_to_the_republic_of_ireland_electronic_travel_authorisation, for_response: "republic_of_ireland"
       end
 
       should "have a next node of outcome_transit_to_the_republic_of_ireland for a different country and a " \
@@ -425,11 +423,11 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
           assert_next_node :outcome_study_m, for_response: "six_months_or_less"
         end
 
-        should "have a next node of outcome_study_m for a study visit with a travel document" do
+        should "have a next node of outcome_study_electronic_travel_authorisation for a study visit with a travel document" do
           add_responses what_passport_do_you_have?: @travel_document_country,
                         what_sort_of_travel_document?: "travel_document",
                         purpose_of_visit?: "study"
-          assert_next_node :outcome_study_m, for_response: "six_months_or_less"
+          assert_next_node :outcome_study_electronic_travel_authorisation, for_response: "six_months_or_less"
         end
 
         should "have a next node of outcome_study_no_visa_needed for a study visit with a British overseas " \
@@ -480,11 +478,11 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
           assert_next_node :outcome_work_n, for_response: "six_months_or_less"
         end
 
-        should "have a next node of outcome_work_m for a work visit with a travel document" do
+        should "have a next node of outcome_work_electronic_travel_authorisation for a work visit with a travel document" do
           add_responses what_passport_do_you_have?: @travel_document_country,
                         what_sort_of_travel_document?: "travel_document",
                         purpose_of_visit?: "work"
-          assert_next_node :outcome_work_m, for_response: "six_months_or_less"
+          assert_next_node :outcome_work_electronic_travel_authorisation, for_response: "six_months_or_less"
         end
 
         should "have a next node of outcome_work_m for a work visit for other countries" do
@@ -945,9 +943,9 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
       assert_no_rendered_outcome text: "Whether you need a visa depends"
     end
 
-    should "render callout box for eta_rollout_group_1_rest_of_the_world_country passport holders" do
-      add_responses what_passport_do_you_have?: @eta_rollout_group_1_rest_of_the_world_country
-      assert_rendered_outcome text: @eta_rollout_group_1_rest_of_the_world_text
+    should "render callout box for electronic_travel_authorisation_country passport holders" do
+      add_responses what_passport_do_you_have?: @electronic_travel_authorisation_country
+      assert_rendered_outcome text: @electronic_travel_authorisation_text
     end
 
     should "render callout box for eta_rollout_group_2_eu_eea_country passport holders" do
@@ -969,9 +967,9 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
         assert_no_rendered_outcome text: @eea_eta_text
       end
 
-      should "render callout box for eta_rollout_group_1_rest_of_the_world_country passport holders" do
-        add_responses what_passport_do_you_have?: @eta_rollout_group_1_rest_of_the_world_country
-        assert_rendered_outcome text: @eta_rollout_group_1_rest_of_the_world_text
+      should "render callout box for electronic_travel_authorisation_country passport holders" do
+        add_responses what_passport_do_you_have?: @electronic_travel_authorisation_country
+        assert_rendered_outcome text: @electronic_travel_authorisation_text
       end
 
       should "render callout box for eta_rollout_group_2_eu_eea_country passport holders" do
@@ -993,9 +991,9 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
         assert_no_rendered_outcome text: @eea_eta_text
       end
 
-      should "render callout box for eta_rollout_group_1_rest_of_the_world_country passport holders" do
-        add_responses what_passport_do_you_have?: @eta_rollout_group_1_rest_of_the_world_country
-        assert_rendered_outcome text: @eta_rollout_group_1_rest_of_the_world_text
+      should "render callout box for electronic_travel_authorisation_country passport holders" do
+        add_responses what_passport_do_you_have?: @electronic_travel_authorisation_country
+        assert_rendered_outcome text: @electronic_travel_authorisation_text
       end
 
       should "render callout box for eta_rollout_group_2_eu_eea_country passport holders" do
@@ -1017,9 +1015,9 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
         assert_no_rendered_outcome text: @eea_eta_text
       end
 
-      should "render callout box for eta_rollout_group_1_rest_of_the_world_country passport holders" do
-        add_responses what_passport_do_you_have?: @eta_rollout_group_1_rest_of_the_world_country
-        assert_rendered_outcome text: @eta_rollout_group_1_rest_of_the_world_text
+      should "render callout box for electronic_travel_authorisation_country passport holders" do
+        add_responses what_passport_do_you_have?: @electronic_travel_authorisation_country
+        assert_rendered_outcome text: @electronic_travel_authorisation_text
       end
 
       should "render callout box for eta_rollout_group_2_eu_eea_country passport holders" do
@@ -1040,9 +1038,9 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
         assert_no_rendered_outcome text: @eea_eta_text
       end
 
-      should "render callout box for eta_rollout_group_1_rest_of_the_world_country passport holders" do
-        add_responses what_passport_do_you_have?: @eta_rollout_group_1_rest_of_the_world_country
-        assert_rendered_outcome text: @eta_rollout_group_1_rest_of_the_world_text
+      should "render callout box for electronic_travel_authorisation_country passport holders" do
+        add_responses what_passport_do_you_have?: @electronic_travel_authorisation_country
+        assert_rendered_outcome text: @electronic_travel_authorisation_text
       end
 
       should "render callout box for eta_rollout_group_2_eu_eea_country passport holders" do
@@ -1063,9 +1061,9 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
         assert_no_rendered_outcome text: @eea_eta_text
       end
 
-      should "render callout box for eta_rollout_group_1_rest_of_the_world_country passport holders" do
-        add_responses what_passport_do_you_have?: @eta_rollout_group_1_rest_of_the_world_country
-        assert_rendered_outcome text: @eta_rollout_group_1_rest_of_the_world_text
+      should "render callout box for electronic_travel_authorisation_country passport holders" do
+        add_responses what_passport_do_you_have?: @electronic_travel_authorisation_country
+        assert_rendered_outcome text: @electronic_travel_authorisation_text
       end
 
       should "render callout box for eta_rollout_group_2_eu_eea_country passport holders" do
@@ -1086,9 +1084,9 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
         assert_no_rendered_outcome text: @eea_eta_text
       end
 
-      should "render callout box for eta_rollout_group_1_rest_of_the_world_country passport holders" do
-        add_responses what_passport_do_you_have?: @eta_rollout_group_1_rest_of_the_world_country
-        assert_rendered_outcome text: @eta_rollout_group_1_rest_of_the_world_text
+      should "render callout box for electronic_travel_authorisation_country passport holders" do
+        add_responses what_passport_do_you_have?: @electronic_travel_authorisation_country
+        assert_rendered_outcome text: @electronic_travel_authorisation_text
       end
 
       should "render callout box for eta_rollout_group_2_eu_eea_country passport holders" do
@@ -1110,9 +1108,9 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
         assert_no_rendered_outcome text: @eea_eta_text
       end
 
-      should "render callout box for eta_rollout_group_1_rest_of_the_world_country passport holders" do
-        add_responses what_passport_do_you_have?: @eta_rollout_group_1_rest_of_the_world_country
-        assert_rendered_outcome text: @eta_rollout_group_1_rest_of_the_world_text
+      should "render callout box for electronic_travel_authorisation_country passport holders" do
+        add_responses what_passport_do_you_have?: @electronic_travel_authorisation_country
+        assert_rendered_outcome text: @electronic_travel_authorisation_text
       end
 
       should "render callout box for eta_rollout_group_2_eu_eea_country passport holders" do

--- a/test/support/flows/check_uk_visa_flow_test_helper.rb
+++ b/test/support/flows/check_uk_visa_flow_test_helper.rb
@@ -132,16 +132,16 @@ module CheckUkVisaFlowTestHelper
         assert_next_node :outcome_medical_n, for_response: "medical"
       end
 
-      should "have a next node of outcome_medical_n for a travel document country with a passport" do
+      should "have a next node of outcome_medical_electronic_travel_authorisationfor a travel document country with a passport" do
         add_responses what_passport_do_you_have?: @travel_document_country,
                       what_sort_of_travel_document?: "passport"
-        assert_next_node :outcome_medical_n, for_response: "medical"
+        assert_next_node :outcome_medical_electronic_travel_authorisation, for_response: "medical"
       end
 
-      should "have a next node of outcome_medical_y for a travel document country with a travel document" do
+      should "have a next node of outcome_medical_electronic_travel_authorisation for a travel document country with a travel document" do
         add_responses what_passport_do_you_have?: @travel_document_country,
                       what_sort_of_travel_document?: "travel_document"
-        assert_next_node :outcome_medical_y, for_response: "medical"
+        assert_next_node :outcome_medical_electronic_travel_authorisation, for_response: "medical"
       end
 
       should "have a next node of outcome_medical_y for other passports" do
@@ -176,16 +176,16 @@ module CheckUkVisaFlowTestHelper
         assert_next_node :outcome_tourism_n, for_response: "tourism"
       end
 
-      should "have a next node of outcome_tourism_n for a travel document country with a passport" do
+      should "have a next node of outcome_tourism_electronic_travel_authorisation for a travel document country with a passport" do
         add_responses what_passport_do_you_have?: @travel_document_country,
                       what_sort_of_travel_document?: "passport"
-        assert_next_node :outcome_tourism_n, for_response: "tourism"
+        assert_next_node :outcome_tourism_electronic_travel_authorisation, for_response: "tourism"
       end
 
-      should "have a next node of outcome_tourism_y for a travel document country with a travel document" do
+      should "have a next node of outcome_tourism_electronic_travel_authorisation for a travel document country with a travel document" do
         add_responses what_passport_do_you_have?: @travel_document_country,
                       what_sort_of_travel_document?: "travel_document"
-        assert_next_node :travelling_visiting_partner_family_member?, for_response: "tourism"
+        assert_next_node :outcome_tourism_electronic_travel_authorisation, for_response: "tourism"
       end
 
       should "have a next node of outcome_tourism_y for other passports" do


### PR DESCRIPTION
The 8th of January is the first day that people of certain nationalities need an electronic travel authorisation (ETA) to travel to the UK.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
