### PR TITLE
Update married couples allowance

### DIFF
--- a/config/smart_answers/rates/married_couples_allowance.yml
+++ b/config/smart_answers/rates/married_couples_allowance.yml
@@ -3,12 +3,12 @@
 # and usually 1. The last item in the file should have an end
 # date of 2999-01-01
 ---
-- start_date: 2023-04-06
-  end_date: 2024-04-05
-  maximum_married_couple_allowance: 10375
-  minimum_married_couple_allowance: 4010
-
 - start_date: 2024-04-06
-  end_date: 2999-01-01
+  end_date: 2025-04-05
   maximum_married_couple_allowance: 11080
   minimum_married_couple_allowance: 4270
+
+- start_date: 2025-04-06
+  end_date: 2999-01-01
+  maximum_married_couple_allowance: 11270
+  minimum_married_couple_allowance: 4360

--- a/test/unit/calculators/married_couple_allowance_calculator_test.rb
+++ b/test/unit/calculators/married_couple_allowance_calculator_test.rb
@@ -108,17 +108,6 @@ module SmartAnswer::Calculators
       assert_equal SmartAnswer::Money.new("28250"), result
     end
 
-    test "rate values for 2023/24" do
-      travel_to("2023-06-01") do
-        calculator = MarriedCouplesAllowanceCalculator.new
-
-        assert_equal 12_570, calculator.personal_allowance
-        assert_equal 34_600.0, calculator.income_limit_for_personal_allowances
-        assert_equal 10_375, calculator.maximum_mca
-        assert_equal 4010, calculator.minimum_mca
-      end
-    end
-
     test "rate values for 2024/25" do
       travel_to("2024-06-01") do
         calculator = MarriedCouplesAllowanceCalculator.new
@@ -127,6 +116,17 @@ module SmartAnswer::Calculators
         assert_equal 37_700.0, calculator.income_limit_for_personal_allowances
         assert_equal 11_080, calculator.maximum_mca
         assert_equal 4270, calculator.minimum_mca
+      end
+    end
+
+    test "rate values for 2025/26" do
+      travel_to("2025-06-01") do
+        calculator = MarriedCouplesAllowanceCalculator.new
+
+        assert_equal 12_570, calculator.personal_allowance
+        assert_equal 37_700.0, calculator.income_limit_for_personal_allowances
+        assert_equal 11_270, calculator.maximum_mca
+        assert_equal 4360, calculator.minimum_mca
       end
     end
   end


### PR DESCRIPTION
As part of uprating 2025:

Married couple's allowance will be increased:

Minimum from £4,270 to £4,360

Maximum from £11,080 to £11,270

https://trello.com/c/A5ykVq04/323-7-april-uprating-calculate-your-married-couples-allowance

(The personal allowance/income limit is already at £37,700 if I understand correctly, so haven't updated that)

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
