### PR TITLE
Add new flow for Child Benefit

### DIFF
--- a/app/flows/child_benefit_tax_calculator_flow.rb
+++ b/app/flows/child_benefit_tax_calculator_flow.rb
@@ -30,6 +30,24 @@ class ChildBenefitTaxCalculatorFlow < SmartAnswer::Flow
         calculator.tax_year = response
       end
 
+      next_node do |response|
+        if response == "2024"
+          question :between_april_june?
+        else
+          question :is_part_year_claim?
+        end
+      end
+    end
+
+    # Q2-b
+    radio :between_april_june? do
+      option :yes
+      option :no
+
+      on_response do |response|
+        calculator.between_april_june = response
+      end
+
       next_node do
         question :is_part_year_claim?
       end

--- a/app/flows/child_benefit_tax_calculator_flow/outcomes/results.erb
+++ b/app/flows/child_benefit_tax_calculator_flow/outcomes/results.erb
@@ -17,12 +17,8 @@
 
   <% if calculator.calculate_adjusted_net_income < one_percent_check %>
 
-    <% if calculator.tax_year == "2024" %>
-      ^If you made a new claim between 6 April 2024 and 7 July 2024, it may be backdated by up to 3 months. To calculate the amount to be included in your 2024 to 2025 tax return, use the Child Benefit tax calculator for the tax year 2023 to 2024. Add this estimated Child Benefit and tax to your 2024 to 2025 tax year calculator results.^
-    <% end %>
-
-    <% if calculator.tax_year == "2023" %>
-      ^If you made a new claim between 6 April 2024 and 7 July 2024 and are calculating your backdated amount, you do not need to send a separate Self Assessment tax return for 2023 to 2024. Add the estimated Child Benefit and tax to your 2024 to 2025 Child Benefit tax calculation results.^
+    <% if calculator.between_april_june == "yes" %>
+      If you made a new claim between 6 April 2024 and 7 July 2024, it may be backdated by up to 3 months. To calculate the amount to be included in your 2024 to 2025 tax return, use the Child Benefit tax calculator for the tax year 2023 to 2024. Add this estimated Child Benefit and tax to your 2024 to 2025 tax year calculator results.
     <% end %>
 
     There is no tax charge if your income is below <%= number_to_currency one_percent_check, unit: "£", precision: 0 %>.

--- a/app/flows/child_benefit_tax_calculator_flow/questions/between_april_june.erb
+++ b/app/flows/child_benefit_tax_calculator_flow/questions/between_april_june.erb
@@ -1,0 +1,9 @@
+<% text_for :title do %>
+  Did you claim child benefit between 6 April 2024 
+  and 7 July 2024?
+<% end %>
+
+<% options(
+  "yes": "Yes",
+  "no": "No",
+) %>

--- a/lib/smart_answer/calculators/child_benefit_tax_calculator.rb
+++ b/lib/smart_answer/calculators/child_benefit_tax_calculator.rb
@@ -7,7 +7,8 @@ module SmartAnswer::Calculators
                   :allowable_deductions,
                   :other_allowable_deductions,
                   :part_year_claim_dates,
-                  :child_number
+                  :child_number,
+                  :between_april_june
 
     attr_reader :child_benefit_rates
 
@@ -30,6 +31,7 @@ module SmartAnswer::Calculators
       @part_year_claim_dates = HashWithIndifferentAccess.new
       @child_number = 1
       @child_benefit_rates = self.class.child_benefit_rates
+      @between_april_june = "no"
     end
 
     def self.tax_years

--- a/test/flows/child_benefit_tax_calculator_flow_test.rb
+++ b/test/flows/child_benefit_tax_calculator_flow_test.rb
@@ -48,6 +48,32 @@ class ChildBenefitTaxCalculatorFlowTest < ActiveSupport::TestCase
       should "have a next node of is_part_year_claim?" do
         assert_next_node :is_part_year_claim?, for_response: "2021"
       end
+
+      should "have a next node of between_april_june? for 2024" do
+        assert_next_node :between_april_june?, for_response: "2024"
+      end
+    end
+  end
+
+  context "question: between_april_june?" do
+    setup do
+      testing_node :between_april_june?
+      add_responses how_many_children?: "5",
+                    which_tax_year?: "2024"
+    end
+
+    should "render the question" do
+      assert_rendered_question
+    end
+
+    context "next_node" do
+      should "have a next node of is_part_year_claim? for a 'yes' response" do
+        assert_next_node :is_part_year_claim?, for_response: "yes"
+      end
+
+      should "have a next node of is_part_year_claim? for a 'no' response" do
+        assert_next_node :is_part_year_claim?, for_response: "no"
+      end
     end
   end
 
@@ -351,6 +377,7 @@ class ChildBenefitTaxCalculatorFlowTest < ActiveSupport::TestCase
     should "render no tax charge when the net income is below £60,200 in 2024" do
       add_responses how_many_children?: "1",
                     which_tax_year?: "2024",
+                    between_april_june?: "no",
                     is_part_year_claim?: "no",
                     income_details?: "70000",
                     add_allowable_deductions?: "yes",
@@ -401,19 +428,10 @@ class ChildBenefitTaxCalculatorFlowTest < ActiveSupport::TestCase
       assert_rendered_outcome text: "Received between 7 January and 5 April 2013"
     end
 
-    should "render specific guidance when the tax year is 2023-2024" do
-      add_responses how_many_children?: "1",
-                    which_tax_year?: "2023",
-                    is_part_year_claim?: "no",
-                    income_details?: "50000",
-                    add_allowable_deductions?: "no"
-
-      assert_rendered_outcome text: "If you made a new claim between 6 April 2024 and 7 July 2024 and are calculating your backdated amount"
-    end
-
-    should "render specific guidance when the tax year is 2024-2025" do
+    should "render specific guidance when the tax year is 2024 and the claim is between April and June" do
       add_responses how_many_children?: "1",
                     which_tax_year?: "2024",
+                    between_april_june?: "yes",
                     is_part_year_claim?: "no",
                     income_details?: "50000",
                     add_allowable_deductions?: "no"


### PR DESCRIPTION
Slight modification to the calculator to reflect a focus on a specific 3 month gap and the users in that gap that need to do something differently. Previous 2023 year details needed to be removed.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
