### PR TITLE
Remove conditonal rendering of component stylesheets

### DIFF
--- a/app/presenters/outcome_presenter.rb
+++ b/app/presenters/outcome_presenter.rb
@@ -37,12 +37,6 @@ class OutcomePresenter < NodePresenter
     @node.view_template_path || "smart_answers/result"
   end
 
-  def add_app_component_stylesheets?
-    base_path == "/check-uk-visa" && @node.slug == "outcome-work-y" ||
-      base_path == "/check-benefits-financial-support" && @node.slug == "results" ||
-      base_path == "/next-steps-for-your-business" && @node.slug == "results"
-  end
-
 private
 
   def base_path

--- a/app/views/components/_result_card.html.erb
+++ b/app/views/components/_result_card.html.erb
@@ -1,4 +1,6 @@
 <%
+  add_app_component_stylesheet("result-card")
+
   title ||= nil
   description ||= nil
   url ||= nil

--- a/app/views/components/_result_item.html.erb
+++ b/app/views/components/_result_item.html.erb
@@ -1,4 +1,6 @@
 <%
+  add_app_component_stylesheet("result-item")
+
   title ||= nil
   url ||= nil
   description ||= nil

--- a/app/views/components/_result_sections.html.erb
+++ b/app/views/components/_result_sections.html.erb
@@ -1,4 +1,6 @@
 <%
+  add_app_component_stylesheet("result-sections")
+
   highlighted ||= true
   group_index ||= 1
   result_index ||= 1

--- a/app/views/smart_answers/custom_result.html.erb
+++ b/app/views/smart_answers/custom_result.html.erb
@@ -1,12 +1,11 @@
-<% # this custom result template is currently tested on the next-steps-for-your-business flow %>
-<% outcome = @presenter.current_node %>
-
-<% add_gem_component_stylesheet("govspeak") %>
-
-<% if outcome.add_app_component_stylesheets? %>
-  <% add_app_component_stylesheet("result-sections") %>
-  <% add_app_component_stylesheet("result-item") %>
-<% end %>
+<%
+  # this custom result template is currently tested on the next-steps-for-your-business flow 
+  outcome = @presenter.current_node
+  add_gem_component_stylesheet("govspeak")
+  add_app_component_stylesheet("result-card")
+  add_app_component_stylesheet("result-sections")
+  add_app_component_stylesheet("result-item")
+%>
 
 <% content_for :outcome_title do %>
   <% if outcome.title.present? %><%= outcome.title %><% else %>Outcome<% end %>

--- a/app/views/smart_answers/custom_result_full_width.erb
+++ b/app/views/smart_answers/custom_result_full_width.erb
@@ -1,12 +1,11 @@
-<% outcome = @presenter.current_node %>
+<%
+  outcome = @presenter.current_node
+  add_gem_component_stylesheet("govspeak")
+  add_app_component_stylesheet("result-card")
+  add_app_component_stylesheet("result-sections")
+  add_app_component_stylesheet("result-item")
+%>
 
-<% add_gem_component_stylesheet("govspeak") %>
-
-<% if outcome.add_app_component_stylesheets? %>
-  <% add_app_component_stylesheet("result-card") %>
-  <% add_app_component_stylesheet("result-sections") %>
-  <% add_app_component_stylesheet("result-item") %>
-<% end %>
 
 <%= outcome.banner %>
 

--- a/app/views/smart_answers/result.html.erb
+++ b/app/views/smart_answers/result.html.erb
@@ -1,11 +1,11 @@
-<% outcome = @presenter.current_node %>
+<%
+  outcome = @presenter.current_node
+  add_gem_component_stylesheet("govspeak")
+  add_app_component_stylesheet("result-card")
+  add_app_component_stylesheet("result-sections")
+  add_app_component_stylesheet("result-item")
+%>
 
-<% add_gem_component_stylesheet("govspeak") %>
-
-<% if outcome.add_app_component_stylesheets? %>
-  <% add_app_component_stylesheet("result-card") %>
-  <% add_app_component_stylesheet("result-sections") %>
-<% end %>
 
 <% content_for :outcome_title do %>
   <% if outcome.title.present? %><%= outcome.title %><% else %>Outcome<% end %>


### PR DESCRIPTION
## What / Why
- During the individual loading of CSS work , stylesheets were rendered based on what page slug was being loaded https://github.com/alphagov/smart-answers/pull/6213
- This broke the CSS rendering for the app's component guide
- Therefore, revert back to adding the stylesheets in without a condition
- See this comment for more context: https://github.com/alphagov/smart-answers/pull/7048#discussion_r1930534945
