### PR TITLE
Check if you need a UK visa: Taiwan specific ETA outcomes

### DIFF
--- a/app/flows/check_uk_visa_flow/outcomes/_electronic_travel_authorisation_taiwan.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/_electronic_travel_authorisation_taiwan.erb
@@ -1,0 +1,18 @@
+What you need to apply for depends on:
+
++ whether or not your passport has a personal ID number on the bio data page
++ what you're coming to the UK to do
+
+## If your passport does not have a personal ID number on the bio data page
+
+You will need a [Standard Visitor visa](/standard-visitor) if you’re coming to the UK for certain business or academic activities, such as:
+
++ going to meetings or conferences
++ doing academic research
++ doing certain paid engagements or events (a ‘permitted paid engagement’) for UK-based organisations
+
+For all other activities, you’ll need a [work visa](/browse/visas-immigration/work-visas).
+
+You will not need an ETA.
+
+##If your passport has a personal ID number on the bio data page

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_medical_electronic_travel_authorisation.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_medical_electronic_travel_authorisation.erb
@@ -3,6 +3,9 @@
 <% end %>
 
 <% govspeak_for :body do %>
+  <% if calculator.passport_country_is_taiwan? %>
+    <%= render partial: "electronic_travel_authorisation_taiwan", locals: {calculator: calculator} %>
+  <% end %>
   You must apply for either:
 
   - an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta)

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_school_electronic_travel_authorisation.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_school_electronic_travel_authorisation.erb
@@ -3,6 +3,9 @@
 <% end %>
 
 <% govspeak_for :body do %>
+  <% if calculator.passport_country_is_taiwan? %>
+    <%= render partial: "electronic_travel_authorisation_taiwan", locals: {calculator: calculator} %>
+  <% end %>
   What you need depends on how long you're staying.
 
   ##If you're staying up to 6 months

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_study_electronic_travel_authorisation.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_study_electronic_travel_authorisation.erb
@@ -3,6 +3,9 @@
 <% end %>
 
 <% govspeak_for :body do %>
+  <% if calculator.passport_country_is_taiwan? %>
+    <%= render partial: "electronic_travel_authorisation_taiwan", locals: {calculator: calculator} %>
+  <% end %>
   You must apply for either:
 
   - an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta)

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_tourism_electronic_travel_authorisation.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_tourism_electronic_travel_authorisation.erb
@@ -3,6 +3,9 @@
 <% end %>
 
 <% govspeak_for :body do %>
+  <% if calculator.passport_country_is_taiwan? %>
+    <%= render partial: "electronic_travel_authorisation_taiwan", locals: {calculator: calculator} %>
+  <% end %>
   You must apply for either:
 
   - an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta)

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_transit_to_the_republic_of_ireland_electronic_travel_authorisation.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_transit_to_the_republic_of_ireland_electronic_travel_authorisation.erb
@@ -3,6 +3,9 @@
 <% end %>
 
 <% govspeak_for :body do %>
+  <% if calculator.passport_country_is_taiwan? %>
+    <%= render partial: "electronic_travel_authorisation_taiwan", locals: {calculator: calculator} %>
+  <% end %>
     [Apply for an ETA](/guidance/apply-for-an-electronic-travel-authorisation-eta).
 
     You do not need an ETA if you will not pass through UK border control. You should bring evidence of your onward journey, such as a ticket to your destination.

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_work_electronic_travel_authorisation.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_work_electronic_travel_authorisation.erb
@@ -3,6 +3,9 @@
 <% end %>
 
 <% govspeak_for :body do %>
+  <% if calculator.passport_country_is_taiwan? %>
+    <%= render partial: "electronic_travel_authorisation_taiwan", locals: {calculator: calculator} %>
+  <% end %>
   What you need to apply for depends on your circumstances.
 
   You need an ETA for some business and academic activities, but you must get a visa if you plan to work in the UK.

--- a/lib/smart_answer/calculators/uk_visa_calculator.rb
+++ b/lib/smart_answer/calculators/uk_visa_calculator.rb
@@ -643,6 +643,7 @@ module SmartAnswer::Calculators
       st-vincent-and-the-grenadines
       sweden
       switzerland
+      taiwan
       tonga
       tuvalu
       united-arab-emirates
@@ -720,9 +721,7 @@ module SmartAnswer::Calculators
       "zimbabwe",
     ].flatten.freeze
 
-    COUNTRY_GROUP_ETA_ROLLOUT_GROUP_1_REST_OF_THE_WORLD = %w[
-      taiwan
-    ].freeze
+    COUNTRY_GROUP_ETA_ROLLOUT_GROUP_1_REST_OF_THE_WORLD = %w[].freeze
 
     COUNTRY_GROUP_ETA_ROLLOUT_GROUP_2_EU_EEA = %w[].freeze
   end

--- a/test/flows/check_uk_visa_flow_test.rb
+++ b/test/flows/check_uk_visa_flow_test.rb
@@ -14,13 +14,11 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
     @british_overseas_territory_country = "anguilla"
     @non_visa_national_country = "pitcairn-island"
     @eea_country = "austria"
-    @eta_rollout_group_1_rest_of_the_world_country = "taiwan"
     @travel_document_country = "hong-kong"
     @b1_b2_country = "syria"
     @youth_mobility_scheme_country = "canada"
 
     @non_visa_national_eta_text = "You currently do not need an electronic travel authorisation (ETA)"
-    @eta_rollout_group_1_rest_of_the_world_text = "If you’re travelling on or after 8 January 2025, you’ll need to apply for an electronic travel authorisation (ETA)."
     @eea_eta_text = "You currently do not need an electronic travel authorisation (ETA)"
 
     # stub only the countries used in this test for less of a performance impact
@@ -45,8 +43,7 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
                                       @eea_country,
                                       @travel_document_country,
                                       @b1_b2_country,
-                                      @youth_mobility_scheme_country,
-                                      @eta_rollout_group_1_rest_of_the_world_country].uniq)
+                                      @youth_mobility_scheme_country].uniq)
   end
 
   should "render a start page" do
@@ -410,9 +407,9 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
           assert_next_node :outcome_study_electronic_travel_authorisation, for_response: "six_months_or_less"
         end
 
-        should "have a next node of outcome_study_waiver_taiwan for a study visit with a Taiwan passport" do
+        should "have a next node of outcome_study_electronic_travel_authorisation for a study visit with a Taiwan passport" do
           add_responses what_passport_do_you_have?: "taiwan", purpose_of_visit?: "study"
-          assert_next_node :outcome_study_waiver_taiwan, for_response: "six_months_or_less"
+          assert_next_node :outcome_study_electronic_travel_authorisation, for_response: "six_months_or_less"
         end
 
         should "have a next node of outcome_study_m for a study visit with a direct airside transit visa" do
@@ -440,7 +437,7 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
           assert_next_node :outcome_study_no_visa_needed, for_response: "six_months_or_less"
         end
 
-        should "have a next node of outcome_study_no_visa_needed for a study visit with an EEA passport" do
+        should "have a next node of outcome_study_electronic_travel_authorisation for a study visit with an EEA passport" do
           add_responses what_passport_do_you_have?: @eea_country,
                         purpose_of_visit?: "study"
           assert_next_node :outcome_study_electronic_travel_authorisation, for_response: "six_months_or_less"
@@ -458,9 +455,9 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
           assert_next_node :outcome_work_n, for_response: "six_months_or_less"
         end
 
-        should "have a next node of outcome_work_n for a work visit with a Taiwan passport" do
+        should "have a next node of outcome_work_electronic_travel_authorisation for a work visit with a Taiwan passport" do
           add_responses what_passport_do_you_have?: "taiwan", purpose_of_visit?: "work"
-          assert_next_node :outcome_work_n, for_response: "six_months_or_less"
+          assert_next_node :outcome_work_electronic_travel_authorisation, for_response: "six_months_or_less"
         end
 
         should "have a next node of outcome_work_n for a work visit with a non-visa national passport" do
@@ -469,7 +466,7 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
           assert_next_node :outcome_work_n, for_response: "six_months_or_less"
         end
 
-        should "have a next node of outcome_work_n for a work visit with an EEA passport" do
+        should "have a next node of outcome_work_electronic_travel_authorisation for a work visit with an EEA passport" do
           add_responses what_passport_do_you_have?: @eea_country,
                         purpose_of_visit?: "work"
           assert_next_node :outcome_work_electronic_travel_authorisation, for_response: "six_months_or_less"
@@ -660,6 +657,74 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
                     travelling_to_cta?: "republic_of_ireland"
       assert_rendered_outcome text: "You may want to apply for a transit visa"
     end
+
+    should "render specific guidance for a Taiwan passport" do
+      add_responses what_passport_do_you_have?: "taiwan",
+                    travelling_to_cta?: "republic_of_ireland"
+      assert_rendered_outcome text: "personal ID number on the bio data page"
+    end
+  end
+
+  context "medical ETA for Taiwan" do
+    setup do
+      testing_node :outcome_medical_electronic_travel_authorisation
+      add_responses what_passport_do_you_have?: "taiwan",
+                    purpose_of_visit?: "medical"
+    end
+
+    should "render specific guidance for a Taiwan passport" do
+      assert_rendered_outcome text: "personal ID number on the bio data page"
+    end
+  end
+
+  context "tourism ETA for Taiwan" do
+    setup do
+      testing_node :outcome_tourism_electronic_travel_authorisation
+      add_responses what_passport_do_you_have?: "taiwan",
+                    purpose_of_visit?: "tourism"
+    end
+
+    should "render specific guidance for a Taiwan passport" do
+      assert_rendered_outcome text: "personal ID number on the bio data page"
+    end
+  end
+
+  context "work ETA for Taiwan" do
+    setup do
+      testing_node :outcome_work_electronic_travel_authorisation
+      add_responses what_passport_do_you_have?: "taiwan",
+                    purpose_of_visit?: "work",
+                    staying_for_how_long?: "six_months_or_less"
+    end
+
+    should "render specific guidance for a Taiwan passport" do
+      assert_rendered_outcome text: "personal ID number on the bio data page"
+    end
+  end
+
+  context "school ETA for Taiwan" do
+    setup do
+      testing_node :outcome_school_electronic_travel_authorisation
+      add_responses what_passport_do_you_have?: "taiwan",
+                    purpose_of_visit?: "school"
+    end
+
+    should "render specific guidance for a Taiwan passport" do
+      assert_rendered_outcome text: "personal ID number on the bio data page"
+    end
+  end
+
+  context "study ETA for Taiwan" do
+    setup do
+      testing_node :outcome_study_electronic_travel_authorisation
+      add_responses what_passport_do_you_have?: "taiwan",
+                    purpose_of_visit?: "study",
+                    staying_for_how_long?: "six_months_or_less"
+    end
+
+    should "render specific guidance for a Taiwan passport" do
+      assert_rendered_outcome text: "personal ID number on the bio data page"
+    end
   end
 
   context "outcome: outcome_school_y" do
@@ -717,11 +782,6 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
       testing_node :outcome_transit_to_the_republic_of_ireland
       add_responses purpose_of_visit?: "transit",
                     travelling_to_cta?: "republic_of_ireland"
-    end
-
-    should "render specific guidance for a Taiwan passport" do
-      add_responses what_passport_do_you_have?: "taiwan"
-      assert_rendered_outcome text: "You will not need a visa if your passport has a personal ID number on the bio data page."
     end
 
     should "render different guidance for passports from outher countries" do
@@ -967,11 +1027,6 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
         add_responses what_passport_do_you_have?: @british_overseas_territory_country
         assert_no_rendered_outcome text: @non_visa_national_eta_text
         assert_no_rendered_outcome text: @eea_eta_text
-      end
-
-      should "render callout box for eta_rollout_group_1_rest_of_the_world_country passport holders" do
-        add_responses what_passport_do_you_have?: @eta_rollout_group_1_rest_of_the_world_country
-        assert_rendered_outcome text: @eta_rollout_group_1_rest_of_the_world_text
       end
     end
 

--- a/test/support/flows/check_uk_visa_flow_test_helper.rb
+++ b/test/support/flows/check_uk_visa_flow_test_helper.rb
@@ -80,9 +80,9 @@ module CheckUkVisaFlowTestHelper
         assert_next_node :outcome_school_electronic_travel_authorisation, for_response: "school"
       end
 
-      should "have a next node of outcome_study_waiver_taiwan for a Taiwan passport" do
+      should "have a next node of outcome_school_electronic_travel_authorisation for a Taiwan passport" do
         add_responses what_passport_do_you_have?: "taiwan"
-        assert_next_node :outcome_study_waiver_taiwan, for_response: "school"
+        assert_next_node :outcome_school_electronic_travel_authorisation, for_response: "school"
       end
 
       should "have a next node of outcome_school_n for a non-visa national passport" do
@@ -95,7 +95,7 @@ module CheckUkVisaFlowTestHelper
         assert_next_node :outcome_school_n, for_response: "school"
       end
 
-      should "have a next node of outcome_school_n for an EEA passport" do
+      should "have a next node of outcome_school_electronic_travel_authorisation for an EEA passport" do
         add_responses what_passport_do_you_have?: @eea_country
         assert_next_node :outcome_school_electronic_travel_authorisation, for_response: "school"
       end
@@ -112,9 +112,9 @@ module CheckUkVisaFlowTestHelper
         assert_next_node :outcome_medical_electronic_travel_authorisation, for_response: "medical"
       end
 
-      should "have a next node of outcome_visit_waiver_taiwan for a Taiwan passport" do
+      should "have a next node of outcome_medical_electronic_travel_authorisation for a Taiwan passport" do
         add_responses what_passport_do_you_have?: "taiwan"
-        assert_next_node :outcome_visit_waiver_taiwan, for_response: "medical"
+        assert_next_node :outcome_medical_electronic_travel_authorisation, for_response: "medical"
       end
 
       should "have a next node of outcome_medical_n for a non-visa national passport" do
@@ -127,7 +127,7 @@ module CheckUkVisaFlowTestHelper
         assert_next_node :outcome_medical_n, for_response: "medical"
       end
 
-      should "have a next node of outcome_medical_n for an EEA passport" do
+      should "have a next node of outcome_medical_electronic_travel_authorisation for an EEA passport" do
         add_responses what_passport_do_you_have?: @eea_country
         assert_next_node :outcome_medical_electronic_travel_authorisation, for_response: "medical"
       end
@@ -144,9 +144,9 @@ module CheckUkVisaFlowTestHelper
         assert_next_node :outcome_tourism_electronic_travel_authorisation, for_response: "tourism"
       end
 
-      should "have a next node of outcome_visit_waiver_taiwan for a Taiwan passport" do
+      should "have a next node of outcome_tourism_requires_electronic_travel_authorisation for a Taiwan passport" do
         add_responses what_passport_do_you_have?: "taiwan"
-        assert_next_node :outcome_visit_waiver_taiwan, for_response: "tourism"
+        assert_next_node :outcome_tourism_electronic_travel_authorisation, for_response: "tourism"
       end
 
       should "have a next node of outcome_tourism_n for a non-visa national passport" do
@@ -154,7 +154,7 @@ module CheckUkVisaFlowTestHelper
         assert_next_node :outcome_tourism_n, for_response: "tourism"
       end
 
-      should "have a next node of outcome_tourism_n for an EEA passport" do
+      should "have a next node of outcome_tourism_requires_electronic_travel_authorisation for an EEA passport" do
         add_responses what_passport_do_you_have?: @eea_country
         assert_next_node :outcome_tourism_electronic_travel_authorisation, for_response: "tourism"
       end


### PR DESCRIPTION
[Trello card](https://trello.com/c/TwnqA52M/315-check-if-you-need-a-uk-visa-taiwan-work-outcomes)

Moved Taiwan to the ETA required group, and created a partial which gets rendered for all ETA outcomes for Taiwan.
(work, study, school, tourism, medical & transit to Ireland)
 
- All Taiwan ETA related outcomes, including work,  now utilise a partial, containing information relating to personal ID number presence on the bio data page of their passport.
- This information is only visible to Taiwan nationals.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
