### PR TITLE
Update register_a_death.yml

### DIFF
--- a/config/smart_answers/rates/register_a_death.yml
+++ b/config/smart_answers/rates/register_a_death.yml
@@ -7,5 +7,5 @@
   end_date: 2999-01-01
   register_a_death: 150.00
   copy_of_death_registration_certificate: 50.00
-  minimum_return_fee: 5.50
-  maximum_return_fee: 29.50
+  minimum_return_fee: 6.00
+  maximum_return_fee: 42.00

--- a/config/smart_answers/rates/register_a_death.yml
+++ b/config/smart_answers/rates/register_a_death.yml
@@ -3,7 +3,7 @@
 # and usually 1. The last item in the file should have an end
 # date of 2999-01-01
 ---
-- start_date: 2016-04-06
+- start_date: 2026-08-03
   end_date: 2999-01-01
   register_a_death: 150.00
   copy_of_death_registration_certificate: 50.00


### PR DESCRIPTION
Fee update for 2026 - publish on or after 8am on 3 August 2026.

Updating:
minimum_return_fee: 5.50
maximum_return_fee: 29.50

To:
minimum_return_fee: 6.00
maximum_return_fee: 42.00

Jira: https://gov-uk.atlassian.net/browse/BT-3367

[MAIN-####](https://gov-uk.atlassian.net/browse/MAIN-####)
(populate the link above to make sure your PR is linked to the Jira ticket)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
