### PR TITLE
Fix error with leap years when calculating holiday entitlement

### DIFF
--- a/lib/smart_answer/year_range_with_fixed_start_date.rb
+++ b/lib/smart_answer/year_range_with_fixed_start_date.rb
@@ -7,6 +7,13 @@ module SmartAnswer
     end
 
     def starting_in(start_year)
+      # To handle the very rare case where we hit a leap year
+      # Prevents us trying to call a nonexistent date e.g. 29th Feb 2025
+      if (@start_month == 2) && (@start_day == 29) && !Date.leap?(start_year)
+        @start_month = 3
+        @start_day = 1
+      end
+
       start_date = Date.new(start_year, @start_month, @start_day)
       YearRange.new(begins_on: start_date)
     end

--- a/test/unit/calculators/holiday_entitlement_test.rb
+++ b/test/unit/calculators/holiday_entitlement_test.rb
@@ -1799,6 +1799,16 @@ module SmartAnswer::Calculators
             assert_equal BigDecimal("5.2786885246").round(10), @calculator.full_time_part_time_weeks.round(10)
             assert_equal "5.28", @calculator.formatted_full_time_part_time_weeks
           end
+
+          # /annualised-hours/leaving/2025-01-29/2024-02-29 discovered leap day calc issue
+          should "return 5.16 weeks when the start_date is 2024-02-29 and leaving_date is 2025-01-29" do
+            @calculator.start_date = Date.parse("2024-02-29")
+            @calculator.leaving_date = Date.parse("2025-01-29")
+
+            assert_equal BigDecimal("0.9205479452").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("5.1550684932").round(10), @calculator.full_time_part_time_weeks.round(10)
+            assert_equal "5.16", @calculator.formatted_full_time_part_time_weeks
+          end
         end
 
         context "for department test data" do


### PR DESCRIPTION
Due to how the calculation is performed to consider one year, we were attempting to call a non-existent date e.g. 29th Feb 2025

Added logic in place to ensure that when we try to do this, we roll forward to the 1st of March to make it a true year.

https://trello.com/c/Fvplku4U/598-invalid-date-in-calculate-holiday-entitlement-smart-answer

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
