### PR TITLE
Update countries to require an ETA

### DIFF
--- a/lib/smart_answer/calculators/uk_visa_calculator.rb
+++ b/lib/smart_answer/calculators/uk_visa_calculator.rb
@@ -549,12 +549,62 @@ module SmartAnswer::Calculators
     ].freeze
 
     COUNTRY_GROUP_ELECTRONIC_TRAVEL_AUTHORISATION = %w[
-      qatar
+      antigua-and-barbuda
+      argentina
+      australia
+      bahamas
       bahrain
+      barbados
+      belize
+      botswana
+      brazil
+      british-national-overseas
+      brunei
+      canada
+      chile
+      colombia
+      costa-rica
+      federated-states-of-micronesia
+      grenada
+      guatemala
+      guyana
+      hong-kong
+      hong-kong-(british-national-overseas)
+      israel
+      japan
+      kiribati
       kuwait
+      macao
+      malaysia
+      maldives
+      marshall-islands
+      mauritius
+      mexico
+      nauru
+      new-zealand
+      nicaragua
       oman
+      palau
+      panama
+      papua-new-guinea
+      paraguay
+      peru
+      qatar
+      samoa
       saudi-arabia
+      seychelles
+      singapore
+      solomon-islands
+      south-korea
+      st-kitts-and-nevis
+      st-lucia
+      st-vincent-and-the-grenadines
+      tonga
+      trinidad-and-tobago
+      tuvalu
       united-arab-emirates
+      uruguay
+      usa
     ].freeze
 
     COUNTRY_GROUP_EPASSPORT_GATES = %w[
@@ -627,57 +677,7 @@ module SmartAnswer::Calculators
     ].flatten.freeze
 
     COUNTRY_GROUP_ETA_ROLLOUT_GROUP_1_REST_OF_THE_WORLD = %w[
-      antigua-and-barbuda
-      argentina
-      australia
-      bahamas
-      barbados
-      belize
-      botswana
-      brazil
-      british-national-overseas
-      brunei
-      canada
-      chile
-      colombia
-      costa-rica
-      federated-states-of-micronesia
-      grenada
-      guatemala
-      guyana
-      hong-kong
-      hong-kong-(british-national-overseas)
-      israel
-      japan
-      kiribati
-      macao
-      malaysia
-      maldives
-      marshall-islands
-      mauritius
-      mexico
-      nauru
-      new-zealand
-      nicaragua
-      palau
-      panama
-      papua-new-guinea
-      paraguay
-      peru
-      samoa
-      seychelles
-      singapore
-      solomon-islands
-      south-korea
-      st-kitts-and-nevis
-      st-lucia
-      st-vincent-and-the-grenadines
       taiwan
-      tonga
-      trinidad-and-tobago
-      tuvalu
-      uruguay
-      usa
     ].freeze
 
     COUNTRY_GROUP_ETA_ROLLOUT_GROUP_2_EU_EEA = %w[

--- a/test/flows/check_uk_visa_flow_test.rb
+++ b/test/flows/check_uk_visa_flow_test.rb
@@ -14,7 +14,7 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
     @british_overseas_territory_country = "anguilla"
     @non_visa_national_country = "andorra"
     @eea_country = "austria"
-    @eta_rollout_group_1_rest_of_the_world_country = "antigua-and-barbuda"
+    @eta_rollout_group_1_rest_of_the_world_country = "taiwan"
     @eta_rollout_group_2_eu_eea_country = "bonaire-st-eustatius-saba"
     @travel_document_country = "hong-kong"
     @b1_b2_country = "syria"
@@ -242,20 +242,20 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
           add_responses what_passport_do_you_have?: @british_overseas_territory_country
           assert_next_node :outcome_no_visa_needed, for_response: response
         end
-
-        should "have a next node of outcome_no_visa_needed for a travel document country with a passport " \
-               "and a '#{response}' response" do
-          add_responses what_passport_do_you_have?: @travel_document_country,
-                        what_sort_of_travel_document?: "passport"
-          assert_next_node :outcome_no_visa_needed, for_response: response
-        end
       end
 
-      should "have a next node of outcome_transit_to_the_republic_of_ireland for a travel document country with " \
-             "a travel document and a 'republic_of_ireland' response" do
+      should "have a next node of outcome_transit_to_the_republic_of_ireland_electronic_travel_authorisation for a travel document country with a passport " \
+             "and a 'republic_of_ireland' response" do
         add_responses what_passport_do_you_have?: @travel_document_country,
-                      what_sort_of_travel_document?: "travel_document"
-        assert_next_node :outcome_transit_to_the_republic_of_ireland, for_response: "republic_of_ireland"
+                      what_sort_of_travel_document?: "passport"
+        assert_next_node :outcome_transit_to_the_republic_of_ireland_electronic_travel_authorisation, for_response: "republic_of_ireland"
+      end
+
+      should "have a next node of outcome_no_visa_needed for a travel document country with a passport " \
+             "and a 'somewhere_else' response" do
+        add_responses what_passport_do_you_have?: @travel_document_country,
+                      what_sort_of_travel_document?: "passport"
+        assert_next_node :outcome_no_visa_needed, for_response: "somewhere_else"
       end
 
       should "have a next node of outcome_transit_to_the_republic_of_ireland for a different country and a " \
@@ -425,13 +425,6 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
           assert_next_node :outcome_study_m, for_response: "six_months_or_less"
         end
 
-        should "have a next node of outcome_study_m for a study visit with a travel document" do
-          add_responses what_passport_do_you_have?: @travel_document_country,
-                        what_sort_of_travel_document?: "travel_document",
-                        purpose_of_visit?: "study"
-          assert_next_node :outcome_study_m, for_response: "six_months_or_less"
-        end
-
         should "have a next node of outcome_study_no_visa_needed for a study visit with a British overseas " \
                "territory passport" do
           add_responses what_passport_do_you_have?: @british_overseas_territory_country,
@@ -478,13 +471,6 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
           add_responses what_passport_do_you_have?: @eea_country,
                         purpose_of_visit?: "work"
           assert_next_node :outcome_work_n, for_response: "six_months_or_less"
-        end
-
-        should "have a next node of outcome_work_m for a work visit with a travel document" do
-          add_responses what_passport_do_you_have?: @travel_document_country,
-                        what_sort_of_travel_document?: "travel_document",
-                        purpose_of_visit?: "work"
-          assert_next_node :outcome_work_m, for_response: "six_months_or_less"
         end
 
         should "have a next node of outcome_work_m for a work visit for other countries" do
@@ -612,7 +598,7 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
     should "render specific guidance to British nationals overseas" do
       add_responses what_passport_do_you_have?: "british-national-overseas"
       assert_rendered_outcome text: "you can apply for a British National Overseas (BNO) visa."
-      assert_rendered_outcome text: "You will not need a visa but"
+      assert_no_rendered_outcome text: "You will not need a visa but"
     end
 
     should "render different guidance to non-British nationals overseas" do
@@ -945,11 +931,6 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
       assert_no_rendered_outcome text: "Whether you need a visa depends"
     end
 
-    should "render callout box for eta_rollout_group_1_rest_of_the_world_country passport holders" do
-      add_responses what_passport_do_you_have?: @eta_rollout_group_1_rest_of_the_world_country
-      assert_rendered_outcome text: @eta_rollout_group_1_rest_of_the_world_text
-    end
-
     should "render callout box for eta_rollout_group_2_eu_eea_country passport holders" do
       add_responses what_passport_do_you_have?: @eta_rollout_group_2_eu_eea_country
       assert_rendered_outcome text: @eta_rollout_group_2_eu_eea_text
@@ -967,11 +948,6 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
         add_responses what_passport_do_you_have?: @british_overseas_territory_country
         assert_no_rendered_outcome text: @non_visa_national_eta_text
         assert_no_rendered_outcome text: @eea_eta_text
-      end
-
-      should "render callout box for eta_rollout_group_1_rest_of_the_world_country passport holders" do
-        add_responses what_passport_do_you_have?: @eta_rollout_group_1_rest_of_the_world_country
-        assert_rendered_outcome text: @eta_rollout_group_1_rest_of_the_world_text
       end
 
       should "render callout box for eta_rollout_group_2_eu_eea_country passport holders" do
@@ -1017,11 +993,6 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
         assert_no_rendered_outcome text: @eea_eta_text
       end
 
-      should "render callout box for eta_rollout_group_1_rest_of_the_world_country passport holders" do
-        add_responses what_passport_do_you_have?: @eta_rollout_group_1_rest_of_the_world_country
-        assert_rendered_outcome text: @eta_rollout_group_1_rest_of_the_world_text
-      end
-
       should "render callout box for eta_rollout_group_2_eu_eea_country passport holders" do
         add_responses what_passport_do_you_have?: @eta_rollout_group_2_eu_eea_country
         assert_rendered_outcome text: @eta_rollout_group_2_eu_eea_text
@@ -1038,11 +1009,6 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
         add_responses what_passport_do_you_have?: @british_overseas_territory_country
         assert_no_rendered_outcome text: @non_visa_national_eta_text
         assert_no_rendered_outcome text: @eea_eta_text
-      end
-
-      should "render callout box for eta_rollout_group_1_rest_of_the_world_country passport holders" do
-        add_responses what_passport_do_you_have?: @eta_rollout_group_1_rest_of_the_world_country
-        assert_rendered_outcome text: @eta_rollout_group_1_rest_of_the_world_text
       end
 
       should "render callout box for eta_rollout_group_2_eu_eea_country passport holders" do
@@ -1063,11 +1029,6 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
         assert_no_rendered_outcome text: @eea_eta_text
       end
 
-      should "render callout box for eta_rollout_group_1_rest_of_the_world_country passport holders" do
-        add_responses what_passport_do_you_have?: @eta_rollout_group_1_rest_of_the_world_country
-        assert_rendered_outcome text: @eta_rollout_group_1_rest_of_the_world_text
-      end
-
       should "render callout box for eta_rollout_group_2_eu_eea_country passport holders" do
         add_responses what_passport_do_you_have?: @eta_rollout_group_2_eu_eea_country
         assert_rendered_outcome text: @eta_rollout_group_2_eu_eea_text
@@ -1084,11 +1045,6 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
         add_responses what_passport_do_you_have?: @british_overseas_territory_country
         assert_no_rendered_outcome text: @non_visa_national_eta_text
         assert_no_rendered_outcome text: @eea_eta_text
-      end
-
-      should "render callout box for eta_rollout_group_1_rest_of_the_world_country passport holders" do
-        add_responses what_passport_do_you_have?: @eta_rollout_group_1_rest_of_the_world_country
-        assert_rendered_outcome text: @eta_rollout_group_1_rest_of_the_world_text
       end
 
       should "render callout box for eta_rollout_group_2_eu_eea_country passport holders" do
@@ -1108,11 +1064,6 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
         add_responses what_passport_do_you_have?: @british_overseas_territory_country
         assert_no_rendered_outcome text: @non_visa_national_eta_text
         assert_no_rendered_outcome text: @eea_eta_text
-      end
-
-      should "render callout box for eta_rollout_group_1_rest_of_the_world_country passport holders" do
-        add_responses what_passport_do_you_have?: @eta_rollout_group_1_rest_of_the_world_country
-        assert_rendered_outcome text: @eta_rollout_group_1_rest_of_the_world_text
       end
 
       should "render callout box for eta_rollout_group_2_eu_eea_country passport holders" do

--- a/test/support/flows/check_uk_visa_flow_test_helper.rb
+++ b/test/support/flows/check_uk_visa_flow_test_helper.rb
@@ -132,18 +132,6 @@ module CheckUkVisaFlowTestHelper
         assert_next_node :outcome_medical_n, for_response: "medical"
       end
 
-      should "have a next node of outcome_medical_n for a travel document country with a passport" do
-        add_responses what_passport_do_you_have?: @travel_document_country,
-                      what_sort_of_travel_document?: "passport"
-        assert_next_node :outcome_medical_n, for_response: "medical"
-      end
-
-      should "have a next node of outcome_medical_y for a travel document country with a travel document" do
-        add_responses what_passport_do_you_have?: @travel_document_country,
-                      what_sort_of_travel_document?: "travel_document"
-        assert_next_node :outcome_medical_y, for_response: "medical"
-      end
-
       should "have a next node of outcome_medical_y for other passports" do
         add_responses what_passport_do_you_have?: @visa_national_country
         assert_next_node :outcome_medical_y, for_response: "medical"
@@ -176,19 +164,13 @@ module CheckUkVisaFlowTestHelper
         assert_next_node :outcome_tourism_n, for_response: "tourism"
       end
 
-      should "have a next node of outcome_tourism_n for a travel document country with a passport" do
+      should "have a next node of outcome_tourism_electronic_travel_authorisation for a travel document country with a passport" do
         add_responses what_passport_do_you_have?: @travel_document_country,
                       what_sort_of_travel_document?: "passport"
-        assert_next_node :outcome_tourism_n, for_response: "tourism"
+        assert_next_node :outcome_tourism_electronic_travel_authorisation, for_response: "tourism"
       end
 
-      should "have a next node of outcome_tourism_y for a travel document country with a travel document" do
-        add_responses what_passport_do_you_have?: @travel_document_country,
-                      what_sort_of_travel_document?: "travel_document"
-        assert_next_node :travelling_visiting_partner_family_member?, for_response: "tourism"
-      end
-
-      should "have a next node of outcome_tourism_y for other passports" do
+      should "have a next node of travelling_visiting_partner_family_member? for other passports" do
         add_responses what_passport_do_you_have?: @visa_national_country
         assert_next_node :travelling_visiting_partner_family_member?, for_response: "tourism"
       end


### PR DESCRIPTION
[Trello card](https://trello.com/c/vpISVH6k/309-8-jan-asap-after-update-eta-wording-in-check-if-you-need-a-uk-visa-content-requests)

Countries that were in the `COUNTRY_GROUP_ETA_ROLLOUT_GROUP_1_REST_OF_THE_WORLD` group should now be requiring an electronic travel authorisation (ETA). All countries have been moved, except for Taiwan, which has some special handling rules to be grappled with in a future commit.

This change has caused a number of flow changes and so tests have been updated to reflect this.

Hong Kong and Macao are the only countries that can get to the `:what_sort_of_travel_document?` question (as seen in the next_node block of Q1). Both of these countries now require an ETA. This makes it impossible to get to the:
- `:outcome_study_m`
- `:outcome_tourism_n`
- `travelling_visiting_partner_family_member?`
- `:outcome_medical_y`
- `:outcome_transit_to_the_republic_of_ireland`
- `:outcome_work_m` nodes for these countries (referred to as travel document countries (see `@travel_document_country`) in the tests). It also means that when travelling to the Republic of Ireland, travellers will be directed to the `:outcome_transit_to_the_republic_of_ireland_electronic_travel_authorisation` outcome instead of the `:outcome_no_visa_needed` outcome.

Taiwan is the only country left in the “ETA rollout group 1” list, and it has its own outcomes, meaning you can no longer get to the:
- `:outcome_tourism_n`
- `:outcome_medical_n`
- `:outcome_study_no_visa_needed`
- `:outcome_marriage_nvn`
- `:outcome_joining_family_nvn` outcomes for “ETA rollout group 1” countries—those tests have been deleted.

British national overseas passport holders now require an ETA, so will not be shown the text saying that they do not need a visa for the `:outcome_marriage_nvn` outcome.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
