### PR TITLE
Update ETA transit outcome

### DIFF
--- a/app/flows/check_uk_visa_flow/outcomes/outcome_no_visa_needed.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_no_visa_needed.erb
@@ -1,6 +1,6 @@
 <% text_for :title do %>
   <%if calculator.passport_country_requires_electronic_travel_authorisation?  %>
-    You'll need an electronic travel authorisation (ETA) to come to the UK
+    You'll need an electronic travel authorisation (ETA) to pass through UK border control
   <% else %>
     You do not need a visa to come to the UK
   <% end %>
@@ -10,7 +10,7 @@
 <% govspeak_for :body do %>
 
   <%if calculator.passport_country_requires_electronic_travel_authorisation? %>
-    [Apply for an (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta).
+    [Apply for an ETA](/guidance/apply-for-an-electronic-travel-authorisation-eta).
   <% end %>
 
   <% if (calculator.travelling_to_elsewhere? || calculator.travelling_to_ireland?) &&
@@ -29,6 +29,20 @@
   <% end %>
 
   <%if calculator.passport_country_requires_electronic_travel_authorisation? %>
+    You do not need an ETA if you will not pass through UK border control. You should bring evidence of your onward journey, such as a ticket to your destination.
+
+    You always pass through border control if you:
+
+    + leave the main airport building for any reason
+    + need to collect your bags and check them in to your onward flight
+
+    You must also pass through border control if both:
+
+    + your onward flight leaves on a different calendar day to when you arrive
+    + there's nowhere for you to stay overnight in the airport, for example in a transit hotel
+
+    Check with your airline if you're not sure if you'll pass through UK border control.
+
     %You may want to apply for a [transit visa](/transit-visa) instead if you have a criminal record or you’ve previously been refused entry into the UK.
   <% end %>
 <% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_transit_to_the_republic_of_ireland_electronic_travel_authorisation.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_transit_to_the_republic_of_ireland_electronic_travel_authorisation.erb
@@ -1,12 +1,23 @@
 <% text_for :title do %>
-  You'll need an electronic travel authorisation (ETA) or a visa
+  You'll need an electronic travel authorisation (ETA) to pass through UK border control
 <% end %>
 
 <% govspeak_for :body do %>
-  You must apply for either:
+    [Apply for an ETA](/guidance/apply-for-an-electronic-travel-authorisation-eta).
 
-  - an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta)
-  - a [Standard Visitor visa](/standard-visitor/apply-standard-visitor-visa)
+    You do not need an ETA if you will not pass through UK border control. You should bring evidence of your onward journey, such as a ticket to your destination.
 
-  %You may want to [apply for a visa](/browse/visas-immigration/tourist-short-stay-visas) if you have a criminal record or you’ve previously been refused entry into the UK.
+    You always pass through border control if you:
+
+    + leave the main airport building for any reason
+    + need to collect your bags and check them in to your onward flight
+
+    You must also pass through border control if both:
+
+    + your onward flight leaves on a different calendar day to when you arrive
+    + there's nowhere for you to stay overnight in the airport, for example in a transit hotel
+
+    Check with your airline if you're not sure if you'll pass through UK border control.
+
+    %You may want to apply for a [transit visa](/transit-visa) instead if you have a criminal record or you’ve previously been refused entry into the UK.
 <% end %>


### PR DESCRIPTION
[Trello card](https://trello.com/c/vpISVH6k/309-8-jan-asap-after-update-eta-wording-in-check-if-you-need-a-uk-visa-content-requests)

This is temporary solution to inform people who need an ETA to transit through the UK that they now only need it if they are passing through border control.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
