### PR TITLE
Replace links to whitehall eta guidance in the Check UK visa smart answer

### DIFF
--- a/app/flows/check_uk_visa_flow/outcomes/_electronic_travel_authorisation_advice.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/_electronic_travel_authorisation_advice.erb
@@ -1,5 +1,5 @@
 <% if calculator.passport_country_in_eta_rollout_group_1_rest_of_the_world? %>
-  ^If you’re travelling on or after 8 January 2025, you’ll need to apply for an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta). 
+  ^If you’re travelling on or after 8 January 2025, you’ll need to apply for an [electronic travel authorisation (ETA)](/eta). 
 <% elsif calculator.passport_country_in_eta_rollout_group_2_eu_eea? %>
-  ^If you’re travelling on or after 2 April 2025, you’ll need to apply for an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta).
+  ^If you’re travelling on or after 2 April 2025, you’ll need to apply for an [electronic travel authorisation (ETA)](/eta).
 <% end %>

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_diplomatic_business.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_diplomatic_business.erb
@@ -17,7 +17,7 @@
 
 You will not need a visa to transit through the UK (on your way to another country) while travelling on any official government business if you:
 
-+ have an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta)
++ have an [electronic travel authorisation (ETA)](/eta)
 + have an [EU Settlement Scheme family permit](/family-permit/eu-settlement-scheme-family-permit)
 + have a [Home Office travel document](/apply-home-office-travel-document), for example you're a refugee or stateless person
 + have a [Standard Visitor visa](/standard-visitor)

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_marriage_nvn.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_marriage_nvn.erb
@@ -25,7 +25,7 @@
   <% if calculator.passport_country_requires_electronic_travel_authorisation? %>
     You'll need to apply for either:
 
-    - an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta)
+    - an [electronic travel authorisation (ETA)](/eta)
     - a [Standard Visitor visa](/standard-visitor/apply-standard-visitor-visa)
   <% else %>
     You will not need a visa but you must meet the [Standard Visitor eligibility requirements](/standard-visitor).

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_marriage_taiwan.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_marriage_taiwan.erb
@@ -15,7 +15,7 @@
 
   You will not need a visa if your passport has a personal ID number on the bio data page. 
 
-  You’ll need to [apply for an electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta) instead.
+  You’ll need to [apply for an electronic travel authorisation (ETA)](/eta) instead.
 
   [Check what documents you need to bring](/government/publications/visitor-visa-guide-to-supporting-documents) to show officers at the UK border.
 

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_medical_electronic_travel_authorisation.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_medical_electronic_travel_authorisation.erb
@@ -8,7 +8,7 @@
   <% end %>
   You must apply for either:
 
-  - an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta)
+  - an [electronic travel authorisation (ETA)](/eta)
   - a [Standard Visitor visa](/standard-visitor)
 
   ^The rules on what you’ll need to enter the UK may be different if you’re [travelling from Ireland, Jersey, Guernsey or the Isle of Man](/guidance/travelling-between-the-uk-and-ireland-isle-of-man-guernsey-or-jersey).

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_no_visa_needed.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_no_visa_needed.erb
@@ -10,7 +10,7 @@
 <% govspeak_for :body do %>
 
   <% if calculator.passport_country_requires_electronic_travel_authorisation? %>
-    [Apply for an ETA](/guidance/apply-for-an-electronic-travel-authorisation-eta).
+    [Apply for an ETA](/eta).
   <% end %>
 
   <% if (calculator.travelling_to_elsewhere? || calculator.travelling_to_ireland?) &&
@@ -52,7 +52,7 @@
   ##If you’re travelling on or after 2 April 2025
     You'll need an electronic travel authorisation (ETA) to pass through UK border control.
 
-    [Apply for an ETA](/guidance/apply-for-an-electronic-travel-authorisation-eta).
+    [Apply for an ETA](/eta).
 
     You do not need an ETA if you will not pass through UK border control. You should bring evidence of your onward journey, such as a ticket to your destination.
 

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_school_electronic_travel_authorisation.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_school_electronic_travel_authorisation.erb
@@ -10,7 +10,7 @@
 
   ##If you're staying up to 6 months
 
-  You'll need an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta) to stay for up to 6 months.
+  You'll need an [electronic travel authorisation (ETA)](/eta) to stay for up to 6 months.
 
   %If you have a criminal record or you’ve previously been refused entry into the UK, you may want to apply for a [Standard Visitor visa](/standard-visitor/apply-standard-visitor-visa).
 

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_study_electronic_travel_authorisation.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_study_electronic_travel_authorisation.erb
@@ -8,7 +8,7 @@
   <% end %>
   You must apply for either:
 
-  - an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta)
+  - an [electronic travel authorisation (ETA)](/eta)
   - a [Standard Visitor visa](/standard-visitor/apply-standard-visitor-visa)
 
   %You may want to [apply for a Standard Visitor visa](/standard-visitor/apply-standard-visitor-visa) if you have a criminal record or you’ve previously been refused entry into the UK.

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_study_waiver_taiwan.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_study_waiver_taiwan.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% govspeak_for :body do %>
-  You’ll need to [apply for an electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta) instead.
+  You’ll need to [apply for an electronic travel authorisation (ETA)](/eta) instead.
 
   [Check what other documents you need to bring](/government/publications/visitor-visa-guide-to-supporting-documents) to show officers at the UK border.
 

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_tourism_electronic_travel_authorisation.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_tourism_electronic_travel_authorisation.erb
@@ -8,7 +8,7 @@
   <% end %>
   You must apply for either:
 
-  - an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta)
+  - an [electronic travel authorisation (ETA)](/eta)
   - a [Standard Visitor visa](/standard-visitor)
 
   %You may want to [apply for a Standard Visitor](/standard-visitor/apply-standard-visitor-visa) visa if you have a criminal record or you’ve previously been refused entry into the UK.

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_transit_taiwan_through_border_control.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_transit_taiwan_through_border_control.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% govspeak_for :body do %>
-  You’ll need to [apply for an electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta) instead.
+  You’ll need to [apply for an electronic travel authorisation (ETA)](/eta) instead.
 
   You should also bring the [same documents](/government/publications/visitor-visa-guide-to-supporting-documents) you’d need to apply for a visa to show to officers at the UK border.
 

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_transit_to_the_republic_of_ireland.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_transit_to_the_republic_of_ireland.erb
@@ -8,7 +8,7 @@
 
 <% govspeak_for :body do %>
   <% if calculator.passport_country_is_taiwan? %>
-    You’ll need to [apply for an electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta) instead.
+    You’ll need to [apply for an electronic travel authorisation (ETA)](/eta) instead.
 
     You must meet the [Standard Visitor eligibility requirements](/standard-visitor).
 

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_transit_to_the_republic_of_ireland_electronic_travel_authorisation.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_transit_to_the_republic_of_ireland_electronic_travel_authorisation.erb
@@ -6,7 +6,7 @@
   <% if calculator.passport_country_is_taiwan? %>
     <%= render partial: "electronic_travel_authorisation_taiwan", locals: {calculator: calculator} %>
   <% end %>
-    [Apply for an ETA](/guidance/apply-for-an-electronic-travel-authorisation-eta).
+    [Apply for an ETA](/eta).
 
     You do not need an ETA if you will not pass through UK border control. You should bring evidence of your onward journey, such as a ticket to your destination.
 

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_visit_waiver_taiwan.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_visit_waiver_taiwan.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% govspeak_for :body do %>
-  You’ll need to [apply for an electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta) instead.
+  You’ll need to [apply for an electronic travel authorisation (ETA)](/eta) instead.
 
   [Check what other documents you need to bring](/government/publications/visitor-visa-guide-to-supporting-documents) to show officers at the UK border.
 

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_work_electronic_travel_authorisation.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_work_electronic_travel_authorisation.erb
@@ -10,7 +10,7 @@
 
   You need an ETA for some business and academic activities, but you must get a visa if you plan to work in the UK.
 
-  You will need to [apply for an ETA](/guidance/apply-for-an-electronic-travel-authorisation-eta) to come to the UK if you're either:
+  You will need to [apply for an ETA](/eta) to come to the UK if you're either:
 
   - invited as an expert in your profession doing a '[permitted paid engagement](/standard-visitor/paid-engagement-event)'
   - visiting for certain business or academic activities, but not working in the UK
@@ -19,7 +19,7 @@
 
   ##If you’re invited as an expert in your profession
 
-  You can come to the UK as a Standard Visitor for up to 6 months if you [apply for an ETA](/guidance/apply-for-an-electronic-travel-authorisation-eta). You can only be paid by a UK-based organisation to do certain things, for example:
+  You can come to the UK as a Standard Visitor for up to 6 months if you [apply for an ETA](/eta). You can only be paid by a UK-based organisation to do certain things, for example:
 
   - give guest lectures at a higher education institution
   - provide advocacy in legal proceedings
@@ -48,7 +48,7 @@
 
   ##If you’re visiting for certain business or academic activities
 
-  You can come to the UK as a Standard Visitor for up to 6 months if you [apply for an ETA](/guidance/apply-for-an-electronic-travel-authorisation-eta). You can only do certain business or academic activities, for example go to a conference or a meeting.
+  You can come to the UK as a Standard Visitor for up to 6 months if you [apply for an ETA](/eta). You can only do certain business or academic activities, for example go to a conference or a meeting.
 
   You cannot:
 

--- a/app/flows/check_uk_visa_flow/outcomes/trinidad-and-tobago/_outcome_marriage_visa_nat_direct_airside_transit_visa.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/trinidad-and-tobago/_outcome_marriage_visa_nat_direct_airside_transit_visa.erb
@@ -7,7 +7,7 @@
 
     ###If you’re arriving in the UK before 3pm (UK time) on 23 April 2025
 
-    You may be able to use an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta) to come to the UK if you already have one.
+    You may be able to use an [electronic travel authorisation (ETA)](/eta) to come to the UK if you already have one.
 
 
     All of the following must apply:

--- a/app/flows/check_uk_visa_flow/outcomes/trinidad-and-tobago/_outcome_medical_y.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/trinidad-and-tobago/_outcome_medical_y.erb
@@ -9,7 +9,7 @@
     You can come to the UK with either of the following:
 
     * a [Standard Visitor visa](/standard-visitor)
-    * an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta), if you already have one 
+    * an [electronic travel authorisation (ETA)](/eta), if you already have one 
 
     You must meet the [Standard Visitor visa](/standard-visitor) eligibility requirements even if you have an ETA.
 

--- a/app/flows/check_uk_visa_flow/outcomes/trinidad-and-tobago/_outcome_partner_family_british_citizen_y_2.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/trinidad-and-tobago/_outcome_partner_family_british_citizen_y_2.erb
@@ -1,7 +1,7 @@
 <% if calculator.passport_country_is_trinidad_and_tobago? && Time.zone.now <= Time.zone.local(2025, 4, 23) %>
     ##If you’re arriving in the UK before 3pm (UK time) on 23 April 2025
 
-    You may be able to use an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta) to come to the UK if you already have one.
+    You may be able to use an [electronic travel authorisation (ETA)](/eta) to come to the UK if you already have one.
 
     All of the following must apply:
 

--- a/app/flows/check_uk_visa_flow/outcomes/trinidad-and-tobago/_outcome_partner_family_eea_n_2.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/trinidad-and-tobago/_outcome_partner_family_eea_n_2.erb
@@ -1,7 +1,7 @@
 <% if calculator.passport_country_is_trinidad_and_tobago? && Time.zone.now <= Time.zone.local(2025, 4, 23) %>
     ##If you’re arriving in the UK before 3pm (UK time) on 23 April 2025
 
-    You may be able to use your [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta) to come to the UK if you already have one.
+    You may be able to use your [electronic travel authorisation (ETA)](/eta) to come to the UK if you already have one.
 
     All of the following must apply:
 

--- a/app/flows/check_uk_visa_flow/outcomes/trinidad-and-tobago/_outcome_partner_family_eea_y.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/trinidad-and-tobago/_outcome_partner_family_eea_y.erb
@@ -1,7 +1,7 @@
 <% if calculator.passport_country_is_trinidad_and_tobago? && Time.zone.now <= Time.zone.local(2025, 4, 23) %>
     ###If you’re arriving in the UK before 3pm (UK time) on 23 April 2025
 
-    You may be able to use an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta) to come to the UK if you already have one.
+    You may be able to use an [electronic travel authorisation (ETA)](/eta) to come to the UK if you already have one.
 
     All of the following must apply:
 

--- a/app/flows/check_uk_visa_flow/outcomes/trinidad-and-tobago/_outcome_school_y.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/trinidad-and-tobago/_outcome_school_y.erb
@@ -1,7 +1,7 @@
 <% if calculator.passport_country_is_trinidad_and_tobago? && Time.zone.now <= Time.zone.local(2025, 4, 23) %>
     ##If you’re arriving in the UK before 3pm (UK time) on 23 April 2025
 
-    You may be able to use an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta) to come to the UK if you already have one.
+    You may be able to use an [electronic travel authorisation (ETA)](/eta) to come to the UK if you already have one.
 
     All of the following must apply:
 

--- a/app/flows/check_uk_visa_flow/outcomes/trinidad-and-tobago/_outcome_standard_visitor_visa.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/trinidad-and-tobago/_outcome_standard_visitor_visa.erb
@@ -1,7 +1,7 @@
 <% if calculator.passport_country_is_trinidad_and_tobago? && Time.zone.now <= Time.zone.local(2025, 4, 23) %>
     ##If you’re arriving in the UK before 3pm (UK time) on 23 April 2025
 
-    You may be able to use an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta) to come to the UK if you already have one.
+    You may be able to use an [electronic travel authorisation (ETA)](/eta) to come to the UK if you already have one.
 
     All of the following must apply:
 

--- a/app/flows/check_uk_visa_flow/outcomes/trinidad-and-tobago/_outcome_study_m.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/trinidad-and-tobago/_outcome_study_m.erb
@@ -1,7 +1,7 @@
 <% if calculator.passport_country_is_trinidad_and_tobago? && Time.zone.now <= Time.zone.local(2025, 4, 23) %>
     ##If you’re arriving in the UK before 3pm (UK time) on 23 April 2025
 
-    You may be able to use an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta) to come to the UK if you already have one.
+    You may be able to use an [electronic travel authorisation (ETA)](/eta) to come to the UK if you already have one.
 
     All of the following must apply:
 

--- a/app/flows/check_uk_visa_flow/outcomes/trinidad-and-tobago/_outcome_tourism_visa_partner.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/trinidad-and-tobago/_outcome_tourism_visa_partner.erb
@@ -1,7 +1,7 @@
 <% if calculator.passport_country_is_trinidad_and_tobago? && Time.zone.now <= Time.zone.local(2025, 4, 23) %>
     ##If you’re arriving in the UK before 3pm (UK time) on 23 April 2025
 
-    You may be able to use an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta) to come to the UK if you already have one.
+    You may be able to use an [electronic travel authorisation (ETA)](/eta) to come to the UK if you already have one.
 
     All of the following must apply:
 

--- a/app/flows/check_uk_visa_flow/outcomes/trinidad-and-tobago/_outcome_transit_leaving_airport_direct_airside_transit_visa_2.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/trinidad-and-tobago/_outcome_transit_leaving_airport_direct_airside_transit_visa_2.erb
@@ -1,7 +1,7 @@
 <% if calculator.passport_country_is_trinidad_and_tobago? && Time.zone.now <= Time.zone.local(2025, 4, 23) %>
     ##If you’re arriving in the UK before 3pm (UK time) on 23 April 2025
 
-    You may be able to use an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta) to pass through the UK if you already have one.
+    You may be able to use an [electronic travel authorisation (ETA)](/eta) to pass through the UK if you already have one.
 
     All of the following must apply:
 

--- a/app/flows/check_uk_visa_flow/outcomes/trinidad-and-tobago/_outcome_transit_to_the_republic_of_ireland_2.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/trinidad-and-tobago/_outcome_transit_to_the_republic_of_ireland_2.erb
@@ -1,7 +1,7 @@
 <% if calculator.passport_country_is_trinidad_and_tobago? && Time.zone.now <= Time.zone.local(2025, 4, 23) %>
     ##If you’re arriving in the UK before 3pm (UK time) on 23 April 2025
 
-    You may be able to use an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta) to pass through the UK if you already have one.
+    You may be able to use an [electronic travel authorisation (ETA)](/eta) to pass through the UK if you already have one.
 
     All of the following must apply:
 

--- a/app/flows/check_uk_visa_flow/outcomes/trinidad-and-tobago/_outcome_work_m_2.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/trinidad-and-tobago/_outcome_work_m_2.erb
@@ -1,7 +1,7 @@
 <% if calculator.passport_country_is_trinidad_and_tobago? && Time.zone.now <= Time.zone.local(2025, 4, 23) %>
     ##If you’re arriving in the UK before 3pm (UK time) on 23 April 2025
 
-    You may be able to use an [electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta) to come to the UK if you already have one.
+    You may be able to use an [electronic travel authorisation (ETA)](/eta) to come to the UK if you already have one.
 
     All of the following must apply:
 
@@ -11,7 +11,7 @@
 
     You can use an ETA for some business and academic activities, but you must get a visa if you plan to work in the UK.
 
-    You can use [an ETA](/guidance/apply-for-an-electronic-travel-authorisation-eta) to come to the UK if you’re either:
+    You can use [an ETA](/eta) to come to the UK if you’re either:
 
     - invited as an expert in your profession doing a ‘[permitted paid engagement](/standard-visitor/paid-engagement-event)’
     - visiting for certain business or academic activities, but not working in the UK
@@ -20,7 +20,7 @@
 
     ## If you’re invited as an expert in your profession and you have an ETA
 
-    You can use [an ETA](/guidance/apply-for-an-electronic-travel-authorisation-eta) to come to the UK for up to 6 months. You can only be paid by a UK-based organisation to do certain things, for example:
+    You can use [an ETA](/eta) to come to the UK for up to 6 months. You can only be paid by a UK-based organisation to do certain things, for example:
 
     - give guest lectures at a higher education institution
     - provide advocacy in legal proceedings
@@ -47,7 +47,7 @@
 
     ## If you’re visiting for certain business or academic activities and you have an ETA
 
-    You can come to the UK as a Standard Visitor for up to 6 months using [an ETA](/guidance/apply-for-an-electronic-travel-authorisation-eta) if you already have one. You can only do certain business or academic activities, for example go to a conference or a meeting.
+    You can come to the UK as a Standard Visitor for up to 6 months using [an ETA](/eta) if you already have one. You can only do certain business or academic activities, for example go to a conference or a meeting.
 
     You cannot:
 


### PR DESCRIPTION
This PR replaces all links to the Whitehall ETA guidance (http://www.gov.uk/guidance/apply-for-an-electronic-travel-authorisation-eta) across the 'Check if you need a UK visa' smart answer, with links to the Mainstream ETA guide (www.gov.uk/eta).

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
