### PR TITLE
Student finance calculator care leavers [MAIN-7436]

### DIFF
--- a/app/flows/student_finance_calculator_flow/outcomes/_tuition_maintenance_summary.erb
+++ b/app/flows/student_finance_calculator_flow/outcomes/_tuition_maintenance_summary.erb
@@ -5,7 +5,7 @@ You could get a <%= format_money(tuition_fee_amount, pounds_only: true) %> [Tuit
 <% if maintenance_loan_amount > 0 %>
   ## Maintenance Loan
 
-  <% if uk_ft_circumstances.include?('care-leaver') || uk_all_circumstances.include?('care-leaver') %>
+  <% if start_date == ("2026-2027") && (uk_ft_circumstances.include?('care-leaver') || uk_all_circumstances.include?('care-leaver')) %>
     You can choose to borrow the maximum amount.
 
     If you’re a care leaver, your household income is not used to calculate your Maintenance Loan. Student Loans Company (SLC) will still use your household income to check what other funding you can get.

--- a/app/flows/student_finance_calculator_flow/questions/whats_your_household_income.erb
+++ b/app/flows/student_finance_calculator_flow/questions/whats_your_household_income.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% text_for :hint do %>
-  This is your parents’ or partner’s taxable income plus your own. It affects how much help you'll get with living costs.
+  This is your parents’ or partner’s taxable income. It affects how much help you'll get with living costs.
 <% end %>
 
 <% text_for :error_message do %>

--- a/test/flows/student_finance_calculator_flow_test.rb
+++ b/test/flows/student_finance_calculator_flow_test.rb
@@ -333,7 +333,7 @@ class StudentFinanceCalculatorTest < ActiveSupport::TestCase
   context "outcome: outcome_uk_full_time_students" do
     setup do
       testing_node :outcome_uk_full_time_students
-      add_responses when_does_your_course_start?: "2025-2026",
+      add_responses when_does_your_course_start?: "2026-2027",
                     what_loans_are_you_eligible_for?: "tuition-and-maintenance",
                     will_you_be_studying_full_or_part_time?: "full-time",
                     how_much_are_your_tuition_fees_per_year?: "9250",
@@ -429,7 +429,7 @@ class StudentFinanceCalculatorTest < ActiveSupport::TestCase
   context "outcome: outcome_uk_part_time_students" do
     setup do
       testing_node :outcome_uk_part_time_students
-      add_responses when_does_your_course_start?: "2025-2026",
+      add_responses when_does_your_course_start?: "2026-2027",
                     what_loans_are_you_eligible_for?: "tuition-and-maintenance",
                     will_you_be_studying_full_or_part_time?: "part-time",
                     how_much_are_your_tuition_fees_per_year?: "6935",
@@ -573,7 +573,7 @@ class StudentFinanceCalculatorTest < ActiveSupport::TestCase
     should "render text if student is a care leaver" do
       add_responses do_any_of_the_following_apply_uk_full_time_students_only?: "care-leaver"
 
-      assert_rendered_outcome text: "If you’re a care leaver, your household income is not used to calculate your Maintenance Loan."
+      assert_rendered_outcome text: "If you need more money to fund your living costs and you qualify, you can apply for extra help."
     end
   end
 end


### PR DESCRIPTION
[MAIN-7436](https://gov-uk.atlassian.net/browse/MAIN-7436)

## Description

The 2025/2026 academic year maintenance loan info for care leavers needed to be updated to show the standard guidance, while 2026/2027 should still show the `care leavers` specific information about the maximum loan.

## Screenshots

### 2025/2026

<img width="686" height="438" alt="image" src="https://github.com/user-attachments/assets/82dd685d-50ba-4a22-990f-d3a3ca93c95c" />

### 2026/2027

<img width="636" height="205" alt="image" src="https://github.com/user-attachments/assets/13cb861d-b908-47b7-9e80-bbd8133f9ad3" />

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.


[MAIN-7436]: https://gov-uk.atlassian.net/browse/MAIN-7436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ