### PR TITLE
Add handling for extreme date range to Smart Answers

### DIFF
--- a/lib/smart_answer/question/date.rb
+++ b/lib/smart_answer/question/date.rb
@@ -66,7 +66,6 @@ module SmartAnswer
                end
 
         validate_input(date)
-        date
       rescue ArgumentError => e
         if e.message =~ /invalid date/
           raise InvalidResponse, "Bad date: #{input.inspect}", caller
@@ -85,9 +84,15 @@ module SmartAnswer
       def validate_input(date)
         raise "from date must not be after the to date" if from && to && from > to
 
+        if date.year < 100
+          date = ::Date.new(date.year.to_i + 2000, date.month, date.day)
+        end
+
         if (from && date < from) || (to && date > to)
           raise InvalidResponse, "Provided date is out of range: #{date}", caller
         end
+
+        date
       end
     end
   end


### PR DESCRIPTION
There are cases where the user can type in a date, and sometimes this leads to the user entering just two numbers instead of a full date.

Further down the stack this lead to incorrect dates and days being recorded - for instance, "23" would lead to 0023 in the final result.

This new validation checks for cases where the date is less than the year 100, implying only two digits entered, and brings the actual date in line with expectations - essentially adding 2000 years.

It is a little bit of a workaround, however doing this validation here can cover many instances where this is a problem.

It was first observed in the VAT Payment Deadline calculator.

https://trello.com/c/sW01g4cQ/362-change-step-1-of-vat-payment-deadline-calculator-should-not-be-free-text

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
