### PR TITLE
Update Simplified expenses calculator with new flat rate

### DIFF
--- a/app/flows/simplified_expenses_checker_flow/start.erb
+++ b/app/flows/simplified_expenses_checker_flow/start.erb
@@ -35,6 +35,4 @@ You can either:
 
   ^You have to be a sole trader or business partnership with other people - limited companies or business partnerships that have a corporate partner cannot claim simplified expenses.
 
-  %This calculator is being updated.<br>It will not currently give accurate results for vehicles.
-
 <% end %>

--- a/lib/smart_answer/calculators/simplified_expenses_checker_calculator.rb
+++ b/lib/smart_answer/calculators/simplified_expenses_checker_calculator.rb
@@ -108,13 +108,13 @@ module SmartAnswer::Calculators
 
     def simple_vehicle_costs_car_van
       # Calculation:
-      # [user input 1-10,000] x 0.45
+      # [user input 1-10,000] x 0.55
       # [user input > 10,001]  x 0.25
       if business_miles_car_van.to_f <= 10_000
-        money(business_miles_car_van.to_f * 0.45)
+        money(business_miles_car_van.to_f * 0.55)
       else
         answer_over_amount = (business_miles_car_van.to_f - 10_000) * 0.25
-        money(4500.0 + answer_over_amount)
+        money(5500.0 + answer_over_amount)
       end
     end
 

--- a/test/unit/calculators/simplified_expenses_checker_calculator_test.rb
+++ b/test/unit/calculators/simplified_expenses_checker_calculator_test.rb
@@ -826,14 +826,14 @@ module SmartAnswer::Calculators
           @calculator = SimplifiedExpensesCheckerCalculator.new
         end
 
-        should "equal 45% of business_miles_car_van if business_miles_car_van is less than or equal to 10,000 miles" do
-          @calculator.business_miles_car_van = 9999
-          assert_equal @calculator.simple_vehicle_costs_car_van, 4499.55
+        should "equal 55% of business_miles_car_van if business_miles_car_van is less than or equal to 10,000 miles" do
+          @calculator.business_miles_car_van = 10_000
+          assert_equal @calculator.simple_vehicle_costs_car_van, 5500
         end
 
-        should "equal 25% of business_miles_car_van  if business_miles_car_van is more than or equal to 10,000 miles" do
+        should "equal 25% of business_miles_car_van if business_miles_car_van is more than or equal to 10,000 miles" do
           @calculator.business_miles_car_van = 10_001
-          assert_equal @calculator.simple_vehicle_costs_car_van, 4500.25
+          assert_equal @calculator.simple_vehicle_costs_car_van, 5500.25
         end
       end
 


### PR DESCRIPTION
The flat rate for cars for the first 10,000 miles has updated from 45p per mile to 55p per mile, backdated to 6 April 2026, this updates the value in the calculator to match the new figure, and removes the alert warning users the calculator is being updated

[MAIN-7455](https://gov-uk.atlassian.net/browse/MAIN-7455)
(populate the link above to make sure your PR is linked to the Jira ticket)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.


[MAIN-7455]: https://gov-uk.atlassian.net/browse/MAIN-7455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ