### PR TITLE
Uprating for statutory sick pay 2025

### DIFF
--- a/.github/workflows/minitest.yml
+++ b/.github/workflows/minitest.yml
@@ -31,6 +31,15 @@ jobs:
           ref: ${{ inputs.publishingApiRef }}
           path: vendor/publishing-api
 
+      - name: Remove image-bundled Chrome
+        run: sudo apt-get purge google-chrome-stable
+
+      - name: Setup Chrome
+        uses: browser-actions/setup-chrome@c785b87e244131f27c9f19c1a33e2ead956ab7ce # v1.7.3
+        with:
+          chrome-version: 128
+          install-chromedriver: true
+
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/app.json
+++ b/app.json
@@ -4,6 +4,7 @@
   "repository": "https://github.com/alphagov/smart-answers",
   "success_url": "/",
   "env": {
+    "RATES_QUERY_DATE": "2025-04-06",
     "GOVUK_APP_DOMAIN": "www.gov.uk",
     "GOVUK_WEBSITE_ROOT": "https://www.gov.uk",
     "GOVUK_PROXY_STATIC_ENABLED": "true",

--- a/app.json
+++ b/app.json
@@ -4,7 +4,6 @@
   "repository": "https://github.com/alphagov/smart-answers",
   "success_url": "/",
   "env": {
-    "RATES_QUERY_DATE": "2025-04-06",
     "GOVUK_APP_DOMAIN": "www.gov.uk",
     "GOVUK_WEBSITE_ROOT": "https://www.gov.uk",
     "GOVUK_PROXY_STATIC_ENABLED": "true",

--- a/app/flows/state_pension_through_partner_flow/outcomes/age_dependent_pension_outcome.erb
+++ b/app/flows/state_pension_through_partner_flow/outcomes/age_dependent_pension_outcome.erb
@@ -31,11 +31,11 @@
 
   **Example**
 
-  You’ll reach State Pension age on 6 March 2025. This is in the tax year 6 April 2024 to 5 April 2025.
+  You’ll reach State Pension age on 6 March 2026. This is in the tax year 6 April 2025 to 5 April 2026.
 
   You got married in 1975 and chose to pay National Insurance contributions at a reduced rate.
 
-  Your State Pension will be worked out differently if your reduced rate election still applied to you in 1989.
+  Your State Pension will be worked out differently if your reduced rate election still applied to you in the tax year 6 April 1990 to 5 April 1991.
 
   $E
 

--- a/app/flows/state_pension_through_partner_flow/outcomes/married_woman_and_state_pension_outcome.erb
+++ b/app/flows/state_pension_through_partner_flow/outcomes/married_woman_and_state_pension_outcome.erb
@@ -16,11 +16,11 @@
 
   **Example**
 
-  You’ll reach State Pension age on 6 March 2025. This is in the tax year 6 April 2024 to 5 April 2025.
+  You’ll reach State Pension age on 6 March 2026. This is in the tax year 6 April 2025 to 5 April 2026.
 
   You got married in 1975 and chose to pay National Insurance contributions at a reduced rate.
 
-  Your State Pension will be worked out differently if your reduced rate election still applied to you in 1989.
+  Your State Pension will be worked out differently if your reduced rate election still applied to you in the tax year 6 April 1990 to 5 April 1991.
 
   $E
 

--- a/app/flows/state_pension_through_partner_flow/outcomes/married_woman_no_state_pension_outcome.erb
+++ b/app/flows/state_pension_through_partner_flow/outcomes/married_woman_no_state_pension_outcome.erb
@@ -15,11 +15,11 @@
   $E
   **Example**
 
-  You’ll reach State Pension age on 6 March 2025. This is in the tax year 6 April 2024 to 5 April 2025.
+  You’ll reach State Pension age on 6 March 2026. This is in the tax year 6 April 2025 to 5 April 2026.
 
   You got married in 1975 and chose to pay National Insurance contributions at a reduced rate.
 
-  Your State Pension will be worked out differently if your reduced rate election still applied to you in 1989.
+  Your State Pension will be worked out differently if your reduced rate election still applied to you in the tax year 6 April 1990 to 5 April 1991.
 
   $E
 

--- a/config/smart_answers/rates/state_pension.yml
+++ b/config/smart_answers/rates/state_pension.yml
@@ -4,6 +4,10 @@
 # date of 2999-01-01
 ---
 - start_date: 2024-04-08
-  end_date: 2999-01-01
+  end_date: 2025-04-06
   weekly_rate: 169.50
   lower_weekly_rate: 101.55
+- start_date: 2025-04-07
+  end_date: 2999-01-01
+  weekly_rate: 176.45
+  lower_weekly_rate: 105.70

--- a/config/smart_answers/rates/statutory_sick_pay.yml
+++ b/config/smart_answers/rates/statutory_sick_pay.yml
@@ -70,3 +70,8 @@
   end_date: 2025-04-05
   lower_earning_limit_rate: 123
   ssp_weekly_rate: 116.75
+
+- start_date: 2025-04-06
+  end_date: 2026-04-05
+  lower_earning_limit_rate: 125
+  ssp_weekly_rate: 118.75

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -6,6 +6,19 @@ Capybara.default_driver = :rack_test
 
 GovukTest.configure
 
+Capybara.register_driver :headless_chrome do |app|
+  chrome_options = GovukTest.headless_chrome_selenium_options
+  chrome_options.add_argument("--disable-web-security")
+  chrome_options.add_argument("--no-sandbox")
+  chrome_options.add_argument("--disable-dev-shm-usage")
+
+  Capybara::Selenium::Driver.new(
+    app,
+    browser: :chrome,
+    options: chrome_options,
+  )
+end
+
 class ActionDispatch::IntegrationTest
   include Capybara::DSL
 

--- a/test/unit/calculators/state_pension_through_partner_calculator_test.rb
+++ b/test/unit/calculators/state_pension_through_partner_calculator_test.rb
@@ -6,6 +6,34 @@ module SmartAnswer::Calculators
       @calculator = StatePensionThroughPartnerCalculator.new
     end
 
+    context "#lower_basic_state_pension_rate" do
+      should "return the correct amount for 2024/2025" do
+        travel_to("2024-06-01") do
+          assert_equal @calculator.lower_basic_state_pension_rate, 101.55
+        end
+      end
+
+      should "return the correct amount for 2025/2026" do
+        travel_to("2025-06-01") do
+          assert_equal @calculator.lower_basic_state_pension_rate, 105.70
+        end
+      end
+    end
+
+    context "#higher_basic_state_pension_rate" do
+      should "return the correct amount for 2024/2025" do
+        travel_to("2024-06-01") do
+          assert_equal @calculator.higher_basic_state_pension_rate, 169.50
+        end
+      end
+
+      should "return the correct amount for 2025/2026" do
+        travel_to("2025-06-01") do
+          assert_equal @calculator.higher_basic_state_pension_rate, 176.45
+        end
+      end
+    end
+
     context "widow_and_new_pension?" do
       context "you reached pension age before specific date" do
         setup do

--- a/test/unit/calculators/statutory_sick_pay_calculator_test.rb
+++ b/test/unit/calculators/statutory_sick_pay_calculator_test.rb
@@ -863,6 +863,17 @@ module SmartAnswer
           end
         end
 
+        context "in the beginning of 2025/2026" do
+          setup do
+            @date = Date.parse("6 April 2025")
+            @lel = StatutorySickPayCalculator.lower_earning_limit_on(@date)
+          end
+
+          should "be 125" do
+            assert_equal 125.00, @lel
+          end
+        end
+
         context "fallback when no dates are matching" do
           should "not break and use the rate of the latest available fiscal year" do
             date = Date.parse("6 April 2056")
@@ -1024,6 +1035,19 @@ module SmartAnswer
           )
 
           assert_equal 116.75, calculator.ssp_payment.to_f
+        end
+
+        should "have the correct 2025/2026 value" do
+          calculator = StatutorySickPayCalculator.new(
+            sick_start_date: Date.parse("3 June 2025"),
+            sick_end_date: Date.parse("7 June 2025"),
+            days_of_the_week_worked: %w[1 2 3 4 5],
+            has_linked_sickness: true,
+            linked_sickness_start_date: Date.parse("21 Sep 2024"),
+            linked_sickness_end_date: Date.parse("28 Dec 2024"),
+          )
+
+          assert_equal 118.75, calculator.ssp_payment.to_f
         end
       end
 

--- a/test/unit/calculators/statutory_sick_pay_calculator_test.rb
+++ b/test/unit/calculators/statutory_sick_pay_calculator_test.rb
@@ -1039,8 +1039,8 @@ module SmartAnswer
 
         should "have the correct 2025/2026 value" do
           calculator = StatutorySickPayCalculator.new(
-            sick_start_date: Date.parse("3 June 2025"),
-            sick_end_date: Date.parse("7 June 2025"),
+            sick_start_date: Date.parse("2 June 2025"),
+            sick_end_date: Date.parse("6 June 2025"),
             days_of_the_week_worked: %w[1 2 3 4 5],
             has_linked_sickness: true,
             linked_sickness_start_date: Date.parse("21 Sep 2024"),


### PR DESCRIPTION
Adds the Statutory Sick Pay allowance for the 2025–2026 tax year (up from £116.75 to £118.75).

Adds the Lower Earnings Limit (LEL) for the 2025–2026 tax year (up from £123 to £125).

[Trello ticket](https://trello.com/c/HdxyykLX).

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
