### PR TITLE
Replace title component with heading component

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,7 +2,7 @@
   <div class="smart_answer">
     <%= yield :breadcrumbs %>
     <%= render "govuk_web_banners/recruitment_banner" %>
-    <main id="content" role="main">
+    <main class="govuk-main-wrapper" id="content" role="main">
       <%= yield %>
     </main>
   </div>

--- a/app/views/smart_answers/custom_result.html.erb
+++ b/app/views/smart_answers/custom_result.html.erb
@@ -26,9 +26,11 @@
       "action": "complete",
       "tool_name": @presenter.title,
     }.to_json %>">
-    <%= render "govuk_publishing_components/components/title", {
-      title: outcome.title,
+    <%= render "govuk_publishing_components/components/heading", {
+      text: outcome.title,
       margin_bottom: 6,
+      heading_level: 1,
+      font_size: "xl",
     } %>
 
     <%= outcome.description %>

--- a/app/views/smart_answers/index.html.erb
+++ b/app/views/smart_answers/index.html.erb
@@ -1,7 +1,10 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <%= render "govuk_publishing_components/components/title", {
-      title: "Smart Answers",
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "Smart Answers",
+      heading_level: 1,
+      font_size: "xl",
+      margin_bottom: 8,
     } %>
 
     <div class="smart-answers-list">

--- a/app/views/smart_answers/landing.html.erb
+++ b/app/views/smart_answers/landing.html.erb
@@ -23,8 +23,11 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/title", {
-      title: start_node.title,
+    <%= render "govuk_publishing_components/components/heading", {
+      text: start_node.title,
+      heading_level: 1,
+      font_size: "xl",
+      margin_bottom: 8,
     } %>
   </div>
 </div>

--- a/app/views/smart_answers/result.html.erb
+++ b/app/views/smart_answers/result.html.erb
@@ -30,10 +30,13 @@
     data-ga4-ecommerce-start-index="1"
     data-ga4-list-title="<%= @presenter.title %>">
     <%= render "smart_answers/shared/debug" %>
-    <%= render "govuk_publishing_components/components/title", {
-      title: title,
+    <%= render "govuk_publishing_components/components/heading", {
+      text: title,
       context: @presenter.title + ":",
       context_inside: true,
+      heading_level: 1,
+      font_size: "xl",
+      margin_bottom: 8,
     } %>
 
     <div

--- a/app/views/smart_answers/visualise.html.erb
+++ b/app/views/smart_answers/visualise.html.erb
@@ -14,9 +14,12 @@
   var adjacencyList = <%= JSON.pretty_generate(@graph_data).html_safe %>;
 <%- end %>
 
-<%= render "govuk_publishing_components/components/title", {
+<%= render "govuk_publishing_components/components/heading", {
   context: "Flow visualisation for",
-  title: @title,
+  text: @title,
+  heading_level: 1,
+  font_size: "xl",
+  margin_bottom: 8,
 } %>
 
 <p class="govuk-body">This is a visualisation of the <%= link_to @title, smart_answer_path(params[:id]) %> questions and outcomes.</p>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## What
This PR replaces instances of the [title component](https://components.publishing.service.gov.uk/component-guide/title) with the [heading component](https://components.publishing.service.gov.uk/component-guide/heading).

In order to maintain spacing, I've added a `govuk-main-wrapper` class to the `main` element which adds `40px` worth of `padding` to the top and bottom of the page. This gives the heading some spacing above it, which is something the title component included but isn't something the heading component provides (further details in the [commit message](https://github.com/alphagov/smart-answers/pull/7050/commits/1a4695438ab6132ef60c4ccc2e2c0415e9f5859c)). It has introduced some visual differences (i.e. a bit less spacing above the heading and more spacing below the contextual footer - please see the screenshots below) but I think they may not be significant enough to be a blocker. Happy to discuss.

## Why
[Trello card](https://trello.com/c/QjeqZdIf/454-replace-title-with-heading-in-smart-answers)

## Visual changes

There are spacing differences at the top (slight) and bottom of the page (pronounced)

| ### Top of the page (before) | ### Top of the page (after) |
|------------------------------|-----------------------------|
| ![image](https://github.com/user-attachments/assets/a78e5bcb-5e5c-4ae5-80e6-abae6cd93d4c) | ![image](https://github.com/user-attachments/assets/ac8d3065-aa67-4b95-be52-b33c2355ee15) |

| ### Bottom of the page (before) | ### Bottom of the page (after) |
|------------------------------|-----------------------------|
| ![image](https://github.com/user-attachments/assets/91ce00bb-5884-4dae-9622-7abbde5e1d5d) | ![image](https://github.com/user-attachments/assets/006f3e29-1c30-4737-9c5f-563a7a724b1c)  |

