### PR TITLE
Remove data-ga4-track-links-only references

### DIFF
--- a/app/views/smart_answers/result.html.erb
+++ b/app/views/smart_answers/result.html.erb
@@ -42,7 +42,6 @@
         "action": "information click",
         "tool_name": @presenter.title,
       }.to_json %>"
-    data-ga4-track-links-only
     data-ga4-set-indexes>
       <div class="govuk-!-margin-bottom-6">
         <% if outcome.title.present? %>


### PR DESCRIPTION
## What / Why
- This attribute was removed from govuk_publishing_components as it wasn't actually needed, so we can remove it from this app.
- JIRA Card: https://gov-uk.atlassian.net/browse/PNP-10043