### PR TITLE
content modelling/spike 998 content blocks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem "rails", "8.0.2"
 
 gem "ast"
 gem "bootsnap", require: false
+gem "content_block_tools"
 gem "dartsass-rails"
 gem "erb_lint"
 gem "gds-api-adapters"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,6 +111,8 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.0)
+    content_block_tools (0.4.6)
+      actionview (>= 6)
     crack (1.0.0)
       bigdecimal
       rexml
@@ -722,6 +724,7 @@ DEPENDENCIES
   binding_of_caller
   bootsnap
   byebug
+  content_block_tools
   dartsass-rails
   erb_lint
   gds-api-adapters

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6,6 +6,7 @@ $govuk-include-default-font-face: false;
 @import "govuk_publishing_components/govuk_frontend_support";
 
 @import "smart_answers";
+@import "content_block";
 
 .desktop-min-height {
   @include govuk-media-query($from: tablet) {

--- a/app/assets/stylesheets/content_block.scss
+++ b/app/assets/stylesheets/content_block.scss
@@ -1,0 +1,3 @@
+.content-block--background {
+  background: yellow;
+}

--- a/app/flows/state_pension_age_flow/questions/which_calculation.erb
+++ b/app/flows/state_pension_age_flow/questions/which_calculation.erb
@@ -1,5 +1,6 @@
 <% text_for :title do %>
   What would you like to calculate?
+  <%=  ContentBlock.value_for_embed_code("{{embed:content_block_pension:5a72aef5-e0b6-4718-bf33-a46cb726777d/rates/smart-answer-rate/amount}}").to_sym %>
 <% end %>
 
 <% options(

--- a/app/flows/state_pension_age_flow/start.erb
+++ b/app/flows/state_pension_age_flow/start.erb
@@ -22,7 +22,7 @@ The current basic state pension rate (from a Content Block) is:
 
 <% html_for :body do %>
   <p class="govuk-body content-block--background">
-    <%= ContentBlock.for_embed_code("{{embed:content_block_pension:5a72aef5-e0b6-4718-bf33-a46cb726777d/rates/smart-answer-rate/amount}}") %>
+    <%= ContentBlock.html_for_embed_code("{{embed:content_block_pension:5a72aef5-e0b6-4718-bf33-a46cb726777d/rates/smart-answer-rate/amount}}") %>
   </p>
 <% end %>
 

--- a/app/flows/state_pension_age_flow/start.erb
+++ b/app/flows/state_pension_age_flow/start.erb
@@ -17,6 +17,13 @@ Use this tool to check:
 
 ^The State Pension age is regularly reviewed, so the results of this tool may change in the future. You can [read about the results of the most recent review](/government/news/state-pension-age-review-published).^
 
+The current basic state pension rate (from a Content Block) is:
+<% end %>
+
+<% html_for :body do %>
+  <p class="govuk-body content-block--background">
+    <%= ContentBlock.for_embed_code("{{embed:content_block_pension:5a72aef5-e0b6-4718-bf33-a46cb726777d/rates/smart-answer-rate/amount}}") %>
+  </p>
 <% end %>
 
 <% govspeak_for :post_body do %>

--- a/app/models/content_block.rb
+++ b/app/models/content_block.rb
@@ -1,0 +1,14 @@
+class ContentBlock
+  def self.for_embed_code(embed_code)
+    content_references = ContentBlockTools::ContentBlockReference.find_all_in_document(embed_code)
+    result = GdsApi.publishing_api.get_content(content_references[0].content_id).parsed_content
+    content_block = ContentBlockTools::ContentBlock.new(
+      document_type: result["document_type"],
+      content_id: result["content_id"],
+      title: result["title"],
+      details: result["details"],
+      embed_code: embed_code,
+    )
+    content_block.render
+  end
+end

--- a/app/models/content_block.rb
+++ b/app/models/content_block.rb
@@ -1,5 +1,5 @@
 class ContentBlock
-  def self.for_embed_code(embed_code)
+  def self.html_for_embed_code(embed_code)
     unless Rails.env.development?
       # hacky way of using test code in integration
       embed_code = "{{embed:content_block_pension:640637ae-f9ce-448d-b7d5-180906511248/rates/rate-1/amount}}"
@@ -14,5 +14,15 @@ class ContentBlock
       embed_code: embed_code,
     )
     content_block.render
+  end
+
+  def self.value_for_embed_code(embed_code)
+    unless Rails.env.development?
+      # hacky way of using test code in integration
+      embed_code = "{{embed:content_block_pension:640637ae-f9ce-448d-b7d5-180906511248/rates/rate-1/amount}}"
+    end
+    content_references = ContentBlockTools::ContentBlockReference.find_all_in_document(embed_code)
+    result = GdsApi.publishing_api.get_content(content_references[0].content_id).parsed_content
+    result["title"]
   end
 end

--- a/app/models/content_block.rb
+++ b/app/models/content_block.rb
@@ -1,5 +1,9 @@
 class ContentBlock
   def self.for_embed_code(embed_code)
+    unless Rails.env.development?
+      # hacky way of using test code in integration
+      embed_code = "{{embed:content_block_pension:640637ae-f9ce-448d-b7d5-180906511248/rates/rate-1/amount}}"
+    end
     content_references = ContentBlockTools::ContentBlockReference.find_all_in_document(embed_code)
     result = GdsApi.publishing_api.get_content(content_references[0].content_id).parsed_content
     content_block = ContentBlockTools::ContentBlock.new(


### PR DESCRIPTION
- **add ContentBlockTools gem**
- **add a ContentBlock model**
- **render ContentBlock**
- **fixup! add a ContentBlock model**
- **just return value**

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
