### PR TITLE
Planned adoption leave start date fix

### DIFF
--- a/lib/smart_answer/calculators/plan_adoption_leave.rb
+++ b/lib/smart_answer/calculators/plan_adoption_leave.rb
@@ -11,7 +11,7 @@ module SmartAnswer::Calculators
 
     def valid_start_date?
       dist = (arrival_date - start_date).to_i
-      (1..14).include? dist
+      (0..14).include? dist
     end
 
     def distance_start

--- a/test/flows/plan_adoption_leave_flow_test.rb
+++ b/test/flows/plan_adoption_leave_flow_test.rb
@@ -74,6 +74,15 @@ class PlanAdoptionLeaveFlowTest < ActiveSupport::TestCase
         not_within_14_days = @child_arrival_date - 15.days
         assert_invalid_response not_within_14_days.to_s
       end
+
+      should "be invalid if the response is after the child_arrival_date" do
+        future_date = @child_arrival_date + 1.day
+        assert_invalid_response future_date.to_s
+      end
+
+      should "be valid if the response matches the child_arrival_date" do
+        assert_valid_response @child_arrival_date.to_s
+      end
     end
 
     context "next_node" do


### PR DESCRIPTION
[MAIN-7521](https://gov-uk.atlassian.net/browse/MAIN-7521)

This PR updates #valid_start_date? to accept when the planned start date is the same as the child's arrival date.


[MAIN-7521]: https://gov-uk.atlassian.net/browse/MAIN-7521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ