### PR TITLE
British Nationals (Overseas) made exempt from ETA

### DIFF
--- a/lib/smart_answer/calculators/uk_visa_calculator.rb
+++ b/lib/smart_answer/calculators/uk_visa_calculator.rb
@@ -566,7 +566,6 @@ module SmartAnswer::Calculators
       belize
       botswana
       brazil
-      british-national-overseas
       brunei
       canada
       chile
@@ -576,7 +575,6 @@ module SmartAnswer::Calculators
       guatemala
       guyana
       hong-kong
-      hong-kong-(british-national-overseas)
       israel
       japan
       kiribati

--- a/test/flows/check_uk_visa_flow_test.rb
+++ b/test/flows/check_uk_visa_flow_test.rb
@@ -598,7 +598,7 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
     should "render specific guidance to British nationals overseas" do
       add_responses what_passport_do_you_have?: "british-national-overseas"
       assert_rendered_outcome text: "you can apply for a British National Overseas (BNO) visa."
-      assert_no_rendered_outcome text: "You will not need a visa but"
+      assert_rendered_outcome text: "You will not need a visa but"
     end
 
     should "render different guidance to non-British nationals overseas" do


### PR DESCRIPTION
 British Nationals (Overseas) made exempt from electronic travel authorisation

[Trello card](https://trello.com/c/CGL2wi2J/328-asap-british-nationals-overseas-made-exempt-from-electronic-travel-authorisation)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
