### PR TITLE
Modify Paternity Adoption path

### DIFF
--- a/app/flows/maternity_paternity_calculator_flow.rb
+++ b/app/flows/maternity_paternity_calculator_flow.rb
@@ -29,7 +29,7 @@ class MaternityPaternityCalculatorFlow < SmartAnswer::Flow
         when "paternity"
           question :where_does_the_employee_live?
         when "adoption"
-          question :taking_paternity_or_maternity_leave_for_adoption?
+          question :adoption_is_from_overseas?
         end
       end
     end

--- a/app/flows/maternity_paternity_calculator_flow/adoption_calculator_flow.rb
+++ b/app/flows/maternity_paternity_calculator_flow/adoption_calculator_flow.rb
@@ -1,20 +1,6 @@
 class MaternityPaternityCalculatorFlow < SmartAnswer::Flow
   class AdoptionCalculatorFlow < SmartAnswer::Flow
     def define
-      radio :taking_paternity_or_maternity_leave_for_adoption? do
-        option :paternity
-        option :maternity
-
-        next_node do |response|
-          case response
-          when "paternity"
-            question :where_does_the_employee_live?
-          when "maternity"
-            question :adoption_is_from_overseas?
-          end
-        end
-      end
-
       radio :adoption_is_from_overseas? do
         option :yes
         option :no

--- a/app/flows/maternity_paternity_calculator_flow/paternity_calculator_flow.rb
+++ b/app/flows/maternity_paternity_calculator_flow/paternity_calculator_flow.rb
@@ -15,12 +15,7 @@ class MaternityPaternityCalculatorFlow < SmartAnswer::Flow
         end
 
         next_node do
-          case leave_type
-          when "paternity"
-            question :leave_or_pay_for_adoption?
-          when "adoption"
-            question :employee_date_matched_paternity_adoption?
-          end
+          question :leave_or_pay_for_adoption?
         end
       end
 

--- a/app/flows/maternity_paternity_calculator_flow/questions/taking_paternity_or_maternity_leave_for_adoption.erb
+++ b/app/flows/maternity_paternity_calculator_flow/questions/taking_paternity_or_maternity_leave_for_adoption.erb
@@ -1,8 +1,0 @@
-<% text_for :title do %>
-Is the employee taking paternity or maternity leave to adopt a child?
-<% end %>
-
-<% options(
-  "maternity": "Maternity",
-  "paternity": "Paternity"
-) %>

--- a/test/flows/maternity_paternity_calculator_flow/adoption_calculator_flow_test.rb
+++ b/test/flows/maternity_paternity_calculator_flow/adoption_calculator_flow_test.rb
@@ -8,32 +8,10 @@ class MaternityPaternityCalculatorFlow::AdoptionCalculatorFlowTest < ActiveSuppo
 
   setup { testing_flow MaternityPaternityCalculatorFlow }
 
-  context "question: taking_paternity_or_maternity_leave_for_adoption?" do
-    setup do
-      testing_node :taking_paternity_or_maternity_leave_for_adoption?
-      add_responses what_type_of_leave?: "adoption"
-    end
-
-    should "render the question" do
-      assert_rendered_question
-    end
-
-    context "next_node" do
-      should "have a next node of where_does_the_employee_live? for a 'paternity' response" do
-        assert_next_node :where_does_the_employee_live?, for_response: "paternity"
-      end
-
-      should "have a next node of adoption_is_from_overseas? for a 'maternity' response" do
-        assert_next_node :adoption_is_from_overseas?, for_response: "maternity"
-      end
-    end
-  end
-
   context "question: adoption_is_from_overseas?" do
     setup do
       testing_node :adoption_is_from_overseas?
-      add_responses what_type_of_leave?: "adoption",
-                    taking_paternity_or_maternity_leave_for_adoption?: "maternity"
+      add_responses what_type_of_leave?: "adoption"
     end
 
     should "render the question" do
@@ -51,7 +29,6 @@ class MaternityPaternityCalculatorFlow::AdoptionCalculatorFlowTest < ActiveSuppo
     setup do
       testing_node :date_of_adoption_match?
       add_responses what_type_of_leave?: "adoption",
-                    taking_paternity_or_maternity_leave_for_adoption?: "maternity",
                     adoption_is_from_overseas?: "yes"
     end
 
@@ -70,7 +47,6 @@ class MaternityPaternityCalculatorFlow::AdoptionCalculatorFlowTest < ActiveSuppo
     setup do
       testing_node :date_of_adoption_placement?
       add_responses what_type_of_leave?: "adoption",
-                    taking_paternity_or_maternity_leave_for_adoption?: "maternity",
                     adoption_is_from_overseas?: "yes",
                     date_of_adoption_match?: "2021-01-01"
     end
@@ -102,7 +78,6 @@ class MaternityPaternityCalculatorFlow::AdoptionCalculatorFlowTest < ActiveSuppo
     setup do
       testing_node :adoption_did_the_employee_work_for_you?
       add_responses what_type_of_leave?: "adoption",
-                    taking_paternity_or_maternity_leave_for_adoption?: "maternity",
                     adoption_is_from_overseas?: "no",
                     date_of_adoption_match?: "2021-01-01",
                     date_of_adoption_placement?: "2021-02-01"
@@ -405,7 +380,6 @@ class MaternityPaternityCalculatorFlow::AdoptionCalculatorFlowTest < ActiveSuppo
     should "render when an employee is entitled to statutory adoption pay and exactly on the threshold" do
       add_responses(
         what_type_of_leave?: "adoption",
-        taking_paternity_or_maternity_leave_for_adoption?: "maternity",
         adoption_is_from_overseas?: "no",
         date_of_adoption_match?: "2022-12-15",
         date_of_adoption_placement?: "2022-12-15",

--- a/test/flows/maternity_paternity_calculator_flow/paternity_calculator_flow_test.rb
+++ b/test/flows/maternity_paternity_calculator_flow/paternity_calculator_flow_test.rb
@@ -25,13 +25,6 @@ class MaternityPaternityCalculatorFlow::PaternityCalculatorFlowTest < ActiveSupp
 
         assert_next_node :leave_or_pay_for_adoption?, for_response: "scotland"
       end
-
-      should "have a next node of leave_or_pay_for_adoption? for any response when employee is taking paternity adoption leave" do
-        add_responses what_type_of_leave?: "adoption",
-                      taking_paternity_or_maternity_leave_for_adoption?: "paternity"
-
-        assert_next_node :employee_date_matched_paternity_adoption?, for_response: "scotland"
-      end
     end
   end
 

--- a/test/flows/maternity_paternity_calculator_flow_test.rb
+++ b/test/flows/maternity_paternity_calculator_flow_test.rb
@@ -26,8 +26,8 @@ class MaternityPaternityCalculatorFlowTest < ActiveSupport::TestCase
         assert_next_node :where_does_the_employee_live?, for_response: "paternity"
       end
 
-      should "have a next node of taking_paternity_or_maternity_leave_for_adoption? for a 'adoption' response" do
-        assert_next_node :taking_paternity_or_maternity_leave_for_adoption?, for_response: "adoption"
+      should "have a next node of adoption_is_from_overseas? for a 'adoption' response" do
+        assert_next_node :adoption_is_from_overseas?, for_response: "adoption"
       end
     end
   end

--- a/test/support/flows/maternity_paternity_calculator_flow_test_helper.rb
+++ b/test/support/flows/maternity_paternity_calculator_flow_test_helper.rb
@@ -65,7 +65,6 @@ module MaternityPaternityCalculatorFlowTestHelper
     payday_eight_weeks = payday_eight_weeks ? Date.parse(payday_eight_weeks) : placement_date - 6.months
 
     responses = { what_type_of_leave?: "adoption",
-                  taking_paternity_or_maternity_leave_for_adoption?: "maternity",
                   adoption_is_from_overseas?: overseas ? "yes" : "no",
                   date_of_adoption_match?: match_date.to_s,
                   date_of_adoption_placement?: placement_date.to_s }


### PR DESCRIPTION
[MAIN-7414](https://gov-uk.atlassian.net/browse/MAIN-7414)

This PR removes the 'Paternity' option when selecting the Adoption path in the Maternity, adoption and paternity calculator for employers


[MAIN-7414]: https://gov-uk.atlassian.net/browse/MAIN-7414?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ