### PR TITLE
Update github actions

### DIFF
--- a/.github/workflows/copy-pr-template-to-dependabot-prs.yml
+++ b/.github/workflows/copy-pr-template-to-dependabot-prs.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Post PR template as a comment
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs')

--- a/.github/workflows/minitest.yml
+++ b/.github/workflows/minitest.yml
@@ -19,13 +19,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: alphagov/smart-answers
           ref: ${{ inputs.ref || github.ref }}
 
       - name: Checkout Publishing API (for Content Schemas)
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: alphagov/publishing-api
           ref: ${{ inputs.publishingApiRef }}


### PR DESCRIPTION
Some GitHub actions that were being referenced were quite old—update to
 use the latest version.

This resolved failing "actionlint" Actions.
