### PR TITLE
Pin Chrome version used in integration tests

### DIFF
--- a/.github/workflows/minitest.yml
+++ b/.github/workflows/minitest.yml
@@ -31,6 +31,15 @@ jobs:
           ref: ${{ inputs.publishingApiRef }}
           path: vendor/publishing-api
 
+      - name: Remove image-bundled Chrome
+        run: sudo apt-get purge google-chrome-stable
+
+      - name: Setup Chrome
+        uses: browser-actions/setup-chrome@c785b87e244131f27c9f19c1a33e2ead956ab7ce # v1.7.3
+        with:
+          chrome-version: 128
+          install-chromedriver: true
+
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -6,6 +6,19 @@ Capybara.default_driver = :rack_test
 
 GovukTest.configure
 
+Capybara.register_driver :headless_chrome do |app|
+  chrome_options = GovukTest.headless_chrome_selenium_options
+  chrome_options.add_argument("--disable-web-security")
+  chrome_options.add_argument("--no-sandbox")
+  chrome_options.add_argument("--disable-dev-shm-usage")
+
+  Capybara::Selenium::Driver.new(
+    app,
+    browser: :chrome,
+    options: chrome_options,
+  )
+end
+
 class ActionDispatch::IntegrationTest
   include Capybara::DSL
 


### PR DESCRIPTION
There is an ongoing issue with recent versions of Chrome (see some discussion on [this Capybara issue](https://github.com/teamcapybara/capybara/issues/2800)) that are causing flakey integration tests. Pin to an older version of Chrome that does not exhibit this issue.

There have been attempts to make the tests more reliable, which seem to have improved matters, but not 100% fixed the issues.

See these previous PRs that were made to improve reliability:
- https://github.com/alphagov/smart-answers/pull/7125
- https://github.com/alphagov/smart-answers/pull/7131
