### PR TITLE
[MAIN-1177] Undo Chrome version pinning in CI

### DIFF
--- a/.github/workflows/minitest.yml
+++ b/.github/workflows/minitest.yml
@@ -31,15 +31,6 @@ jobs:
           ref: ${{ inputs.publishingApiRef }}
           path: vendor/publishing-api
 
-      - name: Remove image-bundled Chrome
-        run: sudo apt-get purge google-chrome-stable
-
-      - name: Setup Chrome
-        uses: browser-actions/setup-chrome@2e1d749697dd1612b833dba4a722266286fbefcd # v2.1.2
-        with:
-          chrome-version: 128
-          install-chromedriver: true
-
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1.310.0
         with:

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -1,4 +1,5 @@
 require_relative "test_helper"
+require_relative "selenium_error_patch"
 require "capybara/rails"
 
 Capybara.server = :webrick

--- a/test/selenium_error_patch.rb
+++ b/test/selenium_error_patch.rb
@@ -1,0 +1,35 @@
+# Taken from https://github.com/alphagov/forms-admin/commit/5ea98767d765a396ed06cf2cba8f9afb1b10fc0e#diff-c36c07a0c7f499b1b95634f9dce1a10ebf4d10a9dee872f39f746a9efa555ddbR1-R34
+# Monkey patch for a specific intermittent Selenium error.
+#
+# Intermittently, Selenium/Chromedriver raises `Selenium::WebDriver::Error::UnknownError`
+# with the message "Node with given id does not belong to the document".
+
+# Capybara's automatic waiting/retrying mechanism doesn't catch it,
+# leading to failure.
+#
+# We intercept the initialization of `UnknownError`. If the message matches this specific
+# case, we raise a `StaleElementReferenceError` instead. This uses Capybara's
+# retry logic which makes doesn't fail the test
+#
+# This can be removed once the following issue is resolved:
+# https://github.com/teamcapybara/capybara/issues/2800
+#
+# taken from the following issue:
+# https://github.com/teamcapybara/capybara/issues/2800#issuecomment-3049956982
+
+module Selenium
+  module WebDriver
+    module Error
+      class UnknownError
+        alias_method :old_initialize, :initialize
+        def initialize(msg = nil)
+          if msg&.include?("Node with given id does not belong to the document")
+            raise StaleElementReferenceError, msg
+          end
+
+          old_initialize(msg)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
[MAIN-1177](https://gov-uk.atlassian.net/browse/MAIN-1177)

This was introduced as a temporary measure until the issues with the latest version of Chrome have been resolved.

The monkey patch [used in Publisher](https://github.com/alphagov/publisher/blob/main/test/selenium_error_patch.rb) is implemented.

I've run CI ~15 times and not seen any flaky test failures.

[MAIN-1177]: https://gov-uk.atlassian.net/browse/MAIN-1177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ