### PR TITLE
Update minitest to 6.0.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ group :test do
   gem "launchy"
   gem "minitest"
   gem "minitest-focus"
+  gem "minitest-mock"
   gem "mocha", require: false
   gem "rails-controller-testing"
   gem "shoulda"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -274,9 +274,12 @@ GEM
     mime-types-data (3.2026.0407)
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
-    minitest (5.27.0)
+    minitest (6.0.3)
+      drb (~> 2.0)
+      prism (~> 1.5)
     minitest-focus (1.4.1)
       minitest (> 5.0)
+    minitest-mock (5.27.0)
     mocha (3.1.0)
       ruby2_keywords (>= 0.0.5)
     msgpack (1.8.0)
@@ -726,6 +729,7 @@ DEPENDENCIES
   method_source
   minitest
   minitest-focus
+  minitest-mock
   mocha
   nokogiri
   parser

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,6 +8,8 @@ require "simplecov-rcov"
 
 require "rails/test_help"
 
+require "minitest/mock"
+
 require "mocha/minitest"
 Mocha.configure { |c| c.stubbing_non_existent_method = :prevent }
 


### PR DESCRIPTION
Minitest 6 no longer includes its mocking framework, so the `minitest-mock` gem has been added to the Gemfile and required in `test_helper.rb`.