### PR TITLE
Fix how assert_current_url, assert_same_url work

### DIFF
--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -17,18 +17,19 @@ class ActionDispatch::IntegrationTest
     assert page.has_content?(text), %(expected there to be content #{text} in #{page.text.inspect})
   end
 
-  def assert_current_url(path_with_query, options = {})
-    assert_same_url(current_url, path_with_query, options.merge(wait_until: true))
+  def assert_current_url(path_with_query)
+    expected = URI.parse(path_with_query)
+    wait_until { expected.path == URI.parse(current_url).path }
+    current = URI.parse(current_url)
+    assert_equal expected.path, current.path
+    assert_equal Rack::Utils.parse_query(expected.query), Rack::Utils.parse_query(current.query)
   end
 
-  def assert_same_url(expected_url, actual_url, options = {})
+  def assert_same_url(expected_url, actual_url)
     expected = URI.parse(expected_url)
-    wait_until { expected.path == URI.parse(current_url).path } if options[:wait_until]
     actual = URI.parse(actual_url)
     assert_equal expected.path, actual.path
-    unless options[:ignore_query]
-      assert_equal Rack::Utils.parse_query(expected.query), Rack::Utils.parse_query(actual.query)
-    end
+    assert_equal Rack::Utils.parse_query(expected.query), Rack::Utils.parse_query(actual.query)
   end
 
   # Adapted from http://www.elabs.se/blog/53-why-wait_until-was-removed-from-capybara


### PR DESCRIPTION
`assert_same_url` has both the expected and actual values known at call time, whereas `assert_current_url` needs to fetch `current_url` dynamically so that it can wait for it to have updated.

This effectively reverts `assert_current_url` back to its implementation before `assert_same_url` was extracted out of it (minus the options parameter, which is never set by any caller).
