### PR TITLE
[MAIN-7407] Add "None of the above" option to SSP calculator checkboxes

### DIFF
--- a/app/flows/calculate_statutory_sick_pay_flow.rb
+++ b/app/flows/calculate_statutory_sick_pay_flow.rb
@@ -13,6 +13,7 @@ class CalculateStatutorySickPayFlow < SmartAnswer::Flow
       option :statutory_adoption_pay
       option :statutory_parental_bereavement_pay
       option :shared_parental_leave_and_pay
+      none_option
 
       on_response do |response|
         self.calculator = SmartAnswer::Calculators::StatutorySickPayCalculator.new

--- a/app/flows/calculate_statutory_sick_pay_flow/questions/is_your_employee_getting.erb
+++ b/app/flows/calculate_statutory_sick_pay_flow/questions/is_your_employee_getting.erb
@@ -8,7 +8,8 @@
   "statutory_paternity_pay": "Statutory Paternity Pay",
   "statutory_adoption_pay": "Statutory Adoption Pay",
   "statutory_parental_bereavement_pay": "Statutory Parental Bereavement Pay",
-  "shared_parental_leave_and_pay": "Shared Parental Leave and Pay"
+  "shared_parental_leave_and_pay": "Shared Parental Leave and Pay",
+  "none": "None of the above",
 ) %>
 
 <% text_for :hint do %>

--- a/app/flows/calculate_statutory_sick_pay_flow/questions/is_your_employee_getting.erb
+++ b/app/flows/calculate_statutory_sick_pay_flow/questions/is_your_employee_getting.erb
@@ -11,7 +11,3 @@
   "shared_parental_leave_and_pay": "Shared Parental Leave and Pay",
   "none": "None of the above",
 ) %>
-
-<% text_for :hint do %>
-  If none apply just click ‘Continue’
-<% end %>

--- a/app/presenters/checkbox_question_presenter.rb
+++ b/app/presenters/checkbox_question_presenter.rb
@@ -38,4 +38,17 @@ private
 
     response.include?(value)
   end
+
+  # Default message for the built-in none-not-exclusive validation; a flow can
+  # still override it with `text_for :error_none_not_exclusive`.
+  def error_message_for(key)
+    super || none_not_exclusive_message(key)
+  end
+
+  def none_not_exclusive_message(key)
+    return unless key.to_sym == :error_none_not_exclusive
+
+    none_label = option_attributes(SmartAnswer::Question::Checkbox::NONE_OPTION)[:label]
+    "Please select either ‘#{none_label}’ or one or more of the other options."
+  end
 end

--- a/docs/design/question-types.md
+++ b/docs/design/question-types.md
@@ -4,7 +4,7 @@
   * User input: Choose zero to many options from a list of options.
   * Validation: Must be in the list of options.
   * Response: String containing comma-separated list of chosen options.
-  * Can specify `none_option` in flow definition to represent a "none" answer. This ensures the user has selected at least one checkbox before continuing.
+  * Can specify `none_option` in flow definition to represent a "none" answer. This ensures the user has selected at least one checkbox before continuing, and that the "none" option is not selected alongside any other option. GOV.UK Frontend enforces this in the browser; the server-side check catches submissions made with JavaScript disabled. A default error message is provided, which a flow can override with `text_for :error_none_not_exclusive`.
 
 ## `country_select`
   * Options:

--- a/lib/smart_answer/question/checkbox.rb
+++ b/lib/smart_answer/question/checkbox.rb
@@ -55,10 +55,21 @@ module SmartAnswer
         return NONE_OPTION if raw_input == NONE_OPTION
 
         raw_input = raw_input.split(",") if raw_input.is_a?(String)
+
+        raise SmartAnswer::InvalidResponse, :error_none_not_exclusive, caller if none_combined_with_other_options?(raw_input)
+
         raw_input.each do |option|
           raise SmartAnswer::InvalidResponse, "Illegal option #{option} for #{name}", caller unless valid_option?(option)
         end
         raw_input.sort.join(",")
+      end
+
+    private
+
+      # The GOV.UK Frontend checkbox component prevents this in the browser, so
+      # this only catches submissions made with JavaScript disabled.
+      def none_combined_with_other_options?(selected_options)
+        none_option? && selected_options.include?(NONE_OPTION) && selected_options.length > 1
       end
     end
   end

--- a/test/flows/calculate_statutory_sick_pay_test.rb
+++ b/test/flows/calculate_statutory_sick_pay_test.rb
@@ -640,7 +640,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
     end
 
     should "not render the statutory paternity warning text if not receiving shared parental or statutory paternity pay" do
-      add_responses is_your_employee_getting?: ""
+      add_responses is_your_employee_getting?: "none"
 
       assert_no_match "Your employee will not be able to collect Statutory Shared Parental Pay, Statutory Paternity Pay", @test_flow.outcome_text
     end

--- a/test/integration/engine/checkbox_questions_test.rb
+++ b/test/integration/engine/checkbox_questions_test.rb
@@ -116,6 +116,27 @@ class CheckboxQuestionsTest < EngineIntegrationTest
     end
   end
 
+  without_javascript do
+    should "reject selecting the none option alongside another option" do
+      visit "/checkbox-sample/y/none"
+
+      find "h1", text: "Are you sure you don't want any toppings?"
+      check("Definitely no toppings", visible: false, allow_label_click: true)
+      check("Hmm I'm not sure, ask me again please", visible: false, allow_label_click: true)
+      click_on "Continue"
+
+      assert_equal current_path, "/checkbox-sample/y/none"
+
+      within(".govuk-error-summary [href]") do
+        assert_page_has_content "Please select either ‘Definitely no toppings’ or one or more of the other options."
+      end
+
+      within(".govuk-error-message") do
+        assert_page_has_content "Please select either ‘Definitely no toppings’ or one or more of the other options."
+      end
+    end
+  end
+
   should "calculate next_node correctly" do
     visit "/checkbox-sample/y"
 

--- a/test/unit/checkbox_question_presenter_test.rb
+++ b/test/unit/checkbox_question_presenter_test.rb
@@ -73,6 +73,21 @@ module SmartAnswer
       assert_not(@presenter.checkboxes.any? { |c| c[:checked] })
     end
 
+    test "#error_message_for returns a default message using the none option's own label" do
+      @renderer.stubs(:content_for).with(:error_none_not_exclusive).returns(nil)
+      @renderer.stubs(:option).with("none").returns("Definitely no toppings")
+
+      assert_equal "Please select either ‘Definitely no toppings’ or one or more of the other options.",
+                   @presenter.send(:error_message_for, :error_none_not_exclusive)
+    end
+
+    test "#error_message_for lets a flow override the none-not-exclusive message" do
+      @renderer.stubs(:content_for).with(:error_none_not_exclusive).returns("Custom message")
+
+      assert_equal "Custom message",
+                   @presenter.send(:error_message_for, :error_none_not_exclusive)
+    end
+
     test "#caption returns the given caption when a caption is given" do
       @renderer.stubs(:hide_caption).returns(false)
       @renderer.stubs(:content_for).with(:caption).returns("caption-text")

--- a/test/unit/checkbox_question_test.rb
+++ b/test/unit/checkbox_question_test.rb
@@ -119,6 +119,17 @@ module SmartAnswer
             @question.parse_input(nil)
           end
         end
+
+        should "raise if 'none' is selected alongside another option" do
+          error = assert_raise InvalidResponse do
+            @question.parse_input("none,red")
+          end
+          assert_equal :error_none_not_exclusive, error.message.to_sym
+        end
+
+        should "return 'none' when it is the only selected option" do
+          assert_equal "none", @question.parse_input("none")
+        end
       end
     end
   end


### PR DESCRIPTION
[MAIN-7407](https://gov-uk.atlassian.net/browse/MAIN-7407)

## Changes

- **SSP flow:** add `none_option` to the question and a "None of the above" label; remove the now-redundant hint text.
- **Checkbox question type:** `parse_input` now rejects a "none" selection combined with any other option, raising `:error_none_not_exclusive`. This applies to every `checkbox_question` using `none_option`, (currently only `next_steps_for_your_business`).
- **Checkbox presenter:** provides a default error message that uses the flow's own "none" label, which a flow can still override with `text_for :error_none_not_exclusive`.
- Updated `docs/design/question-types.md` to describe the new "none" exclusivity behaviour.

## UI

<img width="827" height="714" alt="image" src="https://github.com/user-attachments/assets/8cf36e09-7690-455b-92f0-d405a6068367" />

**With server-side validation error message (JavaScript turned off)**
<img width="780" height="768" alt="image" src="https://github.com/user-attachments/assets/a183fd03-5fd7-4537-9ecc-256447934ddf" />

[MAIN-7407]: https://gov-uk.atlassian.net/browse/MAIN-7407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ