### PR TITLE
Validate user input

### DIFF
--- a/app/flows/shared/redundancy_pay_flow.rb
+++ b/app/flows/shared/redundancy_pay_flow.rb
@@ -35,15 +35,19 @@ class RedundancyPayFlow < SmartAnswer::Flow
 
     value_question :years_employed?, parse: Float do
       on_response do |response|
-        self.years_employed = response.floor
+        if response.infinite? || response.nan?
+          raise SmartAnswer::InvalidResponse
+        else
+          self.years_employed = response.floor
+        end
       end
 
       validate do
         years_employed.to_i <= years_available
       end
 
-      next_node do |response|
-        if response.floor < 2
+      next_node do |years_employed|
+        if years_employed < 2
           outcome :done_no_statutory
         else
           question :weekly_pay_before_tax?

--- a/test/support/flows/redundancy_pay_flow_test_helper.rb
+++ b/test/support/flows/redundancy_pay_flow_test_helper.rb
@@ -72,6 +72,10 @@ module RedundancyPayFlowTestHelper
         should "be invalid for an invalid number of years employed" do
           assert_invalid_response "2"
         end
+
+        should "raise an error if number of years is infinity" do
+          assert_invalid_response "1e999"
+        end
       end
 
       context "next_node" do


### PR DESCRIPTION
Check user input float value before calling float methods, to prevent triggering a FloatDomainError. 
