### PR TITLE
MAIN-7486 Fix issues with UK visa check

### DIFF
--- a/app/flows/check_uk_visa_flow.rb
+++ b/app/flows/check_uk_visa_flow.rb
@@ -392,7 +392,7 @@ class CheckUkVisaFlow < SmartAnswer::Flow
           next outcome(:outcome_visit_waiver_taiwan)
         elsif (calculator.passport_country_in_non_visa_national_list? ||
             calculator.passport_country_in_eea? ||
-            calculator.passport_country_in_british_overseas_territories_list?) &&
+            calculator.passport_country_in_british_overseas_territories_non_eta_list?) &&
             !calculator.travel_document?
           next outcome(:outcome_tourism_n)
         else

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_tourism_n.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_tourism_n.erb
@@ -3,12 +3,6 @@
 <% end %>
 
 <% govspeak_for :body do %>
-  <% if calculator.passport_country_in_british_overseas_territories_list? %>
-    Before you travel to the UK, you will need to [apply for an electronic travel authorisation (ETA)](/guidance/apply-for-an-electronic-travel-authorisation-eta). You do not need a visa.
-  <% end %>
-
-  <%= render partial: "electronic_travel_authorisation_advice", locals: {calculator: calculator} %>
-
   You can stay in the UK as a tourist for up to 6 months without a visa, but you must meet the Standard Visitor eligibility requirements.
 
   %You may want to [apply for a Standard Visitor visa](/standard-visitor/apply-standard-visitor-visa) if you have a criminal record or you’ve previously been refused entry into the UK.%

--- a/app/flows/check_uk_visa_flow/outcomes/outcome_tourism_n.erb
+++ b/app/flows/check_uk_visa_flow/outcomes/outcome_tourism_n.erb
@@ -1,5 +1,5 @@
 <% text_for :title do %>
-  You will not need a visa to come to the UK
+  You will not need a visa or electronic travel authorisation (ETA) to come to the UK
 <% end %>
 
 <% govspeak_for :body do %>

--- a/config/smart_answers/ukba_additional_countries.yml
+++ b/config/smart_answers/ukba_additional_countries.yml
@@ -1,6 +1,6 @@
 ---
-- :name: British dependent territories citizen
-  :slug: british-dependent-territories-citizen
+- :name: British overseas territories citizen
+  :slug: british-overseas-territories-citizen
 - :name: British national overseas
   :slug: british-national-overseas
 - :name: British overseas citizen

--- a/lib/smart_answer/calculators/uk_visa_calculator.rb
+++ b/lib/smart_answer/calculators/uk_visa_calculator.rb
@@ -354,7 +354,7 @@ module SmartAnswer::Calculators
     COUNTRY_GROUP_BRITISH_OVERSEAS_TERRITORIES = %w[
       anguilla
       bermuda
-      british-dependent-territories-citizen
+      british-overseas-territories-citizen
       british-overseas-citizen
       british-protected-person
       british-virgin-islands

--- a/lib/smart_answer/calculators/uk_visa_calculator.rb
+++ b/lib/smart_answer/calculators/uk_visa_calculator.rb
@@ -66,6 +66,10 @@ module SmartAnswer::Calculators
       COUNTRY_GROUP_BRITISH_OVERSEAS_TERRITORIES.include?(@passport_country)
     end
 
+    def passport_country_in_british_overseas_territories_non_eta_list?
+      COUNTRY_GROUP_BRITISH_OVERSEAS_TERRITORIES_NON_ETA.include?(@passport_country)
+    end
+
     def passport_country_in_direct_airside_transit_visa_list?
       COUNTRY_GROUP_DIRECT_AIRSIDE_TRANSIT_VISA.include?(@passport_country)
     end
@@ -351,6 +355,19 @@ module SmartAnswer::Calculators
       zambia
     ].freeze
 
+    COUNTRY_GROUP_BRITISH_OVERSEAS_TERRITORIES_NON_ETA = %w[
+      anguilla
+      bermuda
+      british-overseas-territories-citizen
+      british-virgin-islands
+      cayman-islands
+      falkland-islands
+      montserrat
+      south-georgia-and-the-south-sandwich-islands
+      st-helena-ascension-and-tristan-da-cunha
+      turks-and-caicos-islands
+    ].freeze
+
     COUNTRY_GROUP_BRITISH_OVERSEAS_TERRITORIES = %w[
       anguilla
       bermuda
@@ -604,6 +621,8 @@ module SmartAnswer::Calculators
       belize
       bonaire-st-eustatius-saba
       brazil
+      british-overseas-citizen
+      british-protected-person
       brunei
       bulgaria
       canada

--- a/test/flows/check_uk_visa_flow_test.rb
+++ b/test/flows/check_uk_visa_flow_test.rb
@@ -12,6 +12,7 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
     @direct_airside_transit_visa_country = "afghanistan"
     @visa_national_country = "armenia"
     @british_overseas_territory_country = "anguilla"
+    @british_overseas_territory_eta_country = "british-protected-person"
     @non_visa_national_country = "pitcairn-island"
     @eea_country = "austria"
     @travel_document_country = "hong-kong"
@@ -1108,39 +1109,7 @@ class CheckUkVisaFlowTest < ActiveSupport::TestCase
     end
   end
 
-  context "outcome: outcome_tourism_n" do
-    setup do
-      testing_node :outcome_tourism_n
-      add_responses dual_british_or_irish_citizenship?: "no",
-                    purpose_of_visit?: "tourism"
-    end
-
-    should "render the need for an ETA for a British Overseas Citizen passport" do
-      add_responses what_passport_do_you_have?: @british_overseas_territory_country
-      assert_rendered_outcome text: "Before you travel to the UK, you will need to apply for an electronic travel authorisation (ETA)"
-    end
-
-    should "not render the need for an ETA for a non-British Overseas Citizen passport" do
-      add_responses what_passport_do_you_have?: @non_visa_national_country
-      assert_no_rendered_outcome text: "Before you travel to the UK, you will need to apply for an electronic travel authorisation (ETA)"
-    end
-  end
-
   context "ETA callout box on" do
-    context "outcome: outcome_tourism_n" do
-      setup do
-        testing_node :outcome_tourism_n
-        add_responses dual_british_or_irish_citizenship?: "no",
-                      purpose_of_visit?: "tourism"
-      end
-
-      should "not render callout box for countries that do not require it" do
-        add_responses what_passport_do_you_have?: @british_overseas_territory_country
-        assert_no_rendered_outcome text: @non_visa_national_eta_text
-        assert_no_rendered_outcome text: @eea_eta_text
-      end
-    end
-
     context "outcome: outcome_work_n" do
       setup do
         testing_node :outcome_work_n

--- a/test/support/flows/check_uk_visa_flow_test_helper.rb
+++ b/test/support/flows/check_uk_visa_flow_test_helper.rb
@@ -152,6 +152,11 @@ module CheckUkVisaFlowTestHelper
         assert_next_node :outcome_tourism_electronic_travel_authorisation, for_response: "tourism"
       end
 
+      should "have a next node of outcome_tourism_requires_electronic_travel_authorisation for British overseas territories ETA passport " do
+        add_responses what_passport_do_you_have?: @british_overseas_territory_eta_country
+        assert_next_node :outcome_tourism_electronic_travel_authorisation, for_response: "tourism"
+      end
+
       should "have a next node of outcome_tourism_requires_electronic_travel_authorisation for a Taiwan passport" do
         add_responses what_passport_do_you_have?: "taiwan"
         assert_next_node :outcome_tourism_electronic_travel_authorisation, for_response: "tourism"
@@ -167,7 +172,7 @@ module CheckUkVisaFlowTestHelper
         assert_next_node :outcome_tourism_electronic_travel_authorisation, for_response: "tourism"
       end
 
-      should "have a next node of outcome_tourism_n for a British overseas territory passport" do
+      should "have a next node of outcome_tourism_n for a British overseas territory (non-eta) passport" do
         add_responses what_passport_do_you_have?: @british_overseas_territory_country
         assert_next_node :outcome_tourism_n, for_response: "tourism"
       end


### PR DESCRIPTION
[MAIN-7486](https://gov-uk.atlassian.net/browse/MAIN-7486)

Implements a few requested changes to the Check UK visa flow

- British dependent territories citizen is incorrect (it should be British overseas territories citizen) 
- The 'tourism' outcomes for the following British overseas territories
- The Tourism outcome for British overseas territories text


[MAIN-7486]: https://gov-uk.atlassian.net/browse/MAIN-7486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ