### PR TITLE
Update colours to Design System v6

### DIFF
--- a/app/assets/stylesheets/components/_result-item.scss
+++ b/app/assets/stylesheets/components/_result-item.scss
@@ -4,7 +4,7 @@
 }
 
 .app-c-result-item--highlighted {
-  background-color: govuk-colour("light-grey");
+  background-color: govuk-colour("black", $variant: "tint-95");
   border-left: 5px solid govuk-colour("blue");
   padding: govuk-spacing(3);
   @include govuk-responsive-margin(6, "bottom");

--- a/app/assets/stylesheets/visualise.scss
+++ b/app/assets/stylesheets/visualise.scss
@@ -2,5 +2,5 @@
 
 .visualisation {
   overflow-x: scroll;
-  background-color: govuk-colour("light-grey");
+  background-color: govuk-colour("black", $variant: "tint-95");
 }


### PR DESCRIPTION
Prepare for the update to Design System v6.0.0 by updating colours that were deprecated or replaced in that release.

This PR addresses the changes under "Use GOV.UK brand colours" in the [GOV.UK Frontend v6.0.0 release notes](https://github.com/alphagov/govuk-frontend/releases/tag/v6.0.0).

Jira card: https://gov-uk.atlassian.net/jira/software/c/projects/NAV/boards/1422?quickFilter=2319&selectedIssue=NAV-1892