### PR TITLE
Update Maternity, Paternity and Adoption calculators

### DIFF
--- a/config/smart_answers/rates/maternity_paternity_adoption.yml
+++ b/config/smart_answers/rates/maternity_paternity_adoption.yml
@@ -32,5 +32,8 @@
   end_date: 2022-04-05
   lower_earning_limit_rate: 120
 - start_date: 2022-04-06
-  end_date: 2100-04-03
+  end_date: 2025-04-05
   lower_earning_limit_rate: 123
+- start_date: 2025-04-06
+  end_date: 2100-04-03
+  lower_earning_limit_rate: 125

--- a/config/smart_answers/rates/maternity_paternity_birth.yml
+++ b/config/smart_answers/rates/maternity_paternity_birth.yml
@@ -35,5 +35,8 @@
   end_date: 2022-04-05
   lower_earning_limit_rate: 120
 - start_date: 2022-04-06
-  end_date: 2100-04-03
+  end_date: 2025-04-05
   lower_earning_limit_rate: 123
+- start_date: 2025-04-06
+  end_date: 2100-04-03
+  lower_earning_limit_rate: 125

--- a/lib/smart_answer/calculators/maternity_pay_calculator.rb
+++ b/lib/smart_answer/calculators/maternity_pay_calculator.rb
@@ -317,7 +317,8 @@ module SmartAnswer::Calculators
         { min: uprating_date(2021), max: uprating_date(2022), amount: 151.97 },
         { min: uprating_date(2022), max: uprating_date(2023), amount: 156.66 },
         { min: uprating_date(2023), max: uprating_date(2024), amount: 172.48 },
-        { min: uprating_date(2023), max: uprating_date(2200), amount: 184.03 },
+        { min: uprating_date(2024), max: uprating_date(2025), amount: 184.03 },
+        { min: uprating_date(2025), max: uprating_date(2200), amount: 187.18 },
         ### Change year in future
       ]
       rate = rates.find { |r| r[:min] <= date && date < r[:max] } || rates.last

--- a/test/flows/maternity_paternity_calculator_flow/adoption_calculator_flow_test.rb
+++ b/test/flows/maternity_paternity_calculator_flow/adoption_calculator_flow_test.rb
@@ -393,13 +393,13 @@ class MaternityPaternityCalculatorFlow::AdoptionCalculatorFlowTest < ActiveSuppo
     end
 
     should "render when an employee is entitled to statutory adoption pay" do
-      add_responses maternity_adoption_responses(pay_frequency: "weekly", pay_per_frequency: 1_000, placement_date: "2024-05-01")
+      add_responses maternity_adoption_responses(pay_frequency: "weekly", pay_per_frequency: 1_000, placement_date: "2025-05-01")
 
       assert_rendered_outcome text: "The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP)"
 
-      # 90% of 1000 a week for 6 weeks + (39 - 6) * 184.03 statutory (rate for 2024)
-      # = (900 * 6) + (33 * 184.03)
-      assert_match(/Total SAP:\s*£11,472.99/, @test_flow.outcome_text)
+      # 90% of 1000 a week for 6 weeks + (39 - 6) * 187.18 statutory (rate for 2025)
+      # = (900 * 6) + (33 * 187.18)
+      assert_match(/Total SAP:\s*£11,576.94/, @test_flow.outcome_text)
     end
 
     should "render when an employee is entitled to statutory adoption pay and exactly on the threshold" do

--- a/test/unit/calculators/maternity_pay_calculator_test.rb
+++ b/test/unit/calculators/maternity_pay_calculator_test.rb
@@ -359,6 +359,7 @@ module SmartAnswer::Calculators
 
       context "statutory pay rate for given year" do
         {
+          2025 => 187.18,
           2024 => 184.03,
           2023 => 172.48,
           2022 => 156.66,


### PR DESCRIPTION
[Trello card](https://trello.com/c/ncucyEoQ/324-asap-uprating-maternity-adoption-and-paternity-calculator-for-employers)

As part of 2025 uprating. All rates increase from £184.03 to £187.18 and LEL is changing from £123 to £125 from 6 April 2025. This commit also includes fix, changing incorrect date uprating_date(2023) to 2024 for the previous year.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
