### PR TITLE
Add stubs for MethodMissingHelper to allow task to sync with Publishing API to run

### DIFF
--- a/app/helpers/content_item_helper.rb
+++ b/app/helpers/content_item_helper.rb
@@ -5,6 +5,17 @@ module ContentItemHelper
       "calculator.holiday_entitlement_days" => 10,
       "calculator.path_to_outcome" => %w[italy ceremony_country opposite_sex],
       "calculator.ceremony_country" => "italy",
+      "calculator.tuition_fee_maximum_full_time" => 0,
+      "calculator.tuition_fee_maximum_part_time" => 0,
+      "calculator.tuition_fee_amount" => 0,
+      "calculator.maintenance_loan_amount" => 0,
+      "calculator.max_loan_amount" => 0,
+      "calculator.loan_shortfall" => 0,
+      "calculator.childcare_grant_one_child" => 0,
+      "calculator.childcare_grant_more_than_one_child" => 0,
+      "calculator.parent_learning_allowance" => 0,
+      "calculator.adult_dependant_allowance" => 0,
+      "calculator.reduced_maintenance_loan_for_healthcare" => 0,
     }.freeze
 
     # rubocop:disable Style/MissingRespondToMissing

--- a/test/fixtures/flows/method_missing_sample_flow.rb
+++ b/test/fixtures/flows/method_missing_sample_flow.rb
@@ -1,0 +1,11 @@
+class MethodMissingSampleFlow < SmartAnswer::Flow
+  def define
+    name "method-missing-sample"
+    money_question :how_much_are_you_owed? do
+      next_node do
+        outcome :done
+      end
+    end
+    outcome :done
+  end
+end

--- a/test/fixtures/flows/method_missing_sample_flow/questions/how_much_are_you_owed.erb
+++ b/test/fixtures/flows/method_missing_sample_flow/questions/how_much_are_you_owed.erb
@@ -1,0 +1,3 @@
+<% text_for :hint do %>
+  I am owed <%= format_money(calculator.tuition_fee_maximum_full_time) %>.
+<% end %>

--- a/test/fixtures/flows/method_missing_sample_flow/start.erb
+++ b/test/fixtures/flows/method_missing_sample_flow/start.erb
@@ -1,0 +1,3 @@
+<% text_for :title do %>
+  Method Missing Flow
+<% end %>

--- a/test/helpers/content_item_helper_test.rb
+++ b/test/helpers/content_item_helper_test.rb
@@ -3,10 +3,6 @@ require "test_helper"
 class ContentItemHelperTest < ActionView::TestCase
   def setup
     setup_fixture_flows
-    @flow = RadioSampleFlow.build
-
-    node = SmartAnswer::StartNode.new(@flow, @flow.name.underscore.to_sym)
-    @start_node = node.presenter
   end
 
   def teardown
@@ -15,6 +11,11 @@ class ContentItemHelperTest < ActionView::TestCase
 
   context "extract_flow_content" do
     should "include all flow content" do
+      flow = RadioSampleFlow.build
+
+      node = SmartAnswer::StartNode.new(flow, flow.name.underscore.to_sym)
+      start_node = node.presenter
+
       expected_content = [
         "Hotter or colder?",
         "Body for hotter or colder",
@@ -27,7 +28,18 @@ class ContentItemHelperTest < ActionView::TestCase
         "Frozen outcome title",
         "Frozen outcome body",
       ]
-      assert_equal expected_content, extract_flow_content(@flow, @start_node)
+      assert_equal expected_content, extract_flow_content(flow, start_node)
+    end
+    should "use placeholder text for missing content" do
+      flow = MethodMissingSampleFlow.build
+
+      node = SmartAnswer::StartNode.new(flow, flow.name.underscore.to_sym)
+      start_node = node.presenter
+
+      expected_content = [
+        "I am owed £0.",
+      ]
+      assert_equal expected_content, extract_flow_content(flow, start_node)
     end
   end
 end


### PR DESCRIPTION
To [update the link title](https://trello.com/c/AaXz4Bmd/685-issue-collections-publisher-student-finance-subtopic-page-links) for the student finance calculator smart answer it is necessary to run the `publishing_api:sync` task for the `student-finance-calculator` flow.

The sync task fails when [rendering the content](https://github.com/alphagov/smart-answers/blob/7b50854a49acbba7ed053f5dd8b495554744ac37/app/presenters/content_item_presenter.rb#L17) to produce the payload to send to Publishing API. Some erb files are rendered with the calculator object being substituted with a [MethodMissingObject](https://github.com/alphagov/smart-answers/blob/7e03250fe3c5a9544c1ebeb8ddc02c88686f62fa/lib/method_missing_object.rb). In cases where a property is read on this object the program will throw an exception e.g. when rendering the question ["how much are your tuition fees per year"](https://github.com/alphagov/smart-answers/blob/0b785e830268ecd9d14eb9fd1184e94a919f3135/app/flows/student_finance_calculator_flow/questions/how_much_are_your_tuition_fees_per_year.erb#L6).

Stub values for the missing methods have been added in [ContentItemHelper](https://github.com/alphagov/smart-answers/blob/224425d4ef76d4d0e33cf69030a8cd5aae76defb/app/helpers/content_item_helper.rb). The impact of this change is that the payload sent to Publishing API (for `hidden_search_terms` attribute) will contain a value of "£0" in each instance where the stub methods are used. 