### PR TITLE
Improve integration test reliability

### DIFF
--- a/test/integration/engine/changing_answer_test.rb
+++ b/test/integration/engine/changing_answer_test.rb
@@ -28,6 +28,7 @@ class ChangingAnswerTest < EngineIntegrationTest
       select "Argentina", from: "response"
       click_on "Continue"
 
+      find "h1", text: "What date did you move there?"
       assert_current_url "/moved-to-country/y/argentina"
 
       fill_in "response[day]", with: "10"
@@ -49,6 +50,7 @@ class ChangingAnswerTest < EngineIntegrationTest
       fill_in "response[year]", with: "2000"
       click_on "Continue"
 
+      find "h1", text: "Which country were you born in?"
       assert_current_url "/moved-to-country/y/argentina/2000-04-15"
     end
 
@@ -79,6 +81,7 @@ class ChangingAnswerTest < EngineIntegrationTest
       select "week", from: "response[period]"
       click_on "Continue"
 
+      find "h1", text: "What size bonus do you want?"
       assert_current_url "/annual-bonus/y/2000.0-week"
 
       fill_in "response", with: "2000000"
@@ -94,6 +97,7 @@ class ChangingAnswerTest < EngineIntegrationTest
       fill_in "response", with: "3000000"
       click_on "Continue"
 
+      find "h1", text: "Information based on your answers"
       assert_current_url "/annual-bonus/y/2000.0-week/3000000.0"
     end
 
@@ -125,9 +129,9 @@ class ChangingAnswerTest < EngineIntegrationTest
       fill_in "response", with: "Bors"
       click_on "Continue"
 
+      find "h1", text: "What...is your quest?"
       assert_current_url "/bridge-of-death/y/Bors"
 
-      find "h1", text: "What...is your quest?"
       choose("To seek the Holy Grail", visible: false, allow_label_click: true)
       click_on "Continue"
 
@@ -152,6 +156,7 @@ class ChangingAnswerTest < EngineIntegrationTest
       choose("To rescue the princess", visible: false, allow_label_click: true)
       click_on "Continue"
 
+      find "h1", text: "Colour options"
       assert_current_url "/bridge-of-death/y/Bors/to_rescue_the_princess"
 
       choose("Yes", visible: false, allow_label_click: true)
@@ -174,6 +179,7 @@ class ChangingAnswerTest < EngineIntegrationTest
       choose("Red", visible: false, allow_label_click: true)
       click_on "Continue"
 
+      find "h1", text: "The Bridge of Death: Information based on your answers"
       assert_current_url "/bridge-of-death/y/Bors/to_rescue_the_princess/yes/red"
     end
 
@@ -187,6 +193,7 @@ class ChangingAnswerTest < EngineIntegrationTest
       check("Pepperoni", visible: false, allow_label_click: true)
       click_on "Continue"
 
+      find "h1", text: "Information based on your answers"
       assert_current_url "/checkbox-sample/y/pepperoni,peppers"
 
       within(".govuk-summary-list__row:nth-child(1)") { click_on "Change" }
@@ -202,6 +209,7 @@ class ChangingAnswerTest < EngineIntegrationTest
       check("Ham", visible: false, allow_label_click: true)
       click_on "Continue"
 
+      find "h1", text: "Information based on your answers"
       assert_current_url "/checkbox-sample/y/ham,pepperoni,peppers"
     end
 
@@ -214,6 +222,7 @@ class ChangingAnswerTest < EngineIntegrationTest
       fill_in "response", with: "B1 1PW"
       click_on "Continue"
 
+      find "h1", text: "Sample postcode question: Information based on your answers"
       assert_current_url "/postcode-sample/y/B1%201PW"
 
       within(".govuk-summary-list__row:nth-child(1)") { click_on "Change" }

--- a/test/integration/engine/checkbox_questions_test.rb
+++ b/test/integration/engine/checkbox_questions_test.rb
@@ -9,6 +9,7 @@ class CheckboxQuestionsTest < EngineIntegrationTest
     should "handle checkbox questions" do
       visit "/checkbox-sample/y"
 
+      find "h1", text: "What do you want on your pizza?"
       within "#current-question" do
         within ".govuk-fieldset__legend" do
           assert_page_has_content "What do you want on your pizza?"
@@ -28,6 +29,7 @@ class CheckboxQuestionsTest < EngineIntegrationTest
       check("Pepperoni", visible: false, allow_label_click: true)
       click_on "Continue"
 
+      find "h1", text: "Information based on your answers"
       assert_current_url "/checkbox-sample/y/ham,pepperoni"
 
       assert page.has_link?("Start again", href: "/checkbox-sample")
@@ -48,8 +50,10 @@ class CheckboxQuestionsTest < EngineIntegrationTest
     should "allow selecting no options from a checkbox question" do
       visit "/checkbox-sample/y"
 
+      find "h1", text: "What do you want on your pizza?"
       click_on "Continue"
 
+      find "h1", text: "Are you sure you don't want any toppings?"
       assert_current_url "/checkbox-sample/y/none"
 
       assert page.has_link?("Start again", href: "/checkbox-sample")
@@ -65,6 +69,7 @@ class CheckboxQuestionsTest < EngineIntegrationTest
 
       click_on "Continue"
 
+      find "h1", text: "Sample checkbox question: Information based on your answers"
       assert_current_url "/checkbox-sample/y/none/none"
 
       within ".outcome:nth-child(1)" do
@@ -75,10 +80,12 @@ class CheckboxQuestionsTest < EngineIntegrationTest
     should "expect explicit selection of 'none' option when present" do
       visit "/checkbox-sample/y/none"
 
+      find "h1", text: "Are you sure you don't want any toppings?"
       assert_page_has_content "Are you sure you don't want any toppings?"
 
       click_on "Continue"
 
+      find "p", text: "Please answer this question"
       assert_equal current_path, "/checkbox-sample/y/none"
 
       within(".govuk-error-summary [href]") do
@@ -95,6 +102,7 @@ class CheckboxQuestionsTest < EngineIntegrationTest
     should "toggle options when none option is present" do
       visit "/checkbox-sample/y/none"
 
+      find "h1", text: "Are you sure you don't want any toppings?"
       check("Definitely no toppings", visible: false, allow_label_click: true)
       check("Hmm I'm not sure, ask me again please", visible: false, allow_label_click: true)
       assert_not page.has_checked_field?("Definitely no toppings")
@@ -103,6 +111,7 @@ class CheckboxQuestionsTest < EngineIntegrationTest
       assert_not page.has_checked_field?("Hmm I'm not sure, ask me again please")
       click_on "Continue"
 
+      find "h1", text: "Sample checkbox question: Information based on your answers"
       assert_current_url "/checkbox-sample/y/none/none"
     end
   end
@@ -114,6 +123,7 @@ class CheckboxQuestionsTest < EngineIntegrationTest
     check("Ice Cream!!!", visible: false)
     click_on("Continue", visible: false)
 
+    find "h1", text: "Sample checkbox question: Information based on your answers"
     assert_current_url "/checkbox-sample/y/ham,ice_cream"
     within ".outcome:nth-child(1)" do
       assert_page_has_content "No way. That's disgusting!"

--- a/test/integration/engine/country_and_date_questions_test.rb
+++ b/test/integration/engine/country_and_date_questions_test.rb
@@ -42,6 +42,7 @@ class CountryAndDateQuestionsTest < EngineIntegrationTest
     should "handle country and date questions" do
       visit "/moved-to-country/y"
 
+      find "h1", text: "Which country do you live in?"
       within "#current-question" do
         assert_page_has_content "Which country do you live in?"
       end
@@ -54,6 +55,7 @@ class CountryAndDateQuestionsTest < EngineIntegrationTest
       select "Belarus", from: "response"
       click_on "Continue"
 
+      find "h1", text: "What date did you move there?"
       assert_current_url "/moved-to-country/y/belarus"
 
       assert page.has_link?("Start again", href: "/moved-to-country")
@@ -81,6 +83,7 @@ class CountryAndDateQuestionsTest < EngineIntegrationTest
       fill_in "Year", with: "1975"
       click_on "Continue"
 
+      find "h1", text: "Which country were you born in?"
       assert_current_url "/moved-to-country/y/belarus/1975-05-05"
 
       assert page.has_link?("Start again", href: "/moved-to-country")
@@ -113,6 +116,7 @@ class CountryAndDateQuestionsTest < EngineIntegrationTest
       select "Venezuela", from: "response"
       click_on "Continue"
 
+      find "h1", text: ": Information based on your answers"
       assert_current_url "/moved-to-country/y/belarus/1975-05-05/venezuela"
 
       assert page.has_link?("Start again", href: "/moved-to-country")

--- a/test/integration/engine/custom_button_test.rb
+++ b/test/integration/engine/custom_button_test.rb
@@ -4,7 +4,7 @@ class CustomButtonTest < EngineIntegrationTest
   setup do
     stub_content_store_has_item("/custom-button")
     visit "/custom-button"
-    click_on "Start now"
+    find(:link, text: "Start now").click
   end
 
   should "display custom button text" do

--- a/test/integration/engine/html_escaping_user_input_test.rb
+++ b/test/integration/engine/html_escaping_user_input_test.rb
@@ -4,7 +4,7 @@ class HtmlEscapingUserInputTest < EngineIntegrationTest
   setup do
     stub_content_store_has_item("/value-sample")
     visit "/value-sample"
-    click_on "Start now"
+    find(:link, text: "Start now").click
   end
 
   context "when user input contains unsafe HTML" do
@@ -13,6 +13,7 @@ class HtmlEscapingUserInputTest < EngineIntegrationTest
       unsafe_html = "<script id='naughty'>#{@javascript}"
       fill_in "User input", with: unsafe_html
       click_on "Continue"
+      find "p", text: "text-before-user-input"
     end
 
     should "escape user input interpolated into outcome ERB template" do

--- a/test/integration/engine/input_validation_test.rb
+++ b/test/integration/engine/input_validation_test.rb
@@ -7,9 +7,11 @@ class InputValidationTest < EngineIntegrationTest
 
       visit "/annual-bonus/y"
 
+      find "h1", text: "How much do you earn?"
       fill_in "response[amount]", with: "-123"
       click_on "Continue"
 
+      find "p", text: "Please answer this question"
       within "#current-question" do
         assert_page_has_content "How much do you earn?"
         within(".govuk-error-summary [href]") { assert_page_has_content "Please answer this question" }
@@ -21,11 +23,13 @@ class InputValidationTest < EngineIntegrationTest
       select "month", from: "response[period]"
       click_on "Continue"
 
+      find "h1", text: "What size bonus do you want?"
       assert_current_url "/annual-bonus/y/4000.0-month"
 
       fill_in "response", with: "asdfasdf"
       click_on "Continue"
 
+      find "p", text: "Sorry, that number is not valid. Please try again."
       within "#current-question" do
         assert_page_has_content "What size bonus do you want?"
         within(".govuk-error-message") { assert_page_has_content "Sorry, that number is not valid. Please try again." }
@@ -35,6 +39,7 @@ class InputValidationTest < EngineIntegrationTest
       fill_in "response", with: "50000"
       click_on "Continue"
 
+      find "h1", text: "Information based on your answers"
       assert_current_url "/annual-bonus/y/4000.0-month/50000.0"
     end
 
@@ -43,9 +48,11 @@ class InputValidationTest < EngineIntegrationTest
 
       visit "/annual-bonus/y/4000.0-month"
 
+      find "h1", text: "What size bonus do you want?"
       fill_in "response", with: "3000"
       click_on "Continue"
 
+      find "p", text: "You can't request a bonus less than your annual salary."
       within "#current-question" do
         assert_page_has_content "What size bonus do you want?"
         within(".govuk-error-message") { assert_page_has_content "You can't request a bonus less than your annual salary." }
@@ -55,6 +62,7 @@ class InputValidationTest < EngineIntegrationTest
       fill_in "response", with: "50000"
       click_on "Continue"
 
+      find "h1", text: "Information based on your answers"
       assert_current_url "/annual-bonus/y/4000.0-month/50000.0"
 
       within "#result-info" do
@@ -68,9 +76,11 @@ class InputValidationTest < EngineIntegrationTest
 
       visit "/custom-errors-sample/y"
 
+      find "h1", text: "How many things do you own?"
       fill_in "response", with: "asdfasdf"
       click_on "Continue"
 
+      find "p", text: "Sorry, but that is not a number. Please try again."
       within "#current-question" do
         assert_page_has_content "How many things do you own?"
         within(".govuk-error-message") { assert_page_has_content "Sorry, but that is not a number. Please try again." }

--- a/test/integration/engine/money_and_salary_questions_test.rb
+++ b/test/integration/engine/money_and_salary_questions_test.rb
@@ -9,6 +9,7 @@ class MoneyAndSalaryQuestionsTest < EngineIntegrationTest
     should "handle money and salary questions" do
       visit "/annual-bonus/y"
 
+      find "h1", text: "How much do you earn?"
       within "#current-question" do
         within '.govuk-label[for="response"]' do
           assert_page_has_content "How much do you earn?"
@@ -22,6 +23,7 @@ class MoneyAndSalaryQuestionsTest < EngineIntegrationTest
       select "month", from: "response[period]"
       click_on "Continue"
 
+      find "h1", text: "What size bonus do you want?"
       assert_current_url "/annual-bonus/y/5000.0-month"
 
       assert page.has_link?("Start again", href: "/annual-bonus")
@@ -44,6 +46,7 @@ class MoneyAndSalaryQuestionsTest < EngineIntegrationTest
       fill_in "response", with: "1000000"
       click_on "Continue"
 
+      find "h1", text: "Information based on your answers"
       assert_current_url "/annual-bonus/y/5000.0-month/1000000.0"
 
       assert page.has_link?("Start again", href: "/annual-bonus")

--- a/test/integration/engine/query_parameters_based_flow_test.rb
+++ b/test/integration/engine/query_parameters_based_flow_test.rb
@@ -4,12 +4,15 @@ class QueryParametersBasedFlowTest < EngineIntegrationTest
   should "allow a user to complete a flow" do
     visit "/query-parameters-based/start"
 
+    find "h1", text: "Question 1 title"
     choose "Response 1"
     click_on "Continue"
 
+    find "h1", text: "Question 2 title"
     fill_in "response", with: "Response"
     click_on "Continue"
 
+    find "h1", text: "Information based on your answers"
     assert_page_has_content "Results title"
     assert_current_url "/query-parameters-based/results?question1=response1&question2=Response"
   end
@@ -17,8 +20,10 @@ class QueryParametersBasedFlowTest < EngineIntegrationTest
   should "provide answer validation" do
     visit "/query-parameters-based/start"
 
+    find "h1", text: "Question 1 title"
     click_on "Continue"
 
+    find "h1", text: "Question 1 title"
     assert_page_has_content "Question 1 title"
     assert_page_has_content "Please answer this question"
     assert_current_url "/query-parameters-based/question1?question1="
@@ -27,11 +32,14 @@ class QueryParametersBasedFlowTest < EngineIntegrationTest
   should "allow changing an answer" do
     visit "/query-parameters-based/start"
 
+    find "h1", text: "Question 1 title"
     choose "Response 1"
     click_on "Continue"
 
+    find "h1", text: "Question 2 title"
     click_on "Change"
 
+    find "h1", text: "Question 1 title"
     assert_page_has_content "Question 1 title"
     assert_current_url "/query-parameters-based/question1?question1=response1"
   end
@@ -39,14 +47,18 @@ class QueryParametersBasedFlowTest < EngineIntegrationTest
   should "allow restarting a flow" do
     visit "/query-parameters-based/start"
 
+    find "h1", text: "Question 1 title"
     choose "Response 1"
     click_on "Continue"
 
+    find "h1", text: "Question 2 title"
     fill_in "response", with: "Response"
     click_on "Continue"
 
+    find "h1", text: "Information based on your answers"
     click_on "Start again"
 
+    find "h1", text: "This is a test flow"
     assert_page_has_content "This is a test flow"
     assert_current_url "/query-parameters-based"
   end

--- a/test/integration/engine/radio_and_value_questions_test.rb
+++ b/test/integration/engine/radio_and_value_questions_test.rb
@@ -9,6 +9,7 @@ class RadioAndValueQuestionsTest < EngineIntegrationTest
     should "handle radio and value questions" do
       visit "/bridge-of-death"
 
+      find "h1", text: "The Bridge of Death"
       assert_current_url "/bridge-of-death"
 
       assert page.has_xpath?("//meta[@name = 'description'][@content = 'The Gorge of Eternal Peril!!!']", visible: :all)
@@ -27,6 +28,7 @@ class RadioAndValueQuestionsTest < EngineIntegrationTest
 
       click_on "Start now"
 
+      find "h1", text: "What...is your name?"
       assert_current_url "/bridge-of-death/y"
 
       # This is asserting that the form URL doesn't get created with a trailing /
@@ -47,6 +49,7 @@ class RadioAndValueQuestionsTest < EngineIntegrationTest
       fill_in "response", with: "Lancelot"
       click_on "Continue"
 
+      find "h1", text: "What...is your quest?"
       assert_current_url "/bridge-of-death/y/Lancelot"
 
       assert page.has_link?("Start again", href: "/bridge-of-death")
@@ -75,6 +78,7 @@ class RadioAndValueQuestionsTest < EngineIntegrationTest
       choose("To seek the Holy Grail", visible: false, allow_label_click: true)
       click_on "Continue"
 
+      find "h1", text: "Colour options"
       assert_current_url "/bridge-of-death/y/Lancelot/to_seek_the_holy_grail"
 
       assert page.has_link?("Start again", href: "/bridge-of-death")
@@ -111,6 +115,7 @@ class RadioAndValueQuestionsTest < EngineIntegrationTest
       choose("Yes", visible: false, allow_label_click: true)
       click_on "Continue"
 
+      find "h1", text: "What...is your favorite colour?"
       within "#current-question" do
         within ".govuk-fieldset__legend" do
           assert_page_has_content "What...is your favorite colour?"
@@ -127,6 +132,7 @@ class RadioAndValueQuestionsTest < EngineIntegrationTest
       choose("Blue", visible: false, allow_label_click: true)
       click_on "Continue"
 
+      find "h1", text: "Information based on your answers"
       assert_current_url "/bridge-of-death/y/Lancelot/to_seek_the_holy_grail/yes/blue"
 
       assert page.has_link?("Start again", href: "/bridge-of-death")
@@ -169,12 +175,15 @@ class RadioAndValueQuestionsTest < EngineIntegrationTest
   should "calculate alternate path correctly" do
     visit "/bridge-of-death/y"
 
+    find "h1", text: "What...is your name?"
     fill_in "response", with: "Robin"
     click_on "Continue"
 
+    find "h1", text: "What...is your quest?"
     choose("To seek the Holy Grail", visible: false)
     click_on "Continue"
 
+    find "h1", text: "What...is the capital of Assyria?"
     assert_current_url "/bridge-of-death/y/Robin/to_seek_the_holy_grail"
 
     assert page.has_link?("Start again", href: "/bridge-of-death")
@@ -204,6 +213,7 @@ class RadioAndValueQuestionsTest < EngineIntegrationTest
     fill_in "response", with: "I don't know THAT"
     click_on "Continue"
 
+    find "h1", text: "The Bridge of Death: Information based on your answers"
     within "#result-info" do
       within page.find(".gem-c-heading h2", match: :first) { assert_page_has_content "AAAAARRRRRRRRRRRRRRRRGGGGGHHH!!!!!!!" }
       within(".info-notice") { assert_page_has_content "Robin is thrown into the Gorge of Eternal Peril" }

--- a/test/integration/engine/session_based_flow_test.rb
+++ b/test/integration/engine/session_based_flow_test.rb
@@ -4,12 +4,15 @@ class SessionBasedFlowTest < EngineIntegrationTest
   should "allow a user to complete a flow" do
     visit "/session-based/start"
 
+    find "h1", text: "Question 1 title"
     choose "Response 1"
     click_on "Continue"
 
+    find "h1", text: "Question 2 title"
     fill_in "response", with: "Response"
     click_on "Continue"
 
+    find "h1", text: "Information based on your answers"
     assert_page_has_content "Results title"
     assert_current_url "/session-based/results"
   end
@@ -17,8 +20,10 @@ class SessionBasedFlowTest < EngineIntegrationTest
   should "provide answer validation" do
     visit "/session-based/start"
 
+    find "h1", text: "Question 1 title"
     click_on "Continue"
 
+    find "h1", text: "Question 1 title"
     assert_page_has_content "Question 1 title"
     assert_page_has_content "Please answer this question"
     assert_current_url "/session-based/question1"
@@ -27,11 +32,14 @@ class SessionBasedFlowTest < EngineIntegrationTest
   should "allow changing an answer" do
     visit "/session-based/start"
 
+    find "h1", text: "Question 1 title"
     choose "Response 1"
     click_on "Continue"
 
+    find "h1", text: "Question 2 title"
     click_on "Change"
 
+    find "h1", text: "Question 1 title"
     assert_page_has_content "Question 1 title"
     assert_current_url "/session-based/question1"
   end
@@ -39,14 +47,18 @@ class SessionBasedFlowTest < EngineIntegrationTest
   should "allow restarting a flow" do
     visit "/session-based/start"
 
+    find "h1", text: "Question 1 title"
     choose "Response 1"
     click_on "Continue"
 
+    find "h1", text: "Question 2 title"
     fill_in "response", with: "Response"
     click_on "Continue"
 
+    find "h1", text: "Information based on your answers"
     click_on "Start again"
 
+    find "h1", text: /^This is a test flow$/
     assert_page_has_content "This is a test flow"
     assert_current_url "/session-based"
   end

--- a/test/integration/engine/start_again_test.rb
+++ b/test/integration/engine/start_again_test.rb
@@ -4,9 +4,11 @@ class StartAgainTest < EngineIntegrationTest
   should "should set the GA4 section parameter to the title of the question when the flow is in progress" do
     visit "/session-based/start"
 
+    find "h1", text: "Question 1 title"
     choose "Response 1"
     click_on "Continue"
 
+    find "h1", text: "Question 2 title"
     assert page.has_css?(".govuk-link[data-module='ga4-link-tracker']")
     assert page.has_css?(".govuk-link[data-ga4-link='{\"event_name\":\"form_start_again\",\"type\":\"smart answer\",\"section\":\"Question 2 title\",\"action\":\"start again\",\"tool_name\":\"This is a test flow\"}']")
   end
@@ -14,12 +16,15 @@ class StartAgainTest < EngineIntegrationTest
   should "should set the GA4 section parameter to \"Information based on your answers\" when the flow has been completed" do
     visit "/session-based/start"
 
+    find "h1", text: "Question 1 title"
     choose "Response 1"
     click_on "Continue"
 
+    find "h1", text: "Question 2 title"
     fill_in "response", with: "Response"
     click_on "Continue"
 
+    find "h1", text: "Information based on your answers"
     assert_page_has_content "Results title"
     assert_current_url "/session-based/results"
     assert page.has_css?(".govuk-link[data-module='ga4-link-tracker']")
@@ -29,9 +34,11 @@ class StartAgainTest < EngineIntegrationTest
   should "should set the GA4 section parameter to title of the question when the user revisits a section to change their answer" do
     visit "/session-based/start"
 
+    find "h1", text: "Question 1 title"
     choose "Response 1"
     click_on "Continue"
 
+    find "h1", text: "Question 2 title"
     fill_in "response", with: "Response"
     click_on "Continue"
 
@@ -42,6 +49,7 @@ class StartAgainTest < EngineIntegrationTest
 
     click_on "Change Question 2 title"
 
+    find "h1", text: "Question 2 title"
     assert page.has_css?(".govuk-link[data-module='ga4-link-tracker']")
     assert page.has_css?(".govuk-link[data-ga4-link='{\"event_name\":\"form_start_again\",\"type\":\"smart answer\",\"section\":\"Question 2 title\",\"action\":\"start again\",\"tool_name\":\"This is a test flow\"}']")
   end


### PR DESCRIPTION
Following a recent release of Chrome/Chromium, integration tests have become less reliable. It seems like when a page change occurs (for example, when visiting a URL, or after submitting a form) the new page is less likely to have loaded by the time the next line in the test occurs than was previously the case.

The Capybara `find` method waits (with a timeout) for the specified element, so this commit updates all of the integration tests to add an appropriate `find` call after a page transition (or, in the case of no page transition but a validation message being expected, a `find` for that error message).