### PR TITLE
Update references to Sass variables to use the govuk-functional-colour function

### DIFF
--- a/app/assets/stylesheets/components/_result-card.scss
+++ b/app/assets/stylesheets/components/_result-card.scss
@@ -1,7 +1,7 @@
 .app-c-result-card {
   position: relative;
   padding: govuk-spacing(5) govuk-spacing(4);
-  border: 1px solid $govuk-border-colour;
+  border: 1px solid govuk-functional-colour(border);
   margin-bottom: govuk-spacing(4);
 
   &::before {
@@ -33,7 +33,7 @@
   padding: govuk-spacing(0) govuk-spacing(4);
 
   .app-c-result-card__attribute {
-    border-top: 1px solid $govuk-border-colour;
+    border-top: 1px solid govuk-functional-colour(border);
     padding-top: govuk-spacing(2);
     padding-bottom: govuk-spacing(2);
   }
@@ -46,7 +46,7 @@
 @include govuk-media-query($media-type: print) {
   .app-c-result-card {
     break-inside: avoid;
-    border: 1pt solid $govuk-print-text-colour;
+    border: 1pt solid govuk-functional-colour(print-text);
 
     &::before {
       display: none;
@@ -54,7 +54,7 @@
 
     .app-c-result-card__link,
     .app-c-result-card__link:link {
-      color: $govuk-print-text-colour;
+      color: govuk-functional-colour(print-text);
     }
   }
 }

--- a/app/assets/stylesheets/components/_result-item.scss
+++ b/app/assets/stylesheets/components/_result-item.scss
@@ -14,7 +14,7 @@
 @include govuk-media-query($media-type: print) {
   .app-c-result-item {
     break-inside: avoid;
-    border-color: $govuk-print-text-colour;
+    border-color: govuk-functional-colour(print-text);
 
     .govuk-link::after {
       display: block;
@@ -28,7 +28,7 @@
 
     a,
     a:link {
-      color: $govuk-print-text-colour !important;
+      color: govuk-functional-colour(print-text) !important;
     }
   }
 }

--- a/app/assets/stylesheets/components/_result-sections.scss
+++ b/app/assets/stylesheets/components/_result-sections.scss
@@ -3,7 +3,7 @@
 }
 
 .app-c-result-sections__section {
-  border-top: 1px solid $govuk-border-colour;
+  border-top: 1px solid govuk-functional-colour(border);
   @include govuk-font($size: 19);
   @include govuk-responsive-padding(4, "top");
 }
@@ -17,7 +17,7 @@
     border-top: 0;
 
     &:not(:last-of-type) {
-      border-bottom: 1px solid $govuk-border-colour;
+      border-bottom: 1px solid govuk-functional-colour(border);
     }
   }
 }


### PR DESCRIPTION
## What
Replace colour variables with govuk-functional-colour function

## Why
The Sass variables for accessing functional colours are deprecated, and will be removed in a future breaking release of govuk-frontend

Jira card: https://gov-uk.atlassian.net/browse/NAV-18923