### PR TITLE
Check if you need a UK Visa - Trinidad and Tobago amends

### DIFF
--- a/app/flows/check_uk_visa_flow/outcomes/outcome_transit_not_leaving_airport.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_transit_not_leaving_airport.erb
@@ -7,7 +7,7 @@
 
   <%= render partial: "trinidad-and-tobago/outcome_transit_not_leaving_airport_1", locals: {calculator: calculator} %>
 
-  ##Exemptions
+  ##Transiting without a visa
 
   You do not need a Direct Airside Transit visa if you have one of the following:
 

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_transit_not_leaving_airport.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_transit_not_leaving_airport.erb
@@ -5,8 +5,6 @@
 <% govspeak_for :body do %>
   You normally need a [Direct Airside Transit visa](/transit-visa/direct-airside-transit-visa) if you arrive in the UK on a flight and leave again without passing through immigration control.
 
-  <%= render partial: "trinidad-and-tobago/outcome_transit_not_leaving_airport_1", locals: {calculator: calculator} %>
-
   <%= render partial: "trinidad-and-tobago/outcome_transit_not_leaving_airport_2", locals: {calculator: calculator} %>
 
   ##Transiting without a visa

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_transit_not_leaving_airport.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_transit_not_leaving_airport.erb
@@ -7,6 +7,8 @@
 
   <%= render partial: "trinidad-and-tobago/outcome_transit_not_leaving_airport_1", locals: {calculator: calculator} %>
 
+  <%= render partial: "trinidad-and-tobago/outcome_transit_not_leaving_airport_2", locals: {calculator: calculator} %>
+
   ##Transiting without a visa
 
   You do not need a Direct Airside Transit visa if you have one of the following:
@@ -28,5 +30,4 @@
 
   %E-visas or e-residence permits are not acceptable unless your airline is able to verify it with the issuing country. Contact your airline for more information.%
 
-  <%= render partial: "trinidad-and-tobago/outcome_transit_not_leaving_airport_2", locals: {calculator: calculator} %>
 <% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_transit_to_the_republic_of_ireland.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_transit_to_the_republic_of_ireland.erb
@@ -23,7 +23,16 @@
 
   ##Transiting without a visa
 
-  If your passport does not have a personal ID number, you might be eligible to transit without a visa if:
+  <% if calculator.passport_country_is_taiwan? %>
+
+   If your passport does not have a personal ID number, you might be eligible to transit without a visa if:
+
+  <% else %>
+
+  You may be eligible to transit without a visa if:
+
+  <% end %>
+
 
   - you arrive and depart by air
   - have a confirmed onward flight that leaves on the day you arrive or before midnight on the day after you arrive

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_transit_to_the_republic_of_ireland.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_transit_to_the_republic_of_ireland.erb
@@ -24,13 +24,9 @@
   ##Transiting without a visa
 
   <% if calculator.passport_country_is_taiwan? %>
-
    If your passport does not have a personal ID number, you might be eligible to transit without a visa if:
-
   <% else %>
-
-  You may be eligible to transit without a visa if:
-
+   You may be eligible to transit without a visa if:
   <% end %>
 
 

--- a/app/flows/check_uk_visa_flow/outcomes/trinidad-and-tobago/_outcome_transit_leaving_airport_direct_airside_transit_visa_2.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/trinidad-and-tobago/_outcome_transit_leaving_airport_direct_airside_transit_visa_2.erb
@@ -7,5 +7,4 @@
 
     * you booked and paid for your journey to the UK before 3pm (UK time) on 12 March 2025
     * you’re arriving in the UK before 3pm (UK time) on 23 April 2025
-    * you meet the [Standard Visitor visa](/standard-visitor) eligibility requirements
 <% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/trinidad-and-tobago/_outcome_transit_not_leaving_airport_1.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/trinidad-and-tobago/_outcome_transit_not_leaving_airport_1.erb
@@ -1,6 +1,6 @@
 <% if calculator.passport_country_is_trinidad_and_tobago? && Time.zone.now <= Time.zone.local(2025, 4, 23) %>
-    Depending on your circumstances you may be able to transit without a visa if either: 
+    Depending on your circumstances you may be able to: 
 
-    - you’re exempt
-    - you arrive before 11:59pm (UK time) on 23 April 2025
+    - use an electronic travel authorisation (ETA) if you’re arriving in the UK before 11:59pm (UK time) on 23 April 2025
+    - transit without a visa
 <% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/trinidad-and-tobago/_outcome_transit_to_the_republic_of_ireland_2.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/trinidad-and-tobago/_outcome_transit_to_the_republic_of_ireland_2.erb
@@ -1,25 +1,10 @@
 <% if calculator.passport_country_is_trinidad_and_tobago? && Time.zone.now <= Time.zone.local(2025, 4, 23) %>
     ##If you’re arriving in the UK before 3pm (UK time) on 23 April 2025
 
-    You may be able to use an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta) to pass through UK border control, if you already have one.
+    You may be able to use an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta) to pass through the UK if you already have one.
 
     All of the following must apply:
 
     * you booked and paid for your journey to the UK before 3pm (UK time) on 12 March 2025
     * you’re arriving in the UK before 3pm (UK time) on 23 April 2025
-    * you meet the [Standard Visitor visa](/standard-visitor) eligibility requirements
-
-    ^You do not need an ETA if you will not pass through UK border control. You should bring evidence of your onward journey, such as a ticket to your destination.
-
-    You always pass through border control if you:
-
-    - leave the main airport building for any reason
-    - need to collect your bags and check them in to your onward flight
-
-    You must also pass through border control if both:
-
-    - your onward flight leaves on a different calendar day to when you arrive
-    - there’s nowhere for you to stay overnight in the airport, for example in a transit hotel
-
-    Check with your airline if you’re not sure if you’ll pass through UK border control.
 <% end %>


### PR DESCRIPTION
[Changes 1 & 2]
Since the content has gone live, the department has realised that outcomes for transiting through border control and transiting to Ireland have incorrect content on them. 

[Change 3]
In the outcome for transiting through the UK to Irelan, all users are seeing content that is only meant to be seen by users from Taiwan. Fixing this with an IF statement.

[Changes 4 & 5]
I’m also addressing concerns about the term ‘exempt’ in the Transiting airside outcome that had come up as part of the original fact check, but were not actioned due to the tight turnaround:


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

