### PR TITLE
Update _the_user_should_be_aware.erb

### DIFF
--- a/app/flows/calculate_your_holiday_entitlement_flow/outcomes/_the_user_should_be_aware.erb
+++ b/app/flows/calculate_your_holiday_entitlement_flow/outcomes/_the_user_should_be_aware.erb
@@ -3,5 +3,3 @@ The user should be aware:
 * leave entitlement accrues differently in a worker's first year
 * when a worker starts part way through the month, they usually accrue one-twelfth of their leave from their first day
 * when a worker leaves employment within the first 12 months, their leave is calculated using the "For someone starting and leaving part way through a leave year" option in the calculator
-
-[Read detailed guidance on how holiday entitlement is calculated](/holiday-entitlement-rights/calculate-leave-entitlement).

--- a/app/flows/calculate_your_holiday_entitlement_flow/outcomes/_the_user_should_be_aware.erb
+++ b/app/flows/calculate_your_holiday_entitlement_flow/outcomes/_the_user_should_be_aware.erb
@@ -1,4 +1,7 @@
 The user should be aware:
 
-* leave entitlement accrues differently in a worker's first year - further information is [available online](/holiday-entitlement-rights/calculate-leave-entitlement)
+* leave entitlement accrues differently in a worker's first year
+* when a worker starts part way through the month, they usually accrue one-twelfth of their leave from their first day
 * when a worker leaves employment within the first 12 months, their leave is calculated using the "For someone starting and leaving part way through a leave year" option in the calculator
+
+[Read detailed guidance on how holiday entitlement is calculated](/holiday-entitlement-rights/calculate-leave-entitlement).

--- a/app/flows/calculate_your_holiday_entitlement_flow/outcomes/_the_user_should_be_aware.erb
+++ b/app/flows/calculate_your_holiday_entitlement_flow/outcomes/_the_user_should_be_aware.erb
@@ -1,4 +1,4 @@
 Leave entitlement accrues differently in a worker’s first year. This tool calculates leave for a worker who:
 
-* starts part way through the month, by applying one-twelfth of their leave from their first day - an employer can instead choose to calculate the first month’s leave 'pro-rata' (in proportion to the number of days worked)
+* starts part way through the month, by applying one-twelfth of their leave from their first day - alternatively, an employer can choose to calculate the first month’s leave 'pro-rata' (in proportion to the number of days worked) instead
 * leaves employment within the first 12 months, using the “For someone starting and leaving part way through a leave year” option

--- a/app/flows/calculate_your_holiday_entitlement_flow/outcomes/_the_user_should_be_aware.erb
+++ b/app/flows/calculate_your_holiday_entitlement_flow/outcomes/_the_user_should_be_aware.erb
@@ -1,5 +1,4 @@
-The user should be aware:
+Leave entitlement accrues differently in a worker’s first year. The user should be aware this tool calculates leave for a worker who:
 
-* leave entitlement accrues differently in a worker's first year
-* when a worker starts part way through the month, they usually accrue one-twelfth of their leave from their first day
-* when a worker leaves employment within the first 12 months, their leave is calculated using the "For someone starting and leaving part way through a leave year" option in the calculator
+* starts part way through the month, by applying one-twelfth of their leave from their first day - an employer can also choose to calculate the first month’s leave 'pro-rata' (in proportion to the number of days worked)
+* leaves employment within the first 12 months, using the “For someone starting and leaving part way through a leave year” option

--- a/app/flows/calculate_your_holiday_entitlement_flow/outcomes/_the_user_should_be_aware.erb
+++ b/app/flows/calculate_your_holiday_entitlement_flow/outcomes/_the_user_should_be_aware.erb
@@ -1,4 +1,4 @@
-Leave entitlement accrues differently in a worker’s first year. The user should be aware this tool calculates leave for a worker who:
+Leave entitlement accrues differently in a worker’s first year. This tool calculates leave for a worker who:
 
-* starts part way through the month, by applying one-twelfth of their leave from their first day - an employer can also choose to calculate the first month’s leave 'pro-rata' (in proportion to the number of days worked)
+* starts part way through the month, by applying one-twelfth of their leave from their first day - an employer can instead choose to calculate the first month’s leave 'pro-rata' (in proportion to the number of days worked)
 * leaves employment within the first 12 months, using the “For someone starting and leaving part way through a leave year” option


### PR DESCRIPTION
Content trello card: https://trello.com/c/NI4wlNoa/5337-incorrect-calculations-for-the-holiday-entitlement-calculator
Dev trello card: https://trello.com/c/sAaj4oz0/350-waiting-for-final-content-holiday-entitlement-calculator-changes

Adding a bullet to explain what happens when an employee starts work part way through the leave year and also their first month. Policy gives them a full month's leave entitlement despite how many days they've worked in the first month. But users expect their leave to be calculated pro-rata as they don't know about the policy. They then complain that the calculator is wrong. This explains the policy to set user expectations and reduce user feedback.

Should only show on calculation outcomes 'for someone starting part way through a leave year'.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
