### PR TITLE
Add a callout to the employer maternity, paternity adoption calculator

### DIFF
--- a/app/flows/maternity_paternity_calculator_flow/start.erb
+++ b/app/flows/maternity_paternity_calculator_flow/start.erb
@@ -12,6 +12,7 @@
   + Statutory Maternity Pay (SMP), paternity pay, adoption pay
   + relevant employment period and average weekly earnings
   + leave period
+  %This calculator is being updated.<br>It will not currently give accurate results for Paternity Leave.
 <% end %>
 
 <% govspeak_for :post_body do %>


### PR DESCRIPTION
[MAIN-7377](https://gov-uk.atlassian.net/browse/MAIN-7377)

Added callout to the start page, advising users that the calculator is currently
giving outdated information for Paternity Leave, which will be rectified in due course.

<img width="631" height="415" alt="PatLeaveCallout" src="https://github.com/user-attachments/assets/af3557c4-5e5d-49c3-a628-a463ee7a2284" />




[MAIN-7377]: https://gov-uk.atlassian.net/browse/MAIN-7377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ