### PR TITLE
rename czech republic to czechia

### DIFF
--- a/config/smart_answers/passport_data.yml
+++ b/config/smart_answers/passport_data.yml
@@ -536,7 +536,7 @@ cyprus:
   applying: 6 weeks
   replacing: 6 weeks
   optimistic_processing_time?: true
-czech-republic:
+czechia:
   type: ips_application_1
   group: ips_documents_group_1
   app_form: hmpo_1_application_form

--- a/config/smart_answers/translators.yml
+++ b/config/smart_answers/translators.yml
@@ -20,7 +20,7 @@ colombia: /government/publications/colombia-list-of-lawyers
 democratic-republic-of-the-congo: /government/publications/democratic-republic-of-congo-list-of-lawyers
 cuba: /government/publications/cuba-list-of-lawyers
 cyprus: /government/publications/cyprus-list-of-lawyers
-czech-republic: /government/publications/czech-republic-list-of-lawyers
+czechia: /government/publications/czech-republic-list-of-lawyers
 egypt: /government/publications/egypt-list-of-lawyers
 el-salvador: /government/publications/el-salvador-list-of-lawyers
 eritrea: /government/publications/eritrea-list-of-lawyers

--- a/lib/smart_answer/calculators/country_name_formatter.rb
+++ b/lib/smart_answer/calculators/country_name_formatter.rb
@@ -3,7 +3,6 @@ module SmartAnswer::Calculators
     COUNTRIES_WITH_DEFINITIVE_ARTICLES = %w[bahamas
                                             british-virgin-islands
                                             cayman-islands
-                                            czech-republic
                                             democratic-republic-of-the-congo
                                             dominican-republic
                                             falkland-islands

--- a/lib/smart_answer/calculators/uk_benefits_abroad_calculator.rb
+++ b/lib/smart_answer/calculators/uk_benefits_abroad_calculator.rb
@@ -55,7 +55,7 @@ module SmartAnswer::Calculators
                        bulgaria
                        croatia
                        cyprus
-                       czech-republic
+                       czechia
                        denmark
                        estonia
                        finland

--- a/lib/smart_answer/calculators/uk_visa_calculator.rb
+++ b/lib/smart_answer/calculators/uk_visa_calculator.rb
@@ -526,7 +526,7 @@ module SmartAnswer::Calculators
       bulgaria
       croatia
       cyprus
-      czech-republic
+      czechia
       denmark
       estonia
       finland
@@ -579,7 +579,7 @@ module SmartAnswer::Calculators
       croatia
       curacao
       cyprus
-      czech-republic
+      czechia
       denmark
       estonia
       federated-states-of-micronesia
@@ -660,7 +660,7 @@ module SmartAnswer::Calculators
       canada
       croatia
       cyprus
-      czech-republic
+      czechia
       denmark
       estonia
       finland

--- a/test/fixtures/worldwide/czechia_organisations.json
+++ b/test/fixtures/worldwide/czechia_organisations.json
@@ -30,10 +30,10 @@
               "postal-code": "",
               "locality": "Prague",
               "region": "",
-              "country-name": "Czech Republic"
+              "country-name": "Czechia"
             },
             "label": {
-              "value": "Thunovska 14\r\n118 00\n Prague\nCzech Republic"
+              "value": "Thunovska 14\r\n118 00\n Prague\nCzechia"
             }
           },
           "contact_numbers": [
@@ -93,10 +93,10 @@
                 "postal-code": "",
                 "locality": "Prague",
                 "region": "",
-                "country-name": "Czech Republic"
+                "country-name": "Czechia"
               },
               "label": {
-                "value": "Thunovska 14\r\n118 00  \n Prague\nCzech Republic"
+                "value": "Thunovska 14\r\n118 00  \n Prague\nCzechia"
               }
             },
             "contact_numbers": [
@@ -132,10 +132,10 @@
                 "postal-code": "",
                 "locality": "Prague",
                 "region": "",
-                "country-name": "Czech Republic"
+                "country-name": "Czechia"
               },
               "label": {
-                "value": "Thunovska 14\r\n118 00\n Prague\nCzech Republic"
+                "value": "Thunovska 14\r\n118 00\n Prague\nCzechia"
               }
             },
             "contact_numbers": [
@@ -171,10 +171,10 @@
                 "postal-code": "",
                 "locality": "Prague 1",
                 "region": "",
-                "country-name": "Czech Republic"
+                "country-name": "Czechia"
               },
               "label": {
-                "value": "Thunovska 14\r\n118 00\n Prague 1\nCzech Republic"
+                "value": "Thunovska 14\r\n118 00\n Prague 1\nCzechia"
               }
             },
             "contact_numbers": [
@@ -201,7 +201,7 @@
     },
     {
       "id": "https://www.gov.uk/api/worldwide-organisations/department-for-international-trade-czech-republic",
-      "title": "Department for International Trade Czech Republic",
+      "title": "Department for International Trade Czechia",
       "format": "Worldwide Organisation",
       "updated_at": "2018-05-29T13:24:53.000+01:00",
       "web_url": "https://www.gov.uk/world/organisations/department-for-international-trade-czech-republic",
@@ -211,7 +211,7 @@
       "analytics_identifier": "WO222",
       "offices": {
         "main": {
-          "title": "Department for International Trade Czech Republic",
+          "title": "Department for International Trade Czechia",
           "format": "World Office",
           "updated_at": "2013-03-25T10:37:54.000+00:00",
           "web_url": "https://www.gov.uk/world/organisations/department-for-international-trade-czech-republic/office/uk-trade-investment-czech-republic",
@@ -229,10 +229,10 @@
               "postal-code": "11800",
               "locality": "",
               "region": "Prague",
-              "country-name": "Czech Republic"
+              "country-name": "Czechia"
             },
             "label": {
-              "value": "British Embassy Prague\nThunovska 14\n11800 \nCzech Republic"
+              "value": "British Embassy Prague\nThunovska 14\n11800 \nCzechia"
             }
           },
           "contact_numbers": [
@@ -261,7 +261,7 @@
     },
     {
       "id": "https://www.gov.uk/api/worldwide-organisations/uk-science-innovation-network-in-the-czech-republic",
-      "title": "UK Science & Innovation Network in the Czech Republic",
+      "title": "UK Science & Innovation Network in Czechia",
       "format": "Worldwide Organisation",
       "updated_at": "2016-03-02T13:54:21.000+00:00",
       "web_url": "https://www.gov.uk/world/organisations/uk-science-innovation-network-in-the-czech-republic",
@@ -301,7 +301,7 @@
     "status": "ok",
     "links": [
       {
-        "href": "https://www.gov.uk/api/world-locations/czech-republic/organisations?page=1",
+        "href": "https://www.gov.uk/api/world-locations/czechia/organisations?page=1",
         "rel": "self"
       }
     ]

--- a/test/fixtures/worldwide_locations.yml
+++ b/test/fixtures/worldwide_locations.yml
@@ -53,7 +53,7 @@
 - cuba
 - curacao
 - cyprus
-- czech-republic
+- czechia
 - democratic-republic-of-the-congo
 - denmark
 - djibouti


### PR DESCRIPTION
Replace 'Czech republic' with 'Czechia' - content request [Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?assignee=5caf4d888c2c1a75f3e46ef6&selectedIssue=WHIT-1884)

Following these [docs](https://docs.publishing.service.gov.uk/manual/rename-a-country.html#1-update-travel-advice-publisher)

Previous [example](https://trello.com/c/SU6BliYA/2438-replace-micronesia-with-federated-states-of-micronesia-content-request) of country name change

**NB**

1. The link in translators.yml is currently being redirected, so i don't think we need to change the actual link.
2. I believe we can remove Czechia from the [lib/smart_answer/calculators/country_name_formatter.rb](https://github.com/alphagov/smart-answers/compare/rename-czech-rep?expand=1#diff-ec2aab8dd1ad05e3396b7837dc6b77a97b4337685e3d0d0e093481c9bd0a4c22), as Czechia is the standalone name in English
3. I've changed what I believe to be relevant in [test/fixtures/worldwide/czechia_organisations.json](https://github.com/alphagov/smart-answers/compare/rename-czech-rep?expand=1#diff-cfa26467debb2fbf6ef263fbf6ae54c39d0990710ef9818dd367599f9e84f125), but there may still be references to 'czech republic' with regards to some of the links. I'm reluctant to change these at the moment, and given it's a test fixture I don't think it's a blocker.  