### PR TITLE
Add GA4 tracking to 'next steps for your business'

### DIFF
--- a/app/flows/next_steps_for_your_business_flow/outcomes/results.erb
+++ b/app/flows/next_steps_for_your_business_flow/outcomes/results.erb
@@ -5,6 +5,10 @@
   ======================================================================
 %>
 
+<%
+  @website_root ||= Plek.new.website_root
+%>
+
 <% text_for :title do %>
   Next steps for your limited company
 <% end %>

--- a/app/views/components/_result_item.html.erb
+++ b/app/views/components/_result_item.html.erb
@@ -11,11 +11,20 @@
   if !title || !url || !description
     raise ArgumentError, "The result item component requires a title, url and description"
   end
+
+  @website_root ||= Plek.new.website_root
+  internal_link = url.start_with?("/", @website_root) && !url.start_with?("//") # Treat relative urls (/browse), the site root (https://www.gov.uk) but not relative protocol urls (//www.example.com/) as internal
 %>
 <%= tag.div class: css_classes do %>
   <h4 class="govuk-heading-s govuk-!-margin-bottom-2">
-    <%= link_to url, class: "govuk-link", target: "_blank", rel: "noreferrer noopener" do %>
-      <%= title || url %> <span class="govuk-!-display-none-print">(opens in new tab)</span>
+    <% if internal_link %>
+      <%= link_to url, class: "govuk-link", target: "_blank", rel: "noopener" do %>
+        <%= title || url %> <span class="govuk-!-display-none-print">(opens in new tab)</span>
+      <% end %>
+    <% else %>
+      <%= link_to url, class: "govuk-link", target: "_blank", rel: "noopener noreferrer" do %>
+        <%= title || url %> <span class="govuk-!-display-none-print">(opens in new tab)</span>
+      <% end %>
     <% end %>
   </h4>
   <p class="govuk-body govuk-!-margin-bottom-1">

--- a/app/views/smart_answers/custom_result.html.erb
+++ b/app/views/smart_answers/custom_result.html.erb
@@ -28,7 +28,17 @@
 
     <%= outcome.description %>
 
-    <%= outcome.body %>
+    <%= tag.div data: { module: "ga4-link-tracker",
+      ga4_set_indexes: "",
+      ga4_link: {
+        "event_name": "information_click",
+        "type": "smart answer",
+        "section": outcome.title,
+        "action": "information click",
+        "tool_name": @presenter.title,
+      }} do %>
+      <%= outcome.body %>
+    <% end %>
 
     <div class="govuk-!-display-none-print">
       <%= render "govuk_publishing_components/components/heading", {
@@ -41,7 +51,17 @@
       <%= tag.p class: "govuk-body govuk-!-margin-bottom-8" do %>
         <%= link_to "Answer the questions again to change the results",
           restart_flow_path(@presenter),
-          class: "govuk-link" %>
+          class: "govuk-link",
+          data: {
+            module: "ga4-link-tracker",
+            ga4_link: {
+              event_name: "form_start_again",
+              type: "smart answer",
+              section: @presenter.current_node.title,
+              action: "start again",
+              tool_name: @presenter.title,
+            },
+          } %>
       <% end %>
     </div>
 

--- a/test/components/result_item_test.rb
+++ b/test/components/result_item_test.rb
@@ -65,4 +65,50 @@ class ResultItemTest < ComponentTestCase
     assert_select ".app-c-result-item .govuk-link[href='www.gov.uk']", text: "Result item title (opens in new tab)"
     assert_select ".app-c-result-item .govuk-body", text: "Result item description"
   end
+
+  test "renders with 'rel=noreferrer noopener' if the url is external" do
+    render_component({
+      title: "Result item title",
+      url: "www.example.com",
+      description: "something",
+    })
+
+    assert_select ".app-c-result-item", true
+    assert_select ".app-c-result-item .govuk-link[href='www.example.com'][target=_blank][rel='noopener noreferrer']", text: "Result item title (opens in new tab)"
+  end
+
+  test "does not render with 'rel=noreferrer' if the url is internal" do
+    render_component({
+      title: "Result item title",
+      url: "https://www.test.gov.uk", # This is what Plek.new.website_root returns in tests
+      description: "something",
+    })
+
+    assert_select ".app-c-result-item", true
+    assert_select ".app-c-result-item .govuk-link[href='https://www.test.gov.uk'][target=_blank][rel='noopener noreferrer']", false
+    assert_select ".app-c-result-item .govuk-link[href='https://www.test.gov.uk'][target=_blank][rel='noopener']", text: "Result item title (opens in new tab)"
+  end
+
+  test "does not render with 'rel=noreferrer' if the url is relative" do
+    render_component({
+      title: "Result item title",
+      url: "/browse",
+      description: "something",
+    })
+
+    assert_select ".app-c-result-item", true
+    assert_select ".app-c-result-item .govuk-link[href='/browse'][target=_blank][rel='noopener noreferrer']", false
+    assert_select ".app-c-result-item .govuk-link[href='/browse'][target=_blank][rel='noopener']", text: "Result item title (opens in new tab)"
+  end
+
+  test "renders with 'rel=noreferrer noopener' if the url is protocol relative" do
+    render_component({
+      title: "Result item title",
+      url: "//www.example.com",
+      description: "something",
+    })
+
+    assert_select ".app-c-result-item", true
+    assert_select ".app-c-result-item .govuk-link[href='//www.example.com'][target=_blank][rel='noopener noreferrer']", text: "Result item title (opens in new tab)"
+  end
 end


### PR DESCRIPTION
## What / Why
- Adds GA4 tracking to the 'next steps for your business' route: (example [here](https://smart-answers-pr-7700.herokuapp.com/next-steps-for-your-business/results?activities%5B%5D=export_goods_or_services&annual_turnover_over_90k=not_sure&business_premises%5B%5D=owned&employ_someone=yes&financial_support=yes))
- I also removed the `noreferrer` property from internal links that were opening in a new tab. This is so GA4 will track the referrer when they click a result that's still on gov.uk. I had to duplicate the link to do this since the linter expects `noopener` as an explicit string without any Ruby magic in it, so dynamically setting the `rel` value didn't work.