### PR TITLE
Fix for comparison of Float with BigDecimal error

### DIFF
--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -334,7 +334,7 @@ module SmartAnswer
 
         earnings_based_rate = employee_average_weekly_earnings * BigDecimal("0.8")
 
-        [earnings_based_rate, flat_rate].min
+        [earnings_based_rate, flat_rate].reject(&:nan?).min
       end
 
       def max_days_that_can_be_paid


### PR DESCRIPTION
[MAIN-7374](https://gov-uk.atlassian.net/jira/software/c/projects/MAIN/boards/1555?selectedIssue=MAIN-7374)
BigDecimal does not allow comparisons with Float, we needed to remove invalid NaN objects so they can not break the comparison. 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.


[MAIN-7374]: https://gov-uk.atlassian.net/browse/MAIN-7374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ