### PR TITLE
Unhandled Int handling for dates

### DIFF
--- a/lib/smart_answer/question/date.rb
+++ b/lib/smart_answer/question/date.rb
@@ -49,7 +49,8 @@ module SmartAnswer
         date = case input
                when Hash, ActiveSupport::HashWithIndifferentAccess
                  input = input.symbolize_keys
-                 raise InvalidResponse unless input.values.all? { |value| value.blank? || value.to_i.positive? }
+
+                 raise InvalidResponse unless input.values.all? { |value| value.blank? || (value.to_i.positive? && value.to_i < 10_000) }
 
                  year_month_and_day = [
                    default_year || input[:year],

--- a/test/unit/date_question_test.rb
+++ b/test/unit/date_question_test.rb
@@ -42,6 +42,24 @@ module SmartAnswer
           end
         end
 
+        should "raise an InvalidResponse exception when the hash represents a day too large" do
+          assert_raises(InvalidResponse) do
+            @question.parse_input(day: 10_000, month: 2, year: 2015)
+          end
+        end
+
+        should "raise an InvalidResponse exception when the hash represents a month too large" do
+          assert_raises(InvalidResponse) do
+            @question.parse_input(day: 1, month: 10_000, year: 2015)
+          end
+        end
+
+        should "raise an InvalidResponse exception when the hash represents a year too large" do
+          assert_raises(InvalidResponse) do
+            @question.parse_input(day: 1, month: 1, year: 10_000)
+          end
+        end
+
         context "and the day is missing" do
           should "raise an InvalidResponse exception" do
             assert_raises(InvalidResponse) do


### PR DESCRIPTION
[MAIN-1317](https://gov-uk.atlassian.net/browse/MAIN-1317)

## Changes
Currently our validation correctly validates dates that Ruby can parse, however massive BigInt numbers cause overflow errors. This checks all the fields have entries under 10,000 to ensure that they can be processed for validation.

## Screenshots
### Before
<img width="779" height="209" alt="image" src="https://github.com/user-attachments/assets/612622ec-dcfb-4f44-8725-04f8a1ada3ea" />


### After
<img width="829" height="694" alt="image" src="https://github.com/user-attachments/assets/8a805cf5-cb06-4a3d-9ab4-21dd0966e3f5" />


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.


[MAIN-1317]: https://gov-uk.atlassian.net/browse/MAIN-1317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ