### PR TITLE
MERGE ON APRIL 7th Update start page to mention neonatal care

### DIFF
--- a/app/flows/maternity_paternity_calculator_flow/start.erb
+++ b/app/flows/maternity_paternity_calculator_flow/start.erb
@@ -23,10 +23,11 @@
   + the dates for adoption, for example their match date and date of placement
 
 
-  You can’t use the calculator for:
+  You cannot use the calculator for:
 
   + births 15 weeks before the due date
   + paternity leave or pay for [overseas adoptions](/employers-paternity-pay-leave/adoption)
   + [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide)
+  + [Neonatal Care Pay and Leave](/employers-neonatal-care-pay-leave)
 
 <% end %>


### PR DESCRIPTION
[Trello card](https://trello.com/c/9FmPTvCn/334-6-april-update-start-page-of-maternity-employer-calculator)


CHANGED
You can’t use the calculator for:

+ births 15 weeks before the due date
+ paternity leave or pay for overseas adoptions
+ Shared Parental Leave and Pay

TO
You cannot use the calculator for:

+ births 15 weeks before the due date
+ paternity leave or pay for overseas adoptions
+ Shared Parental Leave and Pay
+ Neonatal Care Pay and Leave

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
