### PR TITLE
Update outcome_diplomatic_business.erb

### DIFF
--- a/app/flows/check_uk_visa_flow/outcomes/outcome_diplomatic_business.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_diplomatic_business.erb
@@ -9,7 +9,7 @@
 
   ##Government business
 
-  You will not need a visa to come to the UK on official government business for your country if you’re a serving government minister.
+  You will not need a visa to come to the UK on official government business for your country if you’re a serving government minister at a national government level.
 
   You can apply for an [exempt vignette](/exempt-vignette) to help you avoid delays when you enter the UK. Your partner or family members might also be able to apply.
 


### PR DESCRIPTION
Under ##Government business 
CHANGED
You will not need a visa to come to the UK on official government business for your country if you’re a serving government minister. TO
You will not need a visa to come to the UK on official government business for your country if you’re a serving government minister at national government level. REASON
Small clarification about exactly which kind of ministers do not need a visa to come to the UK. There's no one name for this type of minister across countries, this added wording was the best way to get the meaning across.