### PR TITLE
Add component wrapper to more components

### DIFF
--- a/app/views/components/_result_sections.html.erb
+++ b/app/views/components/_result_sections.html.erb
@@ -7,8 +7,11 @@
   if !topics.any?
     raise ArgumentError, "The result section component requires topics data"
   end
+
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+  component_helper.add_class("app-c-result-sections")
 %>
-<div class="app-c-result-sections">
+<%= tag.div(**component_helper.all_attributes) do %>
   <% topics.each do |topic, results| %>
     <section class="app-c-result-sections__section">
       <h3 class="govuk-heading-m"><%= topic %></h3>
@@ -22,4 +25,4 @@
       <% end %>
     </section>
   <% end %>
-</div>
+<% end %>

--- a/app/views/components/docs/result_sections.yml
+++ b/app/views/components/docs/result_sections.yml
@@ -6,29 +6,30 @@ uses_component_wrapper_helper: true
 examples:
   default:
     data:
-      title: Business tax
-      results:
+      topics:
+        business_tax:
         - title: "Register for Corporation Tax"
           url: "/corporation-tax"
           description: "You need to register for corporation tax within 3 months of starting to do business, if you haven’t done so already."
   with-multiple-items:
     data:
-      title: Business tax
-      results:
-        - title: "Register for Corporation Tax"
-          url: "/corporation-tax"
-          description: "You need to register for corporation tax within 3 months of starting to do business, if you haven’t done so already."
-        - title: "Register for VAT"
-          url: "/vat-registration"
-          description: "You need to register your business for VAT if your VAT taxable turnover is more than £85,000."
+      topics:
+        business_tax:
+          - title: "Register for Corporation Tax"
+            url: "/corporation-tax"
+            description: "You need to register for corporation tax within 3 months of starting to do business, if you haven’t done so already."
+          - title: "Register for VAT"
+            url: "/vat-registration"
+            description: "You need to register your business for VAT if your VAT taxable turnover is more than £85,000."
   with-multiple-highlighted-items:
     data:
-      title: Business tax
-      highlighted: true
-      results:
-        - title: "Register for Corporation Tax"
-          url: "/corporation-tax"
-          description: "You need to register for corporation tax within 3 months of starting to do business, if you haven’t done so already."
-        - title: "Register for VAT"
-          url: "/vat-registration"
-          description: "You need to register your business for VAT if your VAT taxable turnover is more than £85,000."
+      topics:
+        business_tax:
+          - title: "Register for Corporation Tax"
+            url: "/corporation-tax"
+            description: "You need to register for corporation tax within 3 months of starting to do business, if you haven’t done so already."
+            highlighted: true
+          - title: "Register for VAT"
+            url: "/vat-registration"
+            description: "You need to register your business for VAT if your VAT taxable turnover is more than £85,000."
+            highlighted: true

--- a/app/views/components/docs/result_sections.yml
+++ b/app/views/components/docs/result_sections.yml
@@ -2,6 +2,7 @@ name: Result section
 description: Groups a set of results items under a common title
 shared_accessibility_criteria:
   - link
+uses_component_wrapper_helper: true
 examples:
   default:
     data:


### PR DESCRIPTION
## What

- Adds the component guide to `result-sections` component.
- Fixes the component guide for `result-sections`
- [Trello card](https://trello.com/c/t1x49bym/440-use-component-wrapper-helper-in-application-components)

## Why

Standardising our components to use the component wrapper helper will reduce code, increase standardisation, and improve future feature implementation speed.

## Bug discovered

When making this change I realised that the component guide for these component is not rendering any of the CSS. For example: http://127.0.0.1:3010/component-guide/result_card.

I was going to just add `add_app_component_stylesheet("result-card")`  etc. to the components but first I looked further into why the CSS wasn't rendering on the component guide. It seems to be because the code which determines whether to include the stylesheet or not is tied up in Ruby in the `outcome_presenter.rb` file, which means the CSS stylesheet is only added on outcome pages, and therefore the component guide previews have no stylesheet to use.  

https://github.com/alphagov/smart-answers/blob/d58494fc72e2923d9f62442214a05fd18fdc1ea0/app/presenters/outcome_presenter.rb#L41-L45

https://github.com/alphagov/smart-answers/blob/main/app/views/smart_answers/custom_result_full_width.erb#L5-L9

I couldn't think of a simple way of fixing this - do you have any suggestions? I think the way it currently is breaks our component isolation principle, since Ruby logic is deciding whether the CSS stylesheet is added or not - so the component can't just be placed wherever needed?

I spoke to the developers who introduced the change - they did suggest as it's a small amount of CSS we could just go back to having `add_app_component_stylesheet("result-card")` etc. directly on the components, but I'm guessing that would mean the individual CSS loading might break.

I did look into just passing a boolean to the component previews which would then force them include the stylesheet, but I thought that might look confusing on the component guide previews, as we would have to tell devs not to include this extra boolean when they use the component in production. 