### PR TITLE
Docs - updating smart answer metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ bundle exec rake
 * [Deploying changes for fact-check](docs/tasks/fact-check.md)
 * [Creating a new Smart Answer](docs/tasks/creating-a-new-smart-answer.md)
 * [Publishing a Smart Answer](docs/tasks/publishing.md)
+* [Updating a Smart Answer](docs/tasks/updating.md)
 * [Retiring a Smart Answer](docs/tasks/retiring-a-smart-answer.md)
 
 Further guidance is available in [`docs/tasks`](docs/tasks).

--- a/docs/tasks/updating.md
+++ b/docs/tasks/updating.md
@@ -1,0 +1,5 @@
+### Updating
+
+Any changes to a Smart Answer's metadata, such as the title or description need to be sent to the Publishing API for them to appear on GOV.UK.
+
+Follow the instructions for [publishing a Smart Answer](publishing.md) to ensure the changes are synchronised on the Publishing API.


### PR DESCRIPTION
- Add a section in the documentation to inform developers that changes to Smart Answer metadata need to be synced with the Publisher API in order to appear on GOV.UK
- Direct devs to follow the instructions for publishing a smart answer
