### PR TITLE
Update countries to require an ETA (EU/EEA group)

### DIFF
--- a/app/flows/check_uk_visa_flow/outcomes/outcome_school_electronic_travel_authorisation.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_school_electronic_travel_authorisation.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% govspeak_for :body do %>
-  What you need depends on how long you're staying
+  What you need depends on how long you're staying.
 
   ##If you're staying up to 6 months
 

--- a/lib/smart_answer/calculators/uk_visa_calculator.rb
+++ b/lib/smart_answer/calculators/uk_visa_calculator.rb
@@ -557,58 +557,98 @@ module SmartAnswer::Calculators
     ].freeze
 
     COUNTRY_GROUP_ELECTRONIC_TRAVEL_AUTHORISATION = %w[
+      andorra
       antigua-and-barbuda
       argentina
+      aruba
       australia
+      austria
       bahamas
       bahrain
       barbados
+      belgium
       belize
+      bonaire-st-eustatius-saba
       botswana
       brazil
       brunei
+      bulgaria
       canada
       chile
       costa-rica
+      croatia
+      curacao
+      cyprus
+      czech-republic
+      denmark
+      estonia
       federated-states-of-micronesia
+      finland
+      france
+      germany
+      greece
       grenada
       guatemala
       guyana
       hong-kong
+      hungary
+      iceland
       israel
+      italy
       japan
       kiribati
       kuwait
+      latvia
+      liechtenstein
+      lithuania
+      luxembourg
       macao
       malaysia
       maldives
+      malta
       marshall-islands
       mauritius
       mexico
+      monaco
       nauru
+      netherlands
       new-zealand
       nicaragua
+      norway
       oman
       palau
       panama
       papua-new-guinea
       paraguay
       peru
+      poland
+      portugal
       qatar
+      romania
+      saint-barthelemy
       samoa
+      san-marino
       saudi-arabia
       seychelles
       singapore
+      slovakia
+      slovenia
       solomon-islands
       south-korea
+      spain
       st-kitts-and-nevis
       st-lucia
+      st-maarten
+      st-martin
       st-vincent-and-the-grenadines
+      sweden
+      switzerland
       tonga
       tuvalu
       united-arab-emirates
       uruguay
       usa
+      vatican-city
     ].freeze
 
     COUNTRY_GROUP_EPASSPORT_GATES = %w[
@@ -684,47 +724,6 @@ module SmartAnswer::Calculators
       taiwan
     ].freeze
 
-    COUNTRY_GROUP_ETA_ROLLOUT_GROUP_2_EU_EEA = %w[
-      andorra
-      austria
-      aruba
-      belgium
-      bonaire-st-eustatius-saba
-      bulgaria
-      croatia
-      curacao
-      cyprus
-      czech-republic
-      denmark
-      estonia
-      finland
-      france
-      germany
-      greece
-      hungary
-      iceland
-      italy
-      latvia
-      liechtenstein
-      lithuania
-      luxembourg
-      malta
-      monaco
-      netherlands
-      norway
-      poland
-      portugal
-      romania
-      saint-barthelemy
-      san-marino
-      slovakia
-      slovenia
-      spain
-      st-martin
-      st-maarten
-      sweden
-      switzerland
-      vatican-city
-    ].freeze
+    COUNTRY_GROUP_ETA_ROLLOUT_GROUP_2_EU_EEA = %w[].freeze
   end
 end

--- a/test/support/flows/check_uk_visa_flow_test_helper.rb
+++ b/test/support/flows/check_uk_visa_flow_test_helper.rb
@@ -97,7 +97,7 @@ module CheckUkVisaFlowTestHelper
 
       should "have a next node of outcome_school_n for an EEA passport" do
         add_responses what_passport_do_you_have?: @eea_country
-        assert_next_node :outcome_school_n, for_response: "school"
+        assert_next_node :outcome_school_electronic_travel_authorisation, for_response: "school"
       end
 
       should "have a next node of outcome_school_y for other passports" do
@@ -129,7 +129,7 @@ module CheckUkVisaFlowTestHelper
 
       should "have a next node of outcome_medical_n for an EEA passport" do
         add_responses what_passport_do_you_have?: @eea_country
-        assert_next_node :outcome_medical_n, for_response: "medical"
+        assert_next_node :outcome_medical_electronic_travel_authorisation, for_response: "medical"
       end
 
       should "have a next node of outcome_medical_y for other passports" do
@@ -156,7 +156,7 @@ module CheckUkVisaFlowTestHelper
 
       should "have a next node of outcome_tourism_n for an EEA passport" do
         add_responses what_passport_do_you_have?: @eea_country
-        assert_next_node :outcome_tourism_n, for_response: "tourism"
+        assert_next_node :outcome_tourism_electronic_travel_authorisation, for_response: "tourism"
       end
 
       should "have a next node of outcome_tourism_n for a British overseas territory passport" do


### PR DESCRIPTION
[Trello card](https://trello.com/c/TXffnt1b/318-2-april-check-if-you-need-a-uk-visa-eu-eea-eta-rollout)

Countries that were in the `COUNTRY_GROUP_ETA_ROLLOUT_GROUP_2_EU_EEA` group should now be requiring an electronic travel authorisation (ETA). All countries have been moved.

This follows on the rollout of ETA requirements, now for EU/EEA countries, continuing the work previously from
[Trello card](https://trello.com/c/vpISVH6k/309-8-jan-asap-after-update-eta-wording-in-check-if-you-need-a-uk-visa-content-requests)
[PR #7031](https://github.com/alphagov/smart-answers/pull/7031)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
