### PR TITLE
Updated student finance rates for 2025-2026 academic year

### DIFF
--- a/app/flows/student_finance_calculator_flow.rb
+++ b/app/flows/student_finance_calculator_flow.rb
@@ -6,8 +6,8 @@ class StudentFinanceCalculatorFlow < SmartAnswer::Flow
 
     # Q1
     radio :when_does_your_course_start? do
-      option :"2023-2024"
       option :"2024-2025"
+      option :"2025-2026"
 
       on_response do |response|
         self.calculator = SmartAnswer::Calculators::StudentFinanceCalculator.new

--- a/app/flows/student_finance_calculator_flow/questions/when_does_your_course_start.erb
+++ b/app/flows/student_finance_calculator_flow/questions/when_does_your_course_start.erb
@@ -3,6 +3,6 @@
 <% end %>
 
 <% options(
-  "2023-2024": "Between September 2023 and August 2024",
   "2024-2025": "Between September 2024 and August 2025",
+  "2025-2026": "Between September 2025 and August 2026",
 ) %>

--- a/app/flows/student_finance_calculator_flow/start.erb
+++ b/app/flows/student_finance_calculator_flow/start.erb
@@ -9,8 +9,8 @@
 <% govspeak_for :body do %>
   This calculator is for students living in England starting a new undergraduate course in academic years:
 
-  - 2023 to 2024
   - 2024 to 2025
+  - 2025 to 2026
   
   You'll need to [check if you're eligible for tuition fees and living costs (full support) or tuition fee-only funding before you start](https://www.gov.uk/student-finance/who-qualifies).
   

--- a/lib/smart_answer/calculators/student_finance_calculator.rb
+++ b/lib/smart_answer/calculators/student_finance_calculator.rb
@@ -15,58 +15,58 @@ module SmartAnswer
                     :loan_eligibility
 
       LOAN_MAXIMUMS = {
-        "2023-2024" => {
-          "at-home" => 8_400,
-          "away-outside-london" => 9_978,
-          "away-in-london" => 13_002,
-        },
         "2024-2025" => {
           "at-home" => 8_610,
           "away-outside-london" => 10_227,
           "away-in-london" => 13_348,
         },
+        "2025-2026" => {
+          "at-home" => 8877,
+          "away-outside-london" => 10_544,
+          "away-in-london" => 13_762,
+        },
       }.freeze
 
       REDUCED_MAINTENTANCE_LOAN_AMOUNTS = {
-        "2023-2024" => {
-          "at-home" => 1955,
-          "away-in-london" => 3658,
-          "away-outside-london" => 2605,
-        },
         "2024-2025" => {
           "at-home" => 2_004,
           "away-outside-london" => 2_670,
           "away-in-london" => 3_749,
         },
+        "2025-2026" => {
+          "at-home" => 2_396,
+          "away-in-london" => 3_194,
+          "away-outside-london" => 4_485,
+        },
       }.freeze
 
       CHILD_CARE_GRANTS = {
-        "2023-2024" => {
-          "one-child" => 188.90,
-          "more-than-one-child" => 323.85,
-        },
         "2024-2025" => {
           "one-child" => 193.62,
           "more-than-one-child" => 331.95,
         },
+        "2025-2026" => {
+          "one-child" => 199.62,
+          "more-than-one-child" => 342.24,
+        },
       }.freeze
 
-      CHILD_CARE_GRANTS_ONE_CHILD_HOUSEHOLD_INCOME = 19_795.23
-      CHILD_CARE_GRANTS_MORE_THAN_ONE_CHILD_HOUSEHOLD_INCOME = 28_379.39
+      CHILD_CARE_GRANTS_ONE_CHILD_HOUSEHOLD_INCOME = 20_107.23
+      CHILD_CARE_GRANTS_MORE_THAN_ONE_CHILD_HOUSEHOLD_INCOME = 28_914.47
 
       PARENTS_LEARNING_ALLOWANCE = {
-        "2023-2024" => 1_915,
         "2024-2025" => 1_963,
+        "2025-2026" => 2_024,
       }.freeze
 
-      PARENTS_LEARNING_HOUSEHOLD_INCOME = 18_835.98
+      PARENTS_LEARNING_HOUSEHOLD_INCOME = 18_957.98
 
       ADULT_DEPENDANT_ALLOWANCE = {
-        "2023-2024" => 3_354,
         "2024-2025" => 3_438,
+        "2025-2026" => 3_545,
       }.freeze
 
-      ADULT_DEPENDANT_HOUSEHOLD_INCOME = 15_621.98
+      ADULT_DEPENDANT_HOUSEHOLD_INCOME = 15_835.98
 
       TUITION_FEE_MAXIMUM = {
         "full-time" => 9_250,
@@ -74,15 +74,15 @@ module SmartAnswer
       }.freeze
 
       LOAN_MINIMUMS = {
-        "2023-2024" => {
-          "at-home" => 3_698,
-          "away-outside-london" => 4_651,
-          "away-in-london" => 6_485,
-        },
         "2024-2025" => {
           "at-home" => 3_790,
           "away-outside-london" => 4_767,
           "away-in-london" => 6_647,
+        },
+        "2025-2026" => {
+          "at-home" => 3_907,
+          "away-outside-london" => 4_915,
+          "away-in-london" => 6_853,
         },
       }.freeze
 
@@ -92,10 +92,10 @@ module SmartAnswer
           "away-outside-london" => 7.01,
           "away-in-london" => 6.89,
         },
-        "2024-2025" => {
-          "at-home" => 6.91,
-          "away-outside-london" => 6.84,
-          "away-in-london" => 6.73,
+        "2025-2026" => {
+          "at-home" => 6.71,
+          "away-outside-london" => 6.64,
+          "away-in-london" => 6.53,
         },
       }.freeze
 

--- a/lib/smart_answer/calculators/student_finance_calculator.rb
+++ b/lib/smart_answer/calculators/student_finance_calculator.rb
@@ -35,8 +35,8 @@ module SmartAnswer
         },
         "2025-2026" => {
           "at-home" => 2_396,
-          "away-in-london" => 3_194,
-          "away-outside-london" => 4_485,
+          "away-in-london" => 4_485,
+          "away-outside-london" => 3_194,
         },
       }.freeze
 

--- a/lib/smart_answer/calculators/student_finance_calculator.rb
+++ b/lib/smart_answer/calculators/student_finance_calculator.rb
@@ -87,10 +87,10 @@ module SmartAnswer
       }.freeze
 
       INCOME_PENALTY_RATIO = {
-        "2023-2024" => {
-          "at-home" => 7.08,
-          "away-outside-london" => 7.01,
-          "away-in-london" => 6.89,
+        "2024-2025" => {
+          "at-home" => 6.91,
+          "away-outside-london" => 6.84,
+          "away-in-london" => 6.73,
         },
         "2025-2026" => {
           "at-home" => 6.71,

--- a/test/flows/student_finance_calculator_flow_test.rb
+++ b/test/flows/student_finance_calculator_flow_test.rb
@@ -19,7 +19,7 @@ class StudentFinanceCalculatorTest < ActiveSupport::TestCase
 
     context "next_node" do
       should "have a next node of what_loans_are_you_eligible_for? for any response" do
-        assert_next_node :what_loans_are_you_eligible_for?, for_response: "2023-2024"
+        assert_next_node :what_loans_are_you_eligible_for?, for_response: "2024-2025"
       end
     end
   end
@@ -27,7 +27,7 @@ class StudentFinanceCalculatorTest < ActiveSupport::TestCase
   context "question: what_loans_are_you_eligible_for?," do
     setup do
       testing_node :what_loans_are_you_eligible_for?
-      add_responses when_does_your_course_start?: "2023-2024"
+      add_responses when_does_your_course_start?: "2024-2025"
     end
 
     should "render the question" do
@@ -44,7 +44,7 @@ class StudentFinanceCalculatorTest < ActiveSupport::TestCase
   context "question: will_you_be_studying_full_or_part_time?," do
     setup do
       testing_node :will_you_be_studying_full_or_part_time?
-      add_responses when_does_your_course_start?: "2023-2024",
+      add_responses when_does_your_course_start?: "2024-2025",
                     what_loans_are_you_eligible_for?: "tuition-and-maintenance"
     end
 
@@ -62,7 +62,7 @@ class StudentFinanceCalculatorTest < ActiveSupport::TestCase
   context "question: how_much_are_your_tuition_fees_per_year?," do
     setup do
       testing_node :how_much_are_your_tuition_fees_per_year?
-      add_responses when_does_your_course_start?: "2023-2024",
+      add_responses when_does_your_course_start?: "2024-2025",
                     what_loans_are_you_eligible_for?: "tuition-and-maintenance",
                     will_you_be_studying_full_or_part_time?: "full-time"
     end
@@ -109,7 +109,7 @@ class StudentFinanceCalculatorTest < ActiveSupport::TestCase
   context "question: where_will_you_live_while_studying?," do
     setup do
       testing_node :where_will_you_live_while_studying?
-      add_responses when_does_your_course_start?: "2023-2024",
+      add_responses when_does_your_course_start?: "2024-2025",
                     what_loans_are_you_eligible_for?: "tuition-and-maintenance",
                     will_you_be_studying_full_or_part_time?: "full-time",
                     how_much_are_your_tuition_fees_per_year?: "9250"
@@ -129,7 +129,7 @@ class StudentFinanceCalculatorTest < ActiveSupport::TestCase
   context "question: whats_your_household_income?," do
     setup do
       testing_node :whats_your_household_income?
-      add_responses when_does_your_course_start?: "2023-2024",
+      add_responses when_does_your_course_start?: "2024-2025",
                     what_loans_are_you_eligible_for?: "tuition-and-maintenance",
                     will_you_be_studying_full_or_part_time?: "full-time",
                     how_much_are_your_tuition_fees_per_year?: "6935",
@@ -156,7 +156,7 @@ class StudentFinanceCalculatorTest < ActiveSupport::TestCase
   context "question: how_many_credits_will_you_study?" do
     setup do
       testing_node :how_many_credits_will_you_study?
-      add_responses when_does_your_course_start?: "2023-2024",
+      add_responses when_does_your_course_start?: "2024-2025",
                     what_loans_are_you_eligible_for?: "tuition-and-maintenance",
                     will_you_be_studying_full_or_part_time?: "part-time",
                     how_much_are_your_tuition_fees_per_year?: "6935",
@@ -184,7 +184,7 @@ class StudentFinanceCalculatorTest < ActiveSupport::TestCase
   context "question: how_many_credits_does_a_full_time_student_study?" do
     setup do
       testing_node :how_many_credits_does_a_full_time_student_study?
-      add_responses when_does_your_course_start?: "2023-2024",
+      add_responses when_does_your_course_start?: "2024-2025",
                     what_loans_are_you_eligible_for?: "tuition-and-maintenance",
                     will_you_be_studying_full_or_part_time?: "part-time",
                     how_much_are_your_tuition_fees_per_year?: "6935",
@@ -213,7 +213,7 @@ class StudentFinanceCalculatorTest < ActiveSupport::TestCase
   context "question: do_any_of_the_following_apply_uk_full_time_students_only?," do
     setup do
       testing_node :do_any_of_the_following_apply_uk_full_time_students_only?
-      add_responses when_does_your_course_start?: "2023-2024",
+      add_responses when_does_your_course_start?: "2024-2025",
                     what_loans_are_you_eligible_for?: "tuition-and-maintenance",
                     will_you_be_studying_full_or_part_time?: "full-time",
                     how_much_are_your_tuition_fees_per_year?: "9250",
@@ -235,7 +235,7 @@ class StudentFinanceCalculatorTest < ActiveSupport::TestCase
   context "question: do_any_of_the_following_apply_all_uk_students?" do
     setup do
       testing_node :do_any_of_the_following_apply_all_uk_students?
-      add_responses when_does_your_course_start?: "2023-2024",
+      add_responses when_does_your_course_start?: "2024-2025",
                     what_loans_are_you_eligible_for?: "tuition-and-maintenance",
                     will_you_be_studying_full_or_part_time?: "part-time",
                     how_much_are_your_tuition_fees_per_year?: "6935",
@@ -259,7 +259,7 @@ class StudentFinanceCalculatorTest < ActiveSupport::TestCase
   context "question: what_course_are_you_studying?," do
     setup do
       testing_node :what_course_are_you_studying?
-      add_responses when_does_your_course_start?: "2023-2024",
+      add_responses when_does_your_course_start?: "2024-2025",
                     what_loans_are_you_eligible_for?: "tuition-and-maintenance",
                     will_you_be_studying_full_or_part_time?: "full-time",
                     how_much_are_your_tuition_fees_per_year?: "6935",
@@ -294,7 +294,7 @@ class StudentFinanceCalculatorTest < ActiveSupport::TestCase
   context "question: are_you_a_doctor_or_dentist?," do
     setup do
       testing_node :are_you_a_doctor_or_dentist?
-      add_responses when_does_your_course_start?: "2023-2024",
+      add_responses when_does_your_course_start?: "2024-2025",
                     what_loans_are_you_eligible_for?: "tuition-and-maintenance",
                     will_you_be_studying_full_or_part_time?: "full-time",
                     how_much_are_your_tuition_fees_per_year?: "9250",
@@ -322,7 +322,7 @@ class StudentFinanceCalculatorTest < ActiveSupport::TestCase
   context "outcome: outcome_uk_full_time_students" do
     setup do
       testing_node :outcome_uk_full_time_students
-      add_responses when_does_your_course_start?: "2023-2024",
+      add_responses when_does_your_course_start?: "2024-2025",
                     what_loans_are_you_eligible_for?: "tuition-and-maintenance",
                     will_you_be_studying_full_or_part_time?: "full-time",
                     how_much_are_your_tuition_fees_per_year?: "9250",
@@ -402,7 +402,7 @@ class StudentFinanceCalculatorTest < ActiveSupport::TestCase
   context "outcome: outcome_uk_part_time_students" do
     setup do
       testing_node :outcome_uk_part_time_students
-      add_responses when_does_your_course_start?: "2023-2024",
+      add_responses when_does_your_course_start?: "2024-2025",
                     what_loans_are_you_eligible_for?: "tuition-and-maintenance",
                     will_you_be_studying_full_or_part_time?: "part-time",
                     how_much_are_your_tuition_fees_per_year?: "6935",
@@ -479,7 +479,7 @@ class StudentFinanceCalculatorTest < ActiveSupport::TestCase
   context "outcome: outcome_uk_full_time_dental_medical_students" do
     setup do
       testing_node :outcome_uk_full_time_dental_medical_students
-      add_responses when_does_your_course_start?: "2023-2024",
+      add_responses when_does_your_course_start?: "2024-2025",
                     what_loans_are_you_eligible_for?: "tuition-and-maintenance",
                     will_you_be_studying_full_or_part_time?: "full-time",
                     how_much_are_your_tuition_fees_per_year?: "9250",

--- a/test/unit/calculators/student_finance_calculator_test.rb
+++ b/test/unit/calculators/student_finance_calculator_test.rb
@@ -5,14 +5,14 @@ module SmartAnswer
     class StudentFinanceCalculatorTest < ActiveSupport::TestCase
       test "StudentFinanceCalculator is valid and setup properly" do
         calculator = StudentFinanceCalculator.new(
-          course_start: "2023-2024",
+          course_start: "2024-2025",
           household_income: 25_000,
           residence: "at-home",
           course_type: "full-time",
         )
         assert_instance_of StudentFinanceCalculator, calculator
 
-        assert_equal "2023-2024", calculator.course_start
+        assert_equal "2024-2025", calculator.course_start
         assert_equal 25_000, calculator.household_income
         assert_equal "at-home", calculator.residence
         assert_equal "full-time", calculator.course_type
@@ -28,43 +28,36 @@ module SmartAnswer
         assert_nil calculator.residence
         assert_nil calculator.course_type
 
-        calculator.course_start = "2023-2024"
+        calculator.course_start = "2024-2025"
         calculator.household_income = 25_000
         calculator.residence = "at-home"
         calculator.course_type = "full-time"
 
-        assert_equal "2023-2024", calculator.course_start
+        assert_equal "2024-2025", calculator.course_start
         assert_equal 25_000, calculator.household_income
         assert_equal "at-home", calculator.residence
         assert_equal "full-time", calculator.course_type
       end
 
       context "#eligible_for_childcare_grant_one_child?" do
-        should "have low household income and no dependencies" do
+        should "not be eligible when on a low household income with no dependants" do
           calculator = StudentFinanceCalculator.new(
-            household_income: 18_786,
+            household_income: StudentFinanceCalculator::CHILD_CARE_GRANTS_ONE_CHILD_HOUSEHOLD_INCOME,
           )
           assert_not calculator.eligible_for_childcare_grant_one_child?
         end
 
-        should "have high household income and no dependencies" do
+        should "be eligible when on a low household income with dependants" do
           calculator = StudentFinanceCalculator.new(
-            household_income: 18_787,
-          )
-          assert_not calculator.eligible_for_childcare_grant_one_child?
-        end
-
-        should "have low household income and children" do
-          calculator = StudentFinanceCalculator.new(
-            household_income: 18_786,
+            household_income: StudentFinanceCalculator::CHILD_CARE_GRANTS_ONE_CHILD_HOUSEHOLD_INCOME,
             uk_ft_circumstances: %w[children-under-17],
           )
           assert calculator.eligible_for_childcare_grant_one_child?
         end
 
-        should "have high household income and children" do
+        should "not be eligible when on a high household income with dependants" do
           calculator = StudentFinanceCalculator.new(
-            household_income: 19_800,
+            household_income: StudentFinanceCalculator::CHILD_CARE_GRANTS_ONE_CHILD_HOUSEHOLD_INCOME + 0.01,
             uk_ft_circumstances: %w[children-under-17],
           )
           assert_not calculator.eligible_for_childcare_grant_one_child?
@@ -72,31 +65,24 @@ module SmartAnswer
       end
 
       context "#eligible_for_childcare_grant_more_than_one_child?" do
-        should "have low household income and no dependencies" do
+        should "not be eligible when on a low household income with no dependants" do
           calculator = StudentFinanceCalculator.new(
-            household_income: 26_649,
+            household_income: StudentFinanceCalculator::CHILD_CARE_GRANTS_MORE_THAN_ONE_CHILD_HOUSEHOLD_INCOME,
           )
           assert_not calculator.eligible_for_childcare_grant_more_than_one_child?
         end
 
-        should "have high household income and no dependencies" do
+        should "be eligible when on a low household income with dependants" do
           calculator = StudentFinanceCalculator.new(
-            household_income: 26_650,
-          )
-          assert_not calculator.eligible_for_childcare_grant_more_than_one_child?
-        end
-
-        should "have low household income and children" do
-          calculator = StudentFinanceCalculator.new(
-            household_income: 26_649,
+            household_income: StudentFinanceCalculator::CHILD_CARE_GRANTS_MORE_THAN_ONE_CHILD_HOUSEHOLD_INCOME,
             uk_ft_circumstances: %w[children-under-17],
           )
           assert calculator.eligible_for_childcare_grant_more_than_one_child?
         end
 
-        should "have high household income and children" do
+        should "not be eligible when on a high household income with dependants" do
           calculator = StudentFinanceCalculator.new(
-            household_income: 28_460,
+            household_income: StudentFinanceCalculator::CHILD_CARE_GRANTS_MORE_THAN_ONE_CHILD_HOUSEHOLD_INCOME + 0.01,
             uk_ft_circumstances: %w[children-under-17],
           )
           assert_not calculator.eligible_for_childcare_grant_more_than_one_child?
@@ -104,31 +90,24 @@ module SmartAnswer
       end
 
       context "#eligible_for_parent_learning_allowance?" do
-        should "have low household income and no dependencies" do
+        should "not be eligible when on a low household income with no dependants" do
           calculator = StudentFinanceCalculator.new(
-            household_income: 18_441,
+            household_income: StudentFinanceCalculator::PARENTS_LEARNING_HOUSEHOLD_INCOME,
           )
           assert_not calculator.eligible_for_parent_learning_allowance?
         end
 
-        should "have high household income and no dependencies" do
+        should "be eligible when on a low household income with dependants" do
           calculator = StudentFinanceCalculator.new(
-            household_income: 18_442,
-          )
-          assert_not calculator.eligible_for_parent_learning_allowance?
-        end
-
-        should "have low household income and adult dependant" do
-          calculator = StudentFinanceCalculator.new(
-            household_income: 18_441,
+            household_income: StudentFinanceCalculator::PARENTS_LEARNING_HOUSEHOLD_INCOME,
             uk_ft_circumstances: %w[children-under-17],
           )
           assert calculator.eligible_for_parent_learning_allowance?
         end
 
-        should "have high household income and adult dependant" do
+        should "not be eligible when on a high household income with dependants" do
           calculator = StudentFinanceCalculator.new(
-            household_income: 18_840,
+            household_income: StudentFinanceCalculator::PARENTS_LEARNING_HOUSEHOLD_INCOME + 0.01,
             uk_ft_circumstances: %w[children-under-17],
           )
           assert_not calculator.eligible_for_parent_learning_allowance?
@@ -136,31 +115,24 @@ module SmartAnswer
       end
 
       context "#eligible_for_adult_dependant_allowance?" do
-        should "have low household income and no dependencies" do
+        should "not be eligible when on a low household income with no dependants" do
           calculator = StudentFinanceCalculator.new(
-            household_income: 14_933,
+            household_income: StudentFinanceCalculator::ADULT_DEPENDANT_HOUSEHOLD_INCOME,
           )
           assert_not calculator.eligible_for_adult_dependant_allowance?
         end
 
-        should "have high household income and no dependencies" do
+        should "be eligible when on a low household income with dependants" do
           calculator = StudentFinanceCalculator.new(
-            household_income: 14_934,
-          )
-          assert_not calculator.eligible_for_adult_dependant_allowance?
-        end
-
-        should "have low household income and adult dependant" do
-          calculator = StudentFinanceCalculator.new(
-            household_income: 14_933,
+            household_income: StudentFinanceCalculator::ADULT_DEPENDANT_HOUSEHOLD_INCOME,
             uk_ft_circumstances: %w[dependant-adult],
           )
           assert calculator.eligible_for_adult_dependant_allowance?
         end
 
-        should "have high household income and adult dependant" do
+        should "not be eligible when on a high household income with dependants" do
           calculator = StudentFinanceCalculator.new(
-            household_income: 15_654,
+            household_income: StudentFinanceCalculator::ADULT_DEPENDANT_HOUSEHOLD_INCOME + 0.01,
             uk_ft_circumstances: %w[dependant-adult],
           )
           assert_not calculator.eligible_for_adult_dependant_allowance?
@@ -199,84 +171,84 @@ module SmartAnswer
         end
       end
 
-      context "in 2023-2024" do
-        current_year = "2023-2024"
+      context "in 2024-2025" do
+        current_year = "2024-2025"
 
         context "childcare_grant" do
           context "for one child" do
-            should "be £188.90" do
+            should "be £193.62" do
               calculator = StudentFinanceCalculator.new(
                 course_start: current_year,
                 household_income: 25_000,
                 residence: :unused_variable,
               )
-              assert_equal 188.90, calculator.childcare_grant_one_child
+              assert_equal 193.62, calculator.childcare_grant_one_child
             end
           end
 
           context "for more than one child" do
-            should "be £323.85" do
+            should "be £331.95" do
               calculator = StudentFinanceCalculator.new(
                 course_start: current_year,
                 household_income: 25_000,
                 residence: :unused_variable,
               )
-              assert_equal 323.85, calculator.childcare_grant_more_than_one_child
+              assert_equal 331.95, calculator.childcare_grant_more_than_one_child
             end
           end
         end
 
         context "#parent_learning_allowance" do
-          should "be £1915" do
+          should "be £1_963" do
             calculator = StudentFinanceCalculator.new(
               course_start: current_year,
               household_income: 25_000,
               residence: :unused_variable,
             )
-            assert_equal 1_915, calculator.parent_learning_allowance
+            assert_equal 1_963, calculator.parent_learning_allowance
           end
         end
 
         context "#adult_dependant_allowance" do
-          should "be £3354" do
+          should "be £3_438" do
             calculator = StudentFinanceCalculator.new(
               course_start: current_year,
               household_income: 25_000,
               residence: :unused_variable,
             )
-            assert_equal 3_354, calculator.adult_dependant_allowance
+            assert_equal 3_438, calculator.adult_dependant_allowance
           end
         end
 
         context "#maintenance_loan_amount" do
-          context "for students who started 2023-2024 living at home with parents" do
+          context "for students who started 2024-2025 living at home with parents" do
             setup do
               @residence = "at-home"
             end
 
-            should "give the maximum amount of £8400 if household income is £25k or below" do
+            should "give the maximum amount of £8_610 if household income is £25k or below" do
               calculator = StudentFinanceCalculator.new(
                 course_start: current_year,
                 household_income: 25_000,
                 residence: @residence,
                 course_type: "full-time",
               )
-              assert_equal SmartAnswer::Money.new(8_400).to_s, calculator.maintenance_loan_amount.to_s
+              assert_equal SmartAnswer::Money.new(8_610).to_s, calculator.maintenance_loan_amount.to_s
             end
 
-            should "reduce the maximum amount £8400 by £1 for every complete £7.08 of income above £25k to a minimum of £3698" do
+            should "reduce the maximum amount £8_610 by £1 for every complete £6.91 of income above £25k to a minimum of £3_790" do
               # Samples taken from the document provided
               {
-                30_000 => 7_694,
-                35_000 => 6_988,
-                40_000 => 6_282,
-                42_875 => 5_876,
-                45_000 => 5_576,
-                50_000 => 4_869,
-                55_000 => 4_163,
-                58_215 => 3_709,
-                60_000 => 3_698,
-                65_000 => 3_698,
+                30_000 => 7_887,
+                35_000 => 7_163,
+                40_000 => 6_440,
+                42_875 => 6_024,
+                45_000 => 5_716,
+                50_000 => 4_993,
+                55_000 => 4_269,
+                58_215 => 3_804,
+                60_000 => 3_790,
+                65_000 => 3_790,
               }.each do |household_income, loan_amount|
                 calculator = StudentFinanceCalculator.new(
                   course_start: current_year,
@@ -288,18 +260,18 @@ module SmartAnswer
               end
             end
 
-            should "cap the reductions and give the minimum loan of £3698 for high household income students" do
+            should "cap the reductions and give the minimum loan of £3_790 for high household income students" do
               calculator = StudentFinanceCalculator.new(
                 course_start: current_year,
                 household_income: 500_000,
                 residence: @residence,
                 course_type: "full-time",
               )
-              assert_equal SmartAnswer::Money.new(3_698).to_s, calculator.maintenance_loan_amount.to_s
+              assert_equal SmartAnswer::Money.new(3_790).to_s, calculator.maintenance_loan_amount.to_s
             end
           end
 
-          context "for students who started 2023-2024 living away not in london" do
+          context "for students who started 2024-2025 living away not in london" do
             setup do
               @residence = "away-outside-london"
             end
@@ -311,23 +283,23 @@ module SmartAnswer
                 residence: @residence,
                 course_type: "full-time",
               )
-              assert_equal SmartAnswer::Money.new(9_978).to_s, calculator.maintenance_loan_amount.to_s
+              assert_equal SmartAnswer::Money.new(10_227).to_s, calculator.maintenance_loan_amount.to_s
             end
 
-            should "reduce the maximum amount of £9978 by £1 for every complete £7.01 of income above £25k to a minimum of £4651" do
+            should "reduce the maximum amount of £10_227 by £1 for every complete £6.84 of income above £25k to a minimum of £4_767" do
               # Samples taken from the document provided
               {
-                30_000 => 9_265,
-                35_000 => 8_552,
-                40_000 => 7_839,
-                42_875 => 7_429,
-                45_000 => 7_125,
-                50_000 => 6_412,
-                55_000 => 5_699,
-                60_000 => 4_986,
-                62_215 => 4_670,
-                65_000 => 4_651,
-                70_000 => 4_651,
+                30_000 => 9_497,
+                35_000 => 8_766,
+                40_000 => 8_035,
+                42_875 => 7_614,
+                45_000 => 7_304,
+                50_000 => 6_573,
+                55_000 => 5_842,
+                60_000 => 5_111,
+                62_215 => 4_787,
+                65_000 => 4_767,
+                70_000 => 4_767,
               }.each do |household_income, loan_amount|
                 calculator = StudentFinanceCalculator.new(
                   course_start: current_year,
@@ -339,18 +311,18 @@ module SmartAnswer
               end
             end
 
-            should "cap the reductions and give the minimum loan of £4,651 for high household income students" do
+            should "cap the reductions and give the minimum loan of £4_767 for high household income students" do
               calculator = StudentFinanceCalculator.new(
                 course_start: current_year,
                 household_income: 500_000,
                 residence: @residence,
                 course_type: "full-time",
               )
-              assert_equal SmartAnswer::Money.new(4_651).to_s, calculator.maintenance_loan_amount.to_s
+              assert_equal SmartAnswer::Money.new(4_767).to_s, calculator.maintenance_loan_amount.to_s
             end
           end
 
-          context "for students who started 2023-2024 living away in london" do
+          context "for students who started 2024-2025 living away in london" do
             setup do
               @residence = "away-in-london"
             end
@@ -362,23 +334,22 @@ module SmartAnswer
                 residence: @residence,
                 course_type: "full-time",
               )
-              assert_equal SmartAnswer::Money.new(13_002).to_s, calculator.maintenance_loan_amount.to_s
+              assert_equal SmartAnswer::Money.new(13_348).to_s, calculator.maintenance_loan_amount.to_s
             end
 
-            should "reduce the maximum amount of £13002 by £1 for every complete £6.89 of income above £25k to a minimum of £6485" do
-              # Samples taken from the document provided
+            should "reduce the maximum amount of £13_348 by £1 for every complete £6.73 of income above £25k to a minimum of £6_647" do
               {
-                30_000 => 12_277,
-                35_000 => 11_551,
-                40_000 => 10_825,
-                42_875 => 10_408,
-                45_000 => 10_100,
-                50_000 => 9_374,
-                55_000 => 8_648,
-                60_000 => 7_923,
-                65_000 => 7_197,
-                69_860 => 6_492,
-                70_000 => 6_485,
+                30_000 => 12_606,
+                35_000 => 11_863,
+                40_000 => 11_120,
+                42_875 => 10_692,
+                45_000 => 10_377,
+                50_000 => 9_634,
+                55_000 => 8_891,
+                60_000 => 8_148,
+                65_000 => 7_405,
+                69_860 => 6_683,
+                70_000 => 6_662,
               }.each do |household_income, loan_amount|
                 calculator = StudentFinanceCalculator.new(
                   course_start: current_year,
@@ -390,18 +361,18 @@ module SmartAnswer
               end
             end
 
-            should "cap the reductions and give the minimum loan of £6,485 for high household income students" do
+            should "cap the reductions and give the minimum loan of £6_647 for high household income students" do
               calculator = StudentFinanceCalculator.new(
                 course_start: current_year,
                 household_income: 500_000,
                 residence: @residence,
                 course_type: "full-time",
               )
-              assert_equal SmartAnswer::Money.new(6_485).to_s, calculator.maintenance_loan_amount.to_s
+              assert_equal SmartAnswer::Money.new(6_647).to_s, calculator.maintenance_loan_amount.to_s
             end
           end
 
-          context "for 2023-2024 part-time students" do
+          context "for 2024-2025 part-time students" do
             setup do
               @course_type = "part-time"
             end
@@ -450,7 +421,7 @@ module SmartAnswer
             @doctor_or_dentist = true
           end
 
-          should "be £3658 for students living away from home in London" do
+          should "be £3_749 for students living away from home in London" do
             calculator = StudentFinanceCalculator.new(
               course_start: current_year,
               household_income: @household_income,
@@ -458,10 +429,10 @@ module SmartAnswer
               doctor_or_dentist: @doctor_or_dentist,
             )
 
-            assert_equal 3658, calculator.reduced_maintenance_loan_for_healthcare
+            assert_equal 3_749, calculator.reduced_maintenance_loan_for_healthcare
           end
 
-          should "be £2605 for students living away from home outside London" do
+          should "be £2_670 for students living away from home outside London" do
             calculator = StudentFinanceCalculator.new(
               course_start: current_year,
               household_income: @household_income,
@@ -469,10 +440,10 @@ module SmartAnswer
               doctor_or_dentist: @doctor_or_dentist,
             )
 
-            assert_equal 2605, calculator.reduced_maintenance_loan_for_healthcare
+            assert_equal 2_670, calculator.reduced_maintenance_loan_for_healthcare
           end
 
-          should "be £1955 for students living at home" do
+          should "be £2_004 for students living at home" do
             calculator = StudentFinanceCalculator.new(
               course_start: current_year,
               household_income: @household_income,
@@ -480,7 +451,7 @@ module SmartAnswer
               doctor_or_dentist: @doctor_or_dentist,
             )
 
-            assert_equal 1955, calculator.reduced_maintenance_loan_for_healthcare
+            assert_equal 2_004, calculator.reduced_maintenance_loan_for_healthcare
           end
         end
       end
@@ -501,7 +472,7 @@ module SmartAnswer
           end
 
           context "for more than one child" do
-            should "be £323.85" do
+            should "be £331.95" do
               calculator = StudentFinanceCalculator.new(
                 course_start: current_year,
                 household_income: 25_000,
@@ -771,20 +742,20 @@ module SmartAnswer
 
       context "#course_start_years" do
         context "for students" do
-          should "be 2023 and 2024" do
-            calculator = StudentFinanceCalculator.new(
-              course_start: "2023-2024",
-            )
-
-            assert_equal [2023, 2024], calculator.course_start_years
-          end
-
           should "be 2024 and 2025" do
             calculator = StudentFinanceCalculator.new(
               course_start: "2024-2025",
             )
 
             assert_equal [2024, 2025], calculator.course_start_years
+          end
+
+          should "be 2025 and 2026" do
+            calculator = StudentFinanceCalculator.new(
+              course_start: "2025-2026",
+            )
+
+            assert_equal [2025, 2026], calculator.course_start_years
           end
         end
       end


### PR DESCRIPTION
Go-live is 3rd Feb 2025; await confirmation from SLC before merging.