### PR TITLE
Update Check if you need a UK visa flow

### DIFF
--- a/app/flows/check_uk_visa_flow/outcomes/_electronic_travel_authorisation_advice.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/_electronic_travel_authorisation_advice.erb
@@ -1,5 +1,5 @@
 <% if calculator.passport_country_in_eta_rollout_group_1_rest_of_the_world? %>
   ^If you’re travelling on or after 8 January 2025, you’ll need to apply for an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta). 
 <% elsif calculator.passport_country_in_eta_rollout_group_2_eu_eea? %>
-  ^If you’re travelling on or after 2 April 2025, you’ll need to apply for an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta). You’ll be able to apply from 5 March 2025.
+  ^If you’re travelling on or after 2 April 2025, you’ll need to apply for an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta).
 <% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_no_visa_needed.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_no_visa_needed.erb
@@ -1,5 +1,5 @@
 <% text_for :title do %>
-  <%if calculator.passport_country_requires_electronic_travel_authorisation?  %>
+  <% if calculator.passport_country_requires_electronic_travel_authorisation? %>
     You'll need an electronic travel authorisation (ETA) to pass through UK border control
   <% else %>
     You do not need a visa to come to the UK
@@ -9,7 +9,7 @@
 
 <% govspeak_for :body do %>
 
-  <%if calculator.passport_country_requires_electronic_travel_authorisation? %>
+  <% if calculator.passport_country_requires_electronic_travel_authorisation? %>
     [Apply for an ETA](/guidance/apply-for-an-electronic-travel-authorisation-eta).
   <% end %>
 
@@ -17,18 +17,20 @@
     (calculator.passport_country_in_non_visa_national_list? ||
       calculator.passport_country_in_eea? ||
       calculator.passport_country_in_british_overseas_territories_list?) &&
-    not(calculator.passport_country_requires_electronic_travel_authorisation?)%>
+    not(calculator.passport_country_requires_electronic_travel_authorisation?) %>
 
     However, you should bring evidence of your onward journey to show to officers at the UK border.
 
-    <%= render partial: "electronic_travel_authorisation_advice", locals: {calculator: calculator} %>
+    <% if !calculator.passport_eu_eea_country_requires_electronic_travel_authorisation? %>
+      <%= render partial: "electronic_travel_authorisation_advice", locals: {calculator: calculator} %>
+    <% end %>
 
-    <% if calculator.travelling_to_ireland? %>
+    <% if calculator.travelling_to_ireland? && not(calculator.passport_eu_eea_country_requires_electronic_travel_authorisation?) %>
       %You may want to [apply for a visa](/browse/visas-immigration/tourist-short-stay-visas) if you have a criminal record or you’ve previously been refused entry into the UK.%
     <% end %>
   <% end %>
 
-  <%if calculator.passport_country_requires_electronic_travel_authorisation? %>
+  <% if calculator.passport_country_requires_electronic_travel_authorisation? %>
     You do not need an ETA if you will not pass through UK border control. You should bring evidence of your onward journey, such as a ticket to your destination.
 
     You always pass through border control if you:
@@ -44,5 +46,28 @@
     Check with your airline if you're not sure if you'll pass through UK border control.
 
     %You may want to apply for a [transit visa](/transit-visa) instead if you have a criminal record or you’ve previously been refused entry into the UK.
+  <% end %>
+
+  <% if calculator.passport_eu_eea_country_requires_electronic_travel_authorisation? %>
+  ##If you’re travelling on or after 2 April 2025
+    You'll need an electronic travel authorisation (ETA) to pass through UK border control.
+
+    [Apply for an ETA](/guidance/apply-for-an-electronic-travel-authorisation-eta).
+
+    You do not need an ETA if you will not pass through UK border control. You should bring evidence of your onward journey, such as a ticket to your destination.
+
+        You always pass through border control if you:
+
+        + leave the main airport building for any reason
+        + need to collect your bags and check them in to your onward flight
+
+        You must also pass through border control if both:
+
+        + your onward flight leaves on a different calendar day to when you arrive
+        + there's nowhere for you to stay overnight in the airport, for example in a transit hotel
+
+        Check with your airline if you're not sure if you'll pass through UK border control.
+
+        %You may want to apply for a [transit visa](/transit-visa) instead if you have a criminal record or you’ve previously been refused entry into the UK.
   <% end %>
 <% end %>

--- a/lib/smart_answer/calculators/uk_visa_calculator.rb
+++ b/lib/smart_answer/calculators/uk_visa_calculator.rb
@@ -78,6 +78,10 @@ module SmartAnswer::Calculators
       COUNTRY_GROUP_ELECTRONIC_TRAVEL_AUTHORISATION.include?(@passport_country)
     end
 
+    def passport_eu_eea_country_requires_electronic_travel_authorisation?
+      COUNTRY_GROUP_ETA_ROLLOUT_GROUP_2_EU_EEA.include?(@passport_country)
+    end
+
     def passport_country_in_epassport_gate_list?
       COUNTRY_GROUP_EPASSPORT_GATES.include?(@passport_country)
     end

--- a/test/flows/check_uk_visa_flow_test.rb
+++ b/test/flows/check_uk_visa_flow_test.rb
@@ -22,7 +22,7 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
 
     @non_visa_national_eta_text = "You currently do not need an electronic travel authorisation (ETA)"
     @eta_rollout_group_1_rest_of_the_world_text = "If you’re travelling on or after 8 January 2025, you’ll need to apply for an electronic travel authorisation (ETA)."
-    @eta_rollout_group_2_eu_eea_text = "If you’re travelling on or after 2 April 2025, you’ll need to apply for an electronic travel authorisation (ETA). You’ll be able to apply from 5 March 2025."
+    @eta_rollout_group_2_eu_eea_text = "If you’re travelling on or after 2 April 2025, you’ll need to apply for an electronic travel authorisation (ETA)."
     @eea_eta_text = "You currently do not need an electronic travel authorisation (ETA)"
 
     # stub only the countries used in this test for less of a performance impact
@@ -639,16 +639,16 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
       assert_rendered_outcome text: "You may want to apply for a transit visa"
     end
 
-    should "not render a suggestion of applying for a transit visa for non-ETA countries" do
+    should "render a suggestion of applying for a transit visa for EU/EEA ETA countries" do
       add_responses what_passport_do_you_have?: @eea_country,
                     travelling_to_cta?: "somewhere_else"
-      assert_no_rendered_outcome text: "You may want to apply for a transit visa"
+      assert_rendered_outcome text: "You may want to apply for a transit visa"
     end
 
-    should "render a suggestion of a visa for a further journey to Ireland" do
+    should "render a suggestion of a transit visa for a further journey to Ireland" do
       add_responses what_passport_do_you_have?: @eea_country,
                     travelling_to_cta?: "republic_of_ireland"
-      assert_rendered_outcome text: "You may want to apply for a visa"
+      assert_rendered_outcome text: "You may want to apply for a transit visa"
     end
   end
 
@@ -1066,9 +1066,9 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
         assert_no_rendered_outcome text: @eea_eta_text
       end
 
-      should "render callout box for eta_rollout_group_2_eu_eea_country passport holders" do
+      should "not render ETA callout box for eta_rollout_group_2_eu_eea_country passport holders" do
         add_responses what_passport_do_you_have?: @eta_rollout_group_2_eu_eea_country
-        assert_rendered_outcome text: @eta_rollout_group_2_eu_eea_text
+        assert_no_rendered_outcome text: @eta_rollout_group_2_eu_eea_text
       end
     end
   end


### PR DESCRIPTION
[Trello card](https://trello.com/c/Mkk6wTai/316-5-march-check-if-you-need-a-uk-visa-eu-eea-eta-applications-open)

This is the last stage of the ETA rollout. Users in EU/EEA countries will be able to apply for an ETA from 5 March, which they can use if they are travelling to the UK after 2 April 2025.

Note: Changes in logic visible in test/flows/check_uk_visa_flow_test.rb:642 are confirmed in [this slack conversation](https://gds.slack.com/archives/C02PSUYE9SN/p1741003720785439?thread_ts=1739884684.910959&cid=C02PSUYE9SN) 

Before:

<img width="916" alt="Screenshot 2025-03-03 at 15 15 26" src="https://github.com/user-attachments/assets/8fc98629-2a34-4878-9718-096267e1a87e" />


After:
<img width="875" alt="Screenshot 2025-03-03 at 15 15 56" src="https://github.com/user-attachments/assets/d38f4af0-7059-47d0-b212-02623141eaea" />

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
