### PR TITLE
Add Dependabot grouping for test, lint, and GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,12 +9,47 @@ updates:
       exclude:
         - govuk_*
 
+    groups:
+      test:
+        patterns:
+          - capybara*
+          - factory_bot*
+          - faker
+          - webmock
+          - timecop
+          - database_cleaner*
+          - shoulda*
+          - simplecov*
+          - rails-controller-testing
+          - minitest*
+          - mocha
+          - selenium-webdriver
+          - govuk_test
+          - rack-test
+          - xpath
+
+      lint:
+        patterns:
+          - rubocop*
+          - rubocop-govuk
+          - erb_lint
+          - better_html
+          - parser
+          - ast
+
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: daily
     cooldown:
       default-days: 3
+
+    groups:
+      lint:
+        patterns:
+          - standardx
+          - stylelint*
+          - stylelint-config-gds
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Group Dependabot PRs for test, lint, and CI dependencies

This change introduces Dependabot grouping to reduce PR noise and improve review focus by batching related dependency updates. Without grouping, Dependabot creates many small PRs for individual updates. Grouping related dependencies reduces noise while keeping meaningful updates easy to review. This follows [GitHub guidance](https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/optimizing-pr-creation-version-updates#grouping-related-dependencies-together) on grouping related dependencies.

### Groups introduced:

**Test-related** gems are grouped together.

**Linting tools** are grouped by purpose (Ruby/npm)

All **GitHub Actions** updates are grouped into a single PR as they are low-risk CI maintenance changes.

What is not grouped
- Rails and Ruby dependencies
- GOV.UK platform gems
- Security updates

These are kept separate to ensure important changes are reviewed and applied individually.

[MAIN-7389](https://gov-uk.atlassian.net/jira/software/c/projects/MAIN/boards/1555?selectedIssue=MAIN-7389)
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.


[MAIN-7389]: https://gov-uk.atlassian.net/browse/MAIN-7389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ