### PR TITLE
Update check benefits tool outcomes for wales and northern ireland

### DIFF
--- a/app/flows/check_benefits_financial_support_flow/outcomes/results.erb
+++ b/app/flows/check_benefits_financial_support_flow/outcomes/results.erb
@@ -25,9 +25,7 @@
       font_size: "m"
     } %>
 
-    <p class="govuk-body">If you're getting certain benefits you may be <a class="govuk-link" href="/guidance/cost-of-living-payment">eligible for a cost of living payment</a>. You do not need to apply. If you’re eligible, you’ll be paid automatically.</p>
-
-    <p class="govuk-body">You may also <a class="govuk-link" href="/cost-living-help-local-council">get help from your local council with essential costs</a> like bills and food.</p>
+    <p class="govuk-body">You may be able to <a class="govuk-link" href="/cost-living-help-local-council">get help from your local council with essential costs</a> like bills and food.</p>
 
     <p class="govuk-body">You can also find out more by:</p>
 

--- a/config/smart_answers/check_benefits_financial_support_data.yml
+++ b/config/smart_answers/check_benefits_financial_support_data.yml
@@ -473,7 +473,7 @@
         - scotland
     - name: free_school_meals_wales
       title: Free school meals
-      description: <p>If you’re on certain benefits your child may be able to get free school meals. You’ll need to apply through your local council.</p>
+      description: <p>All primary school children get free school meals automatically. If you’re on certain benefits your child may be able to get free secondary school meals. You’ll need to apply through your local council.</p>
       condition: eligible_for_free_school_meals?
       url_text: Check if your child can get free school meals on the GOV.WALES website
       url: https://gov.wales/find-out-about-free-school-meals

--- a/config/smart_answers/check_benefits_financial_support_data.yml
+++ b/config/smart_answers/check_benefits_financial_support_data.yml
@@ -550,7 +550,6 @@
     - name: apply_for_an_older_persons_bus_pass_scotland
       title: Apply for an older person's bus pass
       description: <p>You can get a bus pass for free travel if you are 60 or over.</p>
-      condition: eligible_for_an_older_persons_bus_pass?
       url_text: Find out how to apply for an older person’s bus pass on the mygov.scot website
       url: https://www.mygov.scot/older-persons-bus-pass
       countries:

--- a/config/smart_answers/check_benefits_financial_support_data.yml
+++ b/config/smart_answers/check_benefits_financial_support_data.yml
@@ -536,14 +536,20 @@
       url: https://www.eani.org.uk/help-available/home-to-school-transport
       countries:
         - northern-ireland
-    - name: apply_for_an_older_persons_bus_pass
+    - name: apply_for_an_older_persons_bus_pass_england
       title: Apply for an older person's bus pass
-      description: <p>In England you can get a bus pass for free travel when you reach the State Pension age. In Wales you can get a pass at 60.</p>
+      description: <p>You can get a bus pass for free travel when you reach the State Pension age.</p>
       condition: eligible_for_an_older_persons_bus_pass?
-      url_text: Find out how to apply for an older person’s bus pass on the nidirect website
-      url: https://www.nidirect.gov.uk/articles/60-smartpass-and-senior-65-smartpass
+      url_text: Find out how to apply for an older person’s bus pass
+      url: https://www.gov.uk/apply-for-elderly-person-bus-pass
       countries:
         - england
+    - name: apply_for_an_older_persons_bus_pass_wales
+      title: Apply for an older person's bus pass
+      description: <p>You can get a bus pass for free travel if you're aged 60 or over.</p>
+      url_text: Find out how to apply for an older person’s bus pass on the GOV.WALES website
+      url: https://www.gov.wales/apply-bus-pass
+      countries:
         - wales
     - name: apply_for_an_older_persons_bus_pass_scotland
       title: Apply for an older person's bus pass

--- a/config/smart_answers/check_benefits_financial_support_data.yml
+++ b/config/smart_answers/check_benefits_financial_support_data.yml
@@ -475,12 +475,12 @@
       url: https://gov.wales/find-out-about-free-school-meals
       countries:
         - wales
-    - name: free_school_meals_northern_ireland
-      title: Free school meals
-      description: <p>If you’re on certain benefits your child may be able to get free school meals. You’ll need to apply through the Northern Ireland Education Authority.</p>
+    - name: free_school_meals_and_uniform_grants_northern_ireland
+      title: Free school meals and uniform grants
+      description: <p>If you’re on certain benefits your child may be able to get free school meals and help with the cost of school uniforms.</p>
       condition: eligible_for_free_school_meals?
-      url_text: Check if your child can get free school meals on the nidirect website
-      url: https://www.nidirect.gov.uk/articles/nutrition-and-school-lunches
+      url_text: Check if your child can get free school meals and uniform grants on the Education Authority NI website
+      url: https://www.eani.org.uk/parents/pupil-applications-and-grants/free-school-meals-and-uniform-grants/apply-for-free-school
       countries:
         - northern-ireland
     - name: school_clothing_grant_scotland
@@ -491,14 +491,6 @@
       url: https://www.mygov.scot/clothing-grants
       countries:
         - scotland
-    - name: uniform_grant_northern_ireland
-      title: Uniform Grant
-      description: <p>If you’re on certain benefits you may be able to get help from your local council with the cost of school uniforms.</p>
-      condition: eligible_for_uniform_grant_northern_ireland?
-      url_text: Check if you can get help with school uniform costs on the Education Authority NI website
-      url: https://www.eani.org.uk/financial-help/free-school-meals-uniform-grants
-      countries:
-        - northern-ireland
     - name: school_essentials_grant_wales
       title: School Essentials Grant
       description: <p>If you’re on certain benefits you may be able to get help from your local council with the cost of school essentials, like uniforms or kit for activities.</p>

--- a/config/smart_answers/check_benefits_financial_support_data.yml
+++ b/config/smart_answers/check_benefits_financial_support_data.yml
@@ -499,12 +499,12 @@
       url: https://www.eani.org.uk/financial-help/free-school-meals-uniform-grants
       countries:
         - northern-ireland
-    - name: pupil_development_grant_wales
-      title: Pupil Development Grant
-      description: <p>If you’re on certain benefits you may be able to get help from your local council with the cost of school uniforms.</p>
-      condition: eligible_for_pupil_development_grant_wales?
-      url_text: Check if you can get help with school uniform costs on the GOV.WALES website
-      url: https://gov.wales/pupil-development-grant-access
+    - name: school_essentials_grant_wales
+      title: School Essentials Grant
+      description: <p>If you’re on certain benefits you may be able to get help from your local council with the cost of school essentials, like uniforms or kit for activities.</p>
+      condition: eligible_for_school_essentials_grant_wales?
+      url_text: Check if you can get help with the cost of school essentials on the GOV.WALES website
+      url: https://www.gov.wales/school-essentials-grant-help-school-costs
       countries:
         - wales
     - name: home_to_school_transport

--- a/config/smart_answers/check_benefits_financial_support_data.yml
+++ b/config/smart_answers/check_benefits_financial_support_data.yml
@@ -87,7 +87,7 @@
         - scotland
     - name: housing_benefit_northern_ireland
       title: Housing Benefit
-      description: <p>You may be able to get help to pay your rent if you’ve reached State Pension age or are in supported, sheltered or temporary housing.</p>
+      description: <p>You may be able to get help to pay your rent if you’ve reached State Pension age or are in temporary or supported accommodation.</p>
       condition: eligible_for_housing_benefit?
       url: https://www.nihe.gov.uk/Housing-Help/Housing-Benefit/Making-a-claim-for-Housing-Benefit
       url_text: Check if you’re eligible for Housing Benefit on the NI Housing Executive website

--- a/config/smart_answers/check_benefits_financial_support_data.yml
+++ b/config/smart_answers/check_benefits_financial_support_data.yml
@@ -659,7 +659,7 @@
         - wales
     - name: disabled_facilities_grant_ni
       title: Disabled Facilities Grant
-      description: <p>You could get a grant from your local health and social services trust to make changes to your home if you’re disabled or you live with someone who is.</p>
+      description: <p>You could get a grant to make changes to your home if you’re disabled or you live with someone who is.</p>
       condition: eligible_disabled_facilities_grant?
       url_text: Check if you’re eligible for a Disabled Facilities Grant on the NI Housing Executive website
       url: https://www.nihe.gov.uk/housing-help/grants/types-of-grants-available/disabled-facilities-grant

--- a/config/smart_answers/check_benefits_financial_support_data.yml
+++ b/config/smart_answers/check_benefits_financial_support_data.yml
@@ -107,7 +107,7 @@
         - scotland
     - name: access_to_work_northern-ireland
       title: Access to Work
-      description: <p>You may be able to get help to find or stay in work if you have a physical or mental health condition or disability.</p>
+      description: <p>You may be eligible for help to get or stay in work if you have a physical or mental health condition or disability.</p>
       condition: eligible_for_access_to_work?
       url: https://www.nidirect.gov.uk/articles/access-work-practical-help-work
       url_text: Check if you’re eligible for Access to Work on the nidirect website

--- a/config/smart_answers/check_benefits_financial_support_data.yml
+++ b/config/smart_answers/check_benefits_financial_support_data.yml
@@ -396,7 +396,7 @@
         - scotland
     - name: nhs_help_with_health_costs_northern_ireland
       title: NHS Help with health costs
-      description: <p>You may be able to get help with prescriptions, dental care, healthcare travel and other health costs, particularly if you’re on a low income or getting certain benefits.</p>
+      description: <p>You may be able to get help with health service dental care, sight tests, healthcare travel and other health costs, particularly if you’re on a low income or getting certain benefits.</p>
       url: https://www.nidirect.gov.uk/articles/help-health-costs
       url_text: Check if you’re eligible for help with health costs on the nidirect website
       group: Healthcare support

--- a/config/smart_answers/check_benefits_financial_support_data.yml
+++ b/config/smart_answers/check_benefits_financial_support_data.yml
@@ -559,11 +559,10 @@
       url: https://www.mygov.scot/older-persons-bus-pass
       countries:
         - scotland
-    - name: apply_for_an_older_persons_bus_pass_ni
-      title: Apply for an older person's bus pass
-      description: <p>You can get a bus pass for free travel if you are 60 or over.</p>
-      condition: eligible_for_an_older_persons_bus_pass?
-      url_text: Find out how to apply for an older person’s bus pass on the nidirect website
+    - name: apply_for_an_older_persons_travel_pass_ni
+      title: Apply for an older person's travel pass
+      description: <p>You can get a pass for free travel on public transport if you're aged 60 or over.</p>
+      url_text: Find out how to apply for an older person’s travel pass on the nidirect website
       url: https://www.nidirect.gov.uk/articles/60-smartpass-and-senior-65-smartpass
       countries:
         - northern-ireland

--- a/config/smart_answers/check_benefits_financial_support_data.yml
+++ b/config/smart_answers/check_benefits_financial_support_data.yml
@@ -590,11 +590,11 @@
       url: https://www.mygov.scot/disabled-bus-pass
       countries:
         - scotland
-    - name: apply_for_a_disabled_persons_bus_pass_ni
-      title: Apply for a disabled person's bus pass
-      description: <p>You can get free or half-price travel on buses if you’re eligible.</p>
+    - name: apply_for_a_disabled_persons_travel_pass_ni
+      title: Apply for a disabled person's travel pass
+      description: <p>You can get free or half-price travel on public transport if you’re eligible.</p>
       condition: eligible_for_a_disabled_persons_bus_pass?
-      url_text: Find out how to apply for a disabled person’s bus pass on the nidirect website
+      url_text: Find out how to apply for a disabled person’s travel pass on the nidirect website
       url: https://www.nidirect.gov.uk/information-and-services/bus-and-coach-travel/free-bus-travel-and-concessions
       countries:
         - northern-ireland

--- a/config/smart_answers/check_benefits_financial_support_data.yml
+++ b/config/smart_answers/check_benefits_financial_support_data.yml
@@ -672,6 +672,6 @@
       title: Discretionary Assistance Fund
       description: <p>If you’re in financial hardship, you could get money as part of the Discretionary Assistance Fund. This can be used if you need support to live independently or for essential costs, such as food, utility bills or emergency travel.</p>
       url_text: Check if you’re eligible for the Discretionary Assistance Fund on the GOV.WALES website
-      url: https://www.gov.wales/discretionary-assistance-fund-daf/eligibility
+      url: https://www.gov.wales/discretionary-assistance-fund-daf
       countries:
         - wales

--- a/config/smart_answers/check_benefits_financial_support_data.yml
+++ b/config/smart_answers/check_benefits_financial_support_data.yml
@@ -632,13 +632,6 @@
       url: https://www.nidirect.gov.uk/articles/education-maintenance-allowance-explained
       countries:
         - northern-ireland
-    - name: wales_fuel_support_scheme_payment
-      title: Wales fuel support scheme payment
-      description: <p>You may be able to claim a one-off payment to help pay your fuel costs if you or your partner get certain benefits. You'll need to apply through your local council.</p>
-      url_text: Check if you're eligible for a Wales fuel support scheme payment on the GOV.WALES website
-      url: https://gov.wales/wales-fuel-support-scheme-2022-2023
-      countries:
-        - wales
     - name: help_to_save
       title: Help to Save
       description: <p>You can get a bonus of 50p for every £1 you save over 4 years through Help to Save if you get certain benefits.</p>

--- a/config/smart_answers/check_benefits_financial_support_data.yml
+++ b/config/smart_answers/check_benefits_financial_support_data.yml
@@ -253,7 +253,6 @@
         - england
         - wales
         - scotland
-        - northern-ireland
     - name: disability_living_allowance_for_children
       title: Disability Living Allowance (DLA) for children
       description: <p>You may be able to get help with the extra costs of looking after a child who is under 16 and has a health condition or disability.</p>
@@ -264,7 +263,6 @@
       countries:
         - england
         - wales
-        - northern-ireland
     - name: child_disability_payment_scotland
       title: Child Disability Payment
       description: <p>You can apply for Child Disability Payment if you’re responsible for a child under 16 who lives in Scotland.</p>
@@ -314,7 +312,6 @@
         - england
         - wales
         - scotland
-        - northern-ireland
     - name: council_tax_reduction
       title: Council Tax Reduction
       description: <p>You may be able to get Council Tax Reduction if you’re on a low income or claim benefits.</p>
@@ -412,7 +409,6 @@
         - england
         - wales
         - scotland
-        - northern-ireland
     - name: sure_start_maternity_grant
       title: Sure Start Maternity Grant
       description: <p>If you or your partner get certain benefits you could get a payment to help towards the costs of having a child. You must usually have no other children under 16.</p>
@@ -608,7 +604,6 @@
         - england
         - wales
         - scotland
-        - northern-ireland
     - name: warm_home_discount_scheme
       title: Warm Home Discount Scheme
       description: <p>You could get a discount on your electricity bill between October and March under the Warm Home Discount Scheme. You'll automatically get the discount if you get certain benefits. If you’re eligible, your electricity supplier will apply the discount to your bill.</p>
@@ -680,3 +675,48 @@
       url: https://www.gov.wales/discretionary-assistance-fund-daf
       countries:
         - wales
+    - name: carers_allowance_ni
+      title: Carer’s Allowance
+      description: <p>You may be able to get Carer’s Allowance if you care for someone at least 35 hours a week. The person you care for must also be getting certain disability benefits.</p>
+      condition: eligible_for_carers_allowance?
+      url: https://www.nidirect.gov.uk/articles/carers-allowance
+      url_text: Check if you’re eligible for Carer’s Allowance on the nidirect website
+      group: Supporting your income
+      countries:
+        - northern-ireland
+    - name: attendance_allowance_ni
+      title: Attendance Allowance
+      description: |
+        <p>You may be able to get help with extra costs if you have a disability severe enough that you need someone to help look after you.</p>
+        <p>If you’re already getting Personal Independence Payment or Adult Disability Payment, you will continue to get this instead when you reach State Pension age.</p>
+      condition: eligible_for_attendance_allowance?
+      url: https://www.nidirect.gov.uk/articles/attendance-allowance
+      url_text: Check if you’re eligible for Attendance Allowance on the nidirect website
+      group: Supporting your income
+      countries:
+        - northern-ireland
+    - name: disability_living_allowance_for_children_ni
+      title: Disability Living Allowance (DLA) for children
+      description: <p>You may be able to get help with the extra costs of looking after a child who is under 16 and has a health condition or disability.</p>
+      condition: eligible_for_child_disability_support?
+      url: https://www.nidirect.gov.uk/articles/disability-living-allowance-children
+      url_text: Check if you’re eligible for Disability Living Allowance (DLA) for children on the nidirect website
+      group: Help with childcare costs
+      countries:
+        - northern-ireland
+    - name: support_for_mortgage_interest_(smi)_ni
+      title: Support for Mortgage Interest (SMI)
+      description: <p>If you’re a homeowner, you might be able to get help towards interest payments on your mortgage or certain loans taken out on your home.</p>
+      condition: eligible_for_support_for_mortgage_interest?
+      url_text: Check if you’re eligible for Support for Mortgage Interest on the nidirect website
+      url: https://www.nidirect.gov.uk/articles/support-mortgage-interest
+      countries:
+        - northern-ireland
+    - name: maternity_allowance_ni
+      title: Maternity Allowance
+      description: <p>You may be eligible to get Maternity Allowance for 39 weeks if you’re employed but cannot get Statutory Maternity Pay (SMP), or are registered self-employed. You may still qualify if you’ve recently stopped working.</p>
+      condition: eligible_for_maternity_allowance?
+      url_text: Check if you’re eligible for Maternity Allowance on the nidirect website
+      url: https://www.nidirect.gov.uk/articles/maternity-allowance
+      countries:
+        - northern-ireland

--- a/lib/smart_answer/calculators/check_benefits_financial_support_calculator.rb
+++ b/lib/smart_answer/calculators/check_benefits_financial_support_calculator.rb
@@ -158,8 +158,6 @@ module SmartAnswer::Calculators
     end
 
     def eligible_for_housing_benefit?
-      return false if @over_state_pension_age == "no"
-
       @on_benefits == "no" || permitted_benefits?(%w[housing_benefit])
     end
 

--- a/lib/smart_answer/calculators/check_benefits_financial_support_calculator.rb
+++ b/lib/smart_answer/calculators/check_benefits_financial_support_calculator.rb
@@ -92,13 +92,6 @@ module SmartAnswer::Calculators
       general_child_benefit_eligibility?(skip_benefit_list, age_groups)
     end
 
-    def eligible_for_uniform_grant_northern_ireland?
-      skip_benefit_list = %w[housing_benefit]
-      age_groups = %w[3_to_4 5_to_7 8_to_11 12_to_15 16_to_17]
-
-      general_child_benefit_eligibility?(skip_benefit_list, age_groups)
-    end
-
     def eligible_for_school_essentials_grant_wales?
       skip_benefit_list = %w[housing_benefit]
       age_groups = %w[3_to_4 5_to_7 8_to_11 12_to_15 16_to_17]

--- a/lib/smart_answer/calculators/check_benefits_financial_support_calculator.rb
+++ b/lib/smart_answer/calculators/check_benefits_financial_support_calculator.rb
@@ -99,7 +99,7 @@ module SmartAnswer::Calculators
       general_child_benefit_eligibility?(skip_benefit_list, age_groups)
     end
 
-    def eligible_for_pupil_development_grant_wales?
+    def eligible_for_school_essentials_grant_wales?
       skip_benefit_list = %w[housing_benefit]
       age_groups = %w[3_to_4 5_to_7 8_to_11 12_to_15 16_to_17]
 

--- a/test/flows/check_benefits_financial_support_flow_test.rb
+++ b/test/flows/check_benefits_financial_support_flow_test.rb
@@ -1018,13 +1018,18 @@ class CheckBenefitsFinancialSupportFlowTest < ActiveSupport::TestCase
       assert_rendered_outcome text: "Check if your child is eligible for help with the cost of home to school transport"
     end
 
-    should "render Apply for an older person's bus pass" do
-      %w[england wales].each do |country|
-        add_responses where_do_you_live: country
+    should "render Apply for an older person's bus pass England" do
+      add_responses where_do_you_live: "england"
 
-        assert_rendered_outcome text: "Apply for an older person's bus pass"
-        assert_rendered_outcome text: "In England you can get a bus pass for free travel when you reach the State Pension age"
-      end
+      assert_rendered_outcome text: "Apply for an older person's bus pass"
+      assert_rendered_outcome text: "You can get a bus pass for free travel when you reach the State Pension age."
+    end
+
+    should "render Apply for an older person's bus pass Wales" do
+      add_responses where_do_you_live: "wales"
+
+      assert_rendered_outcome text: "Apply for an older person's bus pass"
+      assert_rendered_outcome text: "You can get a bus pass for free travel if you're aged 60 or over."
     end
 
     should "render Apply for an older person's bus pass Scotland" do

--- a/test/flows/check_benefits_financial_support_flow_test.rb
+++ b/test/flows/check_benefits_financial_support_flow_test.rb
@@ -975,15 +975,15 @@ class CheckBenefitsFinancialSupportFlowTest < ActiveSupport::TestCase
       assert_rendered_outcome text: "If you’re on certain benefits you may be able to get help from your local council with the cost of school uniforms."
     end
 
-    should "render Pupil Development Grant [Wales]" do
+    should "render School Essentials Grant [Wales]" do
       add_responses where_do_you_live: "wales",
                     children_living_with_you: "yes",
                     age_of_children: "16_to_17",
                     on_benefits: "yes",
                     current_benefits: "universal_credit"
 
-      assert_rendered_outcome text: "Pupil Development Grant"
-      assert_rendered_outcome text: "If you’re on certain benefits you may be able to get help from your local council with the cost of school uniforms."
+      assert_rendered_outcome text: "School Essentials Grant"
+      assert_rendered_outcome text: "If you’re on certain benefits you may be able to get help from your local council with the cost of school essentials, like uniforms or kit for activities."
     end
 
     should "render Home to school transport for eligible countries" do

--- a/test/flows/check_benefits_financial_support_flow_test.rb
+++ b/test/flows/check_benefits_financial_support_flow_test.rb
@@ -1171,7 +1171,7 @@ class CheckBenefitsFinancialSupportFlowTest < ActiveSupport::TestCase
                       disability_affecting_work: "no",
                       assets_and_savings: asset
 
-        assert_rendered_outcome text: "You could get a grant from your local health and social services trust to make changes to your home if you’re disabled or you live with someone who is."
+        assert_rendered_outcome text: "You could get a grant to make changes to your home if you’re disabled or you live with someone who is."
         assert_rendered_outcome text: "Check if you’re eligible for a Disabled Facilities Grant on the NI Housing Executive website"
       end
     end
@@ -1181,7 +1181,7 @@ class CheckBenefitsFinancialSupportFlowTest < ActiveSupport::TestCase
         add_responses where_do_you_live: "northern-ireland",
                       assets_and_savings: asset
 
-        assert_rendered_outcome text: "You could get a grant from your local health and social services trust to make changes to your home if you’re disabled or you live with someone who is."
+        assert_rendered_outcome text: "You could get a grant to make changes to your home if you’re disabled or you live with someone who is."
         assert_rendered_outcome text: "Check if you’re eligible for a Disabled Facilities Grant on the NI Housing Executive website"
       end
     end

--- a/test/flows/check_benefits_financial_support_flow_test.rb
+++ b/test/flows/check_benefits_financial_support_flow_test.rb
@@ -942,15 +942,15 @@ class CheckBenefitsFinancialSupportFlowTest < ActiveSupport::TestCase
       assert_rendered_outcome text: "All primary school children get free school meals automatically. If you’re on certain benefits your child may be able to get free secondary school meals. You’ll need to apply through your local council."
     end
 
-    should "render Free school meals [NI]" do
+    should "render Free school meals and uniform grants [NI]" do
       add_responses where_do_you_live: "northern-ireland",
                     children_living_with_you: "yes",
                     age_of_children: "3_to_4",
                     on_benefits: "yes",
                     current_benefits: "universal_credit"
 
-      assert_rendered_outcome text: "Free school meals"
-      assert_rendered_outcome text: "If you’re on certain benefits your child may be able to get free school meals."
+      assert_rendered_outcome text: "Free school meals and uniform grants"
+      assert_rendered_outcome text: "If you’re on certain benefits your child may be able to get free school meals and help with the cost of school uniforms."
     end
 
     should "render School Clothing Grant [Scotland]" do
@@ -961,17 +961,6 @@ class CheckBenefitsFinancialSupportFlowTest < ActiveSupport::TestCase
                     current_benefits: "universal_credit"
 
       assert_rendered_outcome text: "School Clothing Grant"
-      assert_rendered_outcome text: "If you’re on certain benefits you may be able to get help from your local council with the cost of school uniforms."
-    end
-
-    should "render Uniform Grant [NI]" do
-      add_responses where_do_you_live: "northern-ireland",
-                    children_living_with_you: "yes",
-                    age_of_children: "16_to_17",
-                    on_benefits: "yes",
-                    current_benefits: "universal_credit"
-
-      assert_rendered_outcome text: "Uniform Grant"
       assert_rendered_outcome text: "If you’re on certain benefits you may be able to get help from your local council with the cost of school uniforms."
     end
 

--- a/test/flows/check_benefits_financial_support_flow_test.rb
+++ b/test/flows/check_benefits_financial_support_flow_test.rb
@@ -847,7 +847,7 @@ class CheckBenefitsFinancialSupportFlowTest < ActiveSupport::TestCase
       add_responses where_do_you_live: "northern-ireland"
 
       assert_rendered_outcome text: "NHS Help with health costs"
-      assert_rendered_outcome text: "You may be able to get help with prescriptions, dental care, healthcare travel and other health costs"
+      assert_rendered_outcome text: "You may be able to get help with health service dental care, sight tests, healthcare travel and other health costs, particularly if you’re on a low income or getting certain benefits."
     end
 
     should "render maternity allowance for eligible countries" do

--- a/test/flows/check_benefits_financial_support_flow_test.rb
+++ b/test/flows/check_benefits_financial_support_flow_test.rb
@@ -939,7 +939,7 @@ class CheckBenefitsFinancialSupportFlowTest < ActiveSupport::TestCase
                     current_benefits: "universal_credit"
 
       assert_rendered_outcome text: "Free school meals"
-      assert_rendered_outcome text: "If you’re on certain benefits your child may be able to get free school meals."
+      assert_rendered_outcome text: "All primary school children get free school meals automatically. If you’re on certain benefits your child may be able to get free secondary school meals. You’ll need to apply through your local council."
     end
 
     should "render Free school meals [NI]" do

--- a/test/flows/check_benefits_financial_support_flow_test.rb
+++ b/test/flows/check_benefits_financial_support_flow_test.rb
@@ -1115,13 +1115,6 @@ class CheckBenefitsFinancialSupportFlowTest < ActiveSupport::TestCase
       assert_rendered_outcome text: "Check if you’re eligible and whether you need to apply for the Warm Home Discount scheme"
     end
 
-    should "render Wales fuel support scheme payment" do
-      add_responses where_do_you_live: "wales"
-
-      assert_rendered_outcome text: "Wales fuel support scheme payment"
-      assert_rendered_outcome text: "Check if you're eligible for a Wales fuel support scheme payment on the GOV.WALES website"
-    end
-
     should "render Eligible for help to save (on benefits)" do
       add_responses over_state_pension_age: "no",
                     current_benefits: "universal_credit"

--- a/test/flows/check_benefits_financial_support_flow_test.rb
+++ b/test/flows/check_benefits_financial_support_flow_test.rb
@@ -1076,14 +1076,14 @@ class CheckBenefitsFinancialSupportFlowTest < ActiveSupport::TestCase
       assert_rendered_outcome text: "Find out how to apply for a disabled person’s bus pass on the mygov.scot website"
     end
 
-    should "render Apply for a disabled person's bus pass NI" do
+    should "render Apply for a disabled person's travel pass NI" do
       add_responses where_do_you_live: "northern-ireland",
                     disability_or_health_condition: "yes",
                     disability_affecting_daily_tasks: "no",
                     disability_affecting_work: "yes_unable_to_work"
 
-      assert_rendered_outcome text: "Apply for a disabled person's bus pass"
-      assert_rendered_outcome text: "Find out how to apply for a disabled person’s bus pass on the nidirect website"
+      assert_rendered_outcome text: "Apply for a disabled person's travel pass"
+      assert_rendered_outcome text: "Find out how to apply for a disabled person’s travel pass on the nidirect website"
     end
 
     should "render Support for Mortgage Interest (SMI)" do

--- a/test/flows/check_benefits_financial_support_flow_test.rb
+++ b/test/flows/check_benefits_financial_support_flow_test.rb
@@ -1042,8 +1042,8 @@ class CheckBenefitsFinancialSupportFlowTest < ActiveSupport::TestCase
     should "render Apply for an older person's bus pass NI" do
       add_responses where_do_you_live: "northern-ireland"
 
-      assert_rendered_outcome text: "Apply for an older person's bus pass"
-      assert_rendered_outcome text: "You can get a bus pass for free travel if you are 60 or over."
+      assert_rendered_outcome text: "Apply for an older person's travel pass"
+      assert_rendered_outcome text: "You can get a pass for free travel on public transport if you're aged 60 or over."
     end
 
     should "render Apply for a disabled person's bus pass" do

--- a/test/unit/calculators/checks_benefits_financial_support_calculator_test.rb
+++ b/test/unit/calculators/checks_benefits_financial_support_calculator_test.rb
@@ -401,12 +401,6 @@ module SmartAnswer::Calculators
         end
 
         context "when ineligible" do
-          should "be false if UNDER state pension age" do
-            @calculator.over_state_pension_age = "no"
-            @calculator.on_benefits = "no"
-            assert_not @calculator.eligible_for_housing_benefit?
-          end
-
           should "be false if over state pension age but already claiming associated benefit" do
             @calculator.over_state_pension_age = "yes"
             @calculator.on_benefits = "yes"


### PR DESCRIPTION
[MAIN-7453](https://gov-uk.atlassian.net/browse/MAIN-7453)
(populate the link above to make sure your PR is linked to the Jira ticket)

Updated the tool to fix issues with outcomes as raised by the Welsh Government and Northern Ireland Executive.

For the Welsh Government, that involved updates to these outcomes:

- Wales fuel support scheme payment (removed because it is no longer available)
- Discretionary Assistance Fund (updated the URL to a more relevant page)
- Pupil Development Grant (name and scope of benefit changed to School Essentials Grant)
- Free school meals [Wales] (updated the description to reflect that primary school meals are free for all)
- Apply for an older person's bus pass [England and Wales] (separated these out into different outcomes for England and Wales, as they have different eligibility criteria)

For the Northern Ireland Executive, that involved updates to these outcomes:

- Housing Benefit [Northern Ireland] (updating the description to reflect NIHE's content)
- Older person's bus pass [Northern Ireland] (updating this to reflect it applies to all public transport, not just buses)
- Disabled person's bus pass [Northern Ireland] (again, updating this to reflect it applies to all public transport)
- Free school meals [Northern Ireland] and Uniform Grant (combining these together as they use the same application process)
- Disabled Facilities Grant [Northern Ireland] (updating the description for accuracy)
- NHS Help with health costs [Northern Ireland] (updating the description for accuracy)
- Carer's Allowance, Attendance Allowance, DLA for children, Support for Mortgage Interest and Maternity Allowance (adding separate outcomes for Northern Ireland users, as they have different application processes than rest of UK)
- Finally, for other changes:

- removed the State Pension age requirement for older person's bus passes outside of England, as their age limit is 60
- removed the State Pension age requirement for Housing Benefit, as you can get it even if you're under State Pension age
- updated the results page to remove a reference to cost of living payments, which are no longer being made.

(this is a duplication of https://github.com/alphagov/smart-answers/pull/7631/, splitting out changes into unique commits and updating testing)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.


[MAIN-7453]: https://gov-uk.atlassian.net/browse/MAIN-7453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ