### PR TITLE
Update redundancy smart answers with new weekly pay cap

### DIFF
--- a/config/smart_answers/rates/redundancy_pay.yml
+++ b/config/smart_answers/rates/redundancy_pay.yml
@@ -27,3 +27,7 @@
   end_date: 2025-04-05
   max: "21,000"
   rate: 700
+- start_date: 2025-04-06
+  end_date: 2026-04-05
+  max: "21,570"
+  rate: 719

--- a/config/smart_answers/rates/redundancy_pay_northern_ireland.yml
+++ b/config/smart_answers/rates/redundancy_pay_northern_ireland.yml
@@ -27,3 +27,7 @@
   end_date: 2025-04-05
   max: "21,870"
   rate: 729
+- start_date: 2025-04-06
+  end_date: 2026-04-05
+  max: "22,470"
+  rate: 749

--- a/test/unit/calculators/redundancy_calculator_test.rb
+++ b/test/unit/calculators/redundancy_calculator_test.rb
@@ -29,13 +29,12 @@ module SmartAnswer::Calculators
         end
       end
 
-      # There are rates missing for the current year, so this test is failing and blocking the pipeline.
-      # should "have max and rate for the current tax year" do
-      #   rate = RedundancyCalculator.redundancy_rates(Time.zone.now)
-      #   assert rate.end_date >= Time.zone.now.to_date, "Config file missing current redundancy rates"
-      #   assert rate.rate.is_a?(Numeric)
-      #   assert rate.max.present?
-      # end
+      should "have max and rate for the current tax year" do
+        rate = RedundancyCalculator.redundancy_rates(Time.zone.now)
+        assert rate.end_date >= Time.zone.now.to_date, "Config file missing current redundancy rates"
+        assert rate.rate.is_a?(Numeric)
+        assert rate.max.present?
+      end
     end
 
     context "Northern Ireland amounts for the redundancy date" do
@@ -49,14 +48,12 @@ module SmartAnswer::Calculators
         end
       end
 
-      # There are rates missing for the current year, so this test is failing and blocking the pipeline.
-
-      # should "have max and rate for the current tax year" do
-      #   rate = RedundancyCalculator.northern_ireland_redundancy_rates(Time.zone.now)
-      #   assert rate.end_date >= Time.zone.now.to_date, "Config file missing current NI redundancy rates"
-      #   assert rate.rate.is_a?(Numeric)
-      #   assert rate.max.present?
-      # end
+      should "have max and rate for the current tax year" do
+        rate = RedundancyCalculator.northern_ireland_redundancy_rates(Time.zone.now)
+        assert rate.end_date >= Time.zone.now.to_date, "Config file missing current NI redundancy rates"
+        assert rate.rate.is_a?(Numeric)
+        assert rate.max.present?
+      end
     end
 
     context "use correct weekly pay and number of years limits" do


### PR DESCRIPTION
[Trello Card](https://trello.com/c/GfG2njeV/343-uprating-update-redundancy-smart-answers-with-new-weekly-pay-cap)
- Adds new figures for redundancy for the current business year.

Scotland, England, Wales figures:
start_date: 2025-04-06
end_date: 2026-04-05
max: “21,570”
rate: 719

Northern Ireland figures:
start_date: 2025-04-06
end_date: 2026-04-05
max: “22,470” ([source](https://www.nidirect.gov.uk/articles/redundancy-pay#:~:text=The%20maximum%20statutory%20redundancy%20pay%20you%20can%20get%20in%20total%20is%20%C2%A322%2C470.))
rate: 749 ([source](https://www.nidirect.gov.uk/articles/redundancy-pay#:~:text=20%20years%27%20employment.-,Weekly%20pay,commission.%20Weekly%20pay%20capped%20at%20a%20certain%20limit%20(current%20maximum%20%C2%A3749).,-Your%20employer%20must))


