### PR TITLE
Paternity and Adoption Leave Changes for Employers

### DIFF
--- a/app/flows/maternity_paternity_calculator_flow/outcomes/_entitled_to_leave_not_pay_2026.erb
+++ b/app/flows/maternity_paternity_calculator_flow/outcomes/_entitled_to_leave_not_pay_2026.erb
@@ -1,0 +1,36 @@
+<% if leave_type == "paternity_adoption" %>
+  ## Entitled to Statutory Paternity Leave
+
+  The employee is entitled to Statutory Paternity Leave.
+
+  |Leave                         | Key dates                    |
+  |------------------------------|------------------------------|
+  |Start                         | <%= format_date(leave_start_date) %>          |
+  |End                           | <%= format_date(leave_end_date) %>            |
+  |Latest date to [give notice](/employers-paternity-pay-leave/<%= leave_spp_claim_link %>)
+<% else %>
+  ## Entitled to Statutory Paternity Leave
+
+  The employee is entitled to Statutory Paternity Leave.
+
+  They can take 2 consecutive or non-consecutive weeks.
+
+  Their leave starts on <%= format_date(leave_start_date) %> and must finish by <%= format_date(paternity_deadline) %>.
+
+  <% if due_date > Date.parse("2026-07-25") %>
+  The latest date they can [claim leave](/employers-paternity-pay-leave/<%= leave_spp_claim_link %>) is <%= format_date(notice_of_leave_deadline) %>
+  <% else %>
+  Until 25 July 2026, the employee does not need to give the usual 15 weeks’ notice of their baby’s due date.
+
+  They’ll still need to [give notice](/employers-paternity-pay-leave/notice-period) by <%= format_date(leave_start_date - 28) %>.
+  <% end %>
+<% end %>
+
+
+## Not entitled to Statutory Paternity Pay 
+
+The employee is not entitled to Statutory Paternity Pay because:
+
++ they must have started working for you on or before <%= format_date(employment_start) %>
+
+You must write to them confirming this. Also, send them [form SPP1](/government/publications/statutory-paternity-pay-non-payment-explanation-spp1) confirming they’re not entitled to pay within 28 days of their pay request.

--- a/app/flows/maternity_paternity_calculator_flow/outcomes/paternity_not_entitled_to_leave_or_pay.erb
+++ b/app/flows/maternity_paternity_calculator_flow/outcomes/paternity_not_entitled_to_leave_or_pay.erb
@@ -13,33 +13,50 @@
                      notice_of_leave_deadline: notice_of_leave_deadline,
                    } %>
       <% else %>
-        <%= render partial: 'paternity_entitled_to_leave',
-                   locals: {
-                     leave_must_be_taken_consecutively: calculator.leave_must_be_taken_consecutively?,
-                     leave_start_date: leave_start_date,
-                     leave_end_date: leave_end_date,
-                     leave_spp_claim_link: leave_spp_claim_link,
-                     notice_of_leave_deadline: notice_of_leave_deadline,
-                     paternity_deadline: calculator.paternity_deadline,
-                   } %>
+        <% if paternity_employment_start == "no" %>
+          <%= render partial: 'entitled_to_leave_not_pay_2026',
+                    locals: {
+                      due_date: calculator.due_date,
+                      employment_start: employment_start,
+                      leave_must_be_taken_consecutively: calculator.leave_must_be_taken_consecutively?,
+                      leave_type: calculator.leave_type,
+                      leave_start_date: leave_start_date,
+                      leave_end_date: leave_end_date,
+                      leave_spp_claim_link: leave_spp_claim_link,
+                      notice_of_leave_deadline: notice_of_leave_deadline,
+                      paternity_deadline: calculator.paternity_deadline,
+                    } %>
+        <% else %>
+          <%= render partial: 'paternity_entitled_to_leave',
+                    locals: {
+                      leave_must_be_taken_consecutively: calculator.leave_must_be_taken_consecutively?,
+                      leave_start_date: leave_start_date,
+                      leave_end_date: leave_end_date,
+                      leave_spp_claim_link: leave_spp_claim_link,
+                      notice_of_leave_deadline: notice_of_leave_deadline,
+                      paternity_deadline: calculator.paternity_deadline,
+                    } %>
+        <% end %>
       <% end %>
     <% end %>
 
-    <%= render partial: 'paternity_not_entitled_to_pay_intro' %>
+    <% if paternity_employment_start != "no" || (has_contract == 'no' && calculator.on_payroll == 'no') %>
+      <%= render partial: 'paternity_not_entitled_to_pay_intro' %>
 
-    <% if calculator.on_payroll == 'no' %>
-      + <%= render partial: 'must_be_on_payroll' %>
-    <% elsif employed_dob == 'no' %>
-      <% case leave_type %>
-      <% when 'paternity' %>
-        + they must still be employed by you on <%= format_date(due_date) %>
-      <% when 'paternity_adoption' %>
-        + they must still be employed by you on <%= ap_adoption_date_formatted %>
+      <% if calculator.on_payroll == 'no' %>
+        + <%= render partial: 'must_be_on_payroll' %>
+      <% elsif employed_dob == 'no' %>
+        <% case leave_type %>
+        <% when 'paternity' %>
+          + they must still be employed by you on <%= format_date(due_date) %>
+        <% when 'paternity_adoption' %>
+          + they must still be employed by you on <%= ap_adoption_date_formatted %>
+        <% end %>
       <% end %>
 
-    <% end %>
-
-    <%= render partial: 'paternity_not_entitled_to_pay_outro' %>
+      <%= render partial: 'paternity_not_entitled_to_pay_outro' %>
+    <% end %>  
+    
   <% else %>
     ##Not entitled to Statutory Paternity Pay or Leave
 
@@ -62,11 +79,11 @@
                  locals: {employment_start: employment_start} %>
     <% end %>
 
-    You must write confirming this. Also, send them [form SPP1](/government/publications/statutory-paternity-pay-non-payment-explanation-spp1) confirming they’re not entitled to pay within 28 days of their pay request.
+    You must write to them confirming this. Also, send them [form SPP1](/government/publications/statutory-paternity-pay-non-payment-explanation-spp1) confirming they’re not entitled to pay within 28 days of their pay request.
 
   <% end %>
 <% end %>
 
 <% govspeak_for :next_steps do %>
-  Read the [guide to Statutory Adoption Pay and Leave](/employers-adoption-pay-leave)
+    Read the [guide to Statutory Paternity Pay and Leave](/employers-paternity-pay-leave)
 <% end %>

--- a/app/flows/maternity_paternity_calculator_flow/paternity_calculator_flow.rb
+++ b/app/flows/maternity_paternity_calculator_flow/paternity_calculator_flow.rb
@@ -72,6 +72,7 @@ class MaternityPaternityCalculatorFlow < SmartAnswer::Flow
         on_response do |response|
           self.date_of_birth = response
           calculator.date_of_birth = date_of_birth
+          self.date_of_birth_formatted = calculator.format_date_day date_of_birth
         end
 
         next_node do
@@ -156,7 +157,13 @@ class MaternityPaternityCalculatorFlow < SmartAnswer::Flow
           when "yes"
             question :employee_has_contract_paternity?
           when "no"
-            outcome :paternity_not_entitled_to_leave_or_pay
+            has_grace_leave = paternity_adoption ? calculator.grace_adoption_leave? : calculator.grace_paternity_leave?
+
+            if has_grace_leave
+              question :employee_has_contract_paternity?
+            else
+              outcome :paternity_not_entitled_to_leave_or_pay
+            end
           end
         end
       end
@@ -168,10 +175,31 @@ class MaternityPaternityCalculatorFlow < SmartAnswer::Flow
 
         on_response do |response|
           self.has_contract = response
+
+          if paternity_adoption
+            self.leave_spp_claim_link = "adoption"
+            self.to_saturday = calculator.matched_week.last
+            self.still_employed_date = calculator.employment_end
+            self.start_leave_hint = ap_adoption_date_formatted
+          else
+            self.leave_spp_claim_link = "notice-period"
+            self.to_saturday = calculator.qualifying_week.last
+            self.still_employed_date = date_of_birth
+            self.start_leave_hint = date_of_birth_formatted
+          end
+
+          self.to_saturday_formatted = calculator.format_date_day to_saturday
         end
 
         next_node do
-          question :employee_on_payroll_paternity?
+          has_grace_leave = paternity_adoption ? calculator.grace_adoption_leave? : calculator.grace_paternity_leave?
+
+          if has_grace_leave && paternity_employment_start == "no"
+            calculator.on_payroll = "no"
+            question :employee_start_paternity?
+          else
+            question :employee_on_payroll_paternity?
+          end
         end
       end
 
@@ -261,7 +289,7 @@ class MaternityPaternityCalculatorFlow < SmartAnswer::Flow
         end
 
         next_node do
-          if has_contract == "yes" && (calculator.on_payroll == "no" || employed_dob == "no")
+          if has_contract == "yes" && (calculator.on_payroll == "no" || employed_dob == "no") || (paternity_employment_start == "no" && has_contract == "no")
             outcome :paternity_not_entitled_to_leave_or_pay
           else
             question :last_normal_payday_paternity?

--- a/app/flows/maternity_paternity_calculator_flow/questions/employee_paternity_length.erb
+++ b/app/flows/maternity_paternity_calculator_flow/questions/employee_paternity_length.erb
@@ -3,8 +3,10 @@
 <% end %>
 
 <% govspeak_for :body do %>
-  The last day of leave the employee will be eligible for statutory paternity pay is <%= calculator.paternity_deadline.strftime("%d %B %Y") %>.
-  If their leave falls outside this period, this calculator may not be accurate and you'll need to use your payroll software or [calculate payments manually](/guidance/statutory-paternity-pay-manually-calculate-your-employees-payments).
+  <% unless paternity_adoption ? calculator.grace_adoption_leave? : calculator.grace_paternity_leave? %>
+    The last day of leave the employee will be eligible for statutory paternity pay is <%= calculator.paternity_deadline.strftime("%d %B %Y") %>.
+    If their leave falls outside this period, this calculator may not be accurate and you'll need to use your payroll software or [calculate payments manually](/guidance/statutory-paternity-pay-manually-calculate-your-employees-payments).
+  <% end %>
 <% end %>
 
 <% options(

--- a/app/flows/maternity_paternity_calculator_flow/start.erb
+++ b/app/flows/maternity_paternity_calculator_flow/start.erb
@@ -12,7 +12,6 @@
   + Statutory Maternity Pay (SMP), paternity pay, adoption pay
   + relevant employment period and average weekly earnings
   + leave period
-  %This calculator is being updated.<br>It will not currently give accurate results for Paternity Leave.
 <% end %>
 
 <% govspeak_for :post_body do %>
@@ -30,8 +29,8 @@
   + paternity leave or pay for [overseas adoptions](/employers-paternity-pay-leave/adoption)
   + [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide)
   + [Neonatal Care Pay and Leave](/employers-neonatal-care-pay-leave)
+  + [Bereaved Partner’s Paternity Leave](/employers-bereaved-partners-paternity-leave)
   + adoption leave or pay for [overseas adoptions](/employers-paternity-pay-leave/adoption) unless the employee has been [continuously employed](/continuous-employment-what-it-is) for at least 26 weeks by the ‘qualifying week’
   + employees [using a surrogate to have a baby](/paternity-pay-leave/adoption)
-
 
 <% end %>

--- a/lib/smart_answer/calculators/paternity_adoption_pay_calculator.rb
+++ b/lib/smart_answer/calculators/paternity_adoption_pay_calculator.rb
@@ -32,6 +32,11 @@ module SmartAnswer::Calculators
       @matched_week
     end
 
+    def grace_adoption_leave?
+      where_does_the_employee_live != "northern_ireland" &&
+        adoption_placement_date.present? && match_date >= Date.parse("2026-04-06")
+    end
+
     def leave_must_be_taken_consecutively?
       employee_lives_in_northern_ireland? || adoption_placement_date <= Date.new(2024, 4, 5)
     end

--- a/lib/smart_answer/calculators/paternity_pay_calculator.rb
+++ b/lib/smart_answer/calculators/paternity_pay_calculator.rb
@@ -22,6 +22,18 @@ module SmartAnswer::Calculators
       start_date + deadline_period
     end
 
+    def grace_paternity_leave?
+      where_does_the_employee_live != "northern_ireland" &&
+
+        date_of_birth.present? && (
+        (due_date <= Date.parse("2026-07-25") &&
+        date_of_birth >= Date.parse("2026-04-06") &&
+        date_of_birth <= Date.parse("2026-07-25")) ||
+      (due_date >= Date.parse("2026-04-05")
+      )
+      )
+    end
+
     def leave_must_be_taken_consecutively?
       employee_lives_in_northern_ireland? || due_date <= Date.new(2024, 4, 6)
     end


### PR DESCRIPTION
[MAIN-7396](https://gov-uk.atlassian.net/browse/MAIN-7396)

Updated the calculator similarly to the [employee calculator](https://gov-uk.atlassian.net/browse/MAIN-7396) to show different outcomes depending on when the baby is due/born or matched/placed for adoption.



[MAIN-7396]: https://gov-uk.atlassian.net/browse/MAIN-7396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ